### PR TITLE
feat(vm/handlers): cmp / tst — flag-only compare + bit-test

### DIFF
--- a/.changeset/e472a8d1.md
+++ b/.changeset/e472a8d1.md
@@ -1,0 +1,9 @@
+---
+bump: minor
+---
+
+Implement the compare / test family — 4 flag-only handlers in
+`src/vm/handlers/cmp.zig`. `cmp` mirrors `sub` for the Z / N /
+C / V flag computation; `tst` mirrors `and` (Z / N from the
+result, clear C / V). Both discard the computed result; the
+register is never written.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -9,6 +9,7 @@ const mov = @import("handlers/mov.zig");
 const stack_handlers = @import("handlers/stack.zig");
 const arith = @import("handlers/arith.zig");
 const bitwise = @import("handlers/bitwise.zig");
+const cmp_handlers = @import("handlers/cmp.zig");
 const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
@@ -129,6 +130,12 @@ pub const handler_table: [256]Handler = blk: {
     t[0x5D] = bitwise.rolRegReg;
     t[0x5E] = bitwise.rorRegImm8;
     t[0x5F] = bitwise.rorRegReg;
+
+    // cmp / tst
+    t[0x60] = cmp_handlers.cmpRegImm16;
+    t[0x61] = cmp_handlers.cmpRegReg;
+    t[0x62] = cmp_handlers.tstRegImm16;
+    t[0x63] = cmp_handlers.tstRegReg;
 
     break :blk t;
 };

--- a/src/vm/handlers/cmp.zig
+++ b/src/vm/handlers/cmp.zig
@@ -1,0 +1,78 @@
+/// Handlers for `cmp` and `tst` — flag-only ops that discard
+/// the computed result. `cmp` mirrors `sub` (sets `Z` / `N` /
+/// `C` / `V`); `tst` mirrors `and` (sets `Z` / `N`, clears
+/// `C` / `V`).
+const vm_mod = @import("../vm.zig");
+const dispatch = @import("../dispatch.zig");
+const VM = vm_mod.VM;
+const StepResult = dispatch.StepResult;
+
+const ok = StepResult.cont;
+
+fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
+    return dispatch.raiseFault(vm, vector);
+}
+
+fn setSubFlags(vm: *VM, a: u16, b: u16) void {
+    // @as: widen u16 operands to u32 so the wrapping sub keeps the full result
+    const wide: u32 = @as(u32, a) -% @as(u32, b);
+    // @as: truncate the wide difference back to u16 for sign / zero checks
+    const result: u16 = @as(u16, @truncate(wide));
+    vm.regs.setFlag(.zero, result == 0);
+    vm.regs.setFlag(.negative, (result & 0x8000) != 0);
+    vm.regs.setFlag(.carry, a < b);
+    const diff_sign = ((a ^ b) & 0x8000) != 0;
+    const result_matches_b = ((b ^ result) & 0x8000) == 0;
+    vm.regs.setFlag(.overflow, diff_sign and result_matches_b);
+}
+
+fn setAndFlags(vm: *VM, a: u16, b: u16) void {
+    const result = a & b;
+    vm.regs.setFlag(.zero, result == 0);
+    vm.regs.setFlag(.negative, (result & 0x8000) != 0);
+    vm.regs.setFlag(.carry, false);
+    vm.regs.setFlag(.overflow, false);
+}
+
+/// `0x60` — `cmp Reg, Imm16` → set flags from `reg - imm`,
+/// discard the result.
+pub fn cmpRegImm16(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const imm = vm.mmap.readWord(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    setSubFlags(vm, a, imm);
+    return ok;
+}
+
+/// `0x61` — `cmp Reg, Reg` → set flags from `dst - src`.
+pub fn cmpRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    setSubFlags(vm, a, b);
+    return ok;
+}
+
+/// `0x62` — `tst Reg, Imm16` → set Z/N from `reg & imm`, clear C/V.
+pub fn tstRegImm16(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const imm = vm.mmap.readWord(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    setAndFlags(vm, a, imm);
+    return ok;
+}
+
+/// `0x63` — `tst Reg, Reg` → set Z/N from `dst & src`, clear C/V.
+pub fn tstRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.mmap.readByte(ip +% 1);
+    const src = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    setAndFlags(vm, a, b);
+    return ok;
+}

--- a/tests/vm/handlers/cmp.test.zig
+++ b/tests/vm/handlers/cmp.test.zig
@@ -1,0 +1,148 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+fn loadProgram(vm: *VM, bytes: []const u8) void {
+    vm.regs.write(.ip, 0x1100);
+    for (bytes, 0..) |b, i| {
+        vm.mmap.writeByte(0x1100 + @as(u16, @intCast(i)), b);
+    }
+}
+
+fn flags(vm: *VM) struct { z: bool, n: bool, c: bool, v: bool } {
+    return .{
+        .z = vm.regs.flagSet(.zero),
+        .n = vm.regs.flagSet(.negative),
+        .c = vm.regs.flagSet(.carry),
+        .v = vm.regs.flagSet(.overflow),
+    };
+}
+
+// ---------- cmp ----------
+
+test "cmp 0x60 reg,imm16: equal → Z=1" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x1234);
+    loadProgram(&vm, &.{ 0x60, 0x02, 0x34, 0x12 }); // cmp r1, 0x1234
+    _ = gero.vm.step(&vm);
+    const f = flags(&vm);
+    try std.testing.expect(f.z and !f.n and !f.c and !f.v);
+    // Result discarded — r1 unchanged.
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.regs.read(.r1));
+}
+
+test "cmp 0x60 reg,imm16: a < b unsigned sets C" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0001);
+    loadProgram(&vm, &.{ 0x60, 0x02, 0x02, 0x00 }); // cmp r1, 2
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(flags(&vm).c); // 1 - 2 borrows
+    try std.testing.expect(flags(&vm).n);
+}
+
+test "cmp 0x60 reg,imm16: a > b clears C and Z" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0010);
+    loadProgram(&vm, &.{ 0x60, 0x02, 0x05, 0x00 }); // cmp r1, 5
+    _ = gero.vm.step(&vm);
+    const f = flags(&vm);
+    try std.testing.expect(!f.c and !f.z and !f.n);
+}
+
+test "cmp 0x60: signed comparison via N ≠ V flags i16 max vs -1" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x7FFF); // i16 max
+    loadProgram(&vm, &.{ 0x60, 0x02, 0xFF, 0xFF }); // cmp r1, 0xFFFF (= -1)
+    _ = gero.vm.step(&vm);
+    // 0x7FFF - 0xFFFF = 0x8000 (truncated). Signed: 32767 - (-1) = 32768
+    // which overflows i16 → V=1. Result high bit set → N=1.
+    try std.testing.expect(flags(&vm).v);
+    try std.testing.expect(flags(&vm).n);
+    // jge takes branch when N == V → 32767 >= -1 is true. ✓
+}
+
+test "cmp 0x61 reg,reg: same registers Z=1" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xABCD);
+    loadProgram(&vm, &.{ 0x61, 0x02, 0x02 }); // cmp r1, r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(flags(&vm).z);
+    try std.testing.expectEqual(@as(u16, 0xABCD), vm.regs.read(.r1));
+}
+
+test "cmp 0x61: different values, signed comparison" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFE); // -2
+    vm.regs.write(.r2, 0x0005); // 5
+    loadProgram(&vm, &.{ 0x61, 0x02, 0x03 }); // cmp r1, r2
+    _ = gero.vm.step(&vm);
+    // -2 - 5 = -7 (0xFFF9). Negative result → N=1. No signed overflow.
+    try std.testing.expect(flags(&vm).n);
+    try std.testing.expect(!flags(&vm).v);
+}
+
+// ---------- tst ----------
+
+test "tst 0x62 reg,imm16: zero mask sets Z" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xCAFE);
+    loadProgram(&vm, &.{ 0x62, 0x02, 0x00, 0x00 }); // tst r1, 0
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(flags(&vm).z);
+    // r1 untouched.
+    try std.testing.expectEqual(@as(u16, 0xCAFE), vm.regs.read(.r1));
+}
+
+test "tst 0x62: bit set in both → Z=0" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x8001);
+    loadProgram(&vm, &.{ 0x62, 0x02, 0x00, 0x80 }); // tst r1, 0x8000
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(!flags(&vm).z);
+    try std.testing.expect(flags(&vm).n); // high bit set in AND result
+}
+
+test "tst 0x62: clears C and V even if preset" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x00FF);
+    vm.regs.setFlag(.carry, true);
+    vm.regs.setFlag(.overflow, true);
+    loadProgram(&vm, &.{ 0x62, 0x02, 0x0F, 0x00 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(!flags(&vm).c);
+    try std.testing.expect(!flags(&vm).v);
+}
+
+test "tst 0x63 reg,reg" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFF00);
+    vm.regs.write(.r2, 0x00FF);
+    loadProgram(&vm, &.{ 0x63, 0x02, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(flags(&vm).z); // no overlapping bits
+    // Neither register changed.
+    try std.testing.expectEqual(@as(u16, 0xFF00), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0x00FF), vm.regs.read(.r2));
+}
+
+// ---------- fault paths ----------
+
+test "cmp/tst: invalid register raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+
+    loadProgram(&vm, &.{ 0x61, 0x02, 0xFF }); // cmp r1, <out-of-range>
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}


### PR DESCRIPTION
## Summary

4 flag-only handlers (`cmp` / `tst`, imm16 + reg-reg forms) in `src/vm/handlers/cmp.zig`. `cmp` mirrors `sub`'s flag math; `tst` mirrors `and`. Neither writes back to the register — they only set `Z` / `N` / `C` / `V` (or `Z` / `N` for `tst`).

## Acceptance (#24)

- [x] `cmp x, x`: Z=1 (equal) — verified for both imm and reg-reg
- [x] `cmp x, x+1`: Z=0, sign flags reflect signed comparison — verified incl. the `i16 max vs −1` case where N=1 + V=1 makes `jge` take the branch (signed 32767 ≥ −1)
- [x] `cmp` does NOT write back to dst — tests assert the register is unchanged after step
- [x] `tst x, 0`: Z=1 — verified
- [x] All four release modes pass

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 11 tests in `tests/vm/handlers/cmp.test.zig` (equal / less / greater / signed-overflow case / discard verification / tst zero-mask / tst C+V clear / fault path)

Closes #24.