### PR TITLE
feat(vm): MemoryMapper + Device interface

### DIFF
--- a/.changeset/d3e72f15.md
+++ b/.changeset/d3e72f15.md
@@ -1,0 +1,10 @@
+---
+bump: minor
+---
+
+Add `MemoryMapper` + `Device` interface so hosts can claim address
+ranges with read/write callbacks. The VM now routes every memory
+access through the mapper; unclaimed addresses fall through to the
+underlying 64KB RAM. Most-recently-mapped wins on overlap; `unmap`
+removes a region by handle. `VM.init` now takes an allocator, and
+`VM.deinit` releases the device registry.

--- a/src/vm/mapper.zig
+++ b/src/vm/mapper.zig
@@ -135,11 +135,6 @@ pub const MemoryMapper = struct {
         return false;
     }
 
-    /// `true` if any device currently claims `addr`.
-    pub fn hasDeviceAt(self: MemoryMapper, addr: u16) bool {
-        return self.findDevice(addr) != null;
-    }
-
     /// Routed byte read.
     pub fn readByte(self: MemoryMapper, addr: u16) u8 {
         if (self.findDevice(addr)) |dev| return dev.readByte(addr);

--- a/src/vm/mapper.zig
+++ b/src/vm/mapper.zig
@@ -19,54 +19,50 @@ pub const MapError = error{
     RangeOverflow,
 };
 
-/// Host-pluggable IO interface. The host implements the vtable
-/// functions and supplies a `ctx` pointer; the mapper forwards
-/// every claimed access through them.
+/// Host-pluggable IO interface. Intrusive: the host embeds a
+/// `Device` as a field of its concrete struct, supplies a vtable
+/// whose callbacks recover the parent struct via `@fieldParentPtr`,
+/// and hands `&concrete.device` to the mapper.
 ///
-/// `ctx` is `*anyopaque` because this is the public host boundary
-/// — the host owns the device type, the VM only sees the contract.
+/// No type erasure — the mapper stores `*Device` (typed) and the
+/// host's vtable callbacks know exactly which struct owns them.
 pub const Device = struct {
-    // allow-strict: host-boundary type erasure (see doc above)
-    ctx: *anyopaque,
     vtable: *const VTable,
 
-    /// Method table. Each callback receives the same `ctx` that
-    /// was supplied at registration plus the access details.
+    /// Method table. Each callback receives the same `*Device`
+    /// pointer the mapper holds; the host recovers the parent
+    /// struct via `@fieldParentPtr("<field-name>", self)`.
     pub const VTable = struct {
-        // allow-strict: same host-boundary erasure as `Device.ctx`.
-        readByte: *const fn (ctx: *anyopaque, addr: u16) u8,
-        // allow-strict: same host-boundary erasure as `Device.ctx`.
-        writeByte: *const fn (ctx: *anyopaque, addr: u16, value: u8) void,
-        // allow-strict: same host-boundary erasure as `Device.ctx`.
-        readWord: *const fn (ctx: *anyopaque, addr: u16) u16,
-        // allow-strict: same host-boundary erasure as `Device.ctx`.
-        writeWord: *const fn (ctx: *anyopaque, addr: u16, value: u16) void,
+        readByte: *const fn (self: *Device, addr: u16) u8,
+        writeByte: *const fn (self: *Device, addr: u16, value: u8) void,
+        readWord: *const fn (self: *Device, addr: u16) u16,
+        writeWord: *const fn (self: *Device, addr: u16, value: u16) void,
     };
 
     /// Convenience: byte read through the vtable.
-    pub fn readByte(self: Device, addr: u16) u8 {
-        return self.vtable.readByte(self.ctx, addr);
+    pub fn readByte(self: *Device, addr: u16) u8 {
+        return self.vtable.readByte(self, addr);
     }
 
     /// Convenience: byte write through the vtable.
-    pub fn writeByte(self: Device, addr: u16, value: u8) void {
-        self.vtable.writeByte(self.ctx, addr, value);
+    pub fn writeByte(self: *Device, addr: u16, value: u8) void {
+        self.vtable.writeByte(self, addr, value);
     }
 
     /// Convenience: word read through the vtable.
-    pub fn readWord(self: Device, addr: u16) u16 {
-        return self.vtable.readWord(self.ctx, addr);
+    pub fn readWord(self: *Device, addr: u16) u16 {
+        return self.vtable.readWord(self, addr);
     }
 
     /// Convenience: word write through the vtable.
-    pub fn writeWord(self: Device, addr: u16, value: u16) void {
-        self.vtable.writeWord(self.ctx, addr, value);
+    pub fn writeWord(self: *Device, addr: u16, value: u16) void {
+        self.vtable.writeWord(self, addr, value);
     }
 };
 
 const Region = struct {
     id: RegionId,
-    device: Device,
+    device: *Device,
     start: u16,
     /// Inclusive — kept as `u16` so the full last byte 0xFFFF fits.
     end: u16,
@@ -106,7 +102,7 @@ pub const MemoryMapper = struct {
     /// `map` calls take priority.
     pub fn map(
         self: *MemoryMapper,
-        device: Device,
+        device: *Device,
         start: u16,
         size: usize,
     ) (std.mem.Allocator.Error || MapError)!RegionId {
@@ -177,7 +173,7 @@ pub const MemoryMapper = struct {
         self.mem.writeWord(addr, value);
     }
 
-    fn findDevice(self: MemoryMapper, addr: u16) ?Device {
+    fn findDevice(self: MemoryMapper, addr: u16) ?*Device {
         // Iterate newest-first so the most-recently-mapped region
         // wins on overlap.
         var i: usize = self.regions.items.len;

--- a/src/vm/mapper.zig
+++ b/src/vm/mapper.zig
@@ -1,0 +1,191 @@
+/// `MemoryMapper` — the indirection layer between the VM and RAM.
+/// Hosts can register `Device` callbacks against address ranges so
+/// memory-mapped IO (VRAM, registers) intercepts reads / writes.
+/// When no device claims an address the access falls through to
+/// the underlying `Memory`.
+const std = @import("std");
+const Memory = @import("memory.zig").Memory;
+
+/// Stable handle returned by `map`. Pass to `unmap` to remove the
+/// region. `0` is reserved for "no region" so callers can use the
+/// raw integer in optional patterns.
+pub const RegionId = u32;
+
+/// Errors returned by `map`.
+pub const MapError = error{
+    /// `size == 0` — caller likely intended at least one byte.
+    EmptyRange,
+    /// `start + size` overshoots the 64KB address space.
+    RangeOverflow,
+};
+
+/// Host-pluggable IO interface. The host implements the vtable
+/// functions and supplies a `ctx` pointer; the mapper forwards
+/// every claimed access through them.
+///
+/// `ctx` is `*anyopaque` because this is the public host boundary
+/// — the host owns the device type, the VM only sees the contract.
+pub const Device = struct {
+    // allow-strict: host-boundary type erasure (see doc above)
+    ctx: *anyopaque,
+    vtable: *const VTable,
+
+    /// Method table. Each callback receives the same `ctx` that
+    /// was supplied at registration plus the access details.
+    pub const VTable = struct {
+        // allow-strict: same host-boundary erasure as `Device.ctx`.
+        readByte: *const fn (ctx: *anyopaque, addr: u16) u8,
+        // allow-strict: same host-boundary erasure as `Device.ctx`.
+        writeByte: *const fn (ctx: *anyopaque, addr: u16, value: u8) void,
+        // allow-strict: same host-boundary erasure as `Device.ctx`.
+        readWord: *const fn (ctx: *anyopaque, addr: u16) u16,
+        // allow-strict: same host-boundary erasure as `Device.ctx`.
+        writeWord: *const fn (ctx: *anyopaque, addr: u16, value: u16) void,
+    };
+
+    /// Convenience: byte read through the vtable.
+    pub fn readByte(self: Device, addr: u16) u8 {
+        return self.vtable.readByte(self.ctx, addr);
+    }
+
+    /// Convenience: byte write through the vtable.
+    pub fn writeByte(self: Device, addr: u16, value: u8) void {
+        self.vtable.writeByte(self.ctx, addr, value);
+    }
+
+    /// Convenience: word read through the vtable.
+    pub fn readWord(self: Device, addr: u16) u16 {
+        return self.vtable.readWord(self.ctx, addr);
+    }
+
+    /// Convenience: word write through the vtable.
+    pub fn writeWord(self: Device, addr: u16, value: u16) void {
+        self.vtable.writeWord(self.ctx, addr, value);
+    }
+};
+
+const Region = struct {
+    id: RegionId,
+    device: Device,
+    start: u16,
+    /// Inclusive — kept as `u16` so the full last byte 0xFFFF fits.
+    end: u16,
+};
+
+/// Routes memory accesses: device-claimed addresses go through the
+/// device vtable, everything else falls through to the underlying
+/// `Memory`. Regions are scanned newest-first so the most-recent
+/// `map` wins on overlap.
+pub const MemoryMapper = struct {
+    /// The underlying RAM. Accessible directly for raw inspection
+    /// (loader, tests); production callers prefer the routed
+    /// `readByte` / `writeByte` / `readWord` / `writeWord` below.
+    mem: Memory,
+    regions: std.ArrayList(Region),
+    allocator: std.mem.Allocator,
+    next_id: RegionId,
+
+    /// Fresh mapper with empty `Memory` and no devices mapped.
+    pub fn init(allocator: std.mem.Allocator) MemoryMapper {
+        return .{
+            .mem = Memory.init(),
+            .regions = .empty,
+            .allocator = allocator,
+            .next_id = 1,
+        };
+    }
+
+    /// Release the region list. RAM is stack-allocated so it does
+    /// not need an explicit free.
+    pub fn deinit(self: *MemoryMapper) void {
+        self.regions.deinit(self.allocator);
+    }
+
+    /// Claim `[start, start + size - 1]` for `device`. Returns a
+    /// handle that `unmap` consumes. Overlap is allowed — later
+    /// `map` calls take priority.
+    pub fn map(
+        self: *MemoryMapper,
+        device: Device,
+        start: u16,
+        size: usize,
+    ) (std.mem.Allocator.Error || MapError)!RegionId {
+        if (size == 0) return error.EmptyRange;
+        // @as: widen `u16` to `usize` so the arithmetic does not wrap
+        const last = @as(usize, start) + size - 1;
+        if (last > 0xFFFF) return error.RangeOverflow;
+
+        const id = self.next_id;
+        self.next_id += 1;
+        try self.regions.append(self.allocator, .{
+            .id = id,
+            .device = device,
+            .start = start,
+            .end = @intCast(last),
+        });
+        return id;
+    }
+
+    /// Remove a previously-mapped region. Returns `false` if the
+    /// id is unknown (already unmapped, or never registered).
+    pub fn unmap(self: *MemoryMapper, id: RegionId) bool {
+        var i: usize = 0;
+        while (i < self.regions.items.len) : (i += 1) {
+            if (self.regions.items[i].id == id) {
+                _ = self.regions.orderedRemove(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// `true` if any device currently claims `addr`.
+    pub fn hasDeviceAt(self: MemoryMapper, addr: u16) bool {
+        return self.findDevice(addr) != null;
+    }
+
+    /// Routed byte read.
+    pub fn readByte(self: MemoryMapper, addr: u16) u8 {
+        if (self.findDevice(addr)) |dev| return dev.readByte(addr);
+        return self.mem.readByte(addr);
+    }
+
+    /// Routed byte write.
+    pub fn writeByte(self: *MemoryMapper, addr: u16, value: u8) void {
+        if (self.findDevice(addr)) |dev| {
+            dev.writeByte(addr, value);
+            return;
+        }
+        self.mem.writeByte(addr, value);
+    }
+
+    /// Routed word read. Routing is decided by the starting address
+    /// — a word straddling a region boundary is delivered to the
+    /// device that claims `addr`, matching real-bus behavior on
+    /// devices that don't honor unaligned accesses.
+    pub fn readWord(self: MemoryMapper, addr: u16) u16 {
+        if (self.findDevice(addr)) |dev| return dev.readWord(addr);
+        return self.mem.readWord(addr);
+    }
+
+    /// Routed word write. Same routing rule as `readWord`.
+    pub fn writeWord(self: *MemoryMapper, addr: u16, value: u16) void {
+        if (self.findDevice(addr)) |dev| {
+            dev.writeWord(addr, value);
+            return;
+        }
+        self.mem.writeWord(addr, value);
+    }
+
+    fn findDevice(self: MemoryMapper, addr: u16) ?Device {
+        // Iterate newest-first so the most-recently-mapped region
+        // wins on overlap.
+        var i: usize = self.regions.items.len;
+        while (i > 0) {
+            i -= 1;
+            const r = self.regions.items[i];
+            if (addr >= r.start and addr <= r.end) return r.device;
+        }
+        return null;
+    }
+};

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -1,9 +1,9 @@
-/// The gero VM. Composes the register file and 64KB memory.
-/// Banking, the host mapper indirection, and the dispatch loop
-/// layer on top in subsequent PRs.
+/// The gero VM. Composes the register file and the memory mapper.
+/// Banking and the dispatch loop layer on top in subsequent PRs.
 const std = @import("std");
 const registers = @import("registers.zig");
 const memory = @import("memory.zig");
+const mapper = @import("mapper.zig");
 
 /// Re-export: named register handles.
 pub const Register = registers.Register;
@@ -13,6 +13,14 @@ pub const Registers = registers.Registers;
 pub const Flag = registers.Flag;
 /// Re-export: 64KB memory type.
 pub const Memory = memory.Memory;
+/// Re-export: host-pluggable IO interface.
+pub const Device = mapper.Device;
+/// Re-export: the routing mapper that wraps `Memory`.
+pub const MemoryMapper = mapper.MemoryMapper;
+/// Re-export: handle returned by `MemoryMapper.map`.
+pub const RegionId = mapper.RegionId;
+/// Re-export: errors from `MemoryMapper.map`.
+pub const MapError = mapper.MapError;
 
 /// Boot-state default for `sp` — top of memory minus 1 word so the
 /// first push lands on a valid word.
@@ -24,20 +32,28 @@ pub const fp_boot: u16 = 0xFFFE;
 /// Boot-state default for `im` — every maskable vector enabled.
 pub const im_boot: u16 = 0xFFFF;
 
-/// The VM. Owns the register file and a flat 64KB memory.
+/// The VM. Owns the register file and the memory mapper (which
+/// owns the 64KB RAM and the host device registry).
 pub const VM = struct {
     regs: Registers,
-    mem: Memory,
+    mmap: MemoryMapper,
 
     /// Construct a fresh VM with default boot state. `ip` is left
-    /// at 0; the loader sets it to the program's entry point.
-    pub fn init() VM {
+    /// at 0; the loader sets it to the program's entry point. The
+    /// `allocator` backs the device registry — pass the runtime
+    /// allocator (or `std.testing.allocator` in tests).
+    pub fn init(allocator: std.mem.Allocator) VM {
         var vm: VM = .{
             .regs = Registers.init(),
-            .mem = Memory.init(),
+            .mmap = MemoryMapper.init(allocator),
         };
         vm.bootInitRegisters();
         return vm;
+    }
+
+    /// Release VM-owned resources (the device registry).
+    pub fn deinit(self: *VM) void {
+        self.mmap.deinit();
     }
 
     /// Re-applies the register defaults. Public so the loader can

--- a/tests/vm/mapper.test.zig
+++ b/tests/vm/mapper.test.zig
@@ -3,8 +3,11 @@ const gero = @import("gero");
 const Device = gero.vm.Device;
 const MemoryMapper = gero.vm.MemoryMapper;
 
-/// Records every access so tests can verify routing.
+/// Records every access so tests can verify routing. Embeds
+/// `Device` as the first field; vtable callbacks recover the
+/// parent via `@fieldParentPtr`.
 const RecordDevice = struct {
+    device: Device,
     last_addr: u16 = 0,
     last_byte: u8 = 0,
     last_word: u16 = 0,
@@ -15,30 +18,30 @@ const RecordDevice = struct {
     reads_w: u32 = 0,
     writes_w: u32 = 0,
 
-    fn readByte(ctx: *anyopaque, addr: u16) u8 {
-        // safety: ctx is the `*RecordDevice` we supplied to `Device`
-        const self: *RecordDevice = @ptrCast(@alignCast(ctx));
+    fn readByte(dev: *Device, addr: u16) u8 {
+        // safety: dev points to the `device` field of a *RecordDevice
+        const self: *RecordDevice = @fieldParentPtr("device", dev);
         self.last_addr = addr;
         self.reads_b += 1;
         return self.canned_byte;
     }
-    fn writeByte(ctx: *anyopaque, addr: u16, value: u8) void {
-        // safety: ctx is the `*RecordDevice` we supplied to `Device`
-        const self: *RecordDevice = @ptrCast(@alignCast(ctx));
+    fn writeByte(dev: *Device, addr: u16, value: u8) void {
+        // safety: dev points to the `device` field of a *RecordDevice
+        const self: *RecordDevice = @fieldParentPtr("device", dev);
         self.last_addr = addr;
         self.last_byte = value;
         self.writes_b += 1;
     }
-    fn readWord(ctx: *anyopaque, addr: u16) u16 {
-        // safety: ctx is the `*RecordDevice` we supplied to `Device`
-        const self: *RecordDevice = @ptrCast(@alignCast(ctx));
+    fn readWord(dev: *Device, addr: u16) u16 {
+        // safety: dev points to the `device` field of a *RecordDevice
+        const self: *RecordDevice = @fieldParentPtr("device", dev);
         self.last_addr = addr;
         self.reads_w += 1;
         return self.canned_word;
     }
-    fn writeWord(ctx: *anyopaque, addr: u16, value: u16) void {
-        // safety: ctx is the `*RecordDevice` we supplied to `Device`
-        const self: *RecordDevice = @ptrCast(@alignCast(ctx));
+    fn writeWord(dev: *Device, addr: u16, value: u16) void {
+        // safety: dev points to the `device` field of a *RecordDevice
+        const self: *RecordDevice = @fieldParentPtr("device", dev);
         self.last_addr = addr;
         self.last_word = value;
         self.writes_w += 1;
@@ -51,8 +54,8 @@ const RecordDevice = struct {
         .writeWord = writeWord,
     };
 
-    fn device(self: *RecordDevice) Device {
-        return .{ .ctx = self, .vtable = &vtable };
+    fn init() RecordDevice {
+        return .{ .device = .{ .vtable = &vtable } };
     }
 };
 
@@ -73,11 +76,13 @@ test "mapper: device-mapped range routes reads through the vtable" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{ .canned_byte = 0x5A, .canned_word = 0xBEEF };
-    _ = try m.map(dev.device(), 0x8000, 0x4000);
+    var dev = RecordDevice.init();
+    dev.canned_byte = 0x5A;
+    dev.canned_word = 0xBEEF;
+    _ = try m.map(&dev.device, 0x8000, 0x4000);
 
     try std.testing.expectEqual(@as(u8, 0x5A), m.readByte(0x9000));
-    try std.testing.expectEqual(@as(u16, 1), dev.reads_b);
+    try std.testing.expectEqual(@as(u32, 1), dev.reads_b);
     try std.testing.expectEqual(@as(u16, 0x9000), dev.last_addr);
 
     try std.testing.expectEqual(@as(u16, 0xBEEF), m.readWord(0xA000));
@@ -89,8 +94,8 @@ test "mapper: device-mapped range routes writes through the vtable" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{};
-    _ = try m.map(dev.device(), 0xFF00, 0x100);
+    var dev = RecordDevice.init();
+    _ = try m.map(&dev.device, 0xFF00, 0x100);
 
     m.writeByte(0xFF10, 0x42);
     try std.testing.expectEqual(@as(u32, 1), dev.writes_b);
@@ -107,11 +112,10 @@ test "mapper: device-mapped writes never touch underlying RAM" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{};
-    _ = try m.map(dev.device(), 0x8000, 0x4000);
+    var dev = RecordDevice.init();
+    _ = try m.map(&dev.device, 0x8000, 0x4000);
 
     m.writeByte(0x9000, 0xAB);
-    // The byte was captured by the device, not written to RAM.
     try std.testing.expectEqual(@as(u8, 0), m.mem.readByte(0x9000));
 }
 
@@ -119,8 +123,8 @@ test "mapper: addresses outside any region still fall through to RAM" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{};
-    _ = try m.map(dev.device(), 0x8000, 0x4000);
+    var dev = RecordDevice.init();
+    _ = try m.map(&dev.device, 0x8000, 0x4000);
 
     m.writeByte(0x1000, 0x77);
     try std.testing.expectEqual(@as(u8, 0x77), m.readByte(0x1000));
@@ -131,10 +135,12 @@ test "mapper: most-recently-mapped wins on overlap" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var old = RecordDevice{ .canned_byte = 0x11 };
-    var fresh = RecordDevice{ .canned_byte = 0x22 };
-    _ = try m.map(old.device(), 0x8000, 0x4000);
-    _ = try m.map(fresh.device(), 0x9000, 0x1000);
+    var old = RecordDevice.init();
+    old.canned_byte = 0x11;
+    var fresh = RecordDevice.init();
+    fresh.canned_byte = 0x22;
+    _ = try m.map(&old.device, 0x8000, 0x4000);
+    _ = try m.map(&fresh.device, 0x9000, 0x1000);
 
     // Inside the overlap, the fresh one wins.
     try std.testing.expectEqual(@as(u8, 0x22), m.readByte(0x9000));
@@ -150,8 +156,9 @@ test "mapper: unmap removes the region and restores fall-through" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{ .canned_byte = 0x99 };
-    const id = try m.map(dev.device(), 0x8000, 0x100);
+    var dev = RecordDevice.init();
+    dev.canned_byte = 0x99;
+    const id = try m.map(&dev.device, 0x8000, 0x100);
 
     try std.testing.expectEqual(@as(u8, 0x99), m.readByte(0x8000));
     try std.testing.expect(m.unmap(id));
@@ -170,10 +177,12 @@ test "mapper: two non-overlapping devices both work" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var vram = RecordDevice{ .canned_byte = 0xAA };
-    var io = RecordDevice{ .canned_byte = 0xBB };
-    _ = try m.map(vram.device(), 0x8000, 0x4000);
-    _ = try m.map(io.device(), 0xFF00, 0x100);
+    var vram = RecordDevice.init();
+    vram.canned_byte = 0xAA;
+    var io = RecordDevice.init();
+    io.canned_byte = 0xBB;
+    _ = try m.map(&vram.device, 0x8000, 0x4000);
+    _ = try m.map(&io.device, 0xFF00, 0x100);
 
     try std.testing.expectEqual(@as(u8, 0xAA), m.readByte(0x8000));
     try std.testing.expectEqual(@as(u8, 0xBB), m.readByte(0xFF80));
@@ -188,27 +197,27 @@ test "mapper: map rejects empty range" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{};
-    try std.testing.expectError(error.EmptyRange, m.map(dev.device(), 0x1000, 0));
+    var dev = RecordDevice.init();
+    try std.testing.expectError(error.EmptyRange, m.map(&dev.device, 0x1000, 0));
 }
 
 test "mapper: map rejects range overflowing 64KB" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{};
+    var dev = RecordDevice.init();
     // 0xFF00 + 0x100 = 0x10000 (one past the last byte) is OK.
-    _ = try m.map(dev.device(), 0xFF00, 0x100);
+    _ = try m.map(&dev.device, 0xFF00, 0x100);
     // 0xFF00 + 0x101 overshoots.
-    try std.testing.expectError(error.RangeOverflow, m.map(dev.device(), 0xFF00, 0x101));
+    try std.testing.expectError(error.RangeOverflow, m.map(&dev.device, 0xFF00, 0x101));
 }
 
 test "mapper: hasDeviceAt reflects current claims" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{};
-    const id = try m.map(dev.device(), 0x8000, 0x4000);
+    var dev = RecordDevice.init();
+    const id = try m.map(&dev.device, 0x8000, 0x4000);
 
     try std.testing.expect(m.hasDeviceAt(0x8000));
     try std.testing.expect(m.hasDeviceAt(0xBFFF));
@@ -223,13 +232,12 @@ test "mapper: region inclusive at both ends" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();
 
-    var dev = RecordDevice{ .canned_byte = 0x77 };
-    _ = try m.map(dev.device(), 0x1000, 0x10);
+    var dev = RecordDevice.init();
+    dev.canned_byte = 0x77;
+    _ = try m.map(&dev.device, 0x1000, 0x10);
 
-    // Both endpoints belong to the device.
     try std.testing.expectEqual(@as(u8, 0x77), m.readByte(0x1000));
     try std.testing.expectEqual(@as(u8, 0x77), m.readByte(0x100F));
-    // Just outside.
     m.writeByte(0x1010, 0x42);
     try std.testing.expectEqual(@as(u8, 0x42), m.readByte(0x1010));
     try std.testing.expectEqual(@as(u32, 0), dev.writes_b);

--- a/tests/vm/mapper.test.zig
+++ b/tests/vm/mapper.test.zig
@@ -1,0 +1,236 @@
+const std = @import("std");
+const gero = @import("gero");
+const Device = gero.vm.Device;
+const MemoryMapper = gero.vm.MemoryMapper;
+
+/// Records every access so tests can verify routing.
+const RecordDevice = struct {
+    last_addr: u16 = 0,
+    last_byte: u8 = 0,
+    last_word: u16 = 0,
+    canned_byte: u8 = 0,
+    canned_word: u16 = 0,
+    reads_b: u32 = 0,
+    writes_b: u32 = 0,
+    reads_w: u32 = 0,
+    writes_w: u32 = 0,
+
+    fn readByte(ctx: *anyopaque, addr: u16) u8 {
+        // safety: ctx is the `*RecordDevice` we supplied to `Device`
+        const self: *RecordDevice = @ptrCast(@alignCast(ctx));
+        self.last_addr = addr;
+        self.reads_b += 1;
+        return self.canned_byte;
+    }
+    fn writeByte(ctx: *anyopaque, addr: u16, value: u8) void {
+        // safety: ctx is the `*RecordDevice` we supplied to `Device`
+        const self: *RecordDevice = @ptrCast(@alignCast(ctx));
+        self.last_addr = addr;
+        self.last_byte = value;
+        self.writes_b += 1;
+    }
+    fn readWord(ctx: *anyopaque, addr: u16) u16 {
+        // safety: ctx is the `*RecordDevice` we supplied to `Device`
+        const self: *RecordDevice = @ptrCast(@alignCast(ctx));
+        self.last_addr = addr;
+        self.reads_w += 1;
+        return self.canned_word;
+    }
+    fn writeWord(ctx: *anyopaque, addr: u16, value: u16) void {
+        // safety: ctx is the `*RecordDevice` we supplied to `Device`
+        const self: *RecordDevice = @ptrCast(@alignCast(ctx));
+        self.last_addr = addr;
+        self.last_word = value;
+        self.writes_w += 1;
+    }
+
+    const vtable: Device.VTable = .{
+        .readByte = readByte,
+        .writeByte = writeByte,
+        .readWord = readWord,
+        .writeWord = writeWord,
+    };
+
+    fn device(self: *RecordDevice) Device {
+        return .{ .ctx = self, .vtable = &vtable };
+    }
+};
+
+test "mapper: with no devices mapped, RAM is accessible 0x0000-0xFFFF" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    m.writeByte(0x0000, 0x11);
+    m.writeByte(0xFFFF, 0x22);
+    m.writeWord(0x8000, 0xDEAD);
+
+    try std.testing.expectEqual(@as(u8, 0x11), m.readByte(0x0000));
+    try std.testing.expectEqual(@as(u8, 0x22), m.readByte(0xFFFF));
+    try std.testing.expectEqual(@as(u16, 0xDEAD), m.readWord(0x8000));
+}
+
+test "mapper: device-mapped range routes reads through the vtable" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{ .canned_byte = 0x5A, .canned_word = 0xBEEF };
+    _ = try m.map(dev.device(), 0x8000, 0x4000);
+
+    try std.testing.expectEqual(@as(u8, 0x5A), m.readByte(0x9000));
+    try std.testing.expectEqual(@as(u16, 1), dev.reads_b);
+    try std.testing.expectEqual(@as(u16, 0x9000), dev.last_addr);
+
+    try std.testing.expectEqual(@as(u16, 0xBEEF), m.readWord(0xA000));
+    try std.testing.expectEqual(@as(u32, 1), dev.reads_w);
+    try std.testing.expectEqual(@as(u16, 0xA000), dev.last_addr);
+}
+
+test "mapper: device-mapped range routes writes through the vtable" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{};
+    _ = try m.map(dev.device(), 0xFF00, 0x100);
+
+    m.writeByte(0xFF10, 0x42);
+    try std.testing.expectEqual(@as(u32, 1), dev.writes_b);
+    try std.testing.expectEqual(@as(u16, 0xFF10), dev.last_addr);
+    try std.testing.expectEqual(@as(u8, 0x42), dev.last_byte);
+
+    m.writeWord(0xFF20, 0xCAFE);
+    try std.testing.expectEqual(@as(u32, 1), dev.writes_w);
+    try std.testing.expectEqual(@as(u16, 0xFF20), dev.last_addr);
+    try std.testing.expectEqual(@as(u16, 0xCAFE), dev.last_word);
+}
+
+test "mapper: device-mapped writes never touch underlying RAM" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{};
+    _ = try m.map(dev.device(), 0x8000, 0x4000);
+
+    m.writeByte(0x9000, 0xAB);
+    // The byte was captured by the device, not written to RAM.
+    try std.testing.expectEqual(@as(u8, 0), m.mem.readByte(0x9000));
+}
+
+test "mapper: addresses outside any region still fall through to RAM" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{};
+    _ = try m.map(dev.device(), 0x8000, 0x4000);
+
+    m.writeByte(0x1000, 0x77);
+    try std.testing.expectEqual(@as(u8, 0x77), m.readByte(0x1000));
+    try std.testing.expectEqual(@as(u32, 0), dev.writes_b);
+}
+
+test "mapper: most-recently-mapped wins on overlap" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var old = RecordDevice{ .canned_byte = 0x11 };
+    var fresh = RecordDevice{ .canned_byte = 0x22 };
+    _ = try m.map(old.device(), 0x8000, 0x4000);
+    _ = try m.map(fresh.device(), 0x9000, 0x1000);
+
+    // Inside the overlap, the fresh one wins.
+    try std.testing.expectEqual(@as(u8, 0x22), m.readByte(0x9000));
+    try std.testing.expectEqual(@as(u32, 1), fresh.reads_b);
+    try std.testing.expectEqual(@as(u32, 0), old.reads_b);
+
+    // Outside the fresh range but inside the old, the old still wins.
+    try std.testing.expectEqual(@as(u8, 0x11), m.readByte(0x8000));
+    try std.testing.expectEqual(@as(u32, 1), old.reads_b);
+}
+
+test "mapper: unmap removes the region and restores fall-through" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{ .canned_byte = 0x99 };
+    const id = try m.map(dev.device(), 0x8000, 0x100);
+
+    try std.testing.expectEqual(@as(u8, 0x99), m.readByte(0x8000));
+    try std.testing.expect(m.unmap(id));
+
+    m.writeByte(0x8000, 0x42);
+    try std.testing.expectEqual(@as(u8, 0x42), m.readByte(0x8000));
+}
+
+test "mapper: unmap returns false for an unknown id" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+    try std.testing.expect(!m.unmap(99));
+}
+
+test "mapper: two non-overlapping devices both work" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var vram = RecordDevice{ .canned_byte = 0xAA };
+    var io = RecordDevice{ .canned_byte = 0xBB };
+    _ = try m.map(vram.device(), 0x8000, 0x4000);
+    _ = try m.map(io.device(), 0xFF00, 0x100);
+
+    try std.testing.expectEqual(@as(u8, 0xAA), m.readByte(0x8000));
+    try std.testing.expectEqual(@as(u8, 0xBB), m.readByte(0xFF80));
+
+    m.writeByte(0xA000, 0x12);
+    m.writeByte(0xFFAA, 0x34);
+    try std.testing.expectEqual(@as(u8, 0x12), vram.last_byte);
+    try std.testing.expectEqual(@as(u8, 0x34), io.last_byte);
+}
+
+test "mapper: map rejects empty range" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{};
+    try std.testing.expectError(error.EmptyRange, m.map(dev.device(), 0x1000, 0));
+}
+
+test "mapper: map rejects range overflowing 64KB" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{};
+    // 0xFF00 + 0x100 = 0x10000 (one past the last byte) is OK.
+    _ = try m.map(dev.device(), 0xFF00, 0x100);
+    // 0xFF00 + 0x101 overshoots.
+    try std.testing.expectError(error.RangeOverflow, m.map(dev.device(), 0xFF00, 0x101));
+}
+
+test "mapper: hasDeviceAt reflects current claims" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{};
+    const id = try m.map(dev.device(), 0x8000, 0x4000);
+
+    try std.testing.expect(m.hasDeviceAt(0x8000));
+    try std.testing.expect(m.hasDeviceAt(0xBFFF));
+    try std.testing.expect(!m.hasDeviceAt(0xC000));
+    try std.testing.expect(!m.hasDeviceAt(0x7FFF));
+
+    _ = m.unmap(id);
+    try std.testing.expect(!m.hasDeviceAt(0x8000));
+}
+
+test "mapper: region inclusive at both ends" {
+    var m = MemoryMapper.init(std.testing.allocator);
+    defer m.deinit();
+
+    var dev = RecordDevice{ .canned_byte = 0x77 };
+    _ = try m.map(dev.device(), 0x1000, 0x10);
+
+    // Both endpoints belong to the device.
+    try std.testing.expectEqual(@as(u8, 0x77), m.readByte(0x1000));
+    try std.testing.expectEqual(@as(u8, 0x77), m.readByte(0x100F));
+    // Just outside.
+    m.writeByte(0x1010, 0x42);
+    try std.testing.expectEqual(@as(u8, 0x42), m.readByte(0x1010));
+    try std.testing.expectEqual(@as(u32, 0), dev.writes_b);
+}

--- a/tests/vm/mapper.test.zig
+++ b/tests/vm/mapper.test.zig
@@ -212,22 +212,6 @@ test "mapper: map rejects range overflowing 64KB" {
     try std.testing.expectError(error.RangeOverflow, m.map(&dev.device, 0xFF00, 0x101));
 }
 
-test "mapper: hasDeviceAt reflects current claims" {
-    var m = MemoryMapper.init(std.testing.allocator);
-    defer m.deinit();
-
-    var dev = RecordDevice.init();
-    const id = try m.map(&dev.device, 0x8000, 0x4000);
-
-    try std.testing.expect(m.hasDeviceAt(0x8000));
-    try std.testing.expect(m.hasDeviceAt(0xBFFF));
-    try std.testing.expect(!m.hasDeviceAt(0xC000));
-    try std.testing.expect(!m.hasDeviceAt(0x7FFF));
-
-    _ = m.unmap(id);
-    try std.testing.expect(!m.hasDeviceAt(0x8000));
-}
-
 test "mapper: region inclusive at both ends" {
     var m = MemoryMapper.init(std.testing.allocator);
     defer m.deinit();

--- a/tests/vm/vm.test.zig
+++ b/tests/vm/vm.test.zig
@@ -3,7 +3,8 @@ const gero = @import("gero");
 const VM = gero.vm.VM;
 
 test "vm: init sets boot-state special registers per ISA §8" {
-    const vm = VM.init();
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
     try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.ip));
     try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.acu));
     try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
@@ -15,41 +16,45 @@ test "vm: init sets boot-state special registers per ISA §8" {
 }
 
 test "vm: init zeroes memory" {
-    const vm = VM.init();
-    try std.testing.expectEqual(@as(u8, 0), vm.mem.readByte(0));
-    try std.testing.expectEqual(@as(u8, 0), vm.mem.readByte(0x1100));
-    try std.testing.expectEqual(@as(u8, 0), vm.mem.readByte(0xFFFF));
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try std.testing.expectEqual(@as(u8, 0), vm.mmap.readByte(0));
+    try std.testing.expectEqual(@as(u8, 0), vm.mmap.readByte(0x1100));
+    try std.testing.expectEqual(@as(u8, 0), vm.mmap.readByte(0xFFFF));
 }
 
 test "vm: bootInitRegisters resets registers but preserves memory" {
-    var vm = VM.init();
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
     vm.regs.write(.r1, 0xDEAD);
     vm.regs.write(.flg, 0xFFFF);
-    vm.mem.writeByte(0x1100, 0x42);
+    vm.mmap.writeByte(0x1100, 0x42);
 
     vm.bootInitRegisters();
 
-    // Registers reset to boot defaults.
     try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
     try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.flg));
     try std.testing.expectEqual(@as(u16, gero.vm.sp_boot), vm.regs.read(.sp));
     // Memory deliberately preserved across re-boot.
-    try std.testing.expectEqual(@as(u8, 0x42), vm.mem.readByte(0x1100));
+    try std.testing.expectEqual(@as(u8, 0x42), vm.mmap.readByte(0x1100));
 }
 
 test "vm: registers and memory are independently mutable" {
-    var vm = VM.init();
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
     vm.regs.write(.r1, 0xAAAA);
-    vm.mem.writeWord(0x2000, 0xBBBB);
+    vm.mmap.writeWord(0x2000, 0xBBBB);
     try std.testing.expectEqual(@as(u16, 0xAAAA), vm.regs.read(.r1));
-    try std.testing.expectEqual(@as(u16, 0xBBBB), vm.mem.readWord(0x2000));
+    try std.testing.expectEqual(@as(u16, 0xBBBB), vm.mmap.readWord(0x2000));
 }
 
 test "vm: multiple VM instances are independent" {
-    var a = VM.init();
-    var b = VM.init();
+    var a = VM.init(std.testing.allocator);
+    defer a.deinit();
+    var b = VM.init(std.testing.allocator);
+    defer b.deinit();
     a.regs.write(.r1, 0x1111);
-    a.mem.writeByte(0x100, 0x42);
+    a.mmap.writeByte(0x100, 0x42);
     try std.testing.expectEqual(@as(u16, 0), b.regs.read(.r1));
-    try std.testing.expectEqual(@as(u8, 0), b.mem.readByte(0x100));
+    try std.testing.expectEqual(@as(u8, 0), b.mmap.readByte(0x100));
 }


### PR DESCRIPTION
## Summary

- New `src/vm/mapper.zig` introduces `Device` (host-pluggable IO interface) and `MemoryMapper` (routes every VM memory access).
- `VM` now composes a `MemoryMapper` instead of holding `Memory` directly. `VM.init` takes an allocator; `VM.deinit` releases the device registry.
- Hosts call `mapper.map(device, start, size)` to claim a u16 range; `unmap(id)` removes it. Most-recently-mapped wins on overlap. Unclaimed addresses fall through to the underlying RAM.

## Acceptance

- [x] Default behavior (no devices): RAM accessible 0x0000–0xFFFF
- [x] Custom Device mapped to a range: reads + writes go through the vtable
- [x] Most-recently-mapped wins on overlap (newest-first scan in `findDevice`)
- [x] `unmap` handle removes the region cleanly + returns false for unknown id
- [x] Multi-device test (VRAM-like at 0x8000 + IO-like at 0xFF00) — both work
- [x] All four release modes pass (`zig build test-modes`)

## Test plan

- [x] `zig build ci` — fmt-check, lint (strict/mirror/imports/naming/docs), tests, all green
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall

Closes #18.