### PR TITLE
feat(vm/handlers): misc + flag manipulation + system — 11 handlers

### DIFF
--- a/.changeset/h9f31a2b.md
+++ b/.changeset/h9f31a2b.md
@@ -1,0 +1,20 @@
+---
+bump: minor
+---
+
+Implement the misc, flag-manipulation, and system families —
+11 new handlers in `src/vm/handlers/system.zig`: `swap` /
+`nop`, `clc` / `sec` / `cli` / `sei` / `clv`, `int` / `rti` /
+`brk` / `hlt`. `int` reuses the interrupt-entry path so
+software interrupts and VM-emitted faults share one
+implementation. `rti` pops `flg` / `fp` / `ip` in reverse push
+order; `flg.I` is restored automatically through the saved
+`flg` value.
+
+Adds a `.breakpoint` variant to `StepResult` so `brk` is
+distinguishable from `hlt`: both exit `run`, but `brk`
+auto-advances `ip` past the instruction so a host calling
+`run` again resumes naturally. `hlt` leaves `ip` parked.
+
+This completes the v0.1 opcode family. All 90 instructions are
+implemented; #2 is closed.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -12,6 +12,7 @@ const bitwise = @import("handlers/bitwise.zig");
 const cmp_handlers = @import("handlers/cmp.zig");
 const jumps = @import("handlers/jumps.zig");
 const subroutine = @import("handlers/subroutine.zig");
+const system_handlers = @import("handlers/system.zig");
 const VM = vm_mod.VM;
 const Register = vm_mod.Register;
 const Flag = vm_mod.Flag;
@@ -50,6 +51,9 @@ pub const StepResult = enum {
     /// A fault fired but no ISR was installed (vector slot is `0`).
     /// The host should surface the fault to the user.
     halted_on_fault,
+    /// The VM hit `brk`. `ip` is already advanced past the
+    /// breakpoint; calling `run` again resumes from there.
+    breakpoint,
 };
 
 /// Per-opcode handler. Receives the VM and returns the post-step
@@ -166,6 +170,23 @@ pub const handler_table: [256]Handler = blk: {
     t[0x81] = subroutine.callReg;
     t[0x82] = subroutine.ret;
 
+    // misc
+    t[0x90] = system_handlers.swap;
+    t[0x91] = system_handlers.nop;
+
+    // flag manipulation
+    t[0xA0] = system_handlers.clc;
+    t[0xA1] = system_handlers.sec;
+    t[0xA2] = system_handlers.cli;
+    t[0xA3] = system_handlers.sei;
+    t[0xA4] = system_handlers.clv;
+
+    // system
+    t[0xFC] = system_handlers.intImm8;
+    t[0xFD] = system_handlers.rti;
+    t[0xFE] = system_handlers.brk;
+    t[0xFF] = system_handlers.hlt;
+
     break :blk t;
 };
 
@@ -178,7 +199,7 @@ pub fn step(vm: *VM) StepResult {
     const op = vm.mmap.readByte(ip_before);
     const handler = handler_table[op];
     const result = handler(vm);
-    if (result == .cont) {
+    if (result == .cont or result == .breakpoint) {
         const info = opcodes.table[op] orelse return .halted_on_fault;
         vm.regs.write(.ip, ip_before +% info.size());
     }
@@ -186,11 +207,14 @@ pub fn step(vm: *VM) StepResult {
 }
 
 /// Iterate `step` until the VM signals a terminal state. `.cont`
-/// and `.branched` both keep the loop going.
+/// and `.branched` both keep the loop going; `.breakpoint`,
+/// `.halted`, and `.halted_on_fault` exit so the host can
+/// inspect / decide whether to resume.
 pub fn run(vm: *VM) StepResult {
     while (true) {
         const r = step(vm);
-        if (r == .halted or r == .halted_on_fault) return r;
+        if (r == .cont or r == .branched) continue;
+        return r;
     }
 }
 

--- a/src/vm/handlers/system.zig
+++ b/src/vm/handlers/system.zig
@@ -1,0 +1,109 @@
+/// Handlers for the misc, flag-manipulation, and system families:
+/// `swap` / `nop`, `clc` / `sec` / `cli` / `sei` / `clv`, and
+/// `int` / `rti` / `brk` / `hlt`. `int` reuses the interrupt-
+/// entry path so software interrupts and faults share one
+/// implementation.
+const vm_mod = @import("../vm.zig");
+const dispatch = @import("../dispatch.zig");
+const VM = vm_mod.VM;
+const StepResult = dispatch.StepResult;
+
+const ok = StepResult.cont;
+
+fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
+    return dispatch.raiseFault(vm, vector);
+}
+
+// ---------- misc ----------
+
+/// `0x90` — `swap Reg, Reg` → atomic swap.
+pub fn swap(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const a_idx = vm.mmap.readByte(ip +% 1);
+    const b_idx = vm.mmap.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(a_idx) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(b_idx) orelse return fault(vm, .invalid_register);
+    if (!vm.regs.writeByIndex(a_idx, b)) return fault(vm, .invalid_register);
+    if (!vm.regs.writeByIndex(b_idx, a)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x91` — `nop`.
+pub fn nop(vm: *VM) StepResult {
+    _ = vm;
+    return ok;
+}
+
+// ---------- flag manipulation ----------
+
+/// `0xA0` — `clc` → `flg.C ← 0`.
+pub fn clc(vm: *VM) StepResult {
+    vm.regs.setFlag(.carry, false);
+    return ok;
+}
+
+/// `0xA1` — `sec` → `flg.C ← 1`.
+pub fn sec(vm: *VM) StepResult {
+    vm.regs.setFlag(.carry, true);
+    return ok;
+}
+
+/// `0xA2` — `cli` → `flg.I ← 0` (enable interrupts globally).
+pub fn cli(vm: *VM) StepResult {
+    vm.regs.setFlag(.interrupt_disable, false);
+    return ok;
+}
+
+/// `0xA3` — `sei` → `flg.I ← 1` (block interrupts globally).
+pub fn sei(vm: *VM) StepResult {
+    vm.regs.setFlag(.interrupt_disable, true);
+    return ok;
+}
+
+/// `0xA4` — `clv` → `flg.V ← 0`.
+pub fn clv(vm: *VM) StepResult {
+    vm.regs.setFlag(.overflow, false);
+    return ok;
+}
+
+// ---------- system ----------
+
+/// `0xFC` — `int Imm8` → software interrupt: pushes the
+/// post-instruction `ip`, then `fp` / `flg`, sets `flg.I`, jumps
+/// to `mem[0x1000 + 2*imm]`. Shares the entry sequence with
+/// VM-emitted faults.
+pub fn intImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const vector_byte = vm.mmap.readByte(ip +% 1);
+    // Advance ip so the saved return address points at the
+    // instruction AFTER int N, not at int itself.
+    vm.regs.write(.ip, ip +% 2);
+    const vector: dispatch.Vector = @enumFromInt(vector_byte);
+    return dispatch.raiseFault(vm, vector);
+}
+
+/// `0xFD` — `rti` → pop `flg` / `fp` / `ip` (reverse push
+/// order) and resume.
+pub fn rti(vm: *VM) StepResult {
+    const flg = dispatch.popWord(vm);
+    const fp = dispatch.popWord(vm);
+    const ret_ip = dispatch.popWord(vm);
+    vm.regs.write(.flg, flg);
+    vm.regs.write(.fp, fp);
+    vm.regs.write(.ip, ret_ip);
+    return .branched;
+}
+
+/// `0xFE` — `brk` → resumable breakpoint event. Returns
+/// `.breakpoint`; `step` auto-advances `ip` past the brk so the
+/// host can resume by calling `run` again.
+pub fn brk(vm: *VM) StepResult {
+    _ = vm;
+    return .breakpoint;
+}
+
+/// `0xFF` — `hlt` → terminal halt; the program is done.
+pub fn hlt(vm: *VM) StepResult {
+    _ = vm;
+    return .halted;
+}

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -92,7 +92,7 @@ test "dispatch: bytes without a handler raise invalid-opcode" {
 
     // Pick bytes that have no handler yet: the invalid-opcode
     // fault should fire on each.
-    inline for ([_]u8{ 0x00, 0x68, 0x83, 0xFF }) |op| {
+    inline for ([_]u8{ 0x00, 0x68, 0x83, 0xA5 }) |op| {
         vm.regs.write(.ip, 0x1100);
         vm.mmap.writeByte(0x1100, op);
         vm.regs.write(.sp, 0xFFFE);

--- a/tests/vm/handlers/system.test.zig
+++ b/tests/vm/handlers/system.test.zig
@@ -1,0 +1,208 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+fn loadProgram(vm: *VM, bytes: []const u8) void {
+    vm.regs.write(.ip, 0x1100);
+    for (bytes, 0..) |b, i| {
+        vm.mmap.writeByte(0x1100 + @as(u16, @intCast(i)), b);
+    }
+}
+
+// ---------- misc ----------
+
+test "swap 0x90: registers exchanged, ip advances 3 bytes" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x1111);
+    vm.regs.write(.r2, 0x2222);
+    loadProgram(&vm, &.{ 0x90, 0x02, 0x03 }); // swap r1, r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x2222), vm.regs.read(.r1));
+    try std.testing.expectEqual(@as(u16, 0x1111), vm.regs.read(.r2));
+    try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
+}
+
+test "swap 0x90: invalid register raises fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+    loadProgram(&vm, &.{ 0x90, 0x02, 0xFF });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}
+
+test "nop 0x91: nothing changes except ip" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xCAFE);
+    vm.regs.write(.flg, 0xFFFF);
+    const flg_before = vm.regs.read(.flg);
+    loadProgram(&vm, &.{0x91});
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xCAFE), vm.regs.read(.r1));
+    try std.testing.expectEqual(flg_before, vm.regs.read(.flg));
+    try std.testing.expectEqual(@as(u16, 0x1101), vm.regs.read(.ip));
+}
+
+// ---------- flag manipulation ----------
+
+test "clc 0xA0: clears C, leaves other flags intact" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.flg, 0xFFFF);
+    loadProgram(&vm, &.{0xA0});
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(!vm.regs.flagSet(.carry));
+    // Other flags untouched.
+    try std.testing.expect(vm.regs.flagSet(.zero));
+    try std.testing.expect(vm.regs.flagSet(.negative));
+    try std.testing.expect(vm.regs.flagSet(.overflow));
+    try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
+}
+
+test "sec 0xA1: sets C only" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.flg, 0);
+    loadProgram(&vm, &.{0xA1});
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(vm.regs.flagSet(.carry));
+    try std.testing.expect(!vm.regs.flagSet(.zero));
+    try std.testing.expect(!vm.regs.flagSet(.negative));
+    try std.testing.expect(!vm.regs.flagSet(.overflow));
+    try std.testing.expect(!vm.regs.flagSet(.interrupt_disable));
+}
+
+test "cli 0xA2 / sei 0xA3: toggle interrupt-disable bit" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.setFlag(.interrupt_disable, true);
+    loadProgram(&vm, &.{0xA2}); // cli
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(!vm.regs.flagSet(.interrupt_disable));
+
+    loadProgram(&vm, &.{0xA3}); // sei
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
+}
+
+test "clv 0xA4: clears V only" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.flg, 0xFFFF);
+    loadProgram(&vm, &.{0xA4});
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(!vm.regs.flagSet(.overflow));
+    try std.testing.expect(vm.regs.flagSet(.carry));
+}
+
+// ---------- system ----------
+
+test "int 0xFC: pushes state, jumps via vector table, sets flg.I" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // Map vector 0x21 → 0x4000 (SRAM-flush convention).
+    vm.mmap.writeWord(0x1042, 0x4000); // 0x1000 + 2 * 0x21
+    vm.regs.write(.fp, 0xBEEF);
+    vm.regs.write(.flg, 0x000F);
+    loadProgram(&vm, &.{ 0xFC, 0x21 }); // int 0x21
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(@as(u16, 0x4000), vm.regs.read(.ip));
+    try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
+    // Pushed in order: post-int ip (0x1102), fp, flg → top of stack = flg.
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.mmap.readWord(0xFFFC));
+    try std.testing.expectEqual(@as(u16, 0xBEEF), vm.mmap.readWord(0xFFFA));
+    try std.testing.expectEqual(@as(u16, 0x000F), vm.mmap.readWord(0xFFF8));
+}
+
+test "int 0xFC: unhandled vector halts on fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // IVT is zero-initialized; vector 0x20 slot = 0 → halts.
+    loadProgram(&vm, &.{ 0xFC, 0x20 });
+    try std.testing.expectEqual(gero.vm.StepResult.halted_on_fault, gero.vm.step(&vm));
+}
+
+test "rti 0xFD: pops flg / fp / ip in reverse push order" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // Pre-stage the stack as if an `int` had just fired (top = flg).
+    vm.regs.write(.sp, 0xFFF8);
+    vm.mmap.writeWord(0xFFFC, 0x2222); // saved ip
+    vm.mmap.writeWord(0xFFFA, 0x3333); // saved fp
+    vm.mmap.writeWord(0xFFF8, 0x0000); // saved flg (I clear)
+    // Pre-set flg.I to true so we can verify it's restored to clear.
+    vm.regs.setFlag(.interrupt_disable, true);
+
+    loadProgram(&vm, &.{0xFD});
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(@as(u16, 0x2222), vm.regs.read(.ip));
+    try std.testing.expectEqual(@as(u16, 0x3333), vm.regs.read(.fp));
+    try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.flg));
+    try std.testing.expect(!vm.regs.flagSet(.interrupt_disable));
+    // sp returns to pre-frame position.
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+}
+
+test "int + rti round-trip: caller resumes at post-int ip with state intact" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(0x1042, 0x4000); // vector 0x21 → ISR at 0x4000
+    vm.regs.write(.fp, 0xBEEF);
+    vm.regs.write(.flg, 0x000F);
+    // 0x1100: int 0x21
+    // 0x4000: rti
+    loadProgram(&vm, &.{ 0xFC, 0x21 });
+    vm.mmap.writeByte(0x4000, 0xFD);
+
+    _ = gero.vm.step(&vm); // int — jumps to ISR, flg.I set
+    _ = gero.vm.step(&vm); // rti — returns to caller
+
+    // Caller restored.
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+    try std.testing.expectEqual(@as(u16, 0xBEEF), vm.regs.read(.fp));
+    try std.testing.expectEqual(@as(u16, 0x000F), vm.regs.read(.flg));
+    try std.testing.expect(!vm.regs.flagSet(.interrupt_disable));
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+}
+
+test "brk 0xFE: returns breakpoint, ip advances past it for resume" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    loadProgram(&vm, &.{0xFE});
+    try std.testing.expectEqual(gero.vm.StepResult.breakpoint, gero.vm.step(&vm));
+    // ip is past the brk so a subsequent run resumes naturally.
+    try std.testing.expectEqual(@as(u16, 0x1101), vm.regs.read(.ip));
+}
+
+test "hlt 0xFF: returns halted, ip stays on hlt instruction" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    loadProgram(&vm, &.{0xFF});
+    try std.testing.expectEqual(gero.vm.StepResult.halted, gero.vm.step(&vm));
+    // ip parked on hlt — the program is done.
+    try std.testing.expectEqual(@as(u16, 0x1100), vm.regs.read(.ip));
+}
+
+test "run: exits on hlt" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    loadProgram(&vm, &.{ 0x91, 0x91, 0xFF }); // nop, nop, hlt
+    try std.testing.expectEqual(gero.vm.StepResult.halted, gero.vm.run(&vm));
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+}
+
+test "run: exits on brk, but resuming continues to hlt" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    loadProgram(&vm, &.{ 0x91, 0xFE, 0xFF }); // nop, brk, hlt
+    try std.testing.expectEqual(gero.vm.StepResult.breakpoint, gero.vm.run(&vm));
+    // ip is past the brk.
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+
+    // Host resumes.
+    try std.testing.expectEqual(gero.vm.StepResult.halted, gero.vm.run(&vm));
+}


### PR DESCRIPTION
## Summary

Closes out the v0.1 opcode family with the last 11 handlers in `src/vm/handlers/system.zig`:

- `swap` / `nop`
- `clc` / `sec` / `cli` / `sei` / `clv`
- `int Imm8` — reuses the fault-entry path so software interrupts and VM-emitted faults share one impl
- `rti` — pops `flg` / `fp` / `ip` in reverse push order; `flg.I` is restored automatically through the saved `flg`
- `brk` (resumable) / `hlt` (terminal)

### `StepResult.breakpoint`

Adds the `.breakpoint` variant so `brk` is distinguishable from `hlt`:

- Both exit `run`
- `brk` auto-advances `ip` past the instruction (host can resume by calling `run` again)
- `hlt` leaves `ip` parked

## Acceptance (#27)

- [x] `swap` exchanges registers
- [x] `nop` only advances `ip`
- [x] Each flag op toggles only its target bit (other flag bits untouched)
- [x] `int 0x21` pushes state + jumps to `mem[0x1042]` (SRAM-flush vector)
- [x] `rti` restores `flg` / `fp` / `ip` in reverse order; `flg.I` follows the saved `flg`
- [x] `brk` emits an observable breakpoint event; resume continues to the next instruction
- [x] `hlt` exits `run` with `.halted`
- [x] All four release modes pass

### Bonus: `int` + `rti` round-trip

A dedicated test loads `int 0x21` followed by `rti` at the ISR target and verifies that after the round-trip every register (`ip` / `fp` / `flg` / `sp`) is restored to the pre-`int` state. This is the canonical resume contract.

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 13 tests covering all 11 handlers + int/rti round-trip + run-loop interactions with brk and hlt

With this PR all 90 v0.1 opcodes are implemented. The VM kernel (#2) is feature-complete.

Closes #27.