### PR TITLE
feat(vm): raiseIrq + nested-interrupt coverage

### DIFF
--- a/.changeset/i7d42f99.md
+++ b/.changeset/i7d42f99.md
@@ -1,0 +1,12 @@
+---
+bump: minor
+---
+
+Complete the interrupt mechanism: add `raiseIrq` for maskable
+hardware-style IRQs. `raiseIrq` honors `flg.I` (global) and the
+`im` register (per-vector mask for vectors `0..0x0F`); vectors
+`0x10..0x3F` are only blocked by `flg.I`. `raiseFault` stays
+unmaskable — faults and software `int N` always fire so a buggy
+program can't silently swallow a div-by-zero. Includes nested-
+interrupt coverage (cli inside an ISR lets a second `int` fire
+and rti unwinds correctly).

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -218,10 +218,12 @@ pub fn run(vm: *VM) StepResult {
     }
 }
 
-/// Deliver a fault through the interrupt mechanism. If the
-/// vector slot is `0` the VM halts with a host-visible fault
-/// marker; otherwise the entry sequence pushes `ip` / `fp` /
-/// `flg`, sets `flg.I`, and jumps to the ISR.
+/// Deliver a fault through the interrupt mechanism. Faults
+/// (and software `int N`) bypass `flg.I` and `im` — they always
+/// fire, so a buggy program can't silently drop a div-by-zero.
+/// If the vector slot is `0` the VM halts with a host-visible
+/// fault marker; otherwise the entry sequence pushes `ip` /
+/// `fp` / `flg`, sets `flg.I`, and jumps to the ISR.
 pub fn raiseFault(vm: *VM, vector: Vector) StepResult {
     const target = vm.mmap.readWord(ivtSlot(vector));
     if (target == 0) return .halted_on_fault;
@@ -232,6 +234,21 @@ pub fn raiseFault(vm: *VM, vector: Vector) StepResult {
     vm.regs.setFlag(.interrupt_disable, true);
     vm.regs.write(.ip, target);
     return .branched;
+}
+
+/// Deliver a hardware-style IRQ. Honors the maskable layer
+/// (`flg.I` globally + `im` for vectors `0..0x0F`); host /
+/// device code calls this to signal an interrupt. Returns
+/// `null` when the IRQ is blocked by masking, otherwise the
+/// outcome of the entry sequence (same as `raiseFault`).
+pub fn raiseIrq(vm: *VM, vector: Vector) ?StepResult {
+    if (vm.regs.flagSet(.interrupt_disable)) return null;
+    const v = @intFromEnum(vector);
+    if (v < 0x10) {
+        const mask = vm.regs.read(.im);
+        if ((mask >> @intCast(v)) & 1 == 0) return null;
+    }
+    return raiseFault(vm, vector);
 }
 
 /// Address of the slot for `vector` inside the IVT.

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -33,6 +33,8 @@ pub const step = dispatch_mod.step;
 pub const run = dispatch_mod.run;
 /// Re-export: deliver a fault through the interrupt mechanism.
 pub const raiseFault = dispatch_mod.raiseFault;
+/// Re-export: deliver a maskable IRQ (respects `flg.I` and `im`).
+pub const raiseIrq = dispatch_mod.raiseIrq;
 /// Re-export: address of the IVT slot for a given vector.
 pub const ivtSlot = dispatch_mod.ivtSlot;
 /// Re-export: IVT base address.

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -102,6 +102,104 @@ test "dispatch: bytes without a handler raise invalid-opcode" {
     }
 }
 
+// ---------- raiseIrq masking ----------
+
+test "raiseIrq: flg.I set globally blocks delivery" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    setVector(&vm, .invalid_opcode, 0x3000);
+    vm.regs.setFlag(.interrupt_disable, true);
+    try std.testing.expectEqual(@as(?gero.vm.StepResult, null), gero.vm.raiseIrq(&vm, .invalid_opcode));
+    // ip untouched.
+    try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.ip));
+}
+
+test "raiseIrq: im bit clear blocks vectors 0x00..0x0F" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    setVector(&vm, .invalid_opcode, 0x3000);
+    vm.regs.setFlag(.interrupt_disable, false);
+    vm.regs.write(.im, 0xFFFD); // bit 1 (= vector 0x01) cleared
+    try std.testing.expectEqual(@as(?gero.vm.StepResult, null), gero.vm.raiseIrq(&vm, .invalid_opcode));
+}
+
+test "raiseIrq: im bit set delivers vectors 0x00..0x0F" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    setVector(&vm, .invalid_opcode, 0x3000);
+    vm.regs.setFlag(.interrupt_disable, false);
+    vm.regs.write(.im, 0xFFFF); // every maskable vector enabled
+    const r = gero.vm.raiseIrq(&vm, .invalid_opcode);
+    try std.testing.expectEqual(@as(?gero.vm.StepResult, .branched), r);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
+}
+
+test "raiseIrq: vectors >= 0x10 ignore im (only respect flg.I)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // Vector 0x20 — out of im's reach.
+    vm.mmap.writeWord(0x1040, 0x3000); // 0x1000 + 2 * 0x20
+    vm.regs.setFlag(.interrupt_disable, false);
+    vm.regs.write(.im, 0); // im fully clear
+    const v: gero.vm.Vector = @enumFromInt(0x20);
+    const r = gero.vm.raiseIrq(&vm, v);
+    try std.testing.expectEqual(@as(?gero.vm.StepResult, .branched), r);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
+}
+
+test "raiseFault: unmaskable — fires even with flg.I and im fully blocking" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    setVector(&vm, .div_by_zero, 0x3000);
+    vm.regs.setFlag(.interrupt_disable, true);
+    vm.regs.write(.im, 0);
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.raiseFault(&vm, .div_by_zero));
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
+}
+
+// ---------- nested interrupts ----------
+
+test "nested interrupts: cli inside ISR1 lets a second int fire and rti unwinds correctly" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // Vector 0x20 → ISR1 at 0x4000; vector 0x21 → ISR2 at 0x5000.
+    vm.mmap.writeWord(0x1040, 0x4000);
+    vm.mmap.writeWord(0x1042, 0x5000);
+    // main: int 0x20 at 0x1100.
+    vm.regs.write(.ip, 0x1100);
+    vm.mmap.writeByte(0x1100, 0xFC);
+    vm.mmap.writeByte(0x1101, 0x20);
+    // ISR1 at 0x4000: cli; int 0x21; rti.
+    vm.mmap.writeByte(0x4000, 0xA2); // cli
+    vm.mmap.writeByte(0x4001, 0xFC); // int
+    vm.mmap.writeByte(0x4002, 0x21);
+    vm.mmap.writeByte(0x4003, 0xFD); // rti
+    // ISR2 at 0x5000: rti.
+    vm.mmap.writeByte(0x5000, 0xFD);
+
+    _ = gero.vm.step(&vm); // int 0x20 → ip=0x4000, flg.I=1
+    try std.testing.expectEqual(@as(u16, 0x4000), vm.regs.read(.ip));
+    try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
+
+    _ = gero.vm.step(&vm); // cli → flg.I=0
+    try std.testing.expect(!vm.regs.flagSet(.interrupt_disable));
+
+    _ = gero.vm.step(&vm); // int 0x21 → ip=0x5000, flg.I=1 (auto-set on entry)
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+    try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
+
+    _ = gero.vm.step(&vm); // rti (ISR2) → back to ISR1 at 0x4003
+    try std.testing.expectEqual(@as(u16, 0x4003), vm.regs.read(.ip));
+    // flg restored to ISR1's state after cli: I=0.
+    try std.testing.expect(!vm.regs.flagSet(.interrupt_disable));
+
+    _ = gero.vm.step(&vm); // rti (ISR1) → back to main at 0x1102
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+    // sp / fp fully unwound to pre-int state.
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.fp));
+}
+
 test "dispatch: step auto-advances ip by instruction size" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();


### PR DESCRIPTION
## Summary

Completes the interrupt mechanism layer that earlier PRs built up piecemeal.

- New `raiseIrq(vm, vector) ?StepResult` — maskable IRQ entry point for hosts / devices. Returns `null` if blocked, otherwise the delivery outcome (`.branched` / `.halted_on_fault`)
- Masking rules: `flg.I = 1` blocks every IRQ globally; for vectors `0..0x0F` the `im` register provides per-vector masking; vectors `0x10..0x3F` are only blocked by `flg.I`
- `raiseFault` is documented as unmaskable — faults and software `int N` bypass both layers so a buggy program can't silently drop a div-by-zero

## Acceptance (#28)

- [x] Software `int 0x20` fires — already covered in `system.test.zig` (PR #63)
- [x] Handler can call other functions; rti returns — covered by the int/rti round-trip test
- [x] `flg.I` auto-set on entry, restored on rti — covered
- [x] Nested interrupts: ISR1 clears `flg.I`, second `int` fires inside it, rti unwinds correctly — new test in `dispatch.test.zig` covering main → ISR1 → cli → int → ISR2 → rti → rti
- [x] Per-vector `im` masking blocks vectors `0..0x0F` — new test
- [x] `raiseFault` is unmaskable — new test pinning the contract
- [x] Faults dispatch to vectors `0x01` / `0x02` / `0x03` / `0x05` — already covered across `dispatch.test.zig` (0x01) + `arith.test.zig` (0x03 / 0x05) + handler-family invalid-register tests (0x02)
- [x] Vector address `0` ⇒ halt — already covered in `dispatch.test.zig`
- [x] All four release modes pass

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 6 new tests in `dispatch.test.zig` covering `raiseIrq` masking + the nested-interrupt scenario

Closes #28.