### PR TITLE
feat(vm/handlers): mov family — 19 handlers (§5.1 + §5.2)

### DIFF
--- a/.changeset/a17e3b9c.md
+++ b/.changeset/a17e3b9c.md
@@ -1,0 +1,18 @@
+---
+bump: minor
+---
+
+Implement the `mov` family (ISA §5.1 + §5.2) — 19 handlers
+covering: `mov` imm-reg / reg-reg / reg-addr / addr-reg /
+imm-addr / indirect load+store / indexed load / imm-via-ptr /
+zero-page variants, plus the byte-sized `mov8` family and the
+high/low halves (`movh` / `movl`).
+
+Dispatch now consults a `handler_table` in `dispatch.zig` and
+auto-advances `ip` past the instruction when the handler returns
+`.cont` without touching `ip` (jumps, fault entry, etc. set `ip`
+themselves and skip the auto-advance). Unhandled opcodes still
+raise the invalid-opcode fault; out-of-range register operands
+raise the invalid-register fault.
+
+No flags are touched by any `mov` variant.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -1,9 +1,11 @@
-/// The fetch-decode-execute loop. Part 1 wires the dispatch
-/// skeleton + fault delivery — every byte at `ip` currently
-/// triggers the invalid-opcode fault. The opcode table and
-/// named per-opcode stubs land in a follow-up PR.
+/// The fetch-decode-execute loop. Reads the byte at `ip`, dispatches
+/// to the right handler in `handler_table`, and auto-advances `ip`
+/// past the instruction unless the handler set `ip` itself
+/// (jumps / calls / fault entry).
 const std = @import("std");
 const vm_mod = @import("vm.zig");
+const opcodes = @import("opcodes.zig");
+const mov = @import("handlers/mov.zig");
 const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
@@ -40,10 +42,63 @@ pub const StepResult = enum {
     halted_on_fault,
 };
 
-/// One fetch-decode-execute cycle. Part 1 dispatches every byte
-/// to the invalid-opcode fault; later PRs add real handlers.
-pub fn step(vm: *VM) StepResult {
+/// Per-opcode handler. Receives the VM and returns the post-step
+/// outcome. A handler that returns `.cont` without touching `ip`
+/// leaves the auto-advance work to `step`.
+pub const Handler = *const fn (vm: *VM) StepResult;
+
+/// Default handler for bytes with no implementation — raises the
+/// invalid-opcode fault.
+fn unimplemented(vm: *VM) StepResult {
     return raiseFault(vm, .invalid_opcode);
+}
+
+/// 256-slot handler table. Bytes without a real handler default
+/// to `unimplemented`; subsequent opcode-family PRs install their
+/// handlers by overwriting individual slots here.
+pub const handler_table: [256]Handler = blk: {
+    var t = [_]Handler{unimplemented} ** 256;
+
+    // §5.1 — mov family
+    t[0x10] = mov.movImm16Reg;
+    t[0x11] = mov.movRegReg;
+    t[0x12] = mov.movRegAddr;
+    t[0x13] = mov.movAddrReg;
+    t[0x14] = mov.movImm16Addr;
+    t[0x15] = mov.movRegPtr;
+    t[0x16] = mov.movPtrReg;
+    t[0x17] = mov.movIndexed;
+    t[0x18] = mov.movImm16Ptr;
+    t[0x19] = mov.movRegZp;
+    t[0x1A] = mov.movZpReg;
+    t[0x1B] = mov.movImm16Zp;
+
+    // §5.2 — mov8 / movh / movl
+    t[0x20] = mov.mov8Imm8Addr;
+    t[0x21] = mov.mov8Imm8Reg;
+    t[0x22] = mov.mov8AddrReg;
+    t[0x23] = mov.mov8RegPtr;
+    t[0x24] = mov.mov8PtrReg;
+    t[0x25] = mov.movhRegAddr;
+    t[0x26] = mov.movlRegAddr;
+
+    break :blk t;
+};
+
+/// One fetch-decode-execute cycle. Reads the byte at `ip`,
+/// invokes its handler, and (if the handler returned `.cont`
+/// without moving `ip`) advances past the instruction by the
+/// schema-derived size.
+pub fn step(vm: *VM) StepResult {
+    const ip_before = vm.regs.read(.ip);
+    const op = vm.mmap.readByte(ip_before);
+    const handler = handler_table[op];
+    const result = handler(vm);
+    if (result == .cont and vm.regs.read(.ip) == ip_before) {
+        const info = opcodes.table[op] orelse return .halted_on_fault;
+        vm.regs.write(.ip, ip_before +% info.size());
+    }
+    return result;
 }
 
 /// Iterate `step` until it returns anything other than `.cont`.

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -1,0 +1,212 @@
+/// Handlers for the `mov` family (ISA §5.1) and the byte-sized
+/// `mov8` / `movh` / `movl` family (ISA §5.2). None of these
+/// affect flags; ip auto-advances by the instruction size after
+/// the handler returns `.cont`.
+const vm_mod = @import("../vm.zig");
+const dispatch = @import("../dispatch.zig");
+const VM = vm_mod.VM;
+const StepResult = dispatch.StepResult;
+
+const ok = StepResult.cont;
+
+fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
+    return dispatch.raiseFault(vm, vector);
+}
+
+/// `0x10` — `mov Imm16, Reg` → `reg ← imm`.
+pub fn movImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    if (!vm.regs.writeByIndex(reg, imm)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x11` — `mov Reg, Reg` → `dst ← src` (Intel order: dst first).
+pub fn movRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x12` — `mov Reg, Addr` → `mem[addr] ← reg`.
+pub fn movRegAddr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const addr = vm.mmap.readWord(ip +% 2);
+    const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    vm.mmap.writeWord(addr, value);
+    return ok;
+}
+
+/// `0x13` — `mov Addr, Reg` → `reg ← mem[addr]`.
+pub fn movAddrReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const addr = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const value = vm.mmap.readWord(addr);
+    if (!vm.regs.writeByIndex(reg, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x14` — `mov Imm16, Addr` → `mem[addr] ← imm`.
+pub fn movImm16Addr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const addr = vm.mmap.readWord(ip +% 3);
+    vm.mmap.writeWord(addr, imm);
+    return ok;
+}
+
+/// `0x15` — `mov Reg, [Reg]` → `dst ← mem[ptr]` (indirect load,
+/// Intel order: dst first, ptr second).
+pub fn movRegPtr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const ptr = vm.mmap.readByte(ip +% 2);
+    const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
+    const value = vm.mmap.readWord(addr);
+    if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x16` — `mov [Reg], Reg` → `mem[ptr] ← src` (indirect store).
+pub fn movPtrReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const ptr = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
+    const value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    vm.mmap.writeWord(addr, value);
+    return ok;
+}
+
+/// `0x17` — `mov Addr, Reg, Reg` → `dst ← mem[addr + idx]`
+/// (indexed load).
+pub fn movIndexed(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const base = vm.mmap.readWord(ip +% 1);
+    const idx_reg = vm.mmap.readByte(ip +% 3);
+    const dst = vm.mmap.readByte(ip +% 4);
+    const offset = vm.regs.readByIndex(idx_reg) orelse return fault(vm, .invalid_register);
+    const value = vm.mmap.readWord(base +% offset);
+    if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x18` — `mov Imm16, [Reg]` → `mem[ptr] ← imm`.
+pub fn movImm16Ptr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const ptr = vm.mmap.readByte(ip +% 3);
+    const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
+    vm.mmap.writeWord(addr, imm);
+    return ok;
+}
+
+/// `0x19` — `mov Reg, ZP` → `mem[zp] ← reg` (zero-page store).
+pub fn movRegZp(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const zp = vm.mmap.readByte(ip +% 2);
+    const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    vm.mmap.writeWord(zp, value);
+    return ok;
+}
+
+/// `0x1A` — `mov ZP, Reg` → `reg ← mem[zp]` (zero-page load).
+pub fn movZpReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const zp = vm.mmap.readByte(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 2);
+    const value = vm.mmap.readWord(zp);
+    if (!vm.regs.writeByIndex(reg, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x1B` — `mov Imm16, ZP` → `mem[zp] ← imm`.
+pub fn movImm16Zp(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const zp = vm.mmap.readByte(ip +% 3);
+    vm.mmap.writeWord(zp, imm);
+    return ok;
+}
+
+/// `0x20` — `mov8 Imm8, Addr` → `mem[addr] ← imm` (1 byte).
+pub fn mov8Imm8Addr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readByte(ip +% 1);
+    const addr = vm.mmap.readWord(ip +% 2);
+    vm.mmap.writeByte(addr, imm);
+    return ok;
+}
+
+/// `0x21` — `mov8 Imm8, Reg` → `reg.lo ← imm; reg.hi ← 0`.
+pub fn mov8Imm8Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readByte(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 2);
+    if (!vm.regs.writeByIndex(reg, imm)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x22` — `mov8 Addr, Reg` → `reg.lo ← mem[addr]; reg.hi ← 0`.
+pub fn mov8AddrReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const addr = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const value = vm.mmap.readByte(addr);
+    if (!vm.regs.writeByIndex(reg, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x23` — `mov8 Reg, [Reg]` → `mem[ptr] ← reg.lo` (low byte
+/// store via pointer register).
+pub fn mov8RegPtr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const src = vm.mmap.readByte(ip +% 1);
+    const ptr = vm.mmap.readByte(ip +% 2);
+    const value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
+    // safety: truncating the high half is exactly the spec'd
+    //         "mem[ptr] ← reg.lo" behavior for `mov8`
+    vm.mmap.writeByte(addr, @truncate(value));
+    return ok;
+}
+
+/// `0x24` — `mov8 [Reg], Reg` → `reg.lo ← mem[ptr]; reg.hi ← 0`.
+pub fn mov8PtrReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const ptr = vm.mmap.readByte(ip +% 1);
+    const dst = vm.mmap.readByte(ip +% 2);
+    const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
+    const value = vm.mmap.readByte(addr);
+    if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x25` — `movh Reg, Addr` → `mem[addr] ← reg.hi`.
+pub fn movhRegAddr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const addr = vm.mmap.readWord(ip +% 2);
+    const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    // safety: isolating the high byte is the spec'd "reg.hi" half
+    vm.mmap.writeByte(addr, @truncate(value >> 8));
+    return ok;
+}
+
+/// `0x26` — `movl Reg, Addr` → `mem[addr] ← reg.lo`.
+pub fn movlRegAddr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const addr = vm.mmap.readWord(ip +% 2);
+    const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    // safety: isolating the low byte is the spec'd "reg.lo" half
+    vm.mmap.writeByte(addr, @truncate(value));
+    return ok;
+}

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -85,20 +85,36 @@ test "dispatch: run halts when the IVT is empty" {
     try std.testing.expectEqual(gero.vm.StepResult.halted_on_fault, gero.vm.run(&vm));
 }
 
-test "dispatch: every byte at ip currently faults (Part 1 stub)" {
+test "dispatch: bytes without a handler raise invalid-opcode" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     setVector(&vm, .invalid_opcode, 0x4000);
 
-    // Without a real opcode table, any byte at ip dispatches to the
-    // invalid-opcode fault — that's the Part 1 contract.
-    inline for ([_]u8{ 0x00, 0x10, 0x80, 0xFF }) |op| {
+    // Pick bytes that have no handler yet (gaps in §5 + unimplemented
+    // families): the invalid-opcode fault should fire on each.
+    inline for ([_]u8{ 0x00, 0x40, 0x80, 0xFF }) |op| {
         vm.regs.write(.ip, 0x1100);
         vm.mmap.writeByte(0x1100, op);
-        // Reset sp + flg so each iteration starts clean.
         vm.regs.write(.sp, 0xFFFE);
         vm.regs.write(.flg, 0);
         try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
         try std.testing.expectEqual(@as(u16, 0x4000), vm.regs.read(.ip));
     }
+}
+
+test "dispatch: step auto-advances ip by instruction size" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // 0x91 nop is 1 byte and has no handler yet → faults. Use a
+    // mov instead: 0x11 mov reg, reg is 3 bytes total.
+    vm.regs.write(.ip, 0x1100);
+    vm.mmap.writeByte(0x1100, 0x11);
+    vm.mmap.writeByte(0x1101, 0x02); // dst = r1
+    vm.mmap.writeByte(0x1102, 0x03); // src = r2
+    vm.regs.write(.r2, 0xBEEF);
+
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
+    try std.testing.expectEqual(@as(u16, 0xBEEF), vm.regs.read(.r1));
 }

--- a/tests/vm/handlers/mov.test.zig
+++ b/tests/vm/handlers/mov.test.zig
@@ -1,0 +1,258 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+/// Load a sequence of bytes at `0x1100` and set `ip` there.
+fn loadProgram(vm: *VM, bytes: []const u8) void {
+    vm.regs.write(.ip, 0x1100);
+    for (bytes, 0..) |b, i| {
+        vm.mmap.writeByte(0x1100 + @as(u16, @intCast(i)), b);
+    }
+}
+
+/// Save the flag register, run one step, expect the flag register
+/// stayed identical (mov family must not touch flags).
+fn expectFlagsUnchanged(vm: *VM) !void {
+    const before = vm.regs.read(.flg);
+    _ = gero.vm.step(vm);
+    try std.testing.expectEqual(before, vm.regs.read(.flg));
+}
+
+test "mov 0x10 imm16,reg: writes immediate to register" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    loadProgram(&vm, &.{ 0x10, 0xCD, 0xAB, 0x02 }); // mov 0xABCD → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xABCD), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
+}
+
+test "mov 0x11 reg,reg: copies between registers (dst, src order)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r2, 0xDEAD);
+    loadProgram(&vm, &.{ 0x11, 0x02, 0x03 }); // mov r1, r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xDEAD), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0xDEAD), vm.regs.read(.r2));
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
+}
+
+test "mov 0x12 reg,addr: stores register to memory" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0xCAFE);
+    loadProgram(&vm, &.{ 0x12, 0x02, 0x00, 0x20 }); // mov r1 → mem[0x2000]
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xCAFE), vm.mmap.readWord(0x2000));
+    try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
+}
+
+test "mov 0x13 addr,reg: loads memory into register" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.mmap.writeWord(0x2000, 0xF00D);
+    loadProgram(&vm, &.{ 0x13, 0x00, 0x20, 0x02 }); // mov mem[0x2000] → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xF00D), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
+}
+
+test "mov 0x14 imm16,addr: stores immediate to memory" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    loadProgram(&vm, &.{ 0x14, 0x34, 0x12, 0x00, 0x20 }); // mem[0x2000] = 0x1234
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.mmap.readWord(0x2000));
+    try std.testing.expectEqual(@as(u16, 0x1105), vm.regs.read(.ip));
+}
+
+test "mov 0x15 reg,[reg]: indirect load via pointer register" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r2, 0x3000); // ptr
+    vm.mmap.writeWord(0x3000, 0xBABE);
+    loadProgram(&vm, &.{ 0x15, 0x02, 0x03 }); // r1 ← mem[r2]
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xBABE), vm.regs.read(.r1));
+}
+
+test "mov 0x16 [reg],reg: indirect store via pointer register" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x3000); // ptr
+    vm.regs.write(.r2, 0xFACE);
+    loadProgram(&vm, &.{ 0x16, 0x02, 0x03 }); // mem[r1] ← r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFACE), vm.mmap.readWord(0x3000));
+}
+
+test "mov 0x17 addr,reg,reg: indexed load (base + offset_reg)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x10); // offset
+    vm.mmap.writeWord(0x2010, 0xBEEF);
+    loadProgram(&vm, &.{ 0x17, 0x00, 0x20, 0x02, 0x03 }); // r2 ← mem[0x2000 + r1]
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xBEEF), vm.regs.read(.r2));
+    try std.testing.expectEqual(@as(u16, 0x1105), vm.regs.read(.ip));
+}
+
+test "mov 0x18 imm16,[reg]: imm to memory via pointer register" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x3000);
+    loadProgram(&vm, &.{ 0x18, 0xAA, 0x55, 0x02 }); // mem[r1] ← 0x55AA
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x55AA), vm.mmap.readWord(0x3000));
+}
+
+test "mov 0x19 reg,zp: zero-page store" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x1234);
+    loadProgram(&vm, &.{ 0x19, 0x02, 0x40 }); // mem[0x0040] ← r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.mmap.readWord(0x0040));
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
+}
+
+test "mov 0x1A zp,reg: zero-page load" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.mmap.writeWord(0x0040, 0x5678);
+    loadProgram(&vm, &.{ 0x1A, 0x40, 0x02 }); // r1 ← mem[0x0040]
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5678), vm.regs.read(.r1));
+}
+
+test "mov 0x1B imm16,zp: zero-page immediate store" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    loadProgram(&vm, &.{ 0x1B, 0xCD, 0xAB, 0x80 }); // mem[0x0080] ← 0xABCD
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xABCD), vm.mmap.readWord(0x0080));
+    try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
+}
+
+test "mov8 0x20 imm8,addr: byte store" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    loadProgram(&vm, &.{ 0x20, 0x42, 0x00, 0x20 }); // mem[0x2000] ← 0x42 (byte)
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u8, 0x42), vm.mmap.readByte(0x2000));
+    try std.testing.expectEqual(@as(u8, 0), vm.mmap.readByte(0x2001));
+}
+
+test "mov8 0x21 imm8,reg: byte load zero-extends reg.hi" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0xFFFF); // pre-populated with non-zero high
+    loadProgram(&vm, &.{ 0x21, 0x42, 0x02 }); // r1.lo ← 0x42; r1.hi ← 0
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0042), vm.regs.read(.r1));
+}
+
+test "mov8 0x22 addr,reg: byte load zero-extends reg.hi" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0xFFFF);
+    vm.mmap.writeByte(0x2000, 0x7E);
+    loadProgram(&vm, &.{ 0x22, 0x00, 0x20, 0x02 }); // r1.lo ← mem[0x2000]
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x007E), vm.regs.read(.r1));
+}
+
+test "mov8 0x23 reg,[reg]: byte store via pointer" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0xAB12); // source: only low byte (0x12) gets stored
+    vm.regs.write(.r2, 0x3000); // pointer
+    loadProgram(&vm, &.{ 0x23, 0x02, 0x03 }); // mem[r2] ← r1.lo
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u8, 0x12), vm.mmap.readByte(0x3000));
+    try std.testing.expectEqual(@as(u8, 0), vm.mmap.readByte(0x3001));
+}
+
+test "mov8 0x24 [reg],reg: byte load via pointer zero-extends" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x3000);
+    vm.regs.write(.r2, 0xFFFF);
+    vm.mmap.writeByte(0x3000, 0x99);
+    loadProgram(&vm, &.{ 0x24, 0x02, 0x03 }); // r2.lo ← mem[r1]
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0099), vm.regs.read(.r2));
+}
+
+test "movh 0x25 reg,addr: writes the high byte of reg to memory" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0xAB12);
+    loadProgram(&vm, &.{ 0x25, 0x02, 0x00, 0x20 }); // mem[0x2000] ← r1.hi
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u8, 0xAB), vm.mmap.readByte(0x2000));
+}
+
+test "movl 0x26 reg,addr: writes the low byte of reg to memory" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0xAB12);
+    loadProgram(&vm, &.{ 0x26, 0x02, 0x00, 0x20 }); // mem[0x2000] ← r1.lo
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u8, 0x12), vm.mmap.readByte(0x2000));
+}
+
+test "mov family: no variant touches flags" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0xDEAD);
+    vm.regs.write(.r2, 0x3000);
+    vm.regs.write(.flg, 0x000F);
+
+    // Run a representative variant from each section.
+    for ([_][]const u8{
+        &.{ 0x10, 0x00, 0x00, 0x02 }, // mov imm16,reg
+        &.{ 0x11, 0x02, 0x03 }, // mov reg,reg
+        &.{ 0x12, 0x02, 0x00, 0x20 }, // mov reg,addr
+        &.{ 0x13, 0x00, 0x20, 0x02 }, // mov addr,reg
+        &.{ 0x21, 0x42, 0x02 }, // mov8 imm8,reg
+        &.{ 0x25, 0x02, 0x00, 0x21 }, // movh reg,addr
+    }) |bytes| {
+        loadProgram(&vm, bytes);
+        try expectFlagsUnchanged(&vm);
+    }
+}
+
+test "mov: invalid register index raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // Install an ISR for the invalid-register fault.
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+
+    // mov r1, <out-of-range>
+    loadProgram(&vm, &.{ 0x11, 0x02, 0xFF });
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}


### PR DESCRIPTION
## Summary

First real opcode-family PR. Implements all 19 mov-family handlers from ISA §5.1 + §5.2 and converts dispatch to table-driven.

- `src/vm/handlers/mov.zig` (new): 12 `mov` (`0x10`–`0x1B`) + 5 `mov8` + `movh` + `movl` (`0x20`–`0x26`)
- `dispatch.zig`: gains `handler_table[256]` (defaults to a shared `unimplemented` fault stub) and auto-advances `ip` past the instruction when the handler returns `.cont` without touching `ip`
- Out-of-range register operands → invalid-register fault (vector `0x02`)
- No flags are touched by any mov variant

## Auto-advance contract

A handler returning `.cont` without writing `ip` lets `step` advance by `opcodes.table[op].?.size()`. Branches / calls / fault entry change `ip` themselves and the auto-advance is skipped. Future jmp/call/ret handlers (#25/#26) plug in cleanly without dispatch changes.

## Acceptance (#20)

- [x] Each variant moves bytes/words correctly per spec
- [x] mov8 forms zero-extend `reg.hi` when loading (tests for 0x21/0x22/0x24)
- [x] Indexed addressing (`mov &addr, r1, r2` → r2 = mem[addr + r1]) — test 0x17
- [x] Zero-page addressing uses 1-byte address operand — tests 0x19/0x1A/0x1B
- [x] No flag changes after any mov variant — flag-invariant test runs 6 representative variants
- [x] Mirror tests for every opcode (one per opcode + group invariant)
- [x] All four release modes pass

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 21 new tests in `tests/vm/handlers/mov.test.zig` + 1 updated + 1 new in `dispatch.test.zig` (auto-advance verification)

Closes #20.