### PR TITLE
feat(vm/handlers): subroutines — call / ret

### DIFF
--- a/.changeset/g6c81a44.md
+++ b/.changeset/g6c81a44.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+Implement the subroutine family — `call Addr` (`0x80`), `call
+Reg` (`0x81`), and `ret` (`0x82`). `call` pushes the caller's
+`fp`, then the post-instruction `ip`, sets `fp ← sp` so the new
+frame pointer addresses the return ip, and jumps to the target.
+`ret` rewinds locals (`sp ← fp`), pops the return ip and the
+caller's fp, and resumes. Pairs cleanly with the existing
+`push` / `pop` ops via the shared pre-decrement stack convention.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -11,6 +11,7 @@ const arith = @import("handlers/arith.zig");
 const bitwise = @import("handlers/bitwise.zig");
 const cmp_handlers = @import("handlers/cmp.zig");
 const jumps = @import("handlers/jumps.zig");
+const subroutine = @import("handlers/subroutine.zig");
 const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
@@ -159,6 +160,11 @@ pub const handler_table: [256]Handler = blk: {
     t[0x7D] = jumps.jnzAddr;
     t[0x7E] = jumps.djnzRegAddr;
     t[0x7F] = jumps.jrImm8;
+
+    // subroutines
+    t[0x80] = subroutine.callAddr;
+    t[0x81] = subroutine.callReg;
+    t[0x82] = subroutine.ret;
 
     break :blk t;
 };

--- a/src/vm/handlers/subroutine.zig
+++ b/src/vm/handlers/subroutine.zig
@@ -1,0 +1,53 @@
+/// Handlers for `call` / `ret` — the subroutine calling convention.
+///
+/// `call` lays out the activation record:
+///   push fp; push (ip after instruction); fp ← sp; ip ← target.
+/// The new `fp` ends up pointing at the saved return ip — the
+/// subroutine can push locals below it and still find them via
+/// `fp - N` offsets.
+///
+/// `ret` rewinds locals (`sp ← fp`), pops the return ip, then
+/// pops the caller's fp.
+const vm_mod = @import("../vm.zig");
+const dispatch = @import("../dispatch.zig");
+const VM = vm_mod.VM;
+const StepResult = dispatch.StepResult;
+
+const ok = StepResult.cont;
+
+fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
+    return dispatch.raiseFault(vm, vector);
+}
+
+fn enter(vm: *VM, target: u16, ip_after: u16) StepResult {
+    dispatch.pushWord(vm, vm.regs.read(.fp));
+    dispatch.pushWord(vm, ip_after);
+    vm.regs.write(.fp, vm.regs.read(.sp));
+    vm.regs.write(.ip, target);
+    return .branched;
+}
+
+/// `0x80` — `call Addr`.
+pub fn callAddr(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const target = vm.mmap.readWord(ip +% 1);
+    return enter(vm, target, ip +% 3);
+}
+
+/// `0x81` — `call Reg` → `ip ← reg`.
+pub fn callReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.mmap.readByte(ip +% 1);
+    const target = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return enter(vm, target, ip +% 2);
+}
+
+/// `0x82` — `ret` → unwind activation record and resume the caller.
+pub fn ret(vm: *VM) StepResult {
+    vm.regs.write(.sp, vm.regs.read(.fp));
+    const ret_ip = dispatch.popWord(vm);
+    const old_fp = dispatch.popWord(vm);
+    vm.regs.write(.fp, old_fp);
+    vm.regs.write(.ip, ret_ip);
+    return .branched;
+}

--- a/tests/vm/handlers/subroutine.test.zig
+++ b/tests/vm/handlers/subroutine.test.zig
@@ -1,0 +1,118 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+fn loadProgram(vm: *VM, bytes: []const u8) void {
+    vm.regs.write(.ip, 0x1100);
+    for (bytes, 0..) |b, i| {
+        vm.mmap.writeByte(0x1100 + @as(u16, @intCast(i)), b);
+    }
+}
+
+test "call 0x80 addr: pushes fp + ret-ip, sets fp = sp, jumps" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.fp, 0xDEAD);
+    loadProgram(&vm, &.{ 0x80, 0x00, 0x20 }); // call 0x2000
+    _ = gero.vm.step(&vm);
+
+    // After call: ip = target.
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+    // Pushed values (pre-decrement push from sp_boot=0xFFFE):
+    //   mem[0xFFFC] = old fp (0xDEAD)
+    //   mem[0xFFFA] = ret-ip (0x1103, post-instruction)
+    try std.testing.expectEqual(@as(u16, 0xDEAD), vm.mmap.readWord(0xFFFC));
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.mmap.readWord(0xFFFA));
+    // sp = 0xFFFA after the two pushes; fp = sp (points at ret-ip).
+    try std.testing.expectEqual(@as(u16, 0xFFFA), vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0xFFFA), vm.regs.read(.fp));
+}
+
+test "call 0x81 reg: target from register, ret-ip is post-instruction (+2)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x3000);
+    loadProgram(&vm, &.{ 0x81, 0x02 }); // call r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
+    // Ret-ip pushed = ip_before + 2 = 0x1102.
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.mmap.readWord(0xFFFA));
+}
+
+test "call/ret round-trip: control returns to the instruction after call" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // Caller at 0x1100: `call 0x2000` (3 bytes).
+    loadProgram(&vm, &.{ 0x80, 0x00, 0x20 });
+    // Subroutine at 0x2000: a bare `ret`.
+    vm.mmap.writeByte(0x2000, 0x82);
+
+    _ = gero.vm.step(&vm); // call
+    try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
+    _ = gero.vm.step(&vm); // ret
+    // Return to ip after call = 0x1103.
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
+    // Stack and fp restored to pre-call state.
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.fp));
+}
+
+test "call/ret nested two levels: outer ret reaches the original caller" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // 0x1100: call 0x2000
+    // 0x1103: hlt-marker (we won't execute it)
+    loadProgram(&vm, &.{ 0x80, 0x00, 0x20 });
+    // 0x2000: call 0x2100
+    // 0x2003: ret
+    vm.mmap.writeByte(0x2000, 0x80);
+    vm.mmap.writeWord(0x2001, 0x2100);
+    vm.mmap.writeByte(0x2003, 0x82);
+    // 0x2100: ret
+    vm.mmap.writeByte(0x2100, 0x82);
+
+    _ = gero.vm.step(&vm); // outer call → ip=0x2000
+    _ = gero.vm.step(&vm); // inner call → ip=0x2100
+    try std.testing.expectEqual(@as(u16, 0x2100), vm.regs.read(.ip));
+    _ = gero.vm.step(&vm); // inner ret → ip=0x2003
+    try std.testing.expectEqual(@as(u16, 0x2003), vm.regs.read(.ip));
+    _ = gero.vm.step(&vm); // outer ret → ip=0x1103
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
+    // Both frames fully unwound.
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.fp));
+}
+
+test "ret 0x82: unwinds locals that the callee pushed below fp" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // 0x1100: call 0x2000
+    loadProgram(&vm, &.{ 0x80, 0x00, 0x20 });
+    // 0x2000: push 0xCAFE (3 bytes) — a local on the stack.
+    // 0x2003: ret.
+    vm.mmap.writeByte(0x2000, 0x30); // push imm16
+    vm.mmap.writeWord(0x2001, 0xCAFE);
+    vm.mmap.writeByte(0x2003, 0x82);
+
+    _ = gero.vm.step(&vm); // call → ip=0x2000, sp moved 4 bytes (fp+ret-ip).
+    _ = gero.vm.step(&vm); // push imm16 → sp moves another 2 bytes.
+    const sp_inside = vm.regs.read(.sp);
+    try std.testing.expectEqual(@as(u16, 0xFFF8), sp_inside);
+
+    _ = gero.vm.step(&vm); // ret
+    // sp ← fp drops the local; then pop ip; pop fp. Final sp = pre-call.
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
+}
+
+test "call 0x81: invalid register raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+    loadProgram(&vm, &.{ 0x81, 0xFF });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}


### PR DESCRIPTION
## Summary

Three handlers in `src/vm/handlers/subroutine.zig`:

- `call Addr` / `call Reg`: push old `fp`, then the post-instruction `ip`, set `fp ← sp` (so `fp` addresses the return ip), jump to target
- `ret`: `sp ← fp` to drop subroutine locals, pop return ip, pop the caller's fp, resume

## Acceptance (#26)

- [x] `call` / `ret` round-trip — control returns to the instruction after `call`; `sp` / `fp` restored
- [x] Frame pointer set on call, restored on ret
- [x] Recursion works — verified 2 levels deep with proper unwinding
- [x] `call Reg` works with target held in any GP register
- [x] All four release modes pass

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 6 tests covering: stack layout after `call`, post-instruction `ip` for both call forms, round-trip, 2-level nesting, `ret` unwinding locals via `sp ← fp`, and the invalid-register fault on `call Reg`

Closes #26.