### PR TITLE
feat(vm): bank window + SRAM persistence

### DIFF
--- a/.changeset/j8e91d3f.md
+++ b/.changeset/j8e91d3f.md
@@ -1,0 +1,21 @@
+---
+bump: minor
+---
+
+Add bank window + SRAM accessors. `src/vm/banks.zig` exposes a
+`Banks` pool that mirrors into the `0xC000..0xFEFF` window via
+the current `mb` register. Out-of-range `mb` reads `0xFF` and
+drops writes — permissive per spec. `Banks.sramSlice` exposes
+the last `sram_bank_count` banks for the host to persist; the
+mutable counterpart seeds them back on the next boot.
+
+`VM` gains `installBanks` / `installBanksWithImage` to allocate
+and own the pool, plus bank-aware `readByte` / `writeByte` /
+`readWord` / `writeWord` wrappers that route window accesses
+through the active bank and fall through to plain RAM otherwise.
+Every existing opcode handler now uses these wrappers, so user
+code executing from a bank Just Works.
+
+`vm.mmap.*` remains available for direct (non-banked) RAM
+inspection — used by tests and (future) by the boot-time
+program-image loader.

--- a/src/vm/banks.zig
+++ b/src/vm/banks.zig
@@ -1,0 +1,145 @@
+/// Bank pool — the 16KB pages that mirror into the bank window
+/// at `0xC000..0xFEFF`. Bytes outside the window are out of
+/// scope here; the VM only routes window accesses through the
+/// pool.
+///
+/// The last `sram_bank_count` banks are battery-backed: the host
+/// is expected to persist `sramSlice` and to restore it via
+/// `initWithImage` on the next boot. The pool itself does not do
+/// any I/O.
+const std = @import("std");
+
+/// Size of a single bank, matching the window size.
+pub const bank_size: usize = 0x4000;
+
+/// Lowest address that maps into the bank window.
+pub const window_base: u16 = 0xC000;
+
+/// Highest address inclusive that maps into the bank window.
+pub const window_end: u16 = 0xFEFF;
+
+/// Read of an out-of-range `mb` returns this byte per spec.
+pub const out_of_range_byte: u8 = 0xFF;
+
+/// Errors returned by the bank-pool constructors.
+pub const BanksError = error{
+    /// `sram_bank_count > bank_count`.
+    InvalidSramCount,
+    /// Provided image is not `bank_count * bank_size` bytes.
+    ImageSizeMismatch,
+};
+
+/// Allocator-owned bank pool.
+pub const Banks = struct {
+    data: []u8,
+    bank_count: u8,
+    sram_bank_count: u8,
+    allocator: std.mem.Allocator,
+
+    /// Fresh zeroed pool with `bank_count` banks. Use when the
+    /// host has no save store yet — every byte starts at zero.
+    pub fn init(
+        allocator: std.mem.Allocator,
+        bank_count: u8,
+        sram_bank_count: u8,
+    ) (std.mem.Allocator.Error || BanksError)!Banks {
+        if (sram_bank_count > bank_count) return error.InvalidSramCount;
+        const data = try allocator.alloc(u8, bank_size * bank_count);
+        @memset(data, 0);
+        return .{
+            .data = data,
+            .bank_count = bank_count,
+            .sram_bank_count = sram_bank_count,
+            .allocator = allocator,
+        };
+    }
+
+    /// Pool seeded from an existing image. Copies the bytes so
+    /// the caller can release its buffer immediately after.
+    pub fn initWithImage(
+        allocator: std.mem.Allocator,
+        image: []const u8,
+        bank_count: u8,
+        sram_bank_count: u8,
+    ) (std.mem.Allocator.Error || BanksError)!Banks {
+        if (sram_bank_count > bank_count) return error.InvalidSramCount;
+        // @as: widen u8 bank_count to usize for the byte-count math
+        const expected = bank_size * @as(usize, bank_count);
+        if (image.len != expected) return error.ImageSizeMismatch;
+        const data = try allocator.alloc(u8, expected);
+        @memcpy(data, image);
+        return .{
+            .data = data,
+            .bank_count = bank_count,
+            .sram_bank_count = sram_bank_count,
+            .allocator = allocator,
+        };
+    }
+
+    /// Release the bank buffer.
+    pub fn deinit(self: *Banks) void {
+        self.allocator.free(self.data);
+    }
+
+    fn offsetOf(addr: u16) usize {
+        return addr - window_base;
+    }
+
+    fn slotAt(self: Banks, mb: u16, addr: u16) ?usize {
+        if (mb >= self.bank_count) return null;
+        // @as: widen mb to usize so the bank-offset math doesn't wrap
+        return (@as(usize, mb) * bank_size) + offsetOf(addr);
+    }
+
+    /// Read a byte from the bank window. Out-of-range `mb`
+    /// returns `0xFF` per the permissive spec.
+    pub fn readByte(self: Banks, mb: u16, addr: u16) u8 {
+        if (self.slotAt(mb, addr)) |i| return self.data[i];
+        return out_of_range_byte;
+    }
+
+    /// Write a byte into the bank window. Out-of-range `mb`
+    /// drops the write silently.
+    pub fn writeByte(self: *Banks, mb: u16, addr: u16, value: u8) void {
+        if (self.slotAt(mb, addr)) |i| self.data[i] = value;
+    }
+
+    /// Word read that wraps the high byte to the window base if
+    /// `addr` is at the very top of the window (matches the
+    /// `Memory.readWord` wrap behavior at `0xFFFF`).
+    pub fn readWord(self: Banks, mb: u16, addr: u16) u16 {
+        const lo: u16 = self.readByte(mb, addr);
+        const hi: u16 = self.readByte(mb, addr +% 1);
+        return lo | (hi << 8);
+    }
+
+    /// Same wrap rule as `readWord` for the symmetric write.
+    pub fn writeWord(self: *Banks, mb: u16, addr: u16, value: u16) void {
+        self.writeByte(mb, addr, @truncate(value & 0xFF));
+        self.writeByte(mb, addr +% 1, @truncate((value >> 8) & 0xFF));
+    }
+
+    /// Read-only slice of the SRAM portion of the pool. The host
+    /// persists this to disk; on the next boot the same bytes go
+    /// back in via `initWithImage`'s `image` argument (with the
+    /// non-SRAM banks reproduced from the original `.gx`).
+    pub fn sramSlice(self: Banks) []const u8 {
+        // @as: widen sram_bank_count to usize for the byte count
+        const sram_bytes = @as(usize, self.sram_bank_count) * bank_size;
+        if (sram_bytes == 0) return self.data[0..0];
+        return self.data[self.data.len - sram_bytes ..];
+    }
+
+    /// Mutable variant — used by the host to seed SRAM on reload.
+    pub fn sramSliceMut(self: *Banks) []u8 {
+        // @as: widen sram_bank_count to usize for the byte count
+        const sram_bytes = @as(usize, self.sram_bank_count) * bank_size;
+        if (sram_bytes == 0) return self.data[0..0];
+        return self.data[self.data.len - sram_bytes ..];
+    }
+};
+
+/// `true` when `addr` falls inside the bank-window range.
+pub fn inWindow(addr: u16) bool {
+    return addr >= window_base and addr <= window_end;
+}

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -196,7 +196,7 @@ pub const handler_table: [256]Handler = blk: {
 /// schema-derived size.
 pub fn step(vm: *VM) StepResult {
     const ip_before = vm.regs.read(.ip);
-    const op = vm.mmap.readByte(ip_before);
+    const op = vm.readByte(ip_before);
     const handler = handler_table[op];
     const result = handler(vm);
     if (result == .cont or result == .breakpoint) {
@@ -225,7 +225,7 @@ pub fn run(vm: *VM) StepResult {
 /// fault marker; otherwise the entry sequence pushes `ip` /
 /// `fp` / `flg`, sets `flg.I`, and jumps to the ISR.
 pub fn raiseFault(vm: *VM, vector: Vector) StepResult {
-    const target = vm.mmap.readWord(ivtSlot(vector));
+    const target = vm.readWord(ivtSlot(vector));
     if (target == 0) return .halted_on_fault;
 
     pushWord(vm, vm.regs.read(.ip));
@@ -263,14 +263,14 @@ pub fn ivtSlot(vector: Vector) u16 {
 pub fn pushWord(vm: *VM, value: u16) void {
     const new_sp = vm.regs.read(.sp) -% 2;
     vm.regs.write(.sp, new_sp);
-    vm.mmap.writeWord(new_sp, value);
+    vm.writeWord(new_sp, value);
 }
 
 /// Pop a 16-bit word from the stack. Post-increment:
 /// `value = mem[sp]; sp += 2`. Overflow wraps silently.
 pub fn popWord(vm: *VM) u16 {
     const sp = vm.regs.read(.sp);
-    const value = vm.mmap.readWord(sp);
+    const value = vm.readWord(sp);
     vm.regs.write(.sp, sp +% 2);
     return value;
 }

--- a/src/vm/handlers/arith.zig
+++ b/src/vm/handlers/arith.zig
@@ -70,8 +70,8 @@ fn writeAddSub(vm: *VM, dst: u8, eff: AluEffect) StepResult {
 /// `0x40` — `add Imm16, Reg` → `reg ← reg + imm`.
 pub fn addImm16Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, reg, addWithCarry(a, imm, 0));
 }
@@ -79,8 +79,8 @@ pub fn addImm16Reg(vm: *VM) StepResult {
 /// `0x41` — `add Reg, Reg` → `dst ← dst + src`.
 pub fn addRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, dst, addWithCarry(a, b, 0));
@@ -89,7 +89,7 @@ pub fn addRegReg(vm: *VM) StepResult {
 /// `0x42` — `add Reg` → `acu ← acu + reg` (implicit-acu short form).
 pub fn addRegAcu(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const src = vm.mmap.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 1);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     const a = vm.regs.read(.acu);
     const eff = addWithCarry(a, b, 0);
@@ -105,8 +105,8 @@ pub fn addRegAcu(vm: *VM) StepResult {
 /// `0x43` — `sub Imm16, Reg` → `reg ← reg - imm`.
 pub fn subImm16Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, reg, subWithBorrow(a, imm, 0));
 }
@@ -114,8 +114,8 @@ pub fn subImm16Reg(vm: *VM) StepResult {
 /// `0x44` — `sub Reg, Reg` → `dst ← dst - src`.
 pub fn subRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, dst, subWithBorrow(a, b, 0));
@@ -124,7 +124,7 @@ pub fn subRegReg(vm: *VM) StepResult {
 /// `0x45` — `sub Reg` → `acu ← acu - reg`.
 pub fn subRegAcu(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const src = vm.mmap.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 1);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     const a = vm.regs.read(.acu);
     const eff = subWithBorrow(a, b, 0);
@@ -158,8 +158,8 @@ fn doMul(vm: *VM, dst: u8, a: u16, b: u16) StepResult {
 /// `0x46` — `mul Imm16, Reg` → `acu:reg ← reg × imm`.
 pub fn mulImm16Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return doMul(vm, reg, a, imm);
 }
@@ -167,8 +167,8 @@ pub fn mulImm16Reg(vm: *VM) StepResult {
 /// `0x47` — `mul Reg, Reg` → `acu:dst ← dst × src`.
 pub fn mulRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return doMul(vm, dst, a, b);
@@ -180,7 +180,7 @@ pub fn mulRegReg(vm: *VM) StepResult {
 /// leaves `C` intact so the op composes with `adc` sequences.
 pub fn incReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 1);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     const eff = addWithCarry(a, 1, 0);
     if (!vm.regs.writeByIndex(reg, eff.result)) return fault(vm, .invalid_register);
@@ -192,7 +192,7 @@ pub fn incReg(vm: *VM) StepResult {
 /// `0x49` — `dec Reg` → `reg ← reg - 1`. Same flag policy as `inc`.
 pub fn decReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 1);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     const eff = subWithBorrow(a, 1, 0);
     if (!vm.regs.writeByIndex(reg, eff.result)) return fault(vm, .invalid_register);
@@ -205,7 +205,7 @@ pub fn decReg(vm: *VM) StepResult {
 /// every ALU flag.
 pub fn negReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 1);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, reg, subWithBorrow(0, a, 0));
 }
@@ -268,8 +268,8 @@ fn dividend32Signed(vm: *const VM, reg_low: u16) i32 {
 /// quotient in `reg`, remainder in `acu`.
 pub fn divImm16Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const low = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     const divisor: u32 = imm;
     return doDiv(vm, reg, dividend32(vm, low), divisor);
@@ -278,8 +278,8 @@ pub fn divImm16Reg(vm: *VM) StepResult {
 /// `0x4C` — `div Reg, Reg` → unsigned 32÷16: `acu:dst ÷ src`.
 pub fn divRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const low = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const src_value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     const divisor: u32 = src_value;
@@ -289,8 +289,8 @@ pub fn divRegReg(vm: *VM) StepResult {
 /// `0x4D` — `divs Imm16, Reg` → signed 32÷16, same shape as `div`.
 pub fn divsImm16Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const low = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     // safety: u16 immediate → i16 preserves the sign bit for signed division
     const divisor_i16: i16 = @bitCast(imm);
@@ -301,8 +301,8 @@ pub fn divsImm16Reg(vm: *VM) StepResult {
 /// `0x4E` — `divs Reg, Reg` → signed 32÷16.
 pub fn divsRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const low = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const divisor = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     // safety: u16 → i16 preserves the sign bit
@@ -320,8 +320,8 @@ fn carryIn(vm: *const VM) u1 {
 /// `0x64` — `adc Imm16, Reg` → `reg ← reg + imm + C`.
 pub fn adcImm16Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, reg, addWithCarry(a, imm, carryIn(vm)));
 }
@@ -329,8 +329,8 @@ pub fn adcImm16Reg(vm: *VM) StepResult {
 /// `0x65` — `adc Reg, Reg` → `dst ← dst + src + C`.
 pub fn adcRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, dst, addWithCarry(a, b, carryIn(vm)));
@@ -339,8 +339,8 @@ pub fn adcRegReg(vm: *VM) StepResult {
 /// `0x66` — `sbc Imm16, Reg` → `reg ← reg - imm - C`.
 pub fn sbcImm16Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, reg, subWithBorrow(a, imm, carryIn(vm)));
 }
@@ -348,8 +348,8 @@ pub fn sbcImm16Reg(vm: *VM) StepResult {
 /// `0x67` — `sbc Reg, Reg` → `dst ← dst - src - C`.
 pub fn sbcRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, dst, subWithBorrow(a, b, carryIn(vm)));

--- a/src/vm/handlers/bitwise.zig
+++ b/src/vm/handlers/bitwise.zig
@@ -36,8 +36,8 @@ fn writeLogical(vm: *VM, dst: u8, result: u16) StepResult {
 /// `0x50` — `and Reg, Imm16` → `reg ← reg & imm`.
 pub fn andRegImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const imm = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const imm = vm.readWord(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, reg, a & imm);
 }
@@ -45,8 +45,8 @@ pub fn andRegImm16(vm: *VM) StepResult {
 /// `0x51` — `and Reg, Reg` → `dst ← dst & src`.
 pub fn andRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, dst, a & b);
@@ -55,8 +55,8 @@ pub fn andRegReg(vm: *VM) StepResult {
 /// `0x52` — `or Reg, Imm16` → `reg ← reg | imm`.
 pub fn orRegImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const imm = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const imm = vm.readWord(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, reg, a | imm);
 }
@@ -64,8 +64,8 @@ pub fn orRegImm16(vm: *VM) StepResult {
 /// `0x53` — `or Reg, Reg` → `dst ← dst | src`.
 pub fn orRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, dst, a | b);
@@ -74,8 +74,8 @@ pub fn orRegReg(vm: *VM) StepResult {
 /// `0x54` — `xor Reg, Imm16` → `reg ← reg ^ imm`.
 pub fn xorRegImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const imm = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const imm = vm.readWord(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, reg, a ^ imm);
 }
@@ -83,8 +83,8 @@ pub fn xorRegImm16(vm: *VM) StepResult {
 /// `0x55` — `xor Reg, Reg` → `dst ← dst ^ src`.
 pub fn xorRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, dst, a ^ b);
@@ -93,7 +93,7 @@ pub fn xorRegReg(vm: *VM) StepResult {
 /// `0x56` — `not Reg` → `reg ← ~reg`.
 pub fn notReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 1);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, reg, ~a);
 }
@@ -140,8 +140,8 @@ fn writeShift(vm: *VM, dst: u8, count: u16, eff: ShiftEffect) StepResult {
 /// `0x58` — `shl Reg, Imm8` → `reg ← reg << imm`.
 pub fn shlRegImm8(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const count = vm.mmap.readByte(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const count = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeShift(vm, reg, count, doShl(a, count));
 }
@@ -149,8 +149,8 @@ pub fn shlRegImm8(vm: *VM) StepResult {
 /// `0x59` — `shl Reg, Reg` → `dst ← dst << src` (count taken from src).
 pub fn shlRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeShift(vm, dst, count, doShl(a, count));
@@ -159,8 +159,8 @@ pub fn shlRegReg(vm: *VM) StepResult {
 /// `0x5A` — `shr Reg, Imm8` → `reg ← reg >> imm` (logical, zero-fill).
 pub fn shrRegImm8(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const count = vm.mmap.readByte(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const count = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeShift(vm, reg, count, doShr(a, count));
 }
@@ -168,8 +168,8 @@ pub fn shrRegImm8(vm: *VM) StepResult {
 /// `0x5B` — `shr Reg, Reg`.
 pub fn shrRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeShift(vm, dst, count, doShr(a, count));
@@ -218,8 +218,8 @@ fn writeRotate(vm: *VM, dst: u8, count: u16, eff: ShiftEffect) StepResult {
 /// `0x5C` — `rol Reg, Imm8` → rotate left through carry.
 pub fn rolRegImm8(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const count = vm.mmap.readByte(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const count = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     const c_in = vm.regs.flagSet(.carry);
     return writeRotate(vm, reg, count, doRol(a, count, c_in));
@@ -228,8 +228,8 @@ pub fn rolRegImm8(vm: *VM) StepResult {
 /// `0x5D` — `rol Reg, Reg` (count from src register).
 pub fn rolRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     const c_in = vm.regs.flagSet(.carry);
@@ -239,8 +239,8 @@ pub fn rolRegReg(vm: *VM) StepResult {
 /// `0x5E` — `ror Reg, Imm8` → rotate right through carry.
 pub fn rorRegImm8(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const count = vm.mmap.readByte(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const count = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     const c_in = vm.regs.flagSet(.carry);
     return writeRotate(vm, reg, count, doRor(a, count, c_in));
@@ -249,8 +249,8 @@ pub fn rorRegImm8(vm: *VM) StepResult {
 /// `0x5F` — `ror Reg, Reg`.
 pub fn rorRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     const c_in = vm.regs.flagSet(.carry);

--- a/src/vm/handlers/cmp.zig
+++ b/src/vm/handlers/cmp.zig
@@ -38,8 +38,8 @@ fn setAndFlags(vm: *VM, a: u16, b: u16) void {
 /// discard the result.
 pub fn cmpRegImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const imm = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const imm = vm.readWord(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     setSubFlags(vm, a, imm);
     return ok;
@@ -48,8 +48,8 @@ pub fn cmpRegImm16(vm: *VM) StepResult {
 /// `0x61` — `cmp Reg, Reg` → set flags from `dst - src`.
 pub fn cmpRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     setSubFlags(vm, a, b);
@@ -59,8 +59,8 @@ pub fn cmpRegReg(vm: *VM) StepResult {
 /// `0x62` — `tst Reg, Imm16` → set Z/N from `reg & imm`, clear C/V.
 pub fn tstRegImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const imm = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const imm = vm.readWord(ip +% 2);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     setAndFlags(vm, a, imm);
     return ok;
@@ -69,8 +69,8 @@ pub fn tstRegImm16(vm: *VM) StepResult {
 /// `0x63` — `tst Reg, Reg` → set Z/N from `dst & src`, clear C/V.
 pub fn tstRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     setAndFlags(vm, a, b);

--- a/src/vm/handlers/jumps.zig
+++ b/src/vm/handlers/jumps.zig
@@ -15,7 +15,7 @@ fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
 }
 
 fn readAddr(vm: *const VM) u16 {
-    return vm.mmap.readWord(vm.regs.read(.ip) +% 1);
+    return vm.readWord(vm.regs.read(.ip) +% 1);
 }
 
 fn taken(vm: *VM, target: u16) StepResult {
@@ -33,7 +33,7 @@ pub fn jmpAddr(vm: *VM) StepResult {
 /// `0x71` — `jmp Reg` → `ip ← reg`.
 pub fn jmpReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 1);
     const target = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return taken(vm, target);
 }
@@ -123,8 +123,8 @@ pub fn jnzAddr(vm: *VM) StepResult {
 /// disturb a surrounding `cmp` / `tst` chain.
 pub fn djnzRegAddr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const target = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const target = vm.readWord(ip +% 2);
     const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     const new_value = value -% 1;
     if (!vm.regs.writeByIndex(reg, new_value)) return fault(vm, .invalid_register);
@@ -136,7 +136,7 @@ pub fn djnzRegAddr(vm: *VM) StepResult {
 /// Offset is post-instruction (the assembler emits `target - (here + 2)`).
 pub fn jrImm8(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const offset_byte = vm.mmap.readByte(ip +% 1);
+    const offset_byte = vm.readByte(ip +% 1);
     // safety: u8 → i8 preserves the bit pattern as a signed offset
     const offset_i8: i8 = @bitCast(offset_byte);
     const offset_i16: i16 = offset_i8;

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -16,8 +16,8 @@ fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
 /// `0x10` — `mov Imm16, Reg` → `reg ← imm`.
 pub fn movImm16Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     if (!vm.regs.writeByIndex(reg, imm)) return fault(vm, .invalid_register);
     return ok;
 }
@@ -25,8 +25,8 @@ pub fn movImm16Reg(vm: *VM) StepResult {
 /// `0x11` — `mov Reg, Reg` → `dst ← src` (Intel order: dst first).
 pub fn movRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
     return ok;
@@ -35,19 +35,19 @@ pub fn movRegReg(vm: *VM) StepResult {
 /// `0x12` — `mov Reg, Addr` → `mem[addr] ← reg`.
 pub fn movRegAddr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const addr = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const addr = vm.readWord(ip +% 2);
     const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
-    vm.mmap.writeWord(addr, value);
+    vm.writeWord(addr, value);
     return ok;
 }
 
 /// `0x13` — `mov Addr, Reg` → `reg ← mem[addr]`.
 pub fn movAddrReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const addr = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
-    const value = vm.mmap.readWord(addr);
+    const addr = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
+    const value = vm.readWord(addr);
     if (!vm.regs.writeByIndex(reg, value)) return fault(vm, .invalid_register);
     return ok;
 }
@@ -55,9 +55,9 @@ pub fn movAddrReg(vm: *VM) StepResult {
 /// `0x14` — `mov Imm16, Addr` → `mem[addr] ← imm`.
 pub fn movImm16Addr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const addr = vm.mmap.readWord(ip +% 3);
-    vm.mmap.writeWord(addr, imm);
+    const imm = vm.readWord(ip +% 1);
+    const addr = vm.readWord(ip +% 3);
+    vm.writeWord(addr, imm);
     return ok;
 }
 
@@ -65,10 +65,10 @@ pub fn movImm16Addr(vm: *VM) StepResult {
 /// Intel order: dst first, ptr second).
 pub fn movRegPtr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.mmap.readByte(ip +% 1);
-    const ptr = vm.mmap.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 1);
+    const ptr = vm.readByte(ip +% 2);
     const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
-    const value = vm.mmap.readWord(addr);
+    const value = vm.readWord(addr);
     if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
     return ok;
 }
@@ -76,11 +76,11 @@ pub fn movRegPtr(vm: *VM) StepResult {
 /// `0x16` — `mov [Reg], Reg` → `mem[ptr] ← src` (indirect store).
 pub fn movPtrReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const ptr = vm.mmap.readByte(ip +% 1);
-    const src = vm.mmap.readByte(ip +% 2);
+    const ptr = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
     const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
     const value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
-    vm.mmap.writeWord(addr, value);
+    vm.writeWord(addr, value);
     return ok;
 }
 
@@ -88,11 +88,11 @@ pub fn movPtrReg(vm: *VM) StepResult {
 /// (indexed load).
 pub fn movIndexed(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const base = vm.mmap.readWord(ip +% 1);
-    const idx_reg = vm.mmap.readByte(ip +% 3);
-    const dst = vm.mmap.readByte(ip +% 4);
+    const base = vm.readWord(ip +% 1);
+    const idx_reg = vm.readByte(ip +% 3);
+    const dst = vm.readByte(ip +% 4);
     const offset = vm.regs.readByIndex(idx_reg) orelse return fault(vm, .invalid_register);
-    const value = vm.mmap.readWord(base +% offset);
+    const value = vm.readWord(base +% offset);
     if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
     return ok;
 }
@@ -100,29 +100,29 @@ pub fn movIndexed(vm: *VM) StepResult {
 /// `0x18` — `mov Imm16, [Reg]` → `mem[ptr] ← imm`.
 pub fn movImm16Ptr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const ptr = vm.mmap.readByte(ip +% 3);
+    const imm = vm.readWord(ip +% 1);
+    const ptr = vm.readByte(ip +% 3);
     const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
-    vm.mmap.writeWord(addr, imm);
+    vm.writeWord(addr, imm);
     return ok;
 }
 
 /// `0x19` — `mov Reg, ZP` → `mem[zp] ← reg` (zero-page store).
 pub fn movRegZp(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const zp = vm.mmap.readByte(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const zp = vm.readByte(ip +% 2);
     const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
-    vm.mmap.writeWord(zp, value);
+    vm.writeWord(zp, value);
     return ok;
 }
 
 /// `0x1A` — `mov ZP, Reg` → `reg ← mem[zp]` (zero-page load).
 pub fn movZpReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const zp = vm.mmap.readByte(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 2);
-    const value = vm.mmap.readWord(zp);
+    const zp = vm.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 2);
+    const value = vm.readWord(zp);
     if (!vm.regs.writeByIndex(reg, value)) return fault(vm, .invalid_register);
     return ok;
 }
@@ -130,26 +130,26 @@ pub fn movZpReg(vm: *VM) StepResult {
 /// `0x1B` — `mov Imm16, ZP` → `mem[zp] ← imm`.
 pub fn movImm16Zp(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
-    const zp = vm.mmap.readByte(ip +% 3);
-    vm.mmap.writeWord(zp, imm);
+    const imm = vm.readWord(ip +% 1);
+    const zp = vm.readByte(ip +% 3);
+    vm.writeWord(zp, imm);
     return ok;
 }
 
 /// `0x20` — `mov8 Imm8, Addr` → `mem[addr] ← imm` (1 byte).
 pub fn mov8Imm8Addr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readByte(ip +% 1);
-    const addr = vm.mmap.readWord(ip +% 2);
-    vm.mmap.writeByte(addr, imm);
+    const imm = vm.readByte(ip +% 1);
+    const addr = vm.readWord(ip +% 2);
+    vm.writeByte(addr, imm);
     return ok;
 }
 
 /// `0x21` — `mov8 Imm8, Reg` → `reg.lo ← imm; reg.hi ← 0`.
 pub fn mov8Imm8Reg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readByte(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 2);
+    const imm = vm.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 2);
     if (!vm.regs.writeByIndex(reg, imm)) return fault(vm, .invalid_register);
     return ok;
 }
@@ -157,9 +157,9 @@ pub fn mov8Imm8Reg(vm: *VM) StepResult {
 /// `0x22` — `mov8 Addr, Reg` → `reg.lo ← mem[addr]; reg.hi ← 0`.
 pub fn mov8AddrReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const addr = vm.mmap.readWord(ip +% 1);
-    const reg = vm.mmap.readByte(ip +% 3);
-    const value = vm.mmap.readByte(addr);
+    const addr = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
+    const value = vm.readByte(addr);
     if (!vm.regs.writeByIndex(reg, value)) return fault(vm, .invalid_register);
     return ok;
 }
@@ -168,23 +168,23 @@ pub fn mov8AddrReg(vm: *VM) StepResult {
 /// store via pointer register).
 pub fn mov8RegPtr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const src = vm.mmap.readByte(ip +% 1);
-    const ptr = vm.mmap.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const ptr = vm.readByte(ip +% 2);
     const value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
     // safety: truncating the high half is exactly the spec'd
     //         "mem[ptr] ← reg.lo" behavior for `mov8`
-    vm.mmap.writeByte(addr, @truncate(value));
+    vm.writeByte(addr, @truncate(value));
     return ok;
 }
 
 /// `0x24` — `mov8 [Reg], Reg` → `reg.lo ← mem[ptr]; reg.hi ← 0`.
 pub fn mov8PtrReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const ptr = vm.mmap.readByte(ip +% 1);
-    const dst = vm.mmap.readByte(ip +% 2);
+    const ptr = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const addr = vm.regs.readByIndex(ptr) orelse return fault(vm, .invalid_register);
-    const value = vm.mmap.readByte(addr);
+    const value = vm.readByte(addr);
     if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
     return ok;
 }
@@ -192,21 +192,21 @@ pub fn mov8PtrReg(vm: *VM) StepResult {
 /// `0x25` — `movh Reg, Addr` → `mem[addr] ← reg.hi`.
 pub fn movhRegAddr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const addr = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const addr = vm.readWord(ip +% 2);
     const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     // safety: isolating the high byte is the spec'd "reg.hi" half
-    vm.mmap.writeByte(addr, @truncate(value >> 8));
+    vm.writeByte(addr, @truncate(value >> 8));
     return ok;
 }
 
 /// `0x26` — `movl Reg, Addr` → `mem[addr] ← reg.lo`.
 pub fn movlRegAddr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
-    const addr = vm.mmap.readWord(ip +% 2);
+    const reg = vm.readByte(ip +% 1);
+    const addr = vm.readWord(ip +% 2);
     const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     // safety: isolating the low byte is the spec'd "reg.lo" half
-    vm.mmap.writeByte(addr, @truncate(value));
+    vm.writeByte(addr, @truncate(value));
     return ok;
 }

--- a/src/vm/handlers/stack.zig
+++ b/src/vm/handlers/stack.zig
@@ -16,7 +16,7 @@ fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
 /// `0x30` — `push Imm16` → `sp -= 2; mem[sp] = imm`.
 pub fn pushImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const imm = vm.mmap.readWord(ip +% 1);
+    const imm = vm.readWord(ip +% 1);
     dispatch.pushWord(vm, imm);
     return ok;
 }
@@ -24,7 +24,7 @@ pub fn pushImm16(vm: *VM) StepResult {
 /// `0x31` — `push Reg` → `sp -= 2; mem[sp] = reg`.
 pub fn pushReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 1);
     const value = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     dispatch.pushWord(vm, value);
     return ok;
@@ -33,7 +33,7 @@ pub fn pushReg(vm: *VM) StepResult {
 /// `0x32` — `pop Reg` → `reg = mem[sp]; sp += 2`.
 pub fn popReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 1);
     const value = dispatch.popWord(vm);
     if (!vm.regs.writeByIndex(reg, value)) return fault(vm, .invalid_register);
     return ok;

--- a/src/vm/handlers/subroutine.zig
+++ b/src/vm/handlers/subroutine.zig
@@ -30,14 +30,14 @@ fn enter(vm: *VM, target: u16, ip_after: u16) StepResult {
 /// `0x80` — `call Addr`.
 pub fn callAddr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const target = vm.mmap.readWord(ip +% 1);
+    const target = vm.readWord(ip +% 1);
     return enter(vm, target, ip +% 3);
 }
 
 /// `0x81` — `call Reg` → `ip ← reg`.
 pub fn callReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.mmap.readByte(ip +% 1);
+    const reg = vm.readByte(ip +% 1);
     const target = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return enter(vm, target, ip +% 2);
 }

--- a/src/vm/handlers/system.zig
+++ b/src/vm/handlers/system.zig
@@ -19,8 +19,8 @@ fn fault(vm: *VM, vector: dispatch.Vector) StepResult {
 /// `0x90` — `swap Reg, Reg` → atomic swap.
 pub fn swap(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const a_idx = vm.mmap.readByte(ip +% 1);
-    const b_idx = vm.mmap.readByte(ip +% 2);
+    const a_idx = vm.readByte(ip +% 1);
+    const b_idx = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(a_idx) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(b_idx) orelse return fault(vm, .invalid_register);
     if (!vm.regs.writeByIndex(a_idx, b)) return fault(vm, .invalid_register);
@@ -74,7 +74,7 @@ pub fn clv(vm: *VM) StepResult {
 /// VM-emitted faults.
 pub fn intImm8(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const vector_byte = vm.mmap.readByte(ip +% 1);
+    const vector_byte = vm.readByte(ip +% 1);
     // Advance ip so the saved return address points at the
     // instruction AFTER int N, not at int itself.
     vm.regs.write(.ip, ip +% 2);

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -6,6 +6,7 @@ const memory = @import("memory.zig");
 const mapper = @import("mapper.zig");
 const dispatch_mod = @import("dispatch.zig");
 const opcodes_mod = @import("opcodes.zig");
+const banks_mod = @import("banks.zig");
 
 /// Re-export: named register handles.
 pub const Register = registers.Register;
@@ -47,6 +48,16 @@ pub const OpcodeInfo = opcodes_mod.OpcodeInfo;
 pub const opcode_table = opcodes_mod.table;
 /// Re-export: byte size of one operand.
 pub const operandSize = opcodes_mod.operandSize;
+/// Re-export: bank pool type.
+pub const Banks = banks_mod.Banks;
+/// Re-export: bank pool errors.
+pub const BanksError = banks_mod.BanksError;
+/// Re-export: bank-window base address.
+pub const bank_window_base = banks_mod.window_base;
+/// Re-export: bank-window end address inclusive.
+pub const bank_window_end = banks_mod.window_end;
+/// Re-export: single-bank size in bytes.
+pub const bank_size = banks_mod.bank_size;
 
 /// Boot-state default for `sp` — top of memory minus 1 word so the
 /// first push lands on a valid word.
@@ -58,11 +69,15 @@ pub const fp_boot: u16 = 0xFFFE;
 /// Boot-state default for `im` — every maskable vector enabled.
 pub const im_boot: u16 = 0xFFFF;
 
-/// The VM. Owns the register file and the memory mapper (which
-/// owns the 64KB RAM and the host device registry).
+/// The VM. Owns the register file, the memory mapper (which
+/// holds the 64KB RAM and the host device registry), and the
+/// optional bank pool that backs the `0xC000..0xFEFF` window.
 pub const VM = struct {
     regs: Registers,
     mmap: MemoryMapper,
+    /// `null` when the program is unbanked — the bank window
+    /// falls through to plain RAM in that case.
+    banks: ?Banks,
 
     /// Construct a fresh VM with default boot state. `ip` is left
     /// at 0; the loader sets it to the program's entry point. The
@@ -72,14 +87,91 @@ pub const VM = struct {
         var vm: VM = .{
             .regs = Registers.init(),
             .mmap = MemoryMapper.init(allocator),
+            .banks = null,
         };
         vm.bootInitRegisters();
         return vm;
     }
 
-    /// Release VM-owned resources (the device registry).
+    /// Release VM-owned resources (the device registry + banks).
     pub fn deinit(self: *VM) void {
+        if (self.banks) |*b| b.deinit();
         self.mmap.deinit();
+    }
+
+    /// Allocate a fresh bank pool of `bank_count` zero banks,
+    /// the last `sram_bank_count` of which are battery-backed.
+    /// Replaces any previously-installed pool.
+    pub fn installBanks(
+        self: *VM,
+        allocator: std.mem.Allocator,
+        bank_count: u8,
+        sram_bank_count: u8,
+    ) (std.mem.Allocator.Error || BanksError)!void {
+        if (self.banks) |*b| b.deinit();
+        self.banks = try Banks.init(allocator, bank_count, sram_bank_count);
+    }
+
+    /// Same as `installBanks` but seeds the pool from `image`.
+    /// `image.len` must equal `bank_count * bank_size`.
+    pub fn installBanksWithImage(
+        self: *VM,
+        allocator: std.mem.Allocator,
+        image: []const u8,
+        bank_count: u8,
+        sram_bank_count: u8,
+    ) (std.mem.Allocator.Error || BanksError)!void {
+        if (self.banks) |*b| b.deinit();
+        self.banks = try Banks.initWithImage(allocator, image, bank_count, sram_bank_count);
+    }
+
+    /// Persisted SRAM bytes (read-only). Empty when the pool is
+    /// not installed or `sram_bank_count == 0`.
+    pub fn sramSlice(self: *const VM) []const u8 {
+        if (self.banks) |b| return b.sramSlice();
+        return &.{};
+    }
+
+    /// Mutable SRAM bytes — the host writes restored bytes here
+    /// during boot.
+    pub fn sramSliceMut(self: *VM) []u8 {
+        if (self.banks) |*b| return b.sramSliceMut();
+        return &.{};
+    }
+
+    /// Bank-aware byte read. Falls through to plain RAM outside
+    /// the bank window, or when no bank pool is installed.
+    pub fn readByte(self: *const VM, addr: u16) u8 {
+        if (banks_mod.inWindow(addr)) {
+            if (self.banks) |b| return b.readByte(self.regs.read(.mb), addr);
+        }
+        return self.mmap.readByte(addr);
+    }
+
+    /// Bank-aware byte write.
+    pub fn writeByte(self: *VM, addr: u16, value: u8) void {
+        if (banks_mod.inWindow(addr)) {
+            if (self.banks) |*b| {
+                b.writeByte(self.regs.read(.mb), addr, value);
+                return;
+            }
+        }
+        self.mmap.writeByte(addr, value);
+    }
+
+    /// Bank-aware word read. The low and high bytes are routed
+    /// independently, so a word straddling the window edge gets
+    /// the right source for each half.
+    pub fn readWord(self: *const VM, addr: u16) u16 {
+        const lo: u16 = self.readByte(addr);
+        const hi: u16 = self.readByte(addr +% 1);
+        return lo | (hi << 8);
+    }
+
+    /// Bank-aware word write.
+    pub fn writeWord(self: *VM, addr: u16, value: u16) void {
+        self.writeByte(addr, @truncate(value & 0xFF));
+        self.writeByte(addr +% 1, @truncate((value >> 8) & 0xFF));
     }
 
     /// Re-applies the register defaults. Public so the loader can

--- a/tests/vm/banks.test.zig
+++ b/tests/vm/banks.test.zig
@@ -1,0 +1,195 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+const Banks = gero.vm.Banks;
+
+test "banks: window base + end are 0xC000 / 0xFEFF" {
+    try std.testing.expectEqual(@as(u16, 0xC000), gero.vm.bank_window_base);
+    try std.testing.expectEqual(@as(u16, 0xFEFF), gero.vm.bank_window_end);
+    try std.testing.expectEqual(@as(usize, 0x4000), gero.vm.bank_size);
+}
+
+test "banks: zero pool has every byte at 0 across every bank" {
+    var b = try Banks.init(std.testing.allocator, 4, 0);
+    defer b.deinit();
+    for ([_]u16{ 0, 1, 2, 3 }) |mb| {
+        try std.testing.expectEqual(@as(u8, 0), b.readByte(mb, 0xC000));
+        try std.testing.expectEqual(@as(u8, 0), b.readByte(mb, 0xFEFF));
+    }
+}
+
+test "banks: write reads back from same bank, isolated from others" {
+    var b = try Banks.init(std.testing.allocator, 4, 0);
+    defer b.deinit();
+    b.writeByte(2, 0xC000, 0x42);
+    try std.testing.expectEqual(@as(u8, 0x42), b.readByte(2, 0xC000));
+    // Other banks unaffected.
+    try std.testing.expectEqual(@as(u8, 0), b.readByte(0, 0xC000));
+    try std.testing.expectEqual(@as(u8, 0), b.readByte(1, 0xC000));
+    try std.testing.expectEqual(@as(u8, 0), b.readByte(3, 0xC000));
+}
+
+test "banks: out-of-range mb reads 0xFF, writes are dropped" {
+    var b = try Banks.init(std.testing.allocator, 4, 0);
+    defer b.deinit();
+    try std.testing.expectEqual(@as(u8, 0xFF), b.readByte(255, 0xC000));
+    b.writeByte(255, 0xC000, 0x42); // dropped
+    try std.testing.expectEqual(@as(u8, 0xFF), b.readByte(255, 0xC000));
+    // Real banks untouched.
+    try std.testing.expectEqual(@as(u8, 0), b.readByte(0, 0xC000));
+}
+
+test "banks: initWithImage rejects size mismatch + bad sram count" {
+    const small = [_]u8{0} ** 100;
+    try std.testing.expectError(error.ImageSizeMismatch, Banks.initWithImage(std.testing.allocator, &small, 4, 0));
+
+    const right = [_]u8{0} ** (0x4000 * 2);
+    try std.testing.expectError(error.InvalidSramCount, Banks.initWithImage(std.testing.allocator, &right, 2, 3));
+}
+
+test "banks: sramSlice exposes last N banks; empty when sram_bank_count = 0" {
+    var b = try Banks.init(std.testing.allocator, 4, 2);
+    defer b.deinit();
+    // Write a marker at the very start of the SRAM region (= start
+    // of bank 2 = byte offset 2 * 0x4000).
+    b.writeByte(2, 0xC000, 0x55);
+    const sram = b.sramSlice();
+    try std.testing.expectEqual(@as(usize, 0x4000 * 2), sram.len);
+    try std.testing.expectEqual(@as(u8, 0x55), sram[0]);
+
+    var b2 = try Banks.init(std.testing.allocator, 4, 0);
+    defer b2.deinit();
+    try std.testing.expectEqual(@as(usize, 0), b2.sramSlice().len);
+}
+
+test "banks: word reads / writes are little-endian within a bank" {
+    var b = try Banks.init(std.testing.allocator, 1, 0);
+    defer b.deinit();
+    b.writeWord(0, 0xC000, 0xABCD);
+    try std.testing.expectEqual(@as(u8, 0xCD), b.readByte(0, 0xC000));
+    try std.testing.expectEqual(@as(u8, 0xAB), b.readByte(0, 0xC001));
+    try std.testing.expectEqual(@as(u16, 0xABCD), b.readWord(0, 0xC000));
+}
+
+// ---------- VM-level integration ----------
+
+test "vm.readByte unbanked: bank window falls through to plain RAM" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // No banks installed → window is plain RAM.
+    vm.mmap.writeByte(0xC000, 0x42);
+    try std.testing.expectEqual(@as(u8, 0x42), vm.readByte(0xC000));
+}
+
+test "vm.readByte banked: 0xC000 routes to bank mb" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try vm.installBanks(std.testing.allocator, 4, 0);
+    // Seed bank 2 directly so we can verify mb-switching.
+    vm.banks.?.writeByte(2, 0xC000, 0xAA);
+    vm.banks.?.writeByte(0, 0xC000, 0x11);
+
+    vm.regs.write(.mb, 0);
+    try std.testing.expectEqual(@as(u8, 0x11), vm.readByte(0xC000));
+
+    vm.regs.write(.mb, 2);
+    try std.testing.expectEqual(@as(u8, 0xAA), vm.readByte(0xC000));
+}
+
+test "vm.writeByte banked: routes to bank mb, leaves RAM untouched" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try vm.installBanks(std.testing.allocator, 2, 0);
+    vm.regs.write(.mb, 1);
+    vm.writeByte(0xC000, 0x99);
+    // Bank received it.
+    try std.testing.expectEqual(@as(u8, 0x99), vm.banks.?.readByte(1, 0xC000));
+    // Underlying RAM at 0xC000 stays zero — banking intercepts.
+    try std.testing.expectEqual(@as(u8, 0), vm.mmap.mem.readByte(0xC000));
+}
+
+test "vm.readByte: out-of-window addresses bypass banking" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try vm.installBanks(std.testing.allocator, 2, 0);
+    vm.regs.write(.mb, 0);
+    // Address 0x1100 is user RAM — should go through plain mmap.
+    vm.mmap.writeByte(0x1100, 0xDE);
+    try std.testing.expectEqual(@as(u8, 0xDE), vm.readByte(0x1100));
+}
+
+test "vm.readWord: low byte and high byte route independently across window edge" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try vm.installBanks(std.testing.allocator, 1, 0);
+    vm.regs.write(.mb, 0);
+
+    // Word at 0xFEFF: low byte is in window (bank), high byte is
+    // at 0xFF00 (outside the window → mmap).
+    vm.banks.?.writeByte(0, 0xFEFF, 0xAA);
+    vm.mmap.writeByte(0xFF00, 0xBB);
+    try std.testing.expectEqual(@as(u16, 0xBBAA), vm.readWord(0xFEFF));
+}
+
+test "sram round-trip via the host: save slice, install on new VM, read back" {
+    // Step 1 — first boot, write into SRAM.
+    var saved: [0x4000]u8 = undefined;
+    {
+        var vm = VM.init(std.testing.allocator);
+        defer vm.deinit();
+        try vm.installBanks(std.testing.allocator, 2, 1); // bank 1 is SRAM
+        vm.regs.write(.mb, 1);
+        vm.writeWord(0xC000, 0xBEEF);
+        @memcpy(&saved, vm.sramSlice());
+    }
+
+    // Step 2 — second boot, host restores SRAM via the mutable
+    // slice.
+    var vm2 = VM.init(std.testing.allocator);
+    defer vm2.deinit();
+    try vm2.installBanks(std.testing.allocator, 2, 1);
+    @memcpy(vm2.sramSliceMut(), &saved);
+    vm2.regs.write(.mb, 1);
+    try std.testing.expectEqual(@as(u16, 0xBEEF), vm2.readWord(0xC000));
+}
+
+test "installBanks rejects sram_bank_count > bank_count" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try std.testing.expectError(error.InvalidSramCount, vm.installBanks(std.testing.allocator, 2, 3));
+}
+
+test "installBanksWithImage seeds banks from the provided image" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    var image: [0x4000 * 2]u8 = undefined;
+    @memset(&image, 0);
+    image[0] = 0x11; // bank 0 byte 0
+    image[0x4000] = 0x22; // bank 1 byte 0
+    try vm.installBanksWithImage(std.testing.allocator, &image, 2, 0);
+
+    vm.regs.write(.mb, 0);
+    try std.testing.expectEqual(@as(u8, 0x11), vm.readByte(0xC000));
+    vm.regs.write(.mb, 1);
+    try std.testing.expectEqual(@as(u8, 0x22), vm.readByte(0xC000));
+}
+
+test "mov 0x14 imm16,addr: bank-aware write lands in the active bank" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try vm.installBanks(std.testing.allocator, 2, 0);
+    vm.regs.write(.mb, 1);
+
+    // `mov 0xCAFE, [0xC000]` — bytecode `[0x14, lo, hi, addr_lo, addr_hi]`.
+    vm.regs.write(.ip, 0x1100);
+    vm.mmap.writeByte(0x1100, 0x14);
+    vm.mmap.writeByte(0x1101, 0xFE);
+    vm.mmap.writeByte(0x1102, 0xCA);
+    vm.mmap.writeByte(0x1103, 0x00);
+    vm.mmap.writeByte(0x1104, 0xC0);
+
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xCAFE), vm.banks.?.readWord(1, 0xC000));
+    // RAM at 0xC000 untouched.
+    try std.testing.expectEqual(@as(u16, 0), vm.mmap.mem.readWord(0xC000));
+}


### PR DESCRIPTION
## Summary

- New `src/vm/banks.zig` — `Banks` pool that backs the `0xC000..0xFEFF` window. Routes via the active `mb`; out-of-range `mb` reads `0xFF` and drops writes (permissive per spec)
- SRAM exposed via `sramSlice` / `sramSliceMut` — the host persists / restores the last `sram_bank_count` banks. The VM itself does no I/O
- `VM.installBanks` / `installBanksWithImage` to allocate + own the pool; `VM.deinit` releases it
- Bank-aware `VM.readByte` / `writeByte` / `readWord` / `writeWord` wrappers route window accesses through the active bank and fall through to plain RAM otherwise. Every existing handler now uses these wrappers so opcodes executing from a bank just work

## Acceptance (#29)

- [x] Multi-bank: write `mb=2`, read `0xC000` → bank 2's first byte
- [x] `mb=255` with `bank_count=4`: reads return `0xFF`; writes are dropped
- [x] Unbanked program: `mb` is a plain register; window is plain RAM
- [x] SRAM round-trip: write to SRAM bank → save `sramSlice` → fresh VM → restore via `sramSliceMut` → read back same bytes
- [x] `int 0x21` flush convention: handled by the standard `int` mechanism (host installs the IVT slot; the VM provides `sramSlice` for the handler to persist)
- [x] All four release modes pass

### Bonus: opcode-level integration

A `mov 0xCAFE, [0xC000]` test runs through dispatch with `mb=1` and verifies the bytes land in bank 1 (and *not* in underlying RAM) — proves the handler refactor reaches the bank routing.

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 15 tests in `tests/vm/banks.test.zig`: pool basics + out-of-range + image-init errors + SRAM slice + word LE + VM-level routing (banked vs unbanked) + window-edge straddle + sram round-trip + opcode-level integration

Closes #29.