### PR TITLE
feat(vm/handlers): arithmetic family — 19 handlers

### DIFF
--- a/.changeset/d3a91e87.md
+++ b/.changeset/d3a91e87.md
@@ -1,0 +1,13 @@
+---
+bump: minor
+---
+
+Implement the arithmetic family — 19 new handlers: `add` /
+`sub` / `mul` / `div` / `divs` / `inc` / `dec` / `neg` / `adc` /
+`sbc`. All set `Z` / `N` / `C` / `V` except `inc` / `dec`
+which leave `C` intact so they compose with `adc` / `sbc`
+multi-precision sequences. `mul` produces a 32-bit result
+distributed across `acu:dst`; `div` / `divs` consume `acu:reg`
+as the 32-bit dividend. Division-by-zero faults via vector
+`0x03`; quotient-out-of-range (including `i32 MIN / -1`) faults
+via vector `0x05`.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -7,6 +7,7 @@ const vm_mod = @import("vm.zig");
 const opcodes = @import("opcodes.zig");
 const mov = @import("handlers/mov.zig");
 const stack_handlers = @import("handlers/stack.zig");
+const arith = @import("handlers/arith.zig");
 const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
@@ -87,6 +88,27 @@ pub const handler_table: [256]Handler = blk: {
     t[0x30] = stack_handlers.pushImm16;
     t[0x31] = stack_handlers.pushReg;
     t[0x32] = stack_handlers.popReg;
+
+    // arithmetic
+    t[0x40] = arith.addImm16Reg;
+    t[0x41] = arith.addRegReg;
+    t[0x42] = arith.addRegAcu;
+    t[0x43] = arith.subImm16Reg;
+    t[0x44] = arith.subRegReg;
+    t[0x45] = arith.subRegAcu;
+    t[0x46] = arith.mulImm16Reg;
+    t[0x47] = arith.mulRegReg;
+    t[0x48] = arith.incReg;
+    t[0x49] = arith.decReg;
+    t[0x4A] = arith.negReg;
+    t[0x4B] = arith.divImm16Reg;
+    t[0x4C] = arith.divRegReg;
+    t[0x4D] = arith.divsImm16Reg;
+    t[0x4E] = arith.divsRegReg;
+    t[0x64] = arith.adcImm16Reg;
+    t[0x65] = arith.adcRegReg;
+    t[0x66] = arith.sbcImm16Reg;
+    t[0x67] = arith.sbcRegReg;
 
     break :blk t;
 };

--- a/src/vm/handlers/arith.zig
+++ b/src/vm/handlers/arith.zig
@@ -1,0 +1,356 @@
+/// Handlers for the arithmetic family — add / sub / mul / div /
+/// divs / inc / dec / neg / adc / sbc. All set `Z` / `N` / `C` /
+/// `V` except `inc` / `dec`, which leave `C` intact so they can
+/// be used as counter primitives inside `adc` / `sbc` sequences.
+/// `mul` produces a 32-bit result with the high half in `acu`;
+/// `div` / `divs` consume `acu:reg` as the 32-bit dividend.
+const vm_mod = @import("../vm.zig");
+const dispatch = @import("../dispatch.zig");
+const VM = vm_mod.VM;
+const StepResult = dispatch.StepResult;
+
+const ok = StepResult.cont;
+
+fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
+    return dispatch.raiseFault(vm, vector);
+}
+
+/// Output of an ALU add or sub: the 16-bit truncated result and
+/// the two condition bits the operation would set.
+const AluEffect = struct {
+    result: u16,
+    carry: bool,
+    overflow: bool,
+};
+
+fn addWithCarry(a: u16, b: u16, carry_in: u1) AluEffect {
+    // @as: widen u16 operands to u32 so the sum can't wrap before C-detect
+    const wide: u32 = @as(u32, a) + @as(u32, b) + carry_in;
+    // @as: truncate the wide sum back to u16 (the high bit is carry)
+    const result: u16 = @as(u16, @truncate(wide));
+    const same_sign = ((a ^ b) & 0x8000) == 0;
+    const result_flipped = ((a ^ result) & 0x8000) != 0;
+    return .{
+        .result = result,
+        .carry = wide > 0xFFFF,
+        .overflow = same_sign and result_flipped,
+    };
+}
+
+fn subWithBorrow(a: u16, b: u16, borrow_in: u1) AluEffect {
+    // @as: widen u16 operands to u32 so the wrapping sub keeps the full result
+    const wide: u32 = @as(u32, a) -% @as(u32, b) -% borrow_in;
+    // @as: truncate the wide difference back to u16
+    const result: u16 = @as(u16, @truncate(wide));
+    const diff_sign = ((a ^ b) & 0x8000) != 0;
+    const result_matches_b = ((b ^ result) & 0x8000) == 0;
+    return .{
+        .result = result,
+        // @as: widen both operands to u32 for the borrow comparison
+        .carry = @as(u32, a) < @as(u32, b) +% borrow_in,
+        .overflow = diff_sign and result_matches_b,
+    };
+}
+
+fn setZN(vm: *VM, result: u16) void {
+    vm.regs.setFlag(.zero, result == 0);
+    vm.regs.setFlag(.negative, (result & 0x8000) != 0);
+}
+
+fn writeAddSub(vm: *VM, dst: u8, eff: AluEffect) StepResult {
+    if (!vm.regs.writeByIndex(dst, eff.result)) return fault(vm, .invalid_register);
+    setZN(vm, eff.result);
+    vm.regs.setFlag(.carry, eff.carry);
+    vm.regs.setFlag(.overflow, eff.overflow);
+    return ok;
+}
+
+// ---------- add ----------
+
+/// `0x40` — `add Imm16, Reg` → `reg ← reg + imm`.
+pub fn addImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, reg, addWithCarry(a, imm, 0));
+}
+
+/// `0x41` — `add Reg, Reg` → `dst ← dst + src`.
+pub fn addRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, dst, addWithCarry(a, b, 0));
+}
+
+/// `0x42` — `add Reg` → `acu ← acu + reg` (implicit-acu short form).
+pub fn addRegAcu(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const src = vm.mmap.readByte(ip +% 1);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    const a = vm.regs.read(.acu);
+    const eff = addWithCarry(a, b, 0);
+    vm.regs.write(.acu, eff.result);
+    setZN(vm, eff.result);
+    vm.regs.setFlag(.carry, eff.carry);
+    vm.regs.setFlag(.overflow, eff.overflow);
+    return ok;
+}
+
+// ---------- sub ----------
+
+/// `0x43` — `sub Imm16, Reg` → `reg ← reg - imm`.
+pub fn subImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, reg, subWithBorrow(a, imm, 0));
+}
+
+/// `0x44` — `sub Reg, Reg` → `dst ← dst - src`.
+pub fn subRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, dst, subWithBorrow(a, b, 0));
+}
+
+/// `0x45` — `sub Reg` → `acu ← acu - reg`.
+pub fn subRegAcu(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const src = vm.mmap.readByte(ip +% 1);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    const a = vm.regs.read(.acu);
+    const eff = subWithBorrow(a, b, 0);
+    vm.regs.write(.acu, eff.result);
+    setZN(vm, eff.result);
+    vm.regs.setFlag(.carry, eff.carry);
+    vm.regs.setFlag(.overflow, eff.overflow);
+    return ok;
+}
+
+// ---------- mul ----------
+
+fn doMul(vm: *VM, dst: u8, a: u16, b: u16) StepResult {
+    // @as: widen u16 operands to u32 to retain the full 32-bit product
+    const wide: u32 = @as(u32, a) * @as(u32, b);
+    // @as: split the 32-bit product into two 16-bit halves
+    const low: u16 = @as(u16, @truncate(wide));
+    // @as: high half carries the overflow bits
+    const high: u16 = @as(u16, @truncate(wide >> 16));
+    if (!vm.regs.writeByIndex(dst, low)) return fault(vm, .invalid_register);
+    vm.regs.write(.acu, high);
+    vm.regs.setFlag(.zero, wide == 0);
+    vm.regs.setFlag(.negative, (high & 0x8000) != 0);
+    // Carry + overflow signal that the product didn't fit in 16
+    // bits — the high half is the "extra" portion.
+    vm.regs.setFlag(.carry, high != 0);
+    vm.regs.setFlag(.overflow, high != 0);
+    return ok;
+}
+
+/// `0x46` — `mul Imm16, Reg` → `acu:reg ← reg × imm`.
+pub fn mulImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return doMul(vm, reg, a, imm);
+}
+
+/// `0x47` — `mul Reg, Reg` → `acu:dst ← dst × src`.
+pub fn mulRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return doMul(vm, dst, a, b);
+}
+
+// ---------- inc / dec / neg ----------
+
+/// `0x48` — `inc Reg` → `reg ← reg + 1`. Sets `Z`/`N`/`V`,
+/// leaves `C` intact so the op composes with `adc` sequences.
+pub fn incReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    const eff = addWithCarry(a, 1, 0);
+    if (!vm.regs.writeByIndex(reg, eff.result)) return fault(vm, .invalid_register);
+    setZN(vm, eff.result);
+    vm.regs.setFlag(.overflow, eff.overflow);
+    return ok;
+}
+
+/// `0x49` — `dec Reg` → `reg ← reg - 1`. Same flag policy as `inc`.
+pub fn decReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    const eff = subWithBorrow(a, 1, 0);
+    if (!vm.regs.writeByIndex(reg, eff.result)) return fault(vm, .invalid_register);
+    setZN(vm, eff.result);
+    vm.regs.setFlag(.overflow, eff.overflow);
+    return ok;
+}
+
+/// `0x4A` — `neg Reg` → `reg ← -reg` (twos-complement). Sets
+/// every ALU flag.
+pub fn negReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, reg, subWithBorrow(0, a, 0));
+}
+
+// ---------- div / divs ----------
+
+fn doDiv(vm: *VM, dst: u8, dividend: u32, divisor: u32) StepResult {
+    if (divisor == 0) return fault(vm, .div_by_zero);
+    const quotient = dividend / divisor;
+    if (quotient > 0xFFFF) return fault(vm, .arith_overflow);
+    const remainder = dividend % divisor;
+    // @as: truncate from u32 — guarded by the overflow check above
+    const q16: u16 = @as(u16, @truncate(quotient));
+    // @as: remainder of a u16 divisor always fits in u16
+    const r16: u16 = @as(u16, @truncate(remainder));
+    if (!vm.regs.writeByIndex(dst, q16)) return fault(vm, .invalid_register);
+    vm.regs.write(.acu, r16);
+    setZN(vm, q16);
+    vm.regs.setFlag(.carry, false);
+    vm.regs.setFlag(.overflow, false);
+    return ok;
+}
+
+fn doDivs(vm: *VM, dst: u8, dividend: i32, divisor: i32) StepResult {
+    if (divisor == 0) return fault(vm, .div_by_zero);
+    // i32 MIN / -1 would trap in @divTrunc — handle as overflow
+    // before reaching the builtin.
+    if (divisor == -1 and dividend == -0x80000000) {
+        return fault(vm, .arith_overflow);
+    }
+    const quotient = @divTrunc(dividend, divisor);
+    if (quotient < -0x8000 or quotient > 0x7FFF) return fault(vm, .arith_overflow);
+    const remainder = @rem(dividend, divisor);
+    const q_i16: i16 = @intCast(quotient);
+    // safety: i16 → u16 preserves the twos-complement bit pattern
+    const q16: u16 = @bitCast(q_i16);
+    const r_i16: i16 = @intCast(remainder);
+    // safety: same bit-pattern preservation as the quotient
+    const r16: u16 = @bitCast(r_i16);
+    if (!vm.regs.writeByIndex(dst, q16)) return fault(vm, .invalid_register);
+    vm.regs.write(.acu, r16);
+    setZN(vm, q16);
+    vm.regs.setFlag(.carry, false);
+    vm.regs.setFlag(.overflow, false);
+    return ok;
+}
+
+fn dividend32(vm: *const VM, reg_low: u16) u32 {
+    const high: u32 = vm.regs.read(.acu);
+    const low: u32 = reg_low;
+    return (high << 16) | low;
+}
+
+fn dividend32Signed(vm: *const VM, reg_low: u16) i32 {
+    // safety: u32 → i32 preserves the twos-complement bit pattern
+    return @bitCast(dividend32(vm, reg_low));
+}
+
+/// `0x4B` — `div Imm16, Reg` → unsigned 32÷16: `acu:reg ÷ imm`,
+/// quotient in `reg`, remainder in `acu`.
+pub fn divImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const low = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    const divisor: u32 = imm;
+    return doDiv(vm, reg, dividend32(vm, low), divisor);
+}
+
+/// `0x4C` — `div Reg, Reg` → unsigned 32÷16: `acu:dst ÷ src`.
+pub fn divRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const low = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const src_value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    const divisor: u32 = src_value;
+    return doDiv(vm, dst, dividend32(vm, low), divisor);
+}
+
+/// `0x4D` — `divs Imm16, Reg` → signed 32÷16, same shape as `div`.
+pub fn divsImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const low = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    // safety: u16 immediate → i16 preserves the sign bit for signed division
+    const divisor_i16: i16 = @bitCast(imm);
+    const divisor_signed: i32 = divisor_i16;
+    return doDivs(vm, reg, dividend32Signed(vm, low), divisor_signed);
+}
+
+/// `0x4E` — `divs Reg, Reg` → signed 32÷16.
+pub fn divsRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const low = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const divisor = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    // safety: u16 → i16 preserves the sign bit
+    const divisor_i16: i16 = @bitCast(divisor);
+    const divisor_signed: i32 = divisor_i16;
+    return doDivs(vm, dst, dividend32Signed(vm, low), divisor_signed);
+}
+
+// ---------- adc / sbc ----------
+
+fn carryIn(vm: *const VM) u1 {
+    return if (vm.regs.flagSet(.carry)) 1 else 0;
+}
+
+/// `0x64` — `adc Imm16, Reg` → `reg ← reg + imm + C`.
+pub fn adcImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, reg, addWithCarry(a, imm, carryIn(vm)));
+}
+
+/// `0x65` — `adc Reg, Reg` → `dst ← dst + src + C`.
+pub fn adcRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, dst, addWithCarry(a, b, carryIn(vm)));
+}
+
+/// `0x66` — `sbc Imm16, Reg` → `reg ← reg - imm - C`.
+pub fn sbcImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.mmap.readWord(ip +% 1);
+    const reg = vm.mmap.readByte(ip +% 3);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, reg, subWithBorrow(a, imm, carryIn(vm)));
+}
+
+/// `0x67` — `sbc Reg, Reg` → `dst ← dst - src - C`.
+pub fn sbcRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeAddSub(vm, dst, subWithBorrow(a, b, carryIn(vm)));
+}

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -92,7 +92,7 @@ test "dispatch: bytes without a handler raise invalid-opcode" {
 
     // Pick bytes that have no handler yet: the invalid-opcode
     // fault should fire on each.
-    inline for ([_]u8{ 0x00, 0x40, 0x80, 0xFF }) |op| {
+    inline for ([_]u8{ 0x00, 0x70, 0x80, 0xFF }) |op| {
         vm.regs.write(.ip, 0x1100);
         vm.mmap.writeByte(0x1100, op);
         vm.regs.write(.sp, 0xFFFE);

--- a/tests/vm/handlers/arith.test.zig
+++ b/tests/vm/handlers/arith.test.zig
@@ -1,0 +1,411 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+fn loadProgram(vm: *VM, bytes: []const u8) void {
+    vm.regs.write(.ip, 0x1100);
+    for (bytes, 0..) |b, i| {
+        vm.mmap.writeByte(0x1100 + @as(u16, @intCast(i)), b);
+    }
+}
+
+fn flags(vm: *VM) struct { z: bool, n: bool, c: bool, v: bool } {
+    return .{
+        .z = vm.regs.flagSet(.zero),
+        .n = vm.regs.flagSet(.negative),
+        .c = vm.regs.flagSet(.carry),
+        .v = vm.regs.flagSet(.overflow),
+    };
+}
+
+// ---------- add ----------
+
+test "add 0x40 imm16,reg: simple addition + sets Z=0,N=0,C=0,V=0" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0010);
+    loadProgram(&vm, &.{ 0x40, 0x05, 0x00, 0x02 }); // add 0x0005 → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0015), vm.regs.read(.r1));
+    const f = flags(&vm);
+    try std.testing.expect(!f.z and !f.n and !f.c and !f.v);
+}
+
+test "add 0x40 imm16,reg: unsigned overflow sets C" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFF);
+    loadProgram(&vm, &.{ 0x40, 0x02, 0x00, 0x02 }); // add 2 → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0001), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c);
+}
+
+test "add 0x40 imm16,reg: signed overflow sets V" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x7FFF); // i16 max
+    loadProgram(&vm, &.{ 0x40, 0x01, 0x00, 0x02 }); // add 1 → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x8000), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).v);
+    try std.testing.expect(flags(&vm).n);
+}
+
+test "add 0x40 imm16,reg: zero result sets Z" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFF);
+    loadProgram(&vm, &.{ 0x40, 0x01, 0x00, 0x02 }); // add 1 → r1 (wraps to 0)
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).z);
+    try std.testing.expect(flags(&vm).c);
+}
+
+test "add 0x41 reg,reg" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x100);
+    vm.regs.write(.r2, 0x200);
+    loadProgram(&vm, &.{ 0x41, 0x02, 0x03 }); // add r1, r2 → r1 = r1 + r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x300), vm.regs.read(.r1));
+}
+
+test "add 0x42 reg (implicit acu)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.acu, 0x10);
+    vm.regs.write(.r1, 0x05);
+    loadProgram(&vm, &.{ 0x42, 0x02 }); // add r1 → acu
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x15), vm.regs.read(.acu));
+}
+
+// ---------- sub ----------
+
+test "sub 0x43 imm16,reg: simple subtraction" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0010);
+    loadProgram(&vm, &.{ 0x43, 0x05, 0x00, 0x02 }); // sub 5 → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x000B), vm.regs.read(.r1));
+    try std.testing.expect(!flags(&vm).c);
+}
+
+test "sub 0x43 imm16,reg: borrow sets C" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0001);
+    loadProgram(&vm, &.{ 0x43, 0x02, 0x00, 0x02 }); // sub 2 → r1 (underflows)
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFFFF), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c);
+    try std.testing.expect(flags(&vm).n);
+}
+
+test "sub 0x43 imm16,reg: signed overflow sets V" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x8000); // i16 min
+    loadProgram(&vm, &.{ 0x43, 0x01, 0x00, 0x02 }); // sub 1 → r1 (wraps to 0x7FFF)
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x7FFF), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).v);
+}
+
+test "sub 0x44 reg,reg" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x100);
+    vm.regs.write(.r2, 0x040);
+    loadProgram(&vm, &.{ 0x44, 0x02, 0x03 }); // sub r1, r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0C0), vm.regs.read(.r1));
+}
+
+test "sub 0x45 reg (implicit acu)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.acu, 0x10);
+    vm.regs.write(.r1, 0x03);
+    loadProgram(&vm, &.{ 0x45, 0x02 }); // sub r1 from acu
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0D), vm.regs.read(.acu));
+}
+
+// ---------- mul ----------
+
+test "mul 0x46 imm16,reg: 16x16 producing 32-bit result" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x1000);
+    loadProgram(&vm, &.{ 0x46, 0x00, 0x10, 0x02 }); // mul r1 × 0x1000
+    _ = gero.vm.step(&vm);
+    // 0x1000 * 0x1000 = 0x01000000 → low = 0x0000, high (acu) = 0x0100
+    try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0x0100), vm.regs.read(.acu));
+    try std.testing.expect(flags(&vm).c); // high half non-zero
+    try std.testing.expect(flags(&vm).v);
+    try std.testing.expect(!flags(&vm).z); // overall result is non-zero
+}
+
+test "mul 0x46 imm16,reg: result fits in 16 bits clears C+V" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x10);
+    loadProgram(&vm, &.{ 0x46, 0x05, 0x00, 0x02 }); // 0x10 * 5 = 0x50
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x50), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0x00), vm.regs.read(.acu));
+    try std.testing.expect(!flags(&vm).c);
+    try std.testing.expect(!flags(&vm).v);
+}
+
+test "mul 0x47 reg,reg" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x100);
+    vm.regs.write(.r2, 0x20);
+    loadProgram(&vm, &.{ 0x47, 0x02, 0x03 }); // mul r1 × r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.acu));
+}
+
+// ---------- inc / dec / neg ----------
+
+test "inc 0x48 reg: +1 sets Z/N/V, leaves C intact" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x42);
+    vm.regs.setFlag(.carry, true); // pre-set C — inc must preserve it
+    loadProgram(&vm, &.{ 0x48, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x43), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c); // C preserved
+    try std.testing.expect(!flags(&vm).z);
+}
+
+test "inc 0x48 reg: 0xFFFF → 0 sets Z (and would normally set C, but C is preserved)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFF);
+    vm.regs.setFlag(.carry, false); // pre-clear C
+    loadProgram(&vm, &.{ 0x48, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).z);
+    try std.testing.expect(!flags(&vm).c); // remained clear
+}
+
+test "dec 0x49 reg: -1 with C preserved" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0001);
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x49, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).z);
+    try std.testing.expect(flags(&vm).c); // preserved
+}
+
+test "neg 0x4A reg: twos-complement negate" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0001);
+    loadProgram(&vm, &.{ 0x4A, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFFFF), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).n);
+    try std.testing.expect(flags(&vm).c); // 0 - 1 borrows
+}
+
+test "neg 0x4A reg: negate zero stays zero" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0);
+    loadProgram(&vm, &.{ 0x4A, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).z);
+    try std.testing.expect(!flags(&vm).c);
+}
+
+// ---------- div / divs ----------
+
+test "div 0x4B imm16,reg: 32÷16 unsigned, quotient + remainder" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // dividend = acu:r1 = 0x00010005, divisor = 7 → q = 9362 (0x2492), r = 3
+    vm.regs.write(.acu, 0x0001);
+    vm.regs.write(.r1, 0x0005);
+    loadProgram(&vm, &.{ 0x4B, 0x07, 0x00, 0x02 }); // div 7 → r1
+    _ = gero.vm.step(&vm);
+    const expected_q: u16 = @truncate(@as(u32, 0x00010005) / 7);
+    const expected_r: u16 = @truncate(@as(u32, 0x00010005) % 7);
+    try std.testing.expectEqual(expected_q, vm.regs.read(.r1));
+    try std.testing.expectEqual(expected_r, vm.regs.read(.acu));
+    try std.testing.expect(!flags(&vm).c);
+    try std.testing.expect(!flags(&vm).v);
+}
+
+test "div 0x4B imm16,reg: divisor 0 faults via vector 0x03" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.div_by_zero), 0x3000);
+    vm.regs.write(.r1, 100);
+    loadProgram(&vm, &.{ 0x4B, 0x00, 0x00, 0x02 }); // div 0 → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
+}
+
+test "div 0x4B imm16,reg: quotient overflow faults via vector 0x05" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.arith_overflow), 0x4000);
+    // dividend = 0xFFFF0000, divisor = 1 → quotient = 0xFFFF0000 > 0xFFFF
+    vm.regs.write(.acu, 0xFFFF);
+    vm.regs.write(.r1, 0x0000);
+    loadProgram(&vm, &.{ 0x4B, 0x01, 0x00, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x4000), vm.regs.read(.ip));
+}
+
+test "div 0x4C reg,reg" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.acu, 0);
+    vm.regs.write(.r1, 100);
+    vm.regs.write(.r2, 7);
+    loadProgram(&vm, &.{ 0x4C, 0x02, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 14), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 2), vm.regs.read(.acu));
+}
+
+test "divs 0x4D imm16,reg: -10 / 3 = -3, remainder -1" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // dividend = signed -10 in acu:r1 (sign-extended). For 32-bit
+    // signed -10, acu = 0xFFFF, r1 = 0xFFF6.
+    vm.regs.write(.acu, 0xFFFF);
+    vm.regs.write(.r1, 0xFFF6);
+    loadProgram(&vm, &.{ 0x4D, 0x03, 0x00, 0x02 }); // divs 3 → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFFFD), vm.regs.read(.r1)); // -3
+    try std.testing.expectEqual(@as(u16, 0xFFFF), vm.regs.read(.acu)); // -1
+}
+
+test "divs 0x4E reg,reg" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // dividend = signed -10 = 0xFFFFFFF6, split as acu=0xFFFF / r1=0xFFF6.
+    vm.regs.write(.acu, 0xFFFF);
+    vm.regs.write(.r1, 0xFFF6);
+    vm.regs.write(.r2, 3);
+    loadProgram(&vm, &.{ 0x4E, 0x02, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFFFD), vm.regs.read(.r1)); // -3
+}
+
+test "divs 0x4D imm16,reg: i32 MIN / -1 faults via vector 0x05" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.arith_overflow), 0x4000);
+    // dividend = i32 MIN = 0x80000000 → acu=0x8000, r1=0x0000. divisor = -1.
+    vm.regs.write(.acu, 0x8000);
+    vm.regs.write(.r1, 0x0000);
+    loadProgram(&vm, &.{ 0x4D, 0xFF, 0xFF, 0x02 }); // divs -1 → r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x4000), vm.regs.read(.ip));
+}
+
+test "divs 0x4D imm16,reg: quotient outside i16 range faults via vector 0x05" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.arith_overflow), 0x4000);
+    // dividend = 0x10000000 (positive), divisor = 2 → quotient = 0x08000000.
+    // i16 max is 0x7FFF, so this overflows.
+    vm.regs.write(.acu, 0x1000);
+    vm.regs.write(.r1, 0x0000);
+    loadProgram(&vm, &.{ 0x4D, 0x02, 0x00, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x4000), vm.regs.read(.ip));
+}
+
+// ---------- adc / sbc ----------
+
+test "adc 0x64 imm16,reg: 32-bit add via low + adc high" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // Add 0x0001FFFF + 0x00010002 = 0x00030001. Low halves: 0xFFFF +
+    // 0x0002 = 0x0001 + carry. High halves: 0x0001 + 0x0001 + C(=1)
+    // = 0x0003.
+    vm.regs.write(.r1, 0xFFFF); // low half of first operand
+    vm.regs.write(.r2, 0x0001); // high half of first operand
+    // add r1, 0x0002 — sets C.
+    loadProgram(&vm, &.{ 0x40, 0x02, 0x00, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(flags(&vm).c);
+    try std.testing.expectEqual(@as(u16, 0x0001), vm.regs.read(.r1));
+
+    // adc r2, 0x0001 — uses C from above.
+    loadProgram(&vm, &.{ 0x64, 0x01, 0x00, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0003), vm.regs.read(.r2));
+}
+
+test "adc 0x65 reg,reg with carry-in" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x10);
+    vm.regs.write(.r2, 0x05);
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x65, 0x02, 0x03 }); // adc r1, r2 (with C=1)
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x16), vm.regs.read(.r1));
+}
+
+test "sbc 0x66 imm16,reg: 32-bit sub via sub low + sbc high" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // 0x00030000 - 0x00010001 = 0x0001FFFF. Low: 0x0000 - 0x0001 =
+    // 0xFFFF + borrow. High: 0x0003 - 0x0001 - C(=1) = 0x0001.
+    vm.regs.write(.r1, 0x0000);
+    vm.regs.write(.r2, 0x0003);
+    loadProgram(&vm, &.{ 0x43, 0x01, 0x00, 0x02 }); // sub r1, 0x0001 → borrow
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(flags(&vm).c);
+    try std.testing.expectEqual(@as(u16, 0xFFFF), vm.regs.read(.r1));
+
+    loadProgram(&vm, &.{ 0x66, 0x01, 0x00, 0x03 }); // sbc r2, 0x0001 (uses C)
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0001), vm.regs.read(.r2));
+}
+
+test "sbc 0x67 reg,reg with borrow-in" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x10);
+    vm.regs.write(.r2, 0x05);
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x67, 0x02, 0x03 }); // sbc r1, r2 (with C=1)
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0A), vm.regs.read(.r1));
+}
+
+// ---------- fault paths ----------
+
+test "arith: invalid register on add raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+
+    loadProgram(&vm, &.{ 0x41, 0x02, 0xFF }); // add r1, <out-of-range>
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}


### PR DESCRIPTION
## Summary

19 arithmetic opcodes: `add` / `sub` / `mul` / `div` / `divs` / `inc` / `dec` / `neg` / `adc` / `sbc`.

- Shared ALU helpers `addWithCarry` / `subWithBorrow` produce `{ result, carry, overflow }` so `adc` / `sbc` reuse the same code path as `add` / `sub` with `C` plumbed through
- `mul`: u16 × u16 → u32, low half in `dst`, high in `acu`; sets `C` / `V` when the result doesn't fit in 16 bits
- `div` / `divs`: 32÷16 with `acu:reg` as the 32-bit dividend; quotient in `dst`, remainder in `acu`. Faults: divide-by-zero (vector `0x03`), quotient-out-of-range including the `i32 MIN / -1` trap case (vector `0x05`)
- `inc` / `dec` leave `C` intact — keeps them safe inside `adc` / `sbc` loops
- `neg` is `0 - reg`; sets every ALU flag

## Acceptance (#22)

- [x] Each op produces correct result for documented ranges
- [x] Flags verified per op (Z/N/C/V)
- [x] `mul` 32-bit result correctly split across `acu:dst`
- [x] `div` quotient in `dst`, remainder in `acu`
- [x] `divs` signed with proper sign extension
- [x] `/0` → vector `0x03`; overflow → vector `0x05` (both unsigned & signed)
- [x] `adc` / `sbc` 32-bit multi-precision verified
- [x] `inc` / `dec` leave `C` intact (pre-set + post-check)
- [x] All four release modes pass

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 29 tests in `tests/vm/handlers/arith.test.zig` (semantics + flag matrix + fault paths + multi-precision sequences)

Closes #22.