### PR TITLE
feat(vm/handlers): stack ops — push / pop (§5.3)

### DIFF
--- a/.changeset/c8f47e21.md
+++ b/.changeset/c8f47e21.md
@@ -1,0 +1,14 @@
+---
+bump: minor
+---
+
+Implement the stack family (ISA §5.3) — `push Imm16` (`0x30`),
+`push Reg` (`0x31`), `pop Reg` (`0x32`). Pre-decrement push,
+post-increment pop, silent wrap on under/overflow per §3.3.
+
+Also fixes `dispatch.pushWord` to use pre-decrement (the existing
+post-decrement implementation conflicted with §3.3 wording).
+Fault entry (`raiseFault`) now lays out `ip` / `fp` / `flg` at
+`sp_boot − 2 / −4 / −6` instead of `sp_boot / −2 / −4`. The
+final `sp` value is unchanged, only the offsets where each pushed
+word lives.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const vm_mod = @import("vm.zig");
 const opcodes = @import("opcodes.zig");
 const mov = @import("handlers/mov.zig");
+const stack_handlers = @import("handlers/stack.zig");
 const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
@@ -82,6 +83,11 @@ pub const handler_table: [256]Handler = blk: {
     t[0x25] = mov.movhRegAddr;
     t[0x26] = mov.movlRegAddr;
 
+    // §5.3 — stack
+    t[0x30] = stack_handlers.pushImm16;
+    t[0x31] = stack_handlers.pushReg;
+    t[0x32] = stack_handlers.popReg;
+
     break :blk t;
 };
 
@@ -132,9 +138,21 @@ pub fn ivtSlot(vector: Vector) u16 {
     return ivt_base + 2 * @as(u16, @intFromEnum(vector));
 }
 
-fn pushWord(vm: *VM, value: u16) void {
-    // Stack grows downward, `sp` always points at the top word.
+/// Push a 16-bit word onto the stack. Pre-decrement convention
+/// (ISA §3.3): `sp -= 2; mem[sp] = value`. Underflow wraps
+/// silently per §3.3 — no fault, the program is responsible.
+pub fn pushWord(vm: *VM, value: u16) void {
+    const new_sp = vm.regs.read(.sp) -% 2;
+    vm.regs.write(.sp, new_sp);
+    vm.mmap.writeWord(new_sp, value);
+}
+
+/// Pop a 16-bit word from the stack. Post-increment convention
+/// (ISA §3.3): `value = mem[sp]; sp += 2`. Overflow wraps
+/// silently.
+pub fn popWord(vm: *VM) u16 {
     const sp = vm.regs.read(.sp);
-    vm.mmap.writeWord(sp, value);
-    vm.regs.write(.sp, sp -% 2);
+    const value = vm.mmap.readWord(sp);
+    vm.regs.write(.sp, sp +% 2);
+    return value;
 }

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -11,13 +11,13 @@ const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
 
-/// Base address of the interrupt vector table (ISA §6.1).
+/// Base address of the interrupt vector table.
 pub const ivt_base: u16 = 0x1000;
 
-/// Interrupt / fault vector. Non-exhaustive: only the reserved
-/// vectors (ISA §6.1 + §9) get named tags, but any `u8` in
-/// `0..0x3F` is a valid vector index — the `int N` opcode can
-/// raise host-defined or software-int vectors that aren't named.
+/// Interrupt / fault vector. Non-exhaustive: the reserved vectors
+/// get named tags, but any `u8` in `0..0x3F` is a valid vector
+/// index — the `int N` opcode can raise host-defined or
+/// software-int vectors that aren't named.
 pub const Vector = enum(u8) {
     /// Reset — runs at boot when the program's entry point is 0.
     reset = 0x00,
@@ -60,7 +60,7 @@ fn unimplemented(vm: *VM) StepResult {
 pub const handler_table: [256]Handler = blk: {
     var t = [_]Handler{unimplemented} ** 256;
 
-    // §5.1 — mov family
+    // mov family
     t[0x10] = mov.movImm16Reg;
     t[0x11] = mov.movRegReg;
     t[0x12] = mov.movRegAddr;
@@ -74,7 +74,7 @@ pub const handler_table: [256]Handler = blk: {
     t[0x1A] = mov.movZpReg;
     t[0x1B] = mov.movImm16Zp;
 
-    // §5.2 — mov8 / movh / movl
+    // mov8 / movh / movl
     t[0x20] = mov.mov8Imm8Addr;
     t[0x21] = mov.mov8Imm8Reg;
     t[0x22] = mov.mov8AddrReg;
@@ -83,7 +83,7 @@ pub const handler_table: [256]Handler = blk: {
     t[0x25] = mov.movhRegAddr;
     t[0x26] = mov.movlRegAddr;
 
-    // §5.3 — stack
+    // stack
     t[0x30] = stack_handlers.pushImm16;
     t[0x31] = stack_handlers.pushReg;
     t[0x32] = stack_handlers.popReg;
@@ -116,9 +116,9 @@ pub fn run(vm: *VM) StepResult {
     }
 }
 
-/// Deliver a fault through the interrupt mechanism (ISA §6.2 + §9).
-/// If the vector slot is `0` the VM halts with a host-visible
-/// fault marker; otherwise the entry sequence pushes `ip` / `fp` /
+/// Deliver a fault through the interrupt mechanism. If the
+/// vector slot is `0` the VM halts with a host-visible fault
+/// marker; otherwise the entry sequence pushes `ip` / `fp` /
 /// `flg`, sets `flg.I`, and jumps to the ISR.
 pub fn raiseFault(vm: *VM, vector: Vector) StepResult {
     const target = vm.mmap.readWord(ivtSlot(vector));
@@ -138,18 +138,17 @@ pub fn ivtSlot(vector: Vector) u16 {
     return ivt_base + 2 * @as(u16, @intFromEnum(vector));
 }
 
-/// Push a 16-bit word onto the stack. Pre-decrement convention
-/// (ISA §3.3): `sp -= 2; mem[sp] = value`. Underflow wraps
-/// silently per §3.3 — no fault, the program is responsible.
+/// Push a 16-bit word onto the stack. Pre-decrement:
+/// `sp -= 2; mem[sp] = value`. Underflow wraps silently — no
+/// fault, the program is responsible.
 pub fn pushWord(vm: *VM, value: u16) void {
     const new_sp = vm.regs.read(.sp) -% 2;
     vm.regs.write(.sp, new_sp);
     vm.mmap.writeWord(new_sp, value);
 }
 
-/// Pop a 16-bit word from the stack. Post-increment convention
-/// (ISA §3.3): `value = mem[sp]; sp += 2`. Overflow wraps
-/// silently.
+/// Pop a 16-bit word from the stack. Post-increment:
+/// `value = mem[sp]; sp += 2`. Overflow wraps silently.
 pub fn popWord(vm: *VM) u16 {
     const sp = vm.regs.read(.sp);
     const value = vm.mmap.readWord(sp);

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -1,7 +1,7 @@
-/// Handlers for the `mov` family (ISA §5.1) and the byte-sized
-/// `mov8` / `movh` / `movl` family (ISA §5.2). None of these
-/// affect flags; ip auto-advances by the instruction size after
-/// the handler returns `.cont`.
+/// Handlers for the `mov` family and the byte-sized `mov8` /
+/// `movh` / `movl` family. None of these affect flags; ip
+/// auto-advances by the instruction size after the handler
+/// returns `.cont`.
 const vm_mod = @import("../vm.zig");
 const dispatch = @import("../dispatch.zig");
 const VM = vm_mod.VM;

--- a/src/vm/handlers/stack.zig
+++ b/src/vm/handlers/stack.zig
@@ -1,0 +1,40 @@
+/// Handlers for the stack family (ISA §5.3). All three ops use
+/// the pre-decrement push / post-increment pop convention from
+/// §3.3, shared with the fault-entry sequence via
+/// `dispatch.pushWord` / `dispatch.popWord`.
+const vm_mod = @import("../vm.zig");
+const dispatch = @import("../dispatch.zig");
+const VM = vm_mod.VM;
+const StepResult = dispatch.StepResult;
+
+const ok = StepResult.cont;
+
+fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
+    return dispatch.raiseFault(vm, vector);
+}
+
+/// `0x30` — `push Imm16` → `sp -= 2; mem[sp] = imm`.
+pub fn pushImm16(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    dispatch.pushWord(vm, imm);
+    return ok;
+}
+
+/// `0x31` — `push Reg` → `sp -= 2; mem[sp] = reg`.
+pub fn pushReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    dispatch.pushWord(vm, value);
+    return ok;
+}
+
+/// `0x32` — `pop Reg` → `reg = mem[sp]; sp += 2`.
+pub fn popReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const value = dispatch.popWord(vm);
+    if (!vm.regs.writeByIndex(reg, value)) return fault(vm, .invalid_register);
+    return ok;
+}

--- a/src/vm/handlers/stack.zig
+++ b/src/vm/handlers/stack.zig
@@ -1,7 +1,7 @@
-/// Handlers for the stack family (ISA §5.3). All three ops use
-/// the pre-decrement push / post-increment pop convention from
-/// §3.3, shared with the fault-entry sequence via
-/// `dispatch.pushWord` / `dispatch.popWord`.
+/// Handlers for the stack family. All three ops use the
+/// pre-decrement push / post-increment pop convention shared
+/// with the fault-entry sequence via `dispatch.pushWord` /
+/// `dispatch.popWord`.
 const vm_mod = @import("../vm.zig");
 const dispatch = @import("../dispatch.zig");
 const VM = vm_mod.VM;

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -1,10 +1,9 @@
 /// Opcode table — the canonical mapping from byte → mnemonic +
-/// operand schema, transcribed from ISA §5. Populated by this PR
-/// as data only; the dispatch loop will start consulting it when
-/// real per-opcode handlers land (issues #20-#27).
+/// operand schema. Dispatch consults this for instruction sizing;
+/// the disassembler can re-use it for textual rendering.
 const std = @import("std");
 
-/// Operand kinds per ISA §4. Encoding sizes:
+/// Operand kinds. Encoding sizes:
 /// `reg`/`imm8`/`zp` = 1 byte, `imm16`/`addr` = 2 bytes.
 pub const Operand = enum {
     reg,
@@ -42,7 +41,7 @@ pub const OpcodeInfo = struct {
 pub const table: [256]?OpcodeInfo = blk: {
     var t = [_]?OpcodeInfo{null} ** 256;
 
-    // §5.1 — mov family (12 entries)
+    // mov family
     t[0x10] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .reg } };
     t[0x11] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg } };
     t[0x12] = .{ .mnemonic = "mov", .operands = &.{ .reg, .addr } };
@@ -56,7 +55,7 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x1A] = .{ .mnemonic = "mov", .operands = &.{ .zp, .reg } };
     t[0x1B] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .zp } };
 
-    // §5.2 — mov8 / movh / movl (7 entries)
+    // mov8 / movh / movl
     t[0x20] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .addr } };
     t[0x21] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .reg } };
     t[0x22] = .{ .mnemonic = "mov8", .operands = &.{ .addr, .reg } };
@@ -65,12 +64,12 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x25] = .{ .mnemonic = "movh", .operands = &.{ .reg, .addr } };
     t[0x26] = .{ .mnemonic = "movl", .operands = &.{ .reg, .addr } };
 
-    // §5.3 — stack (3 entries)
+    // stack
     t[0x30] = .{ .mnemonic = "push", .operands = &.{.imm16} };
     t[0x31] = .{ .mnemonic = "push", .operands = &.{.reg} };
     t[0x32] = .{ .mnemonic = "pop", .operands = &.{.reg} };
 
-    // §5.4 — arithmetic (19 entries: 0x40-0x4E + 0x64-0x67)
+    // arithmetic
     t[0x40] = .{ .mnemonic = "add", .operands = &.{ .imm16, .reg } };
     t[0x41] = .{ .mnemonic = "add", .operands = &.{ .reg, .reg } };
     t[0x42] = .{ .mnemonic = "add", .operands = &.{.reg} };
@@ -91,7 +90,7 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x66] = .{ .mnemonic = "sbc", .operands = &.{ .imm16, .reg } };
     t[0x67] = .{ .mnemonic = "sbc", .operands = &.{ .reg, .reg } };
 
-    // §5.5 — logical (7 entries)
+    // logical
     t[0x50] = .{ .mnemonic = "and", .operands = &.{ .reg, .imm16 } };
     t[0x51] = .{ .mnemonic = "and", .operands = &.{ .reg, .reg } };
     t[0x52] = .{ .mnemonic = "or", .operands = &.{ .reg, .imm16 } };
@@ -100,7 +99,7 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x55] = .{ .mnemonic = "xor", .operands = &.{ .reg, .reg } };
     t[0x56] = .{ .mnemonic = "not", .operands = &.{.reg} };
 
-    // §5.6 — shifts and rotates (8 entries)
+    // shifts and rotates
     t[0x58] = .{ .mnemonic = "shl", .operands = &.{ .reg, .imm8 } };
     t[0x59] = .{ .mnemonic = "shl", .operands = &.{ .reg, .reg } };
     t[0x5A] = .{ .mnemonic = "shr", .operands = &.{ .reg, .imm8 } };
@@ -110,13 +109,13 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x5E] = .{ .mnemonic = "ror", .operands = &.{ .reg, .imm8 } };
     t[0x5F] = .{ .mnemonic = "ror", .operands = &.{ .reg, .reg } };
 
-    // §5.7 — cmp / tst (4 entries)
+    // cmp / tst
     t[0x60] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .imm16 } };
     t[0x61] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .reg } };
     t[0x62] = .{ .mnemonic = "tst", .operands = &.{ .reg, .imm16 } };
     t[0x63] = .{ .mnemonic = "tst", .operands = &.{ .reg, .reg } };
 
-    // §5.8 — control flow (16 entries)
+    // control flow
     t[0x70] = .{ .mnemonic = "jmp", .operands = &.{.addr} };
     t[0x71] = .{ .mnemonic = "jmp", .operands = &.{.reg} };
     t[0x72] = .{ .mnemonic = "jeq", .operands = &.{.addr} };
@@ -134,23 +133,23 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x7E] = .{ .mnemonic = "djnz", .operands = &.{ .reg, .addr } };
     t[0x7F] = .{ .mnemonic = "jr", .operands = &.{.imm8} };
 
-    // §5.9 — subroutines (3 entries)
+    // subroutines
     t[0x80] = .{ .mnemonic = "call", .operands = &.{.addr} };
     t[0x81] = .{ .mnemonic = "call", .operands = &.{.reg} };
     t[0x82] = .{ .mnemonic = "ret", .operands = &.{} };
 
-    // §5.10 — misc (2 entries)
+    // misc
     t[0x90] = .{ .mnemonic = "swap", .operands = &.{ .reg, .reg } };
     t[0x91] = .{ .mnemonic = "nop", .operands = &.{} };
 
-    // §5.11 — flag manipulation (5 entries)
+    // flag manipulation
     t[0xA0] = .{ .mnemonic = "clc", .operands = &.{} };
     t[0xA1] = .{ .mnemonic = "sec", .operands = &.{} };
     t[0xA2] = .{ .mnemonic = "cli", .operands = &.{} };
     t[0xA3] = .{ .mnemonic = "sei", .operands = &.{} };
     t[0xA4] = .{ .mnemonic = "clv", .operands = &.{} };
 
-    // §5.12 — system (4 entries)
+    // system
     t[0xFC] = .{ .mnemonic = "int", .operands = &.{.imm8} };
     t[0xFD] = .{ .mnemonic = "rti", .operands = &.{} };
     t[0xFE] = .{ .mnemonic = "brk", .operands = &.{} };

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -35,9 +35,9 @@ pub const run = dispatch_mod.run;
 pub const raiseFault = dispatch_mod.raiseFault;
 /// Re-export: address of the IVT slot for a given vector.
 pub const ivtSlot = dispatch_mod.ivtSlot;
-/// Re-export: IVT base address (ISA §6.1).
+/// Re-export: IVT base address.
 pub const ivt_base = dispatch_mod.ivt_base;
-/// Re-export: opcode operand kinds (ISA §4).
+/// Re-export: opcode operand kinds.
 pub const Operand = opcodes_mod.Operand;
 /// Re-export: opcode metadata entry.
 pub const OpcodeInfo = opcodes_mod.OpcodeInfo;

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -8,7 +8,7 @@ fn setVector(vm: *VM, vector: Vector, target: u16) void {
     vm.mmap.writeWord(gero.vm.ivtSlot(vector), target);
 }
 
-test "dispatch: ivtSlot follows ISA §6.1 layout" {
+test "dispatch: ivtSlot maps reserved vectors to expected addresses" {
     try std.testing.expectEqual(@as(u16, 0x1000), gero.vm.ivtSlot(.reset));
     try std.testing.expectEqual(@as(u16, 0x1002), gero.vm.ivtSlot(.invalid_opcode));
     try std.testing.expectEqual(@as(u16, 0x1004), gero.vm.ivtSlot(.invalid_register));
@@ -46,9 +46,9 @@ test "dispatch: fault entry pushes ip, fp, flg in spec order" {
 
     _ = gero.vm.step(&vm);
 
-    // Pre-decrement push (ISA §3.3): each push decrements sp by 2
-    // before writing. Starting at sp_boot=0xFFFE, the three pushes
-    // land at 0xFFFC / 0xFFFA / 0xFFF8 (top of stack = flg).
+    // Pre-decrement push: each push decrements sp by 2 before
+    // writing. Starting at sp_boot=0xFFFE, the three pushes land
+    // at 0xFFFC / 0xFFFA / 0xFFF8 (top of stack = flg).
     try std.testing.expectEqual(@as(u16, 0x1234), vm.mmap.readWord(0xFFFC));
     try std.testing.expectEqual(@as(u16, 0xABCD), vm.mmap.readWord(0xFFFA));
     // flg was 0x000F before the push; flg.I is set AFTER the push.
@@ -90,8 +90,8 @@ test "dispatch: bytes without a handler raise invalid-opcode" {
     defer vm.deinit();
     setVector(&vm, .invalid_opcode, 0x4000);
 
-    // Pick bytes that have no handler yet (gaps in §5 + unimplemented
-    // families): the invalid-opcode fault should fire on each.
+    // Pick bytes that have no handler yet: the invalid-opcode
+    // fault should fire on each.
     inline for ([_]u8{ 0x00, 0x40, 0x80, 0xFF }) |op| {
         vm.regs.write(.ip, 0x1100);
         vm.mmap.writeByte(0x1100, op);

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -46,14 +46,14 @@ test "dispatch: fault entry pushes ip, fp, flg in spec order" {
 
     _ = gero.vm.step(&vm);
 
-    // Stack grows downward; first push lands at 0xFFFE (sp_boot),
-    // each subsequent push 2 bytes below. Order per ISA §6.2:
-    // ip → fp → flg (flg ends up on top of stack).
-    try std.testing.expectEqual(@as(u16, 0x1234), vm.mmap.readWord(0xFFFE));
-    try std.testing.expectEqual(@as(u16, 0xABCD), vm.mmap.readWord(0xFFFC));
+    // Pre-decrement push (ISA §3.3): each push decrements sp by 2
+    // before writing. Starting at sp_boot=0xFFFE, the three pushes
+    // land at 0xFFFC / 0xFFFA / 0xFFF8 (top of stack = flg).
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.mmap.readWord(0xFFFC));
+    try std.testing.expectEqual(@as(u16, 0xABCD), vm.mmap.readWord(0xFFFA));
     // flg was 0x000F before the push; flg.I is set AFTER the push.
-    try std.testing.expectEqual(@as(u16, 0x000F), vm.mmap.readWord(0xFFFA));
-    // sp ends up 6 bytes below boot.
+    try std.testing.expectEqual(@as(u16, 0x000F), vm.mmap.readWord(0xFFF8));
+    // sp ends up 6 bytes below boot, pointing at the top (flg).
     try std.testing.expectEqual(@as(u16, 0xFFF8), vm.regs.read(.sp));
 }
 

--- a/tests/vm/handlers/stack.test.zig
+++ b/tests/vm/handlers/stack.test.zig
@@ -1,0 +1,142 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+fn loadProgram(vm: *VM, bytes: []const u8) void {
+    vm.regs.write(.ip, 0x1100);
+    for (bytes, 0..) |b, i| {
+        vm.mmap.writeByte(0x1100 + @as(u16, @intCast(i)), b);
+    }
+}
+
+test "push 0x30 imm16: pre-decrements sp and writes" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    const sp_before = vm.regs.read(.sp);
+    loadProgram(&vm, &.{ 0x30, 0xCD, 0xAB }); // push 0xABCD
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(sp_before -% 2, vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0xABCD), vm.mmap.readWord(sp_before -% 2));
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
+}
+
+test "push 0x31 reg: pre-decrements sp and writes register value" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    const sp_before = vm.regs.read(.sp);
+    vm.regs.write(.r1, 0xDEAD);
+    loadProgram(&vm, &.{ 0x31, 0x02 }); // push r1
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(sp_before -% 2, vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0xDEAD), vm.mmap.readWord(sp_before -% 2));
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+}
+
+test "pop 0x32 reg: reads then post-increments sp" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // Pre-stage a value on the stack via push semantics.
+    const sp_before = vm.regs.read(.sp);
+    vm.regs.write(.sp, sp_before -% 2);
+    vm.mmap.writeWord(sp_before -% 2, 0xBEEF);
+
+    loadProgram(&vm, &.{ 0x32, 0x02 }); // pop r1
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(@as(u16, 0xBEEF), vm.regs.read(.r1));
+    // sp should be back to its original position.
+    try std.testing.expectEqual(sp_before, vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+}
+
+test "stack: push x then pop r round-trips the value" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    loadProgram(&vm, &.{
+        0x30, 0x34, 0x12, // push 0x1234
+        0x32, 0x02, //       pop r1
+    });
+    _ = gero.vm.step(&vm); // push
+    _ = gero.vm.step(&vm); // pop
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.regs.read(.r1));
+    // sp returns to its original boot value after balanced push/pop.
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+}
+
+test "stack: LIFO ordering across multiple pushes and pops" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x1111);
+    vm.regs.write(.r2, 0x2222);
+    vm.regs.write(.r3, 0x3333);
+
+    loadProgram(&vm, &.{
+        0x31, 0x02, // push r1
+        0x31, 0x03, // push r2
+        0x31, 0x04, // push r3
+        0x32, 0x05, // pop r4
+        0x32, 0x06, // pop r5
+        0x32, 0x07, // pop r6
+    });
+    var i: usize = 0;
+    while (i < 6) : (i += 1) _ = gero.vm.step(&vm);
+
+    // Last in, first out.
+    try std.testing.expectEqual(@as(u16, 0x3333), vm.regs.read(.r4));
+    try std.testing.expectEqual(@as(u16, 0x2222), vm.regs.read(.r5));
+    try std.testing.expectEqual(@as(u16, 0x1111), vm.regs.read(.r6));
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+}
+
+test "stack: underflow wraps silently per §3.3 (not a fault)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // Pop with sp = 0xFFFE (boot, empty stack). Reads garbage and
+    // wraps sp upward; this is permissive behavior per the spec,
+    // NOT a fault.
+    loadProgram(&vm, &.{ 0x32, 0x02 }); // pop r1
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.sp));
+}
+
+test "stack: overflow wraps silently per §3.3 (not a fault)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // Drive sp down to 0x0000 then push once more — should wrap to
+    // 0xFFFE without faulting.
+    vm.regs.write(.sp, 0x0000);
+    vm.regs.write(.r1, 0xFACE);
+    loadProgram(&vm, &.{ 0x31, 0x02 }); // push r1
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0xFACE), vm.mmap.readWord(0xFFFE));
+}
+
+test "stack: invalid register on push raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+
+    loadProgram(&vm, &.{ 0x31, 0xFF }); // push <out-of-range>
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}
+
+test "stack: invalid register on pop raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+
+    loadProgram(&vm, &.{ 0x32, 0xFF }); // pop <out-of-range>
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}

--- a/tests/vm/handlers/stack.test.zig
+++ b/tests/vm/handlers/stack.test.zig
@@ -95,19 +95,18 @@ test "stack: LIFO ordering across multiple pushes and pops" {
     try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
 }
 
-test "stack: underflow wraps silently per §3.3 (not a fault)" {
+test "stack: underflow wraps silently (not a fault)" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
-    // Pop with sp = 0xFFFE (boot, empty stack). Reads garbage and
-    // wraps sp upward; this is permissive behavior per the spec,
-    // NOT a fault.
+    // Pop with sp = 0xFFFE (boot, empty stack). Reads garbage
+    // and wraps sp upward; permissive behavior, NOT a fault.
     loadProgram(&vm, &.{ 0x32, 0x02 }); // pop r1
     try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.sp));
 }
 
-test "stack: overflow wraps silently per §3.3 (not a fault)" {
+test "stack: overflow wraps silently (not a fault)" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -48,7 +48,7 @@ test "opcodes: every named entry has a non-empty mnemonic" {
     }
 }
 
-test "opcodes: table sample — mov family (§5.1)" {
+test "opcodes: table sample — mov family" {
     try std.testing.expectEqualStrings("mov", table[0x10].?.mnemonic);
     try std.testing.expectEqualSlices(Operand, &.{ .imm16, .reg }, table[0x10].?.operands);
     try std.testing.expectEqualStrings("mov", table[0x17].?.mnemonic);
@@ -57,7 +57,7 @@ test "opcodes: table sample — mov family (§5.1)" {
     try std.testing.expectEqualSlices(Operand, &.{ .imm16, .zp }, table[0x1B].?.operands);
 }
 
-test "opcodes: table sample — control flow (§5.8)" {
+test "opcodes: table sample — control flow" {
     try std.testing.expectEqualStrings("jmp", table[0x70].?.mnemonic);
     try std.testing.expectEqualSlices(Operand, &.{.addr}, table[0x70].?.operands);
     try std.testing.expectEqualStrings("djnz", table[0x7E].?.mnemonic);
@@ -66,7 +66,7 @@ test "opcodes: table sample — control flow (§5.8)" {
     try std.testing.expectEqualSlices(Operand, &.{.imm8}, table[0x7F].?.operands);
 }
 
-test "opcodes: table sample — system (§5.12)" {
+test "opcodes: table sample — system" {
     try std.testing.expectEqualStrings("hlt", table[0xFF].?.mnemonic);
     try std.testing.expectEqual(@as(usize, 0), table[0xFF].?.operands.len);
     try std.testing.expectEqualStrings("brk", table[0xFE].?.mnemonic);

--- a/tests/vm/registers.test.zig
+++ b/tests/vm/registers.test.zig
@@ -75,7 +75,7 @@ test "flg: setFlag toggles only its target bit" {
     try std.testing.expect(r.flagSet(.negative));
 }
 
-test "flg: layout matches ISA §2.1 (Z=0, N=1, C=2, V=3, I=4)" {
+test "flg: layout — Z=0, N=1, C=2, V=3, I=4" {
     try std.testing.expectEqual(@as(u4, 0), @intFromEnum(Flag.zero));
     try std.testing.expectEqual(@as(u4, 1), @intFromEnum(Flag.negative));
     try std.testing.expectEqual(@as(u4, 2), @intFromEnum(Flag.carry));

--- a/tests/vm/vm.test.zig
+++ b/tests/vm/vm.test.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const gero = @import("gero");
 const VM = gero.vm.VM;
 
-test "vm: init sets boot-state special registers per ISA §8" {
+test "vm: init sets boot-state special registers" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.ip));


### PR DESCRIPTION
## Summary

Three stack opcodes (`0x30` push imm16 / `0x31` push reg / `0x32` pop reg) plus a correctness fix to `dispatch.pushWord` (pre-decrement per §3.3 — the Part 1 implementation was post-decrement which conflicted with the spec).

- New `src/vm/handlers/stack.zig` (3 handlers, ~50 LOC)
- `dispatch.pushWord` / `dispatch.popWord` now both pub, both pre-dec / post-inc, used by fault entry AND user code so the convention is uniform
- Fault entry stack layout updated: `ip` / `fp` / `flg` land at `sp_boot − 2 / −4 / −6` (final `sp` unchanged)

## Acceptance (#21)

- [x] push imm: sp ← sp-2, mem[sp] ← imm
- [x] push reg: sp ← sp-2, mem[sp] ← reg
- [x] pop reg: reg ← mem[sp], sp ← sp+2
- [x] sp wraps silently per §3.3 — underflow and overflow tests both verified
- [x] Round-trip: push x, pop r → r == x
- [x] LIFO ordering across multiple push/pop verified (3-deep)
- [x] All four release modes pass

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 9 tests in `tests/vm/handlers/stack.test.zig` (round-trip, LIFO, underflow wrap, overflow wrap, fault paths)
- [x] `tests/vm/dispatch.test.zig` fault-entry assertion updated to pre-decrement layout

Closes #21.