### PR TITLE
feat(vm/handlers): logical + shifts + rotates — 15 handlers

### DIFF
--- a/.changeset/b5e91f3a.md
+++ b/.changeset/b5e91f3a.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+Implement the logical + shift + rotate families (15 new handlers
+in `src/vm/handlers/bitwise.zig`). Logical ops (`and` / `or` /
+`xor` / `not`) set `Z` / `N` and clear `C` / `V`. Shifts (`shl` /
+`shr`) set `Z` / `N` from the result and put the last bit shifted
+out in `C` (unchanged when count = 0). Rotates (`rol` / `ror`)
+cycle bits through `C` — a 17-bit chain that's full-cycled by
+count multiples of 17.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -8,6 +8,7 @@ const opcodes = @import("opcodes.zig");
 const mov = @import("handlers/mov.zig");
 const stack_handlers = @import("handlers/stack.zig");
 const arith = @import("handlers/arith.zig");
+const bitwise = @import("handlers/bitwise.zig");
 const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
@@ -109,6 +110,25 @@ pub const handler_table: [256]Handler = blk: {
     t[0x65] = arith.adcRegReg;
     t[0x66] = arith.sbcImm16Reg;
     t[0x67] = arith.sbcRegReg;
+
+    // logical
+    t[0x50] = bitwise.andRegImm16;
+    t[0x51] = bitwise.andRegReg;
+    t[0x52] = bitwise.orRegImm16;
+    t[0x53] = bitwise.orRegReg;
+    t[0x54] = bitwise.xorRegImm16;
+    t[0x55] = bitwise.xorRegReg;
+    t[0x56] = bitwise.notReg;
+
+    // shifts and rotates
+    t[0x58] = bitwise.shlRegImm8;
+    t[0x59] = bitwise.shlRegReg;
+    t[0x5A] = bitwise.shrRegImm8;
+    t[0x5B] = bitwise.shrRegReg;
+    t[0x5C] = bitwise.rolRegImm8;
+    t[0x5D] = bitwise.rolRegReg;
+    t[0x5E] = bitwise.rorRegImm8;
+    t[0x5F] = bitwise.rorRegReg;
 
     break :blk t;
 };

--- a/src/vm/handlers/bitwise.zig
+++ b/src/vm/handlers/bitwise.zig
@@ -1,0 +1,258 @@
+/// Handlers for the logical (`and` / `or` / `xor` / `not`) and
+/// shift / rotate (`shl` / `shr` / `rol` / `ror`) families.
+///
+/// Flag policy:
+///   - Logical: set `Z` / `N`; clear `C` / `V`.
+///   - Shifts:  set `Z` / `N` from result; `C` ← last bit shifted
+///              out (unchanged when count = 0); `V` cleared.
+///   - Rotates: bits cycle through `C` (17-bit chain — 16 reg
+///              bits + 1 carry); `Z` / `N` from result; `V` cleared.
+const vm_mod = @import("../vm.zig");
+const dispatch = @import("../dispatch.zig");
+const VM = vm_mod.VM;
+const StepResult = dispatch.StepResult;
+
+const ok = StepResult.cont;
+
+fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
+    return dispatch.raiseFault(vm, vector);
+}
+
+fn setZN(vm: *VM, result: u16) void {
+    vm.regs.setFlag(.zero, result == 0);
+    vm.regs.setFlag(.negative, (result & 0x8000) != 0);
+}
+
+fn writeLogical(vm: *VM, dst: u8, result: u16) StepResult {
+    if (!vm.regs.writeByIndex(dst, result)) return fault(vm, .invalid_register);
+    setZN(vm, result);
+    vm.regs.setFlag(.carry, false);
+    vm.regs.setFlag(.overflow, false);
+    return ok;
+}
+
+// ---------- and / or / xor / not ----------
+
+/// `0x50` — `and Reg, Imm16` → `reg ← reg & imm`.
+pub fn andRegImm16(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const imm = vm.mmap.readWord(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeLogical(vm, reg, a & imm);
+}
+
+/// `0x51` — `and Reg, Reg` → `dst ← dst & src`.
+pub fn andRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeLogical(vm, dst, a & b);
+}
+
+/// `0x52` — `or Reg, Imm16` → `reg ← reg | imm`.
+pub fn orRegImm16(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const imm = vm.mmap.readWord(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeLogical(vm, reg, a | imm);
+}
+
+/// `0x53` — `or Reg, Reg` → `dst ← dst | src`.
+pub fn orRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeLogical(vm, dst, a | b);
+}
+
+/// `0x54` — `xor Reg, Imm16` → `reg ← reg ^ imm`.
+pub fn xorRegImm16(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const imm = vm.mmap.readWord(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeLogical(vm, reg, a ^ imm);
+}
+
+/// `0x55` — `xor Reg, Reg` → `dst ← dst ^ src`.
+pub fn xorRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeLogical(vm, dst, a ^ b);
+}
+
+/// `0x56` — `not Reg` → `reg ← ~reg`.
+pub fn notReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeLogical(vm, reg, ~a);
+}
+
+// ---------- shifts ----------
+
+const ShiftEffect = struct { result: u16, last_out: bool };
+
+fn doShl(initial: u16, count: u16) ShiftEffect {
+    var v = initial;
+    var c: bool = false;
+    var i: u16 = 0;
+    while (i < count) : (i += 1) {
+        c = (v & 0x8000) != 0;
+        v = v *% 2;
+        // Once value reaches zero with no bit-out, further iterations
+        // are no-ops — bail to keep large counts cheap.
+        if (v == 0 and !c) break;
+    }
+    return .{ .result = v, .last_out = c };
+}
+
+fn doShr(initial: u16, count: u16) ShiftEffect {
+    var v = initial;
+    var c: bool = false;
+    var i: u16 = 0;
+    while (i < count) : (i += 1) {
+        c = (v & 1) != 0;
+        v = v >> 1;
+        if (v == 0 and !c) break;
+    }
+    return .{ .result = v, .last_out = c };
+}
+
+fn writeShift(vm: *VM, dst: u8, count: u16, eff: ShiftEffect) StepResult {
+    if (!vm.regs.writeByIndex(dst, eff.result)) return fault(vm, .invalid_register);
+    setZN(vm, eff.result);
+    // C unchanged on no-op shift; otherwise reflects the last bit out.
+    if (count != 0) vm.regs.setFlag(.carry, eff.last_out);
+    vm.regs.setFlag(.overflow, false);
+    return ok;
+}
+
+/// `0x58` — `shl Reg, Imm8` → `reg ← reg << imm`.
+pub fn shlRegImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const count = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeShift(vm, reg, count, doShl(a, count));
+}
+
+/// `0x59` — `shl Reg, Reg` → `dst ← dst << src` (count taken from src).
+pub fn shlRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeShift(vm, dst, count, doShl(a, count));
+}
+
+/// `0x5A` — `shr Reg, Imm8` → `reg ← reg >> imm` (logical, zero-fill).
+pub fn shrRegImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const count = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeShift(vm, reg, count, doShr(a, count));
+}
+
+/// `0x5B` — `shr Reg, Reg`.
+pub fn shrRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeShift(vm, dst, count, doShr(a, count));
+}
+
+// ---------- rotates ----------
+
+fn doRol(initial: u16, count_in: u16, carry_in: bool) ShiftEffect {
+    // 17-bit chain (16 reg bits + 1 carry slot) cycles back to the
+    // start every 17 rotations — modulo first to keep cost bounded.
+    var v = initial;
+    var c = carry_in;
+    const count = count_in % 17;
+    var i: u16 = 0;
+    while (i < count) : (i += 1) {
+        const next_c = (v & 0x8000) != 0;
+        const carry_bit: u16 = if (c) 1 else 0;
+        v = (v *% 2) | carry_bit;
+        c = next_c;
+    }
+    return .{ .result = v, .last_out = c };
+}
+
+fn doRor(initial: u16, count_in: u16, carry_in: bool) ShiftEffect {
+    var v = initial;
+    var c = carry_in;
+    const count = count_in % 17;
+    var i: u16 = 0;
+    while (i < count) : (i += 1) {
+        const next_c = (v & 1) != 0;
+        const carry_bit: u16 = if (c) 0x8000 else 0;
+        v = (v >> 1) | carry_bit;
+        c = next_c;
+    }
+    return .{ .result = v, .last_out = c };
+}
+
+fn writeRotate(vm: *VM, dst: u8, count: u16, eff: ShiftEffect) StepResult {
+    if (!vm.regs.writeByIndex(dst, eff.result)) return fault(vm, .invalid_register);
+    setZN(vm, eff.result);
+    if (count % 17 != 0) vm.regs.setFlag(.carry, eff.last_out);
+    vm.regs.setFlag(.overflow, false);
+    return ok;
+}
+
+/// `0x5C` — `rol Reg, Imm8` → rotate left through carry.
+pub fn rolRegImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const count = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    const c_in = vm.regs.flagSet(.carry);
+    return writeRotate(vm, reg, count, doRol(a, count, c_in));
+}
+
+/// `0x5D` — `rol Reg, Reg` (count from src register).
+pub fn rolRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    const c_in = vm.regs.flagSet(.carry);
+    return writeRotate(vm, dst, count, doRol(a, count, c_in));
+}
+
+/// `0x5E` — `ror Reg, Imm8` → rotate right through carry.
+pub fn rorRegImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const count = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    const c_in = vm.regs.flagSet(.carry);
+    return writeRotate(vm, reg, count, doRor(a, count, c_in));
+}
+
+/// `0x5F` — `ror Reg, Reg`.
+pub fn rorRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    const c_in = vm.regs.flagSet(.carry);
+    return writeRotate(vm, dst, count, doRor(a, count, c_in));
+}

--- a/tests/vm/handlers/bitwise.test.zig
+++ b/tests/vm/handlers/bitwise.test.zig
@@ -1,0 +1,275 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+fn loadProgram(vm: *VM, bytes: []const u8) void {
+    vm.regs.write(.ip, 0x1100);
+    for (bytes, 0..) |b, i| {
+        vm.mmap.writeByte(0x1100 + @as(u16, @intCast(i)), b);
+    }
+}
+
+fn flags(vm: *VM) struct { z: bool, n: bool, c: bool, v: bool } {
+    return .{
+        .z = vm.regs.flagSet(.zero),
+        .n = vm.regs.flagSet(.negative),
+        .c = vm.regs.flagSet(.carry),
+        .v = vm.regs.flagSet(.overflow),
+    };
+}
+
+// ---------- and ----------
+
+test "and 0x50 reg,imm16" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFF0F);
+    loadProgram(&vm, &.{ 0x50, 0x02, 0xF0, 0x00 }); // and r1, 0x00F0
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.r1));
+    const f = flags(&vm);
+    try std.testing.expect(f.z and !f.n and !f.c and !f.v);
+}
+
+test "and 0x50: high bit set marks N" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFF);
+    loadProgram(&vm, &.{ 0x50, 0x02, 0x00, 0x80 }); // and r1, 0x8000
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x8000), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).n);
+}
+
+test "and 0x51 reg,reg clears C+V even if preset" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFF00);
+    vm.regs.write(.r2, 0xFF0F);
+    vm.regs.setFlag(.carry, true);
+    vm.regs.setFlag(.overflow, true);
+    loadProgram(&vm, &.{ 0x51, 0x02, 0x03 }); // and r1, r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFF00), vm.regs.read(.r1));
+    try std.testing.expect(!flags(&vm).c);
+    try std.testing.expect(!flags(&vm).v);
+}
+
+// ---------- or ----------
+
+test "or 0x52 reg,imm16" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x000F);
+    loadProgram(&vm, &.{ 0x52, 0x02, 0xF0, 0x00 }); // or r1, 0x00F0
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x00FF), vm.regs.read(.r1));
+}
+
+test "or 0x53 reg,reg" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xF000);
+    vm.regs.write(.r2, 0x000F);
+    loadProgram(&vm, &.{ 0x53, 0x02, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xF00F), vm.regs.read(.r1));
+}
+
+// ---------- xor ----------
+
+test "xor 0x54 reg,imm16" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xAAAA);
+    loadProgram(&vm, &.{ 0x54, 0x02, 0xFF, 0xFF }); // xor r1, 0xFFFF (= not)
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5555), vm.regs.read(.r1));
+}
+
+test "xor 0x55 reg,reg: self-xor zeroes the register" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xCAFE);
+    loadProgram(&vm, &.{ 0x55, 0x02, 0x02 }); // xor r1, r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).z);
+}
+
+// ---------- not ----------
+
+test "not 0x56 reg: bitwise complement" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xAAAA);
+    loadProgram(&vm, &.{ 0x56, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5555), vm.regs.read(.r1));
+}
+
+// ---------- shl ----------
+
+test "shl 0x58 reg,imm8: simple left shift, C from last bit out" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x4001); // bit 14 set, bit 0 set
+    loadProgram(&vm, &.{ 0x58, 0x02, 0x02 }); // shl r1, 2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0004), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c); // last bit out was bit 14 = 1
+}
+
+test "shl 0x58 reg,imm8: count 0 preserves C" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x1234);
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x58, 0x02, 0x00 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c); // unchanged
+}
+
+test "shl 0x58: count >= 16 zeroes the result and clears C" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x00FF);
+    loadProgram(&vm, &.{ 0x58, 0x02, 0x14 }); // shl r1, 20
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).z);
+    try std.testing.expect(!flags(&vm).c);
+}
+
+test "shl 0x59 reg,reg: count from src" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0008);
+    vm.regs.write(.r2, 0x0003);
+    loadProgram(&vm, &.{ 0x59, 0x02, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0040), vm.regs.read(.r1));
+}
+
+// ---------- shr ----------
+
+test "shr 0x5A reg,imm8: logical right shift, zero-fills high bit" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x8003);
+    loadProgram(&vm, &.{ 0x5A, 0x02, 0x02 }); // shr r1, 2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c); // last bit out was bit 1 (set)
+}
+
+test "shr 0x5A: count 0 preserves C" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x1234);
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x5A, 0x02, 0x00 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c);
+}
+
+test "shr 0x5B reg,reg: count from src" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0080);
+    vm.regs.write(.r2, 0x0004);
+    loadProgram(&vm, &.{ 0x5B, 0x02, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0008), vm.regs.read(.r1));
+}
+
+// ---------- rol ----------
+
+test "rol 0x5C reg,imm8: rotate left through carry, count 1" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x8001);
+    vm.regs.setFlag(.carry, false);
+    loadProgram(&vm, &.{ 0x5C, 0x02, 0x01 }); // rol r1, 1
+    _ = gero.vm.step(&vm);
+    // bit 15 (1) → C; old C (0) → bit 0 of result; rest shifts left.
+    try std.testing.expectEqual(@as(u16, 0x0002), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c);
+}
+
+test "rol 0x5C: rotation preserves all bits through 17-bit chain" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xABCD);
+    vm.regs.setFlag(.carry, false);
+    // 17 rotations completes a full cycle → register + C back to start.
+    loadProgram(&vm, &.{ 0x5C, 0x02, 0x11 }); // rol r1, 17
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xABCD), vm.regs.read(.r1));
+    try std.testing.expect(!flags(&vm).c);
+}
+
+test "rol 0x5D reg,reg" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x8000);
+    vm.regs.write(.r2, 0x0001);
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x5D, 0x02, 0x03 });
+    _ = gero.vm.step(&vm);
+    // bit 15 → C, old C(=1) → bit 0
+    try std.testing.expectEqual(@as(u16, 0x0001), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c);
+}
+
+// ---------- ror ----------
+
+test "ror 0x5E reg,imm8: rotate right through carry" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0001);
+    vm.regs.setFlag(.carry, false);
+    loadProgram(&vm, &.{ 0x5E, 0x02, 0x01 });
+    _ = gero.vm.step(&vm);
+    // bit 0 → C; old C (0) → bit 15.
+    try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c);
+}
+
+test "ror 0x5E: carry-in feeds into bit 15" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0002);
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x5E, 0x02, 0x01 });
+    _ = gero.vm.step(&vm);
+    // bit 0 (0) → C; old C (1) → bit 15.
+    try std.testing.expectEqual(@as(u16, 0x8001), vm.regs.read(.r1));
+    try std.testing.expect(!flags(&vm).c);
+}
+
+test "ror 0x5F reg,reg: count 17 is a full cycle" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xCAFE);
+    vm.regs.write(.r2, 0x0011); // 17
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x5F, 0x02, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xCAFE), vm.regs.read(.r1));
+    try std.testing.expect(flags(&vm).c); // unchanged after full cycle
+}
+
+// ---------- fault paths ----------
+
+test "logical: invalid register raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+
+    loadProgram(&vm, &.{ 0x51, 0x02, 0xFF }); // and r1, <out-of-range>
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}


### PR DESCRIPTION
## Summary

15 new handlers (`and` / `or` / `xor` / `not` / `shl` / `shr` / `rol` / `ror`) in `src/vm/handlers/bitwise.zig`.

- **Logical**: set `Z` / `N`; clear `C` / `V`
- **Shifts**: set `Z` / `N` from result; `C` ← last bit shifted out (preserved when count = 0)
- **Rotates**: bits cycle through `C` (17-bit chain — 16 reg bits + 1 carry slot). Count taken modulo 17 so a full cycle leaves the register and `C` unchanged

The shift loops early-exit once the register drains to 0 with no pending carry, keeping large `Imm8` counts cheap.

## Acceptance (#23)

- [x] `and` / `or` / `xor` / `not` — boolean correctness + flag setting verified
- [x] `shl` / `shr` — bit shifted out lands in `C` (small + count-0 + count-≥16 cases)
- [x] `rol` / `ror` — 17-bit chain verified by rotating 17 times returning to the original value
- [x] All four release modes pass

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 22 tests in `tests/vm/handlers/bitwise.test.zig` covering semantics, edge counts, flag policy, and the fault path

Closes #23.