### PR TITLE
feat(vm/handlers): control-flow family — 16 handlers (jumps + djnz + jr)

### DIFF
--- a/.changeset/f8a23c91.md
+++ b/.changeset/f8a23c91.md
@@ -1,0 +1,18 @@
+---
+bump: minor
+---
+
+Implement the control-flow family — 16 new handlers in
+`src/vm/handlers/jumps.zig`: `jmp` (addr / reg), the twelve
+flag-conditional jumps (`jeq` / `jne` / `jlt` / `jle` / `jgt` /
+`jge` / `jcc` / `jcs` / `jvc` / `jvs` / `jz` / `jnz`), the
+`djnz` loop primitive (flag-neutral decrement + branch when
+non-zero), and the short relative `jr` (post-instruction
+signed offset).
+
+Adds a `.branched` variant to `StepResult` so branch handlers
+(and the fault-entry path) signal "ip already set — do not
+auto-advance" explicitly. `step` auto-advances only on `.cont`;
+`run` keeps looping on both `.cont` and `.branched`. Fixes the
+edge case where a `jmp` to the current instruction would have
+been incorrectly auto-advanced past.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -10,6 +10,7 @@ const stack_handlers = @import("handlers/stack.zig");
 const arith = @import("handlers/arith.zig");
 const bitwise = @import("handlers/bitwise.zig");
 const cmp_handlers = @import("handlers/cmp.zig");
+const jumps = @import("handlers/jumps.zig");
 const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
@@ -37,8 +38,12 @@ pub const Vector = enum(u8) {
 
 /// Outcome of a `step` call.
 pub const StepResult = enum {
-    /// The VM advanced — keep dispatching.
+    /// The handler completed normally; `step` auto-advances `ip`
+    /// past the instruction.
     cont,
+    /// The handler set `ip` itself (jump, call, fault entry).
+    /// `step` leaves `ip` alone — the run loop keeps going.
+    branched,
     /// The VM hit `hlt` (no resume).
     halted,
     /// A fault fired but no ISR was installed (vector slot is `0`).
@@ -137,6 +142,24 @@ pub const handler_table: [256]Handler = blk: {
     t[0x62] = cmp_handlers.tstRegImm16;
     t[0x63] = cmp_handlers.tstRegReg;
 
+    // control flow
+    t[0x70] = jumps.jmpAddr;
+    t[0x71] = jumps.jmpReg;
+    t[0x72] = jumps.jeqAddr;
+    t[0x73] = jumps.jneAddr;
+    t[0x74] = jumps.jltAddr;
+    t[0x75] = jumps.jleAddr;
+    t[0x76] = jumps.jgtAddr;
+    t[0x77] = jumps.jgeAddr;
+    t[0x78] = jumps.jccAddr;
+    t[0x79] = jumps.jcsAddr;
+    t[0x7A] = jumps.jvcAddr;
+    t[0x7B] = jumps.jvsAddr;
+    t[0x7C] = jumps.jzAddr;
+    t[0x7D] = jumps.jnzAddr;
+    t[0x7E] = jumps.djnzRegAddr;
+    t[0x7F] = jumps.jrImm8;
+
     break :blk t;
 };
 
@@ -149,19 +172,19 @@ pub fn step(vm: *VM) StepResult {
     const op = vm.mmap.readByte(ip_before);
     const handler = handler_table[op];
     const result = handler(vm);
-    if (result == .cont and vm.regs.read(.ip) == ip_before) {
+    if (result == .cont) {
         const info = opcodes.table[op] orelse return .halted_on_fault;
         vm.regs.write(.ip, ip_before +% info.size());
     }
     return result;
 }
 
-/// Iterate `step` until it returns anything other than `.cont`.
-/// Returns the final outcome (`.halted` or `.halted_on_fault`).
+/// Iterate `step` until the VM signals a terminal state. `.cont`
+/// and `.branched` both keep the loop going.
 pub fn run(vm: *VM) StepResult {
     while (true) {
         const r = step(vm);
-        if (r != .cont) return r;
+        if (r == .halted or r == .halted_on_fault) return r;
     }
 }
 
@@ -178,7 +201,7 @@ pub fn raiseFault(vm: *VM, vector: Vector) StepResult {
     pushWord(vm, vm.regs.read(.flg));
     vm.regs.setFlag(.interrupt_disable, true);
     vm.regs.write(.ip, target);
-    return .cont;
+    return .branched;
 }
 
 /// Address of the slot for `vector` inside the IVT.

--- a/src/vm/handlers/jumps.zig
+++ b/src/vm/handlers/jumps.zig
@@ -1,0 +1,146 @@
+/// Handlers for the jump family — unconditional `jmp`, the twelve
+/// conditional jumps, the `djnz` loop primitive, and the short
+/// relative `jr`. Branch targets are written directly into `ip`
+/// and the handler returns `.branched` so dispatch skips the
+/// auto-advance.
+const vm_mod = @import("../vm.zig");
+const dispatch = @import("../dispatch.zig");
+const VM = vm_mod.VM;
+const StepResult = dispatch.StepResult;
+
+const ok = StepResult.cont;
+
+fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
+    return dispatch.raiseFault(vm, vector);
+}
+
+fn readAddr(vm: *const VM) u16 {
+    return vm.mmap.readWord(vm.regs.read(.ip) +% 1);
+}
+
+fn taken(vm: *VM, target: u16) StepResult {
+    vm.regs.write(.ip, target);
+    return .branched;
+}
+
+// ---------- unconditional ----------
+
+/// `0x70` — `jmp Addr`.
+pub fn jmpAddr(vm: *VM) StepResult {
+    return taken(vm, readAddr(vm));
+}
+
+/// `0x71` — `jmp Reg` → `ip ← reg`.
+pub fn jmpReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const target = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return taken(vm, target);
+}
+
+// ---------- conditional (Addr operand) ----------
+
+/// `0x72` — `jeq Addr` → branch when `Z = 1`.
+pub fn jeqAddr(vm: *VM) StepResult {
+    if (vm.regs.flagSet(.zero)) return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x73` — `jne Addr` → branch when `Z = 0`.
+pub fn jneAddr(vm: *VM) StepResult {
+    if (!vm.regs.flagSet(.zero)) return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x74` — `jlt Addr` → signed less: `N ≠ V`.
+pub fn jltAddr(vm: *VM) StepResult {
+    if (vm.regs.flagSet(.negative) != vm.regs.flagSet(.overflow))
+        return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x75` — `jle Addr` → signed less-or-equal: `Z = 1 ∨ N ≠ V`.
+pub fn jleAddr(vm: *VM) StepResult {
+    const z = vm.regs.flagSet(.zero);
+    const lt = vm.regs.flagSet(.negative) != vm.regs.flagSet(.overflow);
+    if (z or lt) return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x76` — `jgt Addr` → signed greater: `Z = 0 ∧ N = V`.
+pub fn jgtAddr(vm: *VM) StepResult {
+    const not_z = !vm.regs.flagSet(.zero);
+    const ge = vm.regs.flagSet(.negative) == vm.regs.flagSet(.overflow);
+    if (not_z and ge) return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x77` — `jge Addr` → signed greater-or-equal: `N = V`.
+pub fn jgeAddr(vm: *VM) StepResult {
+    if (vm.regs.flagSet(.negative) == vm.regs.flagSet(.overflow))
+        return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x78` — `jcc Addr` → unsigned less / no carry: `C = 0`.
+pub fn jccAddr(vm: *VM) StepResult {
+    if (!vm.regs.flagSet(.carry)) return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x79` — `jcs Addr` → unsigned greater-or-equal: `C = 1`.
+pub fn jcsAddr(vm: *VM) StepResult {
+    if (vm.regs.flagSet(.carry)) return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x7A` — `jvc Addr` → `V = 0`.
+pub fn jvcAddr(vm: *VM) StepResult {
+    if (!vm.regs.flagSet(.overflow)) return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x7B` — `jvs Addr` → `V = 1`.
+pub fn jvsAddr(vm: *VM) StepResult {
+    if (vm.regs.flagSet(.overflow)) return taken(vm, readAddr(vm));
+    return ok;
+}
+
+/// `0x7C` — `jz Addr` → alias for `jeq` (`Z = 1`).
+pub fn jzAddr(vm: *VM) StepResult {
+    return jeqAddr(vm);
+}
+
+/// `0x7D` — `jnz Addr` → alias for `jne` (`Z = 0`).
+pub fn jnzAddr(vm: *VM) StepResult {
+    return jneAddr(vm);
+}
+
+// ---------- djnz / jr ----------
+
+/// `0x7E` — `djnz Reg, Addr` → `reg -= 1`; branch when `reg ≠ 0`.
+/// Decrement is flag-neutral so the loop primitive doesn't
+/// disturb a surrounding `cmp` / `tst` chain.
+pub fn djnzRegAddr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const target = vm.mmap.readWord(ip +% 2);
+    const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    const new_value = value -% 1;
+    if (!vm.regs.writeByIndex(reg, new_value)) return fault(vm, .invalid_register);
+    if (new_value != 0) return taken(vm, target);
+    return ok;
+}
+
+/// `0x7F` — `jr Imm8` → relative jump `ip ← (ip + 2) + signed(imm)`.
+/// Offset is post-instruction (the assembler emits `target - (here + 2)`).
+pub fn jrImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const offset_byte = vm.mmap.readByte(ip +% 1);
+    // safety: u8 → i8 preserves the bit pattern as a signed offset
+    const offset_i8: i8 = @bitCast(offset_byte);
+    const offset_i16: i16 = offset_i8;
+    // safety: i16 → u16 for wrapping pointer arithmetic
+    const offset_u16: u16 = @bitCast(offset_i16);
+    return taken(vm, ip +% 2 +% offset_u16);
+}

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -30,7 +30,7 @@ test "dispatch: step with installed ISR enters the handler" {
     setVector(&vm, .invalid_opcode, 0x2000);
     vm.regs.write(.ip, 0x1100);
 
-    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
     try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
 }
@@ -92,12 +92,12 @@ test "dispatch: bytes without a handler raise invalid-opcode" {
 
     // Pick bytes that have no handler yet: the invalid-opcode
     // fault should fire on each.
-    inline for ([_]u8{ 0x00, 0x70, 0x80, 0xFF }) |op| {
+    inline for ([_]u8{ 0x00, 0x68, 0x83, 0xFF }) |op| {
         vm.regs.write(.ip, 0x1100);
         vm.mmap.writeByte(0x1100, op);
         vm.regs.write(.sp, 0xFFFE);
         vm.regs.write(.flg, 0);
-        try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+        try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
         try std.testing.expectEqual(@as(u16, 0x4000), vm.regs.read(.ip));
     }
 }

--- a/tests/vm/handlers/jumps.test.zig
+++ b/tests/vm/handlers/jumps.test.zig
@@ -1,0 +1,279 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+fn loadProgram(vm: *VM, bytes: []const u8) void {
+    vm.regs.write(.ip, 0x1100);
+    for (bytes, 0..) |b, i| {
+        vm.mmap.writeByte(0x1100 + @as(u16, @intCast(i)), b);
+    }
+}
+
+// ---------- unconditional ----------
+
+test "jmp 0x70 addr: always sets ip to target" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    loadProgram(&vm, &.{ 0x70, 0x00, 0x20 }); // jmp 0x2000
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jmp 0x70: jump-to-self does NOT advance past the instruction" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // jmp $1100 — should stay parked on this instruction (infinite loop).
+    loadProgram(&vm, &.{ 0x70, 0x00, 0x11 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x1100), vm.regs.read(.ip));
+}
+
+test "jmp 0x71 reg: target read from register" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x3000);
+    loadProgram(&vm, &.{ 0x71, 0x02 }); // jmp r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
+}
+
+// ---------- conditional jumps ----------
+
+test "jeq 0x72: Z=1 branches, Z=0 falls through" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.zero, true);
+    loadProgram(&vm, &.{ 0x72, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+
+    // Fall-through case: Z=0 → ip advances past the 3-byte instruction.
+    var vm2 = VM.init(std.testing.allocator);
+    defer vm2.deinit();
+    vm2.regs.setFlag(.zero, false);
+    loadProgram(&vm2, &.{ 0x72, 0x00, 0x20 });
+    _ = gero.vm.step(&vm2);
+    try std.testing.expectEqual(@as(u16, 0x1103), vm2.regs.read(.ip));
+}
+
+test "jne 0x73: Z=0 branches" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.zero, false);
+    loadProgram(&vm, &.{ 0x73, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jlt 0x74: N ≠ V branches (signed less)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.negative, true);
+    vm.regs.setFlag(.overflow, false);
+    loadProgram(&vm, &.{ 0x74, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jle 0x75: Z=1 takes the branch" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.zero, true);
+    loadProgram(&vm, &.{ 0x75, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jle 0x75: Z=0 N≠V (signed less) takes the branch" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.zero, false);
+    vm.regs.setFlag(.negative, false);
+    vm.regs.setFlag(.overflow, true);
+    loadProgram(&vm, &.{ 0x75, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jgt 0x76: Z=0 ∧ N=V branches" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.zero, false);
+    vm.regs.setFlag(.negative, false);
+    vm.regs.setFlag(.overflow, false);
+    loadProgram(&vm, &.{ 0x76, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jge 0x77: N=V branches (includes Z=1)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.zero, true);
+    vm.regs.setFlag(.negative, true);
+    vm.regs.setFlag(.overflow, true);
+    loadProgram(&vm, &.{ 0x77, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jcc 0x78: C=0 branches" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.carry, false);
+    loadProgram(&vm, &.{ 0x78, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jcs 0x79: C=1 branches" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x79, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jvc 0x7A: V=0 branches" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.overflow, false);
+    loadProgram(&vm, &.{ 0x7A, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jvs 0x7B: V=1 branches" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.overflow, true);
+    loadProgram(&vm, &.{ 0x7B, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "jz 0x7C / jnz 0x7D: aliases for jeq / jne" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.zero, true);
+    loadProgram(&vm, &.{ 0x7C, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+
+    var vm2 = VM.init(std.testing.allocator);
+    defer vm2.deinit();
+    vm2.regs.setFlag(.zero, false);
+    loadProgram(&vm2, &.{ 0x7D, 0x00, 0x30 });
+    _ = gero.vm.step(&vm2);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm2.regs.read(.ip));
+}
+
+test "conditional jumps: fall-through matrix when the condition is false" {
+    // Flag bits: Z=0, N=1, C=2, V=3 in the `flg` register.
+    const Case = struct { opcode: u8, flg: u16, label: []const u8 };
+    const cases = [_]Case{
+        .{ .opcode = 0x72, .flg = 0b0000, .label = "jeq with Z=0" },
+        .{ .opcode = 0x73, .flg = 0b0001, .label = "jne with Z=1" },
+        .{ .opcode = 0x74, .flg = 0b0000, .label = "jlt with N=V=0" },
+        .{ .opcode = 0x74, .flg = 0b1010, .label = "jlt with N=V=1" },
+        .{ .opcode = 0x75, .flg = 0b0000, .label = "jle with Z=0, N=V=0" },
+        .{ .opcode = 0x76, .flg = 0b0001, .label = "jgt with Z=1" },
+        .{ .opcode = 0x76, .flg = 0b1000, .label = "jgt with N≠V" },
+        .{ .opcode = 0x77, .flg = 0b0010, .label = "jge with N=1, V=0" },
+        .{ .opcode = 0x77, .flg = 0b1000, .label = "jge with N=0, V=1" },
+        .{ .opcode = 0x78, .flg = 0b0100, .label = "jcc with C=1" },
+        .{ .opcode = 0x79, .flg = 0b0000, .label = "jcs with C=0" },
+        .{ .opcode = 0x7A, .flg = 0b1000, .label = "jvc with V=1" },
+        .{ .opcode = 0x7B, .flg = 0b0000, .label = "jvs with V=0" },
+        .{ .opcode = 0x7C, .flg = 0b0000, .label = "jz with Z=0" },
+        .{ .opcode = 0x7D, .flg = 0b0001, .label = "jnz with Z=1" },
+    };
+    for (cases) |c| {
+        var vm = VM.init(std.testing.allocator);
+        defer vm.deinit();
+        vm.regs.write(.flg, c.flg);
+        loadProgram(&vm, &.{ c.opcode, 0x00, 0x20 });
+        _ = gero.vm.step(&vm);
+        // Fall-through advances past the 3-byte instruction.
+        std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip)) catch |e| {
+            std.debug.print("\nfall-through failed: {s}\n", .{c.label});
+            return e;
+        };
+    }
+}
+
+// ---------- djnz ----------
+
+test "djnz 0x7E: decrement and branch while non-zero" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0003);
+    loadProgram(&vm, &.{ 0x7E, 0x02, 0x00, 0x20 }); // djnz r1, 0x2000
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0002), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+}
+
+test "djnz 0x7E: fall through when decrement reaches zero" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0001);
+    loadProgram(&vm, &.{ 0x7E, 0x02, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.r1));
+    // Fall-through: ip advances past the 4-byte instruction.
+    try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
+}
+
+test "djnz 0x7E: flags are NOT touched by the decrement" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0001);
+    vm.regs.setFlag(.zero, false);
+    vm.regs.setFlag(.carry, true);
+    loadProgram(&vm, &.{ 0x7E, 0x02, 0x00, 0x20 });
+    _ = gero.vm.step(&vm);
+    // r1 just hit 0, but Z stays false (djnz is flag-neutral).
+    try std.testing.expect(!vm.regs.flagSet(.zero));
+    try std.testing.expect(vm.regs.flagSet(.carry));
+}
+
+// ---------- jr ----------
+
+test "jr 0x7F: positive offset, post-instruction relative" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    loadProgram(&vm, &.{ 0x7F, 0x10 }); // jr +16
+    _ = gero.vm.step(&vm);
+    // target = ip(0x1100) + 2 + 16 = 0x1112
+    try std.testing.expectEqual(@as(u16, 0x1112), vm.regs.read(.ip));
+}
+
+test "jr 0x7F: negative offset rolls back" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    loadProgram(&vm, &.{ 0x7F, 0xFE }); // jr -2 (i8 = -2)
+    _ = gero.vm.step(&vm);
+    // target = ip(0x1100) + 2 + (-2) = 0x1100 → loops on itself.
+    try std.testing.expectEqual(@as(u16, 0x1100), vm.regs.read(.ip));
+}
+
+test "jr 0x7F: zero offset advances to next instruction" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    loadProgram(&vm, &.{ 0x7F, 0x00 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+}
+
+// ---------- fault paths ----------
+
+test "jmp 0x71: invalid register raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+    loadProgram(&vm, &.{ 0x71, 0xFF });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}

--- a/tests/vm/handlers/mov.test.zig
+++ b/tests/vm/handlers/mov.test.zig
@@ -253,6 +253,6 @@ test "mov: invalid register index raises invalid-register fault" {
 
     // mov r1, <out-of-range>
     loadProgram(&vm, &.{ 0x11, 0x02, 0xFF });
-    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }

--- a/tests/vm/handlers/stack.test.zig
+++ b/tests/vm/handlers/stack.test.zig
@@ -126,7 +126,7 @@ test "stack: invalid register on push raises invalid-register fault" {
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
 
     loadProgram(&vm, &.{ 0x31, 0xFF }); // push <out-of-range>
-    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
 
@@ -136,6 +136,6 @@ test "stack: invalid register on pop raises invalid-register fault" {
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
 
     loadProgram(&vm, &.{ 0x32, 0xFF }); // pop <out-of-range>
-    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }


### PR DESCRIPTION
## Summary

16 new handlers + a `.branched` `StepResult` variant.

- **Unconditional**: `jmp Addr` / `jmp Reg`
- **Conditional (12)**: `jeq` / `jne` / `jlt` / `jle` / `jgt` / `jge` / `jcc` / `jcs` / `jvc` / `jvs` / `jz` / `jnz`
- **Loop primitive**: `djnz Reg, Addr` — flag-neutral decrement + branch while non-zero
- **Relative**: `jr Imm8` — post-instruction signed offset (`ip ← (ip + 2) + signed(imm)`)

### `StepResult.branched`

Branch handlers and the fault-entry path now return `.branched`. `step` auto-advances only on `.cont`; `run` keeps looping on both. Fixes the edge case where a `jmp` to the current instruction would have been incorrectly auto-advanced past by the previous "did ip change" heuristic.

`raiseFault` returns `.branched` instead of `.cont`; existing fault-path test assertions in `dispatch.test.zig` / `mov.test.zig` / `stack.test.zig` are updated to match.

## Acceptance (#25)

- [x] Each branch fires when its condition holds, NOT when it doesn't — table-driven fall-through test covers all 15 conditional opcodes
- [x] `djnz` decrements the reg then jumps if non-zero; flags untouched
- [x] `jr` is post-instruction relative (verified +offset, 0, and -2 → jmp-to-self)
- [x] `jmp Reg`: `ip ← reg`
- [x] All four release modes pass

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 22 tests in `tests/vm/handlers/jumps.test.zig` (taken-path for each + table-driven fall-through matrix + jmp-to-self + djnz both branches + jr signed math + fault path)

Closes #25.