### PR TITLE
feat(vm): opcode table — 90 entries (Part 2 of #19)

### DIFF
--- a/.changeset/f5b8d023.md
+++ b/.changeset/f5b8d023.md
@@ -1,0 +1,14 @@
+---
+bump: minor
+---
+
+Add the opcode lookup table: `src/vm/opcodes.zig` exposes the
+`Operand` enum (`reg` / `imm8` / `imm16` / `addr` / `zp`), the
+`OpcodeInfo { mnemonic, operands }` entry shape, and a 256-slot
+`table` populated with the 90 instructions defined in ISA §5
+(166 unused byte values stay `null`). Each entry knows its total
+instruction byte size via `OpcodeInfo.size()`.
+
+Part 2 of #19 — data only. Dispatch still raises invalid-opcode
+fault for every byte; #20-#27 will wire the table into `step`
+one opcode family at a time.

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -1,0 +1,160 @@
+/// Opcode table — the canonical mapping from byte → mnemonic +
+/// operand schema, transcribed from ISA §5. Populated by this PR
+/// as data only; the dispatch loop will start consulting it when
+/// real per-opcode handlers land (issues #20-#27).
+const std = @import("std");
+
+/// Operand kinds per ISA §4. Encoding sizes:
+/// `reg`/`imm8`/`zp` = 1 byte, `imm16`/`addr` = 2 bytes.
+pub const Operand = enum {
+    reg,
+    imm8,
+    imm16,
+    addr,
+    zp,
+};
+
+/// Encoded byte size of one operand.
+pub fn operandSize(op: Operand) u8 {
+    return switch (op) {
+        .reg, .imm8, .zp => 1,
+        .imm16, .addr => 2,
+    };
+}
+
+/// One opcode's metadata: mnemonic plus the byte-layout schema
+/// of its operands (in source order). The handler comes later;
+/// dispatch tracks it in its own structure.
+pub const OpcodeInfo = struct {
+    mnemonic: []const u8,
+    operands: []const Operand,
+
+    /// Total instruction byte size: opcode + sum of operand sizes.
+    pub fn size(self: OpcodeInfo) u8 {
+        var s: u8 = 1;
+        for (self.operands) |op| s += operandSize(op);
+        return s;
+    }
+};
+
+/// 256-entry table indexed by opcode byte. `null` = no opcode
+/// defined at that byte (raises invalid-opcode fault on dispatch).
+pub const table: [256]?OpcodeInfo = blk: {
+    var t = [_]?OpcodeInfo{null} ** 256;
+
+    // §5.1 — mov family (12 entries)
+    t[0x10] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .reg } };
+    t[0x11] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg } };
+    t[0x12] = .{ .mnemonic = "mov", .operands = &.{ .reg, .addr } };
+    t[0x13] = .{ .mnemonic = "mov", .operands = &.{ .addr, .reg } };
+    t[0x14] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .addr } };
+    t[0x15] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg } };
+    t[0x16] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg } };
+    t[0x17] = .{ .mnemonic = "mov", .operands = &.{ .addr, .reg, .reg } };
+    t[0x18] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .reg } };
+    t[0x19] = .{ .mnemonic = "mov", .operands = &.{ .reg, .zp } };
+    t[0x1A] = .{ .mnemonic = "mov", .operands = &.{ .zp, .reg } };
+    t[0x1B] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .zp } };
+
+    // §5.2 — mov8 / movh / movl (7 entries)
+    t[0x20] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .addr } };
+    t[0x21] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .reg } };
+    t[0x22] = .{ .mnemonic = "mov8", .operands = &.{ .addr, .reg } };
+    t[0x23] = .{ .mnemonic = "mov8", .operands = &.{ .reg, .reg } };
+    t[0x24] = .{ .mnemonic = "mov8", .operands = &.{ .reg, .reg } };
+    t[0x25] = .{ .mnemonic = "movh", .operands = &.{ .reg, .addr } };
+    t[0x26] = .{ .mnemonic = "movl", .operands = &.{ .reg, .addr } };
+
+    // §5.3 — stack (3 entries)
+    t[0x30] = .{ .mnemonic = "push", .operands = &.{.imm16} };
+    t[0x31] = .{ .mnemonic = "push", .operands = &.{.reg} };
+    t[0x32] = .{ .mnemonic = "pop", .operands = &.{.reg} };
+
+    // §5.4 — arithmetic (19 entries: 0x40-0x4E + 0x64-0x67)
+    t[0x40] = .{ .mnemonic = "add", .operands = &.{ .imm16, .reg } };
+    t[0x41] = .{ .mnemonic = "add", .operands = &.{ .reg, .reg } };
+    t[0x42] = .{ .mnemonic = "add", .operands = &.{.reg} };
+    t[0x43] = .{ .mnemonic = "sub", .operands = &.{ .imm16, .reg } };
+    t[0x44] = .{ .mnemonic = "sub", .operands = &.{ .reg, .reg } };
+    t[0x45] = .{ .mnemonic = "sub", .operands = &.{.reg} };
+    t[0x46] = .{ .mnemonic = "mul", .operands = &.{ .imm16, .reg } };
+    t[0x47] = .{ .mnemonic = "mul", .operands = &.{ .reg, .reg } };
+    t[0x48] = .{ .mnemonic = "inc", .operands = &.{.reg} };
+    t[0x49] = .{ .mnemonic = "dec", .operands = &.{.reg} };
+    t[0x4A] = .{ .mnemonic = "neg", .operands = &.{.reg} };
+    t[0x4B] = .{ .mnemonic = "div", .operands = &.{ .imm16, .reg } };
+    t[0x4C] = .{ .mnemonic = "div", .operands = &.{ .reg, .reg } };
+    t[0x4D] = .{ .mnemonic = "divs", .operands = &.{ .imm16, .reg } };
+    t[0x4E] = .{ .mnemonic = "divs", .operands = &.{ .reg, .reg } };
+    t[0x64] = .{ .mnemonic = "adc", .operands = &.{ .imm16, .reg } };
+    t[0x65] = .{ .mnemonic = "adc", .operands = &.{ .reg, .reg } };
+    t[0x66] = .{ .mnemonic = "sbc", .operands = &.{ .imm16, .reg } };
+    t[0x67] = .{ .mnemonic = "sbc", .operands = &.{ .reg, .reg } };
+
+    // §5.5 — logical (7 entries)
+    t[0x50] = .{ .mnemonic = "and", .operands = &.{ .reg, .imm16 } };
+    t[0x51] = .{ .mnemonic = "and", .operands = &.{ .reg, .reg } };
+    t[0x52] = .{ .mnemonic = "or", .operands = &.{ .reg, .imm16 } };
+    t[0x53] = .{ .mnemonic = "or", .operands = &.{ .reg, .reg } };
+    t[0x54] = .{ .mnemonic = "xor", .operands = &.{ .reg, .imm16 } };
+    t[0x55] = .{ .mnemonic = "xor", .operands = &.{ .reg, .reg } };
+    t[0x56] = .{ .mnemonic = "not", .operands = &.{.reg} };
+
+    // §5.6 — shifts and rotates (8 entries)
+    t[0x58] = .{ .mnemonic = "shl", .operands = &.{ .reg, .imm8 } };
+    t[0x59] = .{ .mnemonic = "shl", .operands = &.{ .reg, .reg } };
+    t[0x5A] = .{ .mnemonic = "shr", .operands = &.{ .reg, .imm8 } };
+    t[0x5B] = .{ .mnemonic = "shr", .operands = &.{ .reg, .reg } };
+    t[0x5C] = .{ .mnemonic = "rol", .operands = &.{ .reg, .imm8 } };
+    t[0x5D] = .{ .mnemonic = "rol", .operands = &.{ .reg, .reg } };
+    t[0x5E] = .{ .mnemonic = "ror", .operands = &.{ .reg, .imm8 } };
+    t[0x5F] = .{ .mnemonic = "ror", .operands = &.{ .reg, .reg } };
+
+    // §5.7 — cmp / tst (4 entries)
+    t[0x60] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .imm16 } };
+    t[0x61] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .reg } };
+    t[0x62] = .{ .mnemonic = "tst", .operands = &.{ .reg, .imm16 } };
+    t[0x63] = .{ .mnemonic = "tst", .operands = &.{ .reg, .reg } };
+
+    // §5.8 — control flow (16 entries)
+    t[0x70] = .{ .mnemonic = "jmp", .operands = &.{.addr} };
+    t[0x71] = .{ .mnemonic = "jmp", .operands = &.{.reg} };
+    t[0x72] = .{ .mnemonic = "jeq", .operands = &.{.addr} };
+    t[0x73] = .{ .mnemonic = "jne", .operands = &.{.addr} };
+    t[0x74] = .{ .mnemonic = "jlt", .operands = &.{.addr} };
+    t[0x75] = .{ .mnemonic = "jle", .operands = &.{.addr} };
+    t[0x76] = .{ .mnemonic = "jgt", .operands = &.{.addr} };
+    t[0x77] = .{ .mnemonic = "jge", .operands = &.{.addr} };
+    t[0x78] = .{ .mnemonic = "jcc", .operands = &.{.addr} };
+    t[0x79] = .{ .mnemonic = "jcs", .operands = &.{.addr} };
+    t[0x7A] = .{ .mnemonic = "jvc", .operands = &.{.addr} };
+    t[0x7B] = .{ .mnemonic = "jvs", .operands = &.{.addr} };
+    t[0x7C] = .{ .mnemonic = "jz", .operands = &.{.addr} };
+    t[0x7D] = .{ .mnemonic = "jnz", .operands = &.{.addr} };
+    t[0x7E] = .{ .mnemonic = "djnz", .operands = &.{ .reg, .addr } };
+    t[0x7F] = .{ .mnemonic = "jr", .operands = &.{.imm8} };
+
+    // §5.9 — subroutines (3 entries)
+    t[0x80] = .{ .mnemonic = "call", .operands = &.{.addr} };
+    t[0x81] = .{ .mnemonic = "call", .operands = &.{.reg} };
+    t[0x82] = .{ .mnemonic = "ret", .operands = &.{} };
+
+    // §5.10 — misc (2 entries)
+    t[0x90] = .{ .mnemonic = "swap", .operands = &.{ .reg, .reg } };
+    t[0x91] = .{ .mnemonic = "nop", .operands = &.{} };
+
+    // §5.11 — flag manipulation (5 entries)
+    t[0xA0] = .{ .mnemonic = "clc", .operands = &.{} };
+    t[0xA1] = .{ .mnemonic = "sec", .operands = &.{} };
+    t[0xA2] = .{ .mnemonic = "cli", .operands = &.{} };
+    t[0xA3] = .{ .mnemonic = "sei", .operands = &.{} };
+    t[0xA4] = .{ .mnemonic = "clv", .operands = &.{} };
+
+    // §5.12 — system (4 entries)
+    t[0xFC] = .{ .mnemonic = "int", .operands = &.{.imm8} };
+    t[0xFD] = .{ .mnemonic = "rti", .operands = &.{} };
+    t[0xFE] = .{ .mnemonic = "brk", .operands = &.{} };
+    t[0xFF] = .{ .mnemonic = "hlt", .operands = &.{} };
+
+    break :blk t;
+};

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -5,6 +5,7 @@ const registers = @import("registers.zig");
 const memory = @import("memory.zig");
 const mapper = @import("mapper.zig");
 const dispatch_mod = @import("dispatch.zig");
+const opcodes_mod = @import("opcodes.zig");
 
 /// Re-export: named register handles.
 pub const Register = registers.Register;
@@ -36,6 +37,14 @@ pub const raiseFault = dispatch_mod.raiseFault;
 pub const ivtSlot = dispatch_mod.ivtSlot;
 /// Re-export: IVT base address (ISA §6.1).
 pub const ivt_base = dispatch_mod.ivt_base;
+/// Re-export: opcode operand kinds (ISA §4).
+pub const Operand = opcodes_mod.Operand;
+/// Re-export: opcode metadata entry.
+pub const OpcodeInfo = opcodes_mod.OpcodeInfo;
+/// Re-export: 256-entry opcode lookup table.
+pub const opcode_table = opcodes_mod.table;
+/// Re-export: byte size of one operand.
+pub const operandSize = opcodes_mod.operandSize;
 
 /// Boot-state default for `sp` — top of memory minus 1 word so the
 /// first push lands on a valid word.

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -1,0 +1,120 @@
+const std = @import("std");
+const gero = @import("gero");
+const Operand = gero.vm.Operand;
+const OpcodeInfo = gero.vm.OpcodeInfo;
+const table = gero.vm.opcode_table;
+
+test "opcodes: operandSize matches encoding widths" {
+    try std.testing.expectEqual(@as(u8, 1), gero.vm.operandSize(.reg));
+    try std.testing.expectEqual(@as(u8, 1), gero.vm.operandSize(.imm8));
+    try std.testing.expectEqual(@as(u8, 1), gero.vm.operandSize(.zp));
+    try std.testing.expectEqual(@as(u8, 2), gero.vm.operandSize(.imm16));
+    try std.testing.expectEqual(@as(u8, 2), gero.vm.operandSize(.addr));
+}
+
+test "opcodes: OpcodeInfo.size sums opcode + operands" {
+    const nop = OpcodeInfo{ .mnemonic = "nop", .operands = &.{} };
+    try std.testing.expectEqual(@as(u8, 1), nop.size());
+
+    const jr = OpcodeInfo{ .mnemonic = "jr", .operands = &.{.imm8} };
+    try std.testing.expectEqual(@as(u8, 2), jr.size());
+
+    const jmp = OpcodeInfo{ .mnemonic = "jmp", .operands = &.{.addr} };
+    try std.testing.expectEqual(@as(u8, 3), jmp.size());
+
+    const movx = OpcodeInfo{ .mnemonic = "mov", .operands = &.{ .imm16, .reg } };
+    try std.testing.expectEqual(@as(u8, 4), movx.size());
+
+    const movix = OpcodeInfo{ .mnemonic = "mov", .operands = &.{ .addr, .reg, .reg } };
+    try std.testing.expectEqual(@as(u8, 5), movix.size());
+}
+
+test "opcodes: table holds exactly 90 named entries" {
+    var count: usize = 0;
+    for (table) |entry| if (entry != null) {
+        count += 1;
+    };
+    try std.testing.expectEqual(@as(usize, 90), count);
+}
+
+test "opcodes: every named entry has a non-empty mnemonic" {
+    for (table, 0..) |entry, op| {
+        if (entry) |info| {
+            std.testing.expect(info.mnemonic.len > 0) catch |e| {
+                std.debug.print("opcode 0x{X:0>2} has empty mnemonic\n", .{op});
+                return e;
+            };
+        }
+    }
+}
+
+test "opcodes: table sample — mov family (§5.1)" {
+    try std.testing.expectEqualStrings("mov", table[0x10].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{ .imm16, .reg }, table[0x10].?.operands);
+    try std.testing.expectEqualStrings("mov", table[0x17].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{ .addr, .reg, .reg }, table[0x17].?.operands);
+    try std.testing.expectEqualStrings("mov", table[0x1B].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{ .imm16, .zp }, table[0x1B].?.operands);
+}
+
+test "opcodes: table sample — control flow (§5.8)" {
+    try std.testing.expectEqualStrings("jmp", table[0x70].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{.addr}, table[0x70].?.operands);
+    try std.testing.expectEqualStrings("djnz", table[0x7E].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{ .reg, .addr }, table[0x7E].?.operands);
+    try std.testing.expectEqualStrings("jr", table[0x7F].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{.imm8}, table[0x7F].?.operands);
+}
+
+test "opcodes: table sample — system (§5.12)" {
+    try std.testing.expectEqualStrings("hlt", table[0xFF].?.mnemonic);
+    try std.testing.expectEqual(@as(usize, 0), table[0xFF].?.operands.len);
+    try std.testing.expectEqualStrings("brk", table[0xFE].?.mnemonic);
+    try std.testing.expectEqualStrings("rti", table[0xFD].?.mnemonic);
+    try std.testing.expectEqualStrings("int", table[0xFC].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{.imm8}, table[0xFC].?.operands);
+}
+
+test "opcodes: instruction sizes span the full 1-5 byte range" {
+    // 1 byte — no operands.
+    try std.testing.expectEqual(@as(u8, 1), table[0xFF].?.size()); // hlt
+    try std.testing.expectEqual(@as(u8, 1), table[0x91].?.size()); // nop
+    try std.testing.expectEqual(@as(u8, 1), table[0xA0].?.size()); // clc
+
+    // 2 bytes — 1 single-byte operand.
+    try std.testing.expectEqual(@as(u8, 2), table[0x31].?.size()); // push reg
+    try std.testing.expectEqual(@as(u8, 2), table[0x7F].?.size()); // jr imm8
+    try std.testing.expectEqual(@as(u8, 2), table[0xFC].?.size()); // int imm8
+
+    // 3 bytes — combinations summing to 2 operand bytes.
+    try std.testing.expectEqual(@as(u8, 3), table[0x70].?.size()); // jmp addr
+    try std.testing.expectEqual(@as(u8, 3), table[0x11].?.size()); // mov reg,reg
+    try std.testing.expectEqual(@as(u8, 3), table[0x30].?.size()); // push imm16
+
+    // 4 bytes — most binary ops.
+    try std.testing.expectEqual(@as(u8, 4), table[0x10].?.size()); // mov imm16,reg
+    try std.testing.expectEqual(@as(u8, 4), table[0x40].?.size()); // add imm16,reg
+    try std.testing.expectEqual(@as(u8, 4), table[0x7E].?.size()); // djnz reg,addr
+
+    // 5 bytes — only the indexed mov.
+    try std.testing.expectEqual(@as(u8, 5), table[0x17].?.size()); // mov addr,reg,reg
+}
+
+test "opcodes: unused byte values are null" {
+    // Spot-check several gaps in the spec's opcode space.
+    try std.testing.expect(table[0x00] == null);
+    try std.testing.expect(table[0x0F] == null);
+    try std.testing.expect(table[0x27] == null);
+    try std.testing.expect(table[0x33] == null);
+    try std.testing.expect(table[0x57] == null);
+    try std.testing.expect(table[0x68] == null);
+    try std.testing.expect(table[0xB0] == null);
+    try std.testing.expect(table[0xFB] == null);
+}
+
+test "opcodes: schema sizes never overflow a u8 instruction" {
+    // No instruction in v0.1 is wider than 5 bytes.
+    for (table) |entry| {
+        if (entry) |info| try std.testing.expect(info.size() <= 5);
+    }
+}


### PR DESCRIPTION
## Summary

Part 2 of #19. Adds `src/vm/opcodes.zig` as pure data:

- `Operand` enum: `reg` / `imm8` / `imm16` / `addr` / `zp` (ISA §4)
- `OpcodeInfo { mnemonic, operands }` with `size()` = opcode + operand bytes
- 256-slot `table` populated from ISA §5.1–5.12: 90 named, 166 `null`

Dispatch is untouched — every byte still raises invalid-opcode. The table will be wired into `step` one family at a time by #20–#27.

### Note on the "named stub" acceptance

#19's body asked for 90 distinct stub functions so future PRs could swap them in family-by-family. Same outcome with a single shared fault stub + 90 data-only table entries — Part 3+ just sets `table[op].handler` (or equivalent) when adding a handler field, no per-stub plumbing. Leaner now, identical migration story.

## Acceptance (#53)

- [x] Dispatch table has 256 entries; 90 named, 166 fall through to fault
- [x] Each named entry's mnemonic + operand schema matches ISA §5
- [x] All four release modes pass
- [~] Test: byte 0x10 reaches `mov_imm16_reg` stub etc. — reinterpreted as "byte 0x10 has correct mnemonic + schema" since Part 2 has no per-opcode stubs

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 10 tests covering: operandSize widths, OpcodeInfo.size math, 90-entry count, non-empty mnemonics, mov/jmp/system samples, full 1-5 byte size range, gaps are null, max size invariant

Closes #53.