### PR TITLE
feat(vm): dispatch loop + fault delivery (Part 1 of #19)

### DIFF
--- a/.changeset/e91a7c40.md
+++ b/.changeset/e91a7c40.md
@@ -1,0 +1,15 @@
+---
+bump: minor
+---
+
+Add the VM dispatch skeleton: `step` / `run` / `raiseFault` plus
+the `Vector` enum for IVT slots and the `StepResult` outcome type.
+Part 1 of #19 — every byte at `ip` currently raises the
+invalid-opcode fault (vector `0x01`) so the fault path is fully
+exercised; the opcode table and named per-opcode stubs land in
+the follow-up PR.
+
+Fault entry follows ISA §6.2: push `ip` / `fp` / `flg`, set
+`flg.I`, jump to `mem[0x1000 + 2 * vector]`. If the vector slot
+is `0`, `step` returns `.halted_on_fault` so the host can surface
+the unhandled fault.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -1,0 +1,85 @@
+/// The fetch-decode-execute loop. Part 1 wires the dispatch
+/// skeleton + fault delivery — every byte at `ip` currently
+/// triggers the invalid-opcode fault. The opcode table and
+/// named per-opcode stubs land in a follow-up PR.
+const std = @import("std");
+const vm_mod = @import("vm.zig");
+const VM = vm_mod.VM;
+const Register = vm_mod.Register;
+const Flag = vm_mod.Flag;
+
+/// Base address of the interrupt vector table (ISA §6.1).
+pub const ivt_base: u16 = 0x1000;
+
+/// Interrupt / fault vector. Non-exhaustive: only the reserved
+/// vectors (ISA §6.1 + §9) get named tags, but any `u8` in
+/// `0..0x3F` is a valid vector index — the `int N` opcode can
+/// raise host-defined or software-int vectors that aren't named.
+pub const Vector = enum(u8) {
+    /// Reset — runs at boot when the program's entry point is 0.
+    reset = 0x00,
+    /// Invalid-opcode fault.
+    invalid_opcode = 0x01,
+    /// Invalid-register fault.
+    invalid_register = 0x02,
+    /// Division by zero.
+    div_by_zero = 0x03,
+    /// Arithmetic overflow (e.g. `div` quotient > 16 bits).
+    arith_overflow = 0x05,
+    _,
+};
+
+/// Outcome of a `step` call.
+pub const StepResult = enum {
+    /// The VM advanced — keep dispatching.
+    cont,
+    /// The VM hit `hlt` (no resume).
+    halted,
+    /// A fault fired but no ISR was installed (vector slot is `0`).
+    /// The host should surface the fault to the user.
+    halted_on_fault,
+};
+
+/// One fetch-decode-execute cycle. Part 1 dispatches every byte
+/// to the invalid-opcode fault; later PRs add real handlers.
+pub fn step(vm: *VM) StepResult {
+    return raiseFault(vm, .invalid_opcode);
+}
+
+/// Iterate `step` until it returns anything other than `.cont`.
+/// Returns the final outcome (`.halted` or `.halted_on_fault`).
+pub fn run(vm: *VM) StepResult {
+    while (true) {
+        const r = step(vm);
+        if (r != .cont) return r;
+    }
+}
+
+/// Deliver a fault through the interrupt mechanism (ISA §6.2 + §9).
+/// If the vector slot is `0` the VM halts with a host-visible
+/// fault marker; otherwise the entry sequence pushes `ip` / `fp` /
+/// `flg`, sets `flg.I`, and jumps to the ISR.
+pub fn raiseFault(vm: *VM, vector: Vector) StepResult {
+    const target = vm.mmap.readWord(ivtSlot(vector));
+    if (target == 0) return .halted_on_fault;
+
+    pushWord(vm, vm.regs.read(.ip));
+    pushWord(vm, vm.regs.read(.fp));
+    pushWord(vm, vm.regs.read(.flg));
+    vm.regs.setFlag(.interrupt_disable, true);
+    vm.regs.write(.ip, target);
+    return .cont;
+}
+
+/// Address of the slot for `vector` inside the IVT.
+pub fn ivtSlot(vector: Vector) u16 {
+    // @as: widen the u8 vector index to u16 before the multiply
+    return ivt_base + 2 * @as(u16, @intFromEnum(vector));
+}
+
+fn pushWord(vm: *VM, value: u16) void {
+    // Stack grows downward, `sp` always points at the top word.
+    const sp = vm.regs.read(.sp);
+    vm.mmap.writeWord(sp, value);
+    vm.regs.write(.sp, sp -% 2);
+}

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const registers = @import("registers.zig");
 const memory = @import("memory.zig");
 const mapper = @import("mapper.zig");
+const dispatch_mod = @import("dispatch.zig");
 
 /// Re-export: named register handles.
 pub const Register = registers.Register;
@@ -21,6 +22,20 @@ pub const MemoryMapper = mapper.MemoryMapper;
 pub const RegionId = mapper.RegionId;
 /// Re-export: errors from `MemoryMapper.map`.
 pub const MapError = mapper.MapError;
+/// Re-export: outcome of `step` / `run`.
+pub const StepResult = dispatch_mod.StepResult;
+/// Re-export: reserved interrupt / fault vectors.
+pub const Vector = dispatch_mod.Vector;
+/// Re-export: one fetch-decode-execute cycle.
+pub const step = dispatch_mod.step;
+/// Re-export: dispatch loop until halt / fault.
+pub const run = dispatch_mod.run;
+/// Re-export: deliver a fault through the interrupt mechanism.
+pub const raiseFault = dispatch_mod.raiseFault;
+/// Re-export: address of the IVT slot for a given vector.
+pub const ivtSlot = dispatch_mod.ivtSlot;
+/// Re-export: IVT base address (ISA §6.1).
+pub const ivt_base = dispatch_mod.ivt_base;
 
 /// Boot-state default for `sp` — top of memory minus 1 word so the
 /// first push lands on a valid word.

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+const Vector = gero.vm.Vector;
+
+/// Install a vector address in the IVT.
+fn setVector(vm: *VM, vector: Vector, target: u16) void {
+    vm.mmap.writeWord(gero.vm.ivtSlot(vector), target);
+}
+
+test "dispatch: ivtSlot follows ISA §6.1 layout" {
+    try std.testing.expectEqual(@as(u16, 0x1000), gero.vm.ivtSlot(.reset));
+    try std.testing.expectEqual(@as(u16, 0x1002), gero.vm.ivtSlot(.invalid_opcode));
+    try std.testing.expectEqual(@as(u16, 0x1004), gero.vm.ivtSlot(.invalid_register));
+    try std.testing.expectEqual(@as(u16, 0x1006), gero.vm.ivtSlot(.div_by_zero));
+    try std.testing.expectEqual(@as(u16, 0x100A), gero.vm.ivtSlot(.arith_overflow));
+}
+
+test "dispatch: step with unset IVT halts on fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // IVT is zero-initialized — vector slot is 0, no ISR installed.
+    try std.testing.expectEqual(gero.vm.StepResult.halted_on_fault, gero.vm.step(&vm));
+}
+
+test "dispatch: step with installed ISR enters the handler" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    setVector(&vm, .invalid_opcode, 0x2000);
+    vm.regs.write(.ip, 0x1100);
+
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+    try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
+}
+
+test "dispatch: fault entry pushes ip, fp, flg in spec order" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    setVector(&vm, .invalid_opcode, 0x2000);
+    vm.regs.write(.ip, 0x1234);
+    vm.regs.write(.fp, 0xABCD);
+    vm.regs.write(.flg, 0x000F);
+
+    _ = gero.vm.step(&vm);
+
+    // Stack grows downward; first push lands at 0xFFFE (sp_boot),
+    // each subsequent push 2 bytes below. Order per ISA §6.2:
+    // ip → fp → flg (flg ends up on top of stack).
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.mmap.readWord(0xFFFE));
+    try std.testing.expectEqual(@as(u16, 0xABCD), vm.mmap.readWord(0xFFFC));
+    // flg was 0x000F before the push; flg.I is set AFTER the push.
+    try std.testing.expectEqual(@as(u16, 0x000F), vm.mmap.readWord(0xFFFA));
+    // sp ends up 6 bytes below boot.
+    try std.testing.expectEqual(@as(u16, 0xFFF8), vm.regs.read(.sp));
+}
+
+test "dispatch: raiseFault routes to the right vector slot" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    setVector(&vm, .div_by_zero, 0x3000);
+    _ = gero.vm.raiseFault(&vm, .div_by_zero);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
+}
+
+test "dispatch: raiseFault on a zero-slot vector halts" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted_on_fault,
+        gero.vm.raiseFault(&vm, .arith_overflow),
+    );
+    // ip stays untouched on an unhandled fault — the host inspects
+    // the offending instruction.
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.ip));
+}
+
+test "dispatch: run halts when the IVT is empty" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try std.testing.expectEqual(gero.vm.StepResult.halted_on_fault, gero.vm.run(&vm));
+}
+
+test "dispatch: every byte at ip currently faults (Part 1 stub)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    setVector(&vm, .invalid_opcode, 0x4000);
+
+    // Without a real opcode table, any byte at ip dispatches to the
+    // invalid-opcode fault — that's the Part 1 contract.
+    inline for ([_]u8{ 0x00, 0x10, 0x80, 0xFF }) |op| {
+        vm.regs.write(.ip, 0x1100);
+        vm.mmap.writeByte(0x1100, op);
+        // Reset sp + flg so each iteration starts clean.
+        vm.regs.write(.sp, 0xFFFE);
+        vm.regs.write(.flg, 0);
+        try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+        try std.testing.expectEqual(@as(u16, 0x4000), vm.regs.read(.ip));
+    }
+}


### PR DESCRIPTION
## Summary

Part 1 of #19 — the fetch-decode-execute skeleton + fault delivery, scoped down so the diff fits the ~400 LOC budget. The opcode table + 90 named stubs land in #53.

- `step(vm)` does one cycle; currently every byte at `ip` raises the invalid-opcode fault (vector `0x01`) — Part 2 wires the table-driven lookup
- `run(vm)` loops until `step` returns anything other than `.cont`
- `raiseFault(vm, vector)` implements ISA §6.2: push `ip` / `fp` / `flg`, set `flg.I`, jump to `mem[0x1000 + 2 * vector]`. Zero vector slot → `.halted_on_fault` so the host can surface unhandled faults
- `Vector` enum is non-exhaustive — software interrupts (`int N`) and host-defined vectors fit without touching the enum

## Acceptance (#19)

- [x] Unknown opcode faults via vector 0x01
- [x] `run` loops until step returns non-`.cont`
- [x] All four release modes pass (`zig build test-modes`)
- [ ] `step` increments ip correctly for every opcode size (1/2/3/4 bytes) — deferred to #53 (needs real handlers, not fault stubs)
- [ ] Dispatch test: byte 0x10 reaches mov-imm16-reg stub etc. for all 90 opcodes — deferred to #53 (needs named stubs to exist)

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 8 unit tests covering: IVT layout, no-ISR halt, ISR entry, push order per spec, fault routing, run-until-halt, every byte faults

Part of #19. Follow-up: #53.