### PR TITLE
feat(vm): scaffold — Register / Memory / VM types

### DIFF
--- a/.changeset/c0a5ceb4.md
+++ b/.changeset/c0a5ceb4.md
@@ -1,0 +1,10 @@
+---
+bump: minor
+---
+
+Add the VM kernel scaffold: `Register` / `Registers` / `Flag` /
+`Memory` / `VM` types. 15 named u16 registers indexable by name
+or operand index, 64KB linear address space with little-endian
+word access, ISA §8 boot-state defaults (`sp`/`fp`=0xFFFE, `mb`=0,
+`im`=0xFFFF, `flg`=0). Foundation for the opcode dispatch loop
+(next).

--- a/src/gero.zig
+++ b/src/gero.zig
@@ -1,6 +1,6 @@
-/// Gero — 16-bit virtual machine + assembler + disassembler + Lua-style
-/// language ecosystem in Zig. Public barrel.
-///
-/// Day 1 scaffold; modules land as code does. See CLAUDE.md for the
-/// roadmap and conventions.
+/// Gero — 16-bit virtual machine + assembler + Lua-style language
+/// ecosystem in Zig. Public barrel.
 pub const VERSION = "0.0.0";
+
+/// VM kernel — register file, memory, and the composing `VM` type.
+pub const vm = @import("vm/vm.zig");

--- a/src/vm/memory.zig
+++ b/src/vm/memory.zig
@@ -1,0 +1,53 @@
+/// 64KB linear address space, byte-addressable, with little-endian
+/// `u16` helpers. Pure storage — banking and the host-pluggable
+/// mapper layer on top.
+const std = @import("std");
+
+/// Total address space.
+pub const size: usize = 65536;
+
+/// Flat 64KB byte-addressable RAM.
+pub const Memory = struct {
+    /// Backing bytes. Public so the loader can `loadImage` and
+    /// tests can inspect; production callers use the typed helpers.
+    bytes: [size]u8,
+
+    /// Fresh zeroed region.
+    pub fn init() Memory {
+        return .{ .bytes = @splat(0) };
+    }
+
+    /// Read one byte.
+    pub fn readByte(self: Memory, addr: u16) u8 {
+        return self.bytes[addr];
+    }
+
+    /// Write one byte.
+    pub fn writeByte(self: *Memory, addr: u16, value: u8) void {
+        self.bytes[addr] = value;
+    }
+
+    /// Word read at `0xFFFF` wraps the high byte to `0x0000` —
+    /// matches real-bus behavior, deliberate.
+    pub fn readWord(self: Memory, addr: u16) u16 {
+        const lo: u16 = self.bytes[addr];
+        const hi: u16 = self.bytes[addr +% 1];
+        return lo | (hi << 8);
+    }
+
+    /// Same wrap as `readWord` for the symmetric write.
+    pub fn writeWord(self: *Memory, addr: u16, value: u16) void {
+        self.bytes[addr] = @truncate(value & 0xFF);
+        self.bytes[addr +% 1] = @truncate((value >> 8) & 0xFF);
+    }
+
+    /// Bulk-copy `data` into RAM at `offset`. Returns the number
+    /// of bytes actually written (clamped to remaining space).
+    pub fn loadImage(self: *Memory, offset: u16, data: []const u8) usize {
+        // @as: widen u16 → usize so the subtraction operates in usize
+        const remaining = size - @as(usize, offset);
+        const n = @min(remaining, data.len);
+        @memcpy(self.bytes[offset..][0..n], data[0..n]);
+        return n;
+    }
+};

--- a/src/vm/registers.zig
+++ b/src/vm/registers.zig
@@ -1,0 +1,116 @@
+/// Register file: 15 u16 slots, indexable by name or by operand
+/// index. `flg` gets bit-level helpers so callers don't open-code
+/// the mask math.
+const std = @import("std");
+
+/// Number of named registers.
+pub const reg_count: u8 = 15;
+
+/// Highest valid operand index. Anything above raises an
+/// invalid-register fault.
+pub const max_index: u8 = 0x0E;
+
+/// Named register handles. The numeric value IS the operand-encoding
+/// index — cast via `@intFromEnum` / `@enumFromInt` at decode time.
+pub const Register = enum(u8) {
+    /// Instruction pointer.
+    ip = 0x00,
+    /// Accumulator. Implicit destination for short-form ALU ops;
+    /// holds the high half of `mul` results and the remainder of
+    /// `div`.
+    acu = 0x01,
+    /// General purpose.
+    r1 = 0x02,
+    /// General purpose.
+    r2 = 0x03,
+    /// General purpose.
+    r3 = 0x04,
+    /// General purpose.
+    r4 = 0x05,
+    /// General purpose.
+    r5 = 0x06,
+    /// General purpose.
+    r6 = 0x07,
+    /// General purpose.
+    r7 = 0x08,
+    /// General purpose.
+    r8 = 0x09,
+    /// Stack pointer. Stack grows downward.
+    sp = 0x0A,
+    /// Frame pointer. Set by `call`, restored by `ret`.
+    fp = 0x0B,
+    /// Memory bank — selects the 16KB page mapped at the bank window.
+    mb = 0x0C,
+    /// Interrupt mask. Bit `N` enables vector `N`.
+    im = 0x0D,
+    /// Status flags. See `Flag` for the bit layout.
+    flg = 0x0E,
+};
+
+/// Bit positions inside the `flg` register.
+pub const Flag = enum(u4) {
+    /// Result was zero.
+    zero = 0,
+    /// Result high bit was 1 (signed-negative).
+    negative = 1,
+    /// Set on unsigned overflow / borrow / last bit shifted or
+    /// rotated out.
+    carry = 2,
+    /// Signed overflow.
+    overflow = 3,
+    /// Interrupt-disable. `1` blocks IRQs globally.
+    interrupt_disable = 4,
+};
+
+/// 15-slot u16 register file.
+pub const Registers = struct {
+    /// Backing storage. Public so tests and the loader can poke
+    /// directly; production callers prefer the typed helpers.
+    values: [reg_count]u16,
+
+    /// Fresh zeroed file.
+    pub fn init() Registers {
+        return .{ .values = @splat(0) };
+    }
+
+    /// Read by named handle.
+    pub fn read(self: Registers, reg: Register) u16 {
+        return self.values[@intFromEnum(reg)];
+    }
+
+    /// Write by named handle.
+    pub fn write(self: *Registers, reg: Register, value: u16) void {
+        self.values[@intFromEnum(reg)] = value;
+    }
+
+    /// Read by raw operand index. `null` for out-of-range — caller
+    /// raises the fault.
+    pub fn readByIndex(self: Registers, index: u8) ?u16 {
+        if (index > max_index) return null;
+        return self.values[index];
+    }
+
+    /// Write by raw operand index. `false` for out-of-range — caller
+    /// raises the fault.
+    pub fn writeByIndex(self: *Registers, index: u8, value: u16) bool {
+        if (index > max_index) return false;
+        self.values[index] = value;
+        return true;
+    }
+
+    /// Test a flag bit.
+    pub fn flagSet(self: Registers, flag: Flag) bool {
+        // @as: widen the literal `1` to u16 for the shift to produce a u16 mask
+        const mask: u16 = @as(u16, 1) << @intFromEnum(flag);
+        return (self.read(.flg) & mask) != 0;
+    }
+
+    /// Set a flag bit, leaving the other bits intact.
+    pub fn setFlag(self: *Registers, flag: Flag, value: bool) void {
+        // @as: widen the literal `1` to u16 for the shift to produce a u16 mask
+        const mask: u16 = @as(u16, 1) << @intFromEnum(flag);
+        const cur = self.read(.flg);
+        const next: u16 = if (value) cur | mask else cur & ~mask;
+        self.write(.flg, next);
+    }
+};

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -1,0 +1,63 @@
+/// The gero VM. Composes the register file and 64KB memory.
+/// Banking, the host mapper indirection, and the dispatch loop
+/// layer on top in subsequent PRs.
+const std = @import("std");
+const registers = @import("registers.zig");
+const memory = @import("memory.zig");
+
+/// Re-export: named register handles.
+pub const Register = registers.Register;
+/// Re-export: register file type.
+pub const Registers = registers.Registers;
+/// Re-export: flag bit positions inside `flg`.
+pub const Flag = registers.Flag;
+/// Re-export: 64KB memory type.
+pub const Memory = memory.Memory;
+
+/// Boot-state default for `sp` — top of memory minus 1 word so the
+/// first push lands on a valid word.
+pub const sp_boot: u16 = 0xFFFE;
+
+/// Boot-state default for `fp` — same as `sp_boot` (no frames open).
+pub const fp_boot: u16 = 0xFFFE;
+
+/// Boot-state default for `im` — every maskable vector enabled.
+pub const im_boot: u16 = 0xFFFF;
+
+/// The VM. Owns the register file and a flat 64KB memory.
+pub const VM = struct {
+    regs: Registers,
+    mem: Memory,
+
+    /// Construct a fresh VM with default boot state. `ip` is left
+    /// at 0; the loader sets it to the program's entry point.
+    pub fn init() VM {
+        var vm: VM = .{
+            .regs = Registers.init(),
+            .mem = Memory.init(),
+        };
+        vm.bootInitRegisters();
+        return vm;
+    }
+
+    /// Re-applies the register defaults. Public so the loader can
+    /// re-boot between programs without recreating memory (memory
+    /// is deliberately preserved — useful for SRAM-backed runs).
+    pub fn bootInitRegisters(self: *VM) void {
+        self.regs.write(.ip, 0);
+        self.regs.write(.acu, 0);
+        self.regs.write(.r1, 0);
+        self.regs.write(.r2, 0);
+        self.regs.write(.r3, 0);
+        self.regs.write(.r4, 0);
+        self.regs.write(.r5, 0);
+        self.regs.write(.r6, 0);
+        self.regs.write(.r7, 0);
+        self.regs.write(.r8, 0);
+        self.regs.write(.sp, sp_boot);
+        self.regs.write(.fp, fp_boot);
+        self.regs.write(.mb, 0);
+        self.regs.write(.im, im_boot);
+        self.regs.write(.flg, 0);
+    }
+};

--- a/tests/vm/memory.test.zig
+++ b/tests/vm/memory.test.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const gero = @import("gero");
+const Memory = gero.vm.Memory;
+
+test "memory: init zeroes every byte" {
+    const m = Memory.init();
+    for (m.bytes) |b| {
+        try std.testing.expectEqual(@as(u8, 0), b);
+    }
+}
+
+test "memory: byte read/write at every offset" {
+    var m = Memory.init();
+    var addr: u16 = 0;
+    while (true) {
+        m.writeByte(addr, @truncate(addr & 0xFF));
+        try std.testing.expectEqual(@as(u8, @truncate(addr & 0xFF)), m.readByte(addr));
+        if (addr == 0xFFFF) break;
+        addr +%= 1;
+    }
+}
+
+test "memory: word writes are little-endian" {
+    var m = Memory.init();
+    m.writeWord(0x1000, 0xABCD);
+    try std.testing.expectEqual(@as(u8, 0xCD), m.readByte(0x1000));
+    try std.testing.expectEqual(@as(u8, 0xAB), m.readByte(0x1001));
+}
+
+test "memory: word reads are little-endian" {
+    var m = Memory.init();
+    m.writeByte(0x2000, 0x34);
+    m.writeByte(0x2001, 0x12);
+    try std.testing.expectEqual(@as(u16, 0x1234), m.readWord(0x2000));
+}
+
+test "memory: word round-trip at boundaries" {
+    var m = Memory.init();
+    inline for (.{ 0x0000, 0x00FF, 0x0100, 0x7FFF, 0x8000, 0xFFFE }) |addr| {
+        m.writeWord(addr, 0xDEAD);
+        try std.testing.expectEqual(@as(u16, 0xDEAD), m.readWord(addr));
+    }
+}
+
+test "memory: word at 0xFFFF wraps high byte to 0x0000" {
+    var m = Memory.init();
+    m.writeWord(0xFFFF, 0xABCD);
+    try std.testing.expectEqual(@as(u8, 0xCD), m.readByte(0xFFFF));
+    try std.testing.expectEqual(@as(u8, 0xAB), m.readByte(0x0000));
+    try std.testing.expectEqual(@as(u16, 0xABCD), m.readWord(0xFFFF));
+}
+
+test "memory: loadImage copies bytes at offset" {
+    var m = Memory.init();
+    const data = [_]u8{ 0x10, 0x00, 0x00, 0x02 }; // mov $0000, r1
+    const n = m.loadImage(0x1100, &data);
+    try std.testing.expectEqual(@as(usize, 4), n);
+    try std.testing.expectEqual(@as(u8, 0x10), m.readByte(0x1100));
+    try std.testing.expectEqual(@as(u8, 0x02), m.readByte(0x1103));
+    // Bytes outside the loaded range are untouched.
+    try std.testing.expectEqual(@as(u8, 0), m.readByte(0x1104));
+    try std.testing.expectEqual(@as(u8, 0), m.readByte(0x10FF));
+}
+
+test "memory: loadImage clamps to remaining size" {
+    var m = Memory.init();
+    const data: [10]u8 = @splat(0xAA);
+    const n = m.loadImage(0xFFF8, &data); // 8 bytes fit, 2 truncated
+    try std.testing.expectEqual(@as(usize, 8), n);
+    try std.testing.expectEqual(@as(u8, 0xAA), m.readByte(0xFFFF));
+}

--- a/tests/vm/registers.test.zig
+++ b/tests/vm/registers.test.zig
@@ -1,0 +1,98 @@
+const std = @import("std");
+const gero = @import("gero");
+const Register = gero.vm.Register;
+const Registers = gero.vm.Registers;
+const Flag = gero.vm.Flag;
+
+test "registers: init zeroes every slot" {
+    const r = Registers.init();
+    inline for (.{
+        Register.ip, Register.acu, Register.r1, Register.r2, Register.r3,
+        Register.r4, Register.r5,  Register.r6, Register.r7, Register.r8,
+        Register.sp, Register.fp,  Register.mb, Register.im, Register.flg,
+    }) |reg| {
+        try std.testing.expectEqual(@as(u16, 0), r.read(reg));
+    }
+}
+
+test "registers: read after write round-trips by name" {
+    var r = Registers.init();
+    r.write(.r3, 0x1234);
+    try std.testing.expectEqual(@as(u16, 0x1234), r.read(.r3));
+}
+
+test "registers: each named slot independent" {
+    var r = Registers.init();
+    r.write(.r1, 0xAAAA);
+    r.write(.r2, 0xBBBB);
+    try std.testing.expectEqual(@as(u16, 0xAAAA), r.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0xBBBB), r.read(.r2));
+}
+
+test "registers: index 0..0x0E maps to the right named register" {
+    var r = Registers.init();
+    inline for (.{
+        .{ 0x00, Register.ip }, .{ 0x01, Register.acu }, .{ 0x02, Register.r1 },
+        .{ 0x03, Register.r2 }, .{ 0x04, Register.r3 },  .{ 0x05, Register.r4 },
+        .{ 0x06, Register.r5 }, .{ 0x07, Register.r6 },  .{ 0x08, Register.r7 },
+        .{ 0x09, Register.r8 }, .{ 0x0A, Register.sp },  .{ 0x0B, Register.fp },
+        .{ 0x0C, Register.mb }, .{ 0x0D, Register.im },  .{ 0x0E, Register.flg },
+    }) |pair| {
+        const idx: u8 = pair[0];
+        const named: Register = pair[1];
+        const ok = r.writeByIndex(idx, 0xC0DE);
+        try std.testing.expect(ok);
+        try std.testing.expectEqual(@as(u16, 0xC0DE), r.read(named));
+        try std.testing.expectEqual(@as(?u16, 0xC0DE), r.readByIndex(idx));
+        // Reset so the next iteration sees a clean slot.
+        r.write(named, 0);
+    }
+}
+
+test "registers: index 0x0F..0xFF rejected" {
+    var r = Registers.init();
+    inline for (.{ 0x0F, 0x10, 0x42, 0xFE, 0xFF }) |idx| {
+        try std.testing.expectEqual(@as(?u16, null), r.readByIndex(idx));
+        try std.testing.expect(!r.writeByIndex(idx, 0x1234));
+    }
+}
+
+test "flg: setFlag toggles only its target bit" {
+    var r = Registers.init();
+    r.setFlag(.zero, true);
+    try std.testing.expect(r.flagSet(.zero));
+    try std.testing.expect(!r.flagSet(.negative));
+    try std.testing.expect(!r.flagSet(.carry));
+    try std.testing.expect(!r.flagSet(.overflow));
+    try std.testing.expect(!r.flagSet(.interrupt_disable));
+
+    r.setFlag(.negative, true);
+    try std.testing.expect(r.flagSet(.zero));
+    try std.testing.expect(r.flagSet(.negative));
+
+    r.setFlag(.zero, false);
+    try std.testing.expect(!r.flagSet(.zero));
+    try std.testing.expect(r.flagSet(.negative));
+}
+
+test "flg: layout matches ISA §2.1 (Z=0, N=1, C=2, V=3, I=4)" {
+    try std.testing.expectEqual(@as(u4, 0), @intFromEnum(Flag.zero));
+    try std.testing.expectEqual(@as(u4, 1), @intFromEnum(Flag.negative));
+    try std.testing.expectEqual(@as(u4, 2), @intFromEnum(Flag.carry));
+    try std.testing.expectEqual(@as(u4, 3), @intFromEnum(Flag.overflow));
+    try std.testing.expectEqual(@as(u4, 4), @intFromEnum(Flag.interrupt_disable));
+}
+
+test "flg: setFlag(false) on already-clear bit is a no-op" {
+    var r = Registers.init();
+    r.setFlag(.carry, false);
+    try std.testing.expectEqual(@as(u16, 0), r.read(.flg));
+}
+
+test "flg: unrelated flg bits preserved across setFlag calls" {
+    var r = Registers.init();
+    r.write(.flg, 0xFFFF); // all bits set, including reserved
+    r.setFlag(.zero, false);
+    // Z (bit 0) cleared, every other bit (incl. reserved 5..15) preserved.
+    try std.testing.expectEqual(@as(u16, 0xFFFE), r.read(.flg));
+}

--- a/tests/vm/vm.test.zig
+++ b/tests/vm/vm.test.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+test "vm: init sets boot-state special registers per ISA §8" {
+    const vm = VM.init();
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.ip));
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.acu));
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, gero.vm.sp_boot), vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, gero.vm.fp_boot), vm.regs.read(.fp));
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.mb));
+    try std.testing.expectEqual(@as(u16, gero.vm.im_boot), vm.regs.read(.im));
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.flg));
+}
+
+test "vm: init zeroes memory" {
+    const vm = VM.init();
+    try std.testing.expectEqual(@as(u8, 0), vm.mem.readByte(0));
+    try std.testing.expectEqual(@as(u8, 0), vm.mem.readByte(0x1100));
+    try std.testing.expectEqual(@as(u8, 0), vm.mem.readByte(0xFFFF));
+}
+
+test "vm: bootInitRegisters resets registers but preserves memory" {
+    var vm = VM.init();
+    vm.regs.write(.r1, 0xDEAD);
+    vm.regs.write(.flg, 0xFFFF);
+    vm.mem.writeByte(0x1100, 0x42);
+
+    vm.bootInitRegisters();
+
+    // Registers reset to boot defaults.
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.flg));
+    try std.testing.expectEqual(@as(u16, gero.vm.sp_boot), vm.regs.read(.sp));
+    // Memory deliberately preserved across re-boot.
+    try std.testing.expectEqual(@as(u8, 0x42), vm.mem.readByte(0x1100));
+}
+
+test "vm: registers and memory are independently mutable" {
+    var vm = VM.init();
+    vm.regs.write(.r1, 0xAAAA);
+    vm.mem.writeWord(0x2000, 0xBBBB);
+    try std.testing.expectEqual(@as(u16, 0xAAAA), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0xBBBB), vm.mem.readWord(0x2000));
+}
+
+test "vm: multiple VM instances are independent" {
+    var a = VM.init();
+    var b = VM.init();
+    a.regs.write(.r1, 0x1111);
+    a.mem.writeByte(0x100, 0x42);
+    try std.testing.expectEqual(@as(u16, 0), b.regs.read(.r1));
+    try std.testing.expectEqual(@as(u8, 0), b.mem.readByte(0x100));
+}


### PR DESCRIPTION
Closes #17. First code under \`src/vm/\`. Pure scaffold — zero
opcode dispatch, no banking, no IVT. Just the foundational types.

## Summary

- **\`src/vm/registers.zig\`** — \`Register\` enum (15 named slots
  per ISA §2, indexed 0x00-0x0E), \`Flag\` enum (Z/N/C/V/I per §2.1),
  \`Registers\` struct with read/write by name + by index +
  \`flagSet\` / \`setFlag\` that preserve unrelated bits.
- **\`src/vm/memory.zig\`** — \`Memory\` flat 64KB \`[65536]u8\`,
  little-endian word access per §3.4, documented silent wrap at
  0xFFFF, \`loadImage\` for the future loader (#30).
- **\`src/vm/vm.zig\`** — \`VM\` composing \`Registers\` + \`Memory\`.
  \`init\` applies ISA §8 boot defaults (sp/fp=0xFFFE, mb=0,
  im=0xFFFF, flg=0). \`bootInitRegisters\` re-applicable so the
  loader can re-boot without reallocating memory.
- **\`src/gero.zig\`** — barrel re-exports the \`vm\` namespace.

## Acceptance vs #17

- [x] All 15 registers indexable by name + by index
- [x] flg layout matches ISA §2.1 (Z=0, N=1, C=2, V=3, I=4) — explicit test
- [x] Memory writes/reads at every offset 0x0000-0xFFFF — table test
- [x] u16 writes are little-endian — verified by reading 2 separate u8s
- [x] VM init sets sp=0xFFFE, fp=0xFFFE, mb=0, im=0xFFFF, flg=0
- [x] All four release modes pass (\`zig build ci\` green)

## Test plan

- 22 tests across registers / memory / vm modules
- \`zig build ci\` passes end-to-end (lint + 4 release modes + cross-target compile)
- 92/92 tests green

## Bonus tested

- Index 0x0F-0xFF rejected via \`null\` return / \`false\` write — matches future InvalidRegister fault path (#28)
- \`setFlag(false)\` on already-clear bit is a no-op
- Reserved \`flg\` bits (5-15) preserved through \`setFlag\` calls
- Boot-init resets registers but **deliberately preserves memory** (loader use case)
- Two VM instances are independent — pre-emptive support for multi-VM-instance test (#15 / Phase 14 cross-target hardening)