### PR TITLE
feat(vm): .gx loader + boot + cycle counter

### DIFF
--- a/.changeset/k4d72f81.md
+++ b/.changeset/k4d72f81.md
@@ -1,0 +1,18 @@
+---
+bump: minor
+---
+
+Add the `.gx` parser, the boot helper, and a per-step cycle
+counter — the final pieces of the v0.1 VM kernel. `parseGx`
+validates magic, version, flags, sram count and section sizes,
+then exposes the image / banks / debug slices borrowed from the
+input buffer. `VM.boot` copies the base image into RAM at
+`0x0000`, sets `ip` to the entry point, and installs zeroed
+bank storage from the file (the host seeds SRAM through
+`sramSliceMut` afterward). `step` increments `vm.cycles` by
+one on every dispatch, faulting instructions included — a
+foundation the perf pass refines into a per-opcode cost table.
+
+With this, the VM kernel tracking issue (#2) is complete: 90
+opcodes, banking + SRAM, IVT + IRQ masking, loader + boot +
+cycle counter, all wired through one `step` / `run` API.

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -195,6 +195,7 @@ pub const handler_table: [256]Handler = blk: {
 /// without moving `ip`) advances past the instruction by the
 /// schema-derived size.
 pub fn step(vm: *VM) StepResult {
+    vm.cycles +%= 1;
     const ip_before = vm.regs.read(.ip);
     const op = vm.readByte(ip_before);
     const handler = handler_table[op];

--- a/src/vm/loader.zig
+++ b/src/vm/loader.zig
@@ -1,0 +1,143 @@
+/// `.gx` bytecode-file parser. Validates the 16-byte header,
+/// confirms the image / bank sections fit, and hands back
+/// slices the caller can copy into a VM. No allocation; the
+/// returned slices borrow from the input buffer.
+const std = @import("std");
+
+/// Magic bytes at offset `0x00..0x04`.
+pub const magic: [4]u8 = .{ 'G', 'E', 'R', 'O' };
+
+/// ISA version this loader accepts (high byte = major, low =
+/// minor). Files with a higher major are rejected; same major
+/// + higher minor are accepted (backwards-compatible additions).
+pub const version_target: u16 = 0x0001;
+
+/// Header bytes — fixed 16-byte prefix.
+pub const header_size: usize = 16;
+
+/// Single-bank size on disk (matches the in-memory bank size).
+pub const bank_disk_size: usize = 0x4000;
+
+/// Flag bit 0: bank section follows the base image.
+pub const flag_banked: u16 = 0b0000_0000_0000_0001;
+/// Flag bit 1: debug-symbol section follows the banks.
+pub const flag_has_debug: u16 = 0b0000_0000_0000_0010;
+/// All bits the loader recognizes; the rest are reserved and
+/// must be `0`.
+pub const flag_known_mask: u16 = flag_banked | flag_has_debug;
+
+/// Errors returned by the parser.
+pub const LoaderError = error{
+    /// File shorter than the 16-byte header.
+    TooSmall,
+    /// First four bytes aren't `'G' 'E' 'R' 'O'`.
+    BadMagic,
+    /// Major version exceeds what this loader supports.
+    UnsupportedVersion,
+    /// `flags` has a reserved bit set, or the trailing
+    /// `reserved` field is non-zero.
+    ReservedBitsSet,
+    /// `sram_bank_count > bank_count`.
+    InvalidSramCount,
+    /// File too short for the declared `image_size`.
+    ImageSizeMismatch,
+    /// `banked` flag set but the file is too short for the
+    /// declared `bank_count` banks.
+    BanksSizeMismatch,
+};
+
+/// Parsed file header.
+pub const Header = struct {
+    version: u16,
+    flags: u16,
+    entry_point: u16,
+    image_size: u16,
+    bank_count: u8,
+    sram_bank_count: u8,
+
+    /// `true` when the file carries a bank-pool section.
+    pub fn isBanked(self: Header) bool {
+        return (self.flags & flag_banked) != 0;
+    }
+
+    /// `true` when the file carries a debug-symbol section.
+    pub fn hasDebugSymbols(self: Header) bool {
+        return (self.flags & flag_has_debug) != 0;
+    }
+};
+
+/// Output of `parse` — header plus borrowed slices into the
+/// input buffer. `banks` and `debug` are empty when the
+/// corresponding flag is clear.
+pub const LoadedProgram = struct {
+    header: Header,
+    image: []const u8,
+    banks: []const u8,
+    debug: []const u8,
+};
+
+fn readU16Le(bytes: []const u8, offset: usize) u16 {
+    const lo: u16 = bytes[offset];
+    const hi: u16 = bytes[offset + 1];
+    return lo | (hi << 8);
+}
+
+/// Validate + parse a `.gx` buffer.
+pub fn parse(bytes: []const u8) LoaderError!LoadedProgram {
+    if (bytes.len < header_size) return error.TooSmall;
+    if (!std.mem.eql(u8, bytes[0..4], &magic)) return error.BadMagic;
+
+    const version = readU16Le(bytes, 0x04);
+    // Major check: high byte must match.
+    if ((version >> 8) > (version_target >> 8)) return error.UnsupportedVersion;
+
+    const flags = readU16Le(bytes, 0x06);
+    if ((flags & ~flag_known_mask) != 0) return error.ReservedBitsSet;
+
+    const entry_point = readU16Le(bytes, 0x08);
+    const image_size = readU16Le(bytes, 0x0A);
+    const bank_count = bytes[0x0C];
+    const sram_bank_count = bytes[0x0D];
+    const reserved = readU16Le(bytes, 0x0E);
+    if (reserved != 0) return error.ReservedBitsSet;
+    if (sram_bank_count > bank_count) return error.InvalidSramCount;
+
+    const image_start = header_size;
+    // @as: widen u16 image_size to usize for slice-end math
+    const image_end = image_start + @as(usize, image_size);
+    if (bytes.len < image_end) return error.ImageSizeMismatch;
+    const image = bytes[image_start..image_end];
+
+    var banks: []const u8 = bytes[image_end..image_end];
+    var cursor = image_end;
+    if ((flags & flag_banked) != 0) {
+        // @as: widen u8 bank_count to usize for the byte total
+        const banks_bytes = bank_disk_size * @as(usize, bank_count);
+        const banks_end = cursor + banks_bytes;
+        if (bytes.len < banks_end) return error.BanksSizeMismatch;
+        banks = bytes[cursor..banks_end];
+        cursor = banks_end;
+    }
+
+    var debug: []const u8 = bytes[cursor..cursor];
+    if ((flags & flag_has_debug) != 0) {
+        // Debug symbols are variable-length; for v0.1 the loader
+        // just exposes the trailing slice. The disassembler will
+        // parse it on demand.
+        debug = bytes[cursor..];
+    }
+
+    return .{
+        .header = .{
+            .version = version,
+            .flags = flags,
+            .entry_point = entry_point,
+            .image_size = image_size,
+            .bank_count = bank_count,
+            .sram_bank_count = sram_bank_count,
+        },
+        .image = image,
+        .banks = banks,
+        .debug = debug,
+    };
+}

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -7,6 +7,7 @@ const mapper = @import("mapper.zig");
 const dispatch_mod = @import("dispatch.zig");
 const opcodes_mod = @import("opcodes.zig");
 const banks_mod = @import("banks.zig");
+const loader_mod = @import("loader.zig");
 
 /// Re-export: named register handles.
 pub const Register = registers.Register;
@@ -58,6 +59,12 @@ pub const bank_window_base = banks_mod.window_base;
 pub const bank_window_end = banks_mod.window_end;
 /// Re-export: single-bank size in bytes.
 pub const bank_size = banks_mod.bank_size;
+/// Re-export: `.gx` parser entry point.
+pub const parseGx = loader_mod.parse;
+/// Re-export: parsed program shape.
+pub const LoadedProgram = loader_mod.LoadedProgram;
+/// Re-export: loader error set.
+pub const LoaderError = loader_mod.LoaderError;
 
 /// Boot-state default for `sp` — top of memory minus 1 word so the
 /// first push lands on a valid word.
@@ -78,6 +85,10 @@ pub const VM = struct {
     /// `null` when the program is unbanked — the bank window
     /// falls through to plain RAM in that case.
     banks: ?Banks,
+    /// Total instructions retired since boot. `step` increments
+    /// by one per dispatch (faulting instructions counted too —
+    /// they still consumed a cycle).
+    cycles: u64,
 
     /// Construct a fresh VM with default boot state. `ip` is left
     /// at 0; the loader sets it to the program's entry point. The
@@ -88,6 +99,7 @@ pub const VM = struct {
             .regs = Registers.init(),
             .mmap = MemoryMapper.init(allocator),
             .banks = null,
+            .cycles = 0,
         };
         vm.bootInitRegisters();
         return vm;
@@ -137,6 +149,28 @@ pub const VM = struct {
     pub fn sramSliceMut(self: *VM) []u8 {
         if (self.banks) |*b| return b.sramSliceMut();
         return &.{};
+    }
+
+    /// Load a parsed `.gx` program: copies the base image into
+    /// RAM at `0x0000`, sets `ip` to the entry point, and
+    /// installs zeroed bank storage if the program is banked.
+    /// The caller is responsible for seeding SRAM via
+    /// `sramSliceMut` after boot if a save store exists.
+    pub fn boot(
+        self: *VM,
+        allocator: std.mem.Allocator,
+        loaded: LoadedProgram,
+    ) (std.mem.Allocator.Error || BanksError)!void {
+        @memcpy(self.mmap.mem.bytes[0..loaded.image.len], loaded.image);
+        self.regs.write(.ip, loaded.header.entry_point);
+        if (loaded.header.bank_count > 0) {
+            try self.installBanksWithImage(
+                allocator,
+                loaded.banks,
+                loaded.header.bank_count,
+                loaded.header.sram_bank_count,
+            );
+        }
     }
 
     /// Bank-aware byte read. Falls through to plain RAM outside

--- a/tests/vm/loader.test.zig
+++ b/tests/vm/loader.test.zig
@@ -1,0 +1,221 @@
+const std = @import("std");
+const gero = @import("gero");
+const VM = gero.vm.VM;
+
+/// Build a minimal valid .gx header + image. Returns the
+/// owned-on-stack buffer; caller copies if needed.
+fn buildGx(
+    out: []u8,
+    version: u16,
+    flags: u16,
+    entry: u16,
+    image_size: u16,
+    bank_count: u8,
+    sram_bank_count: u8,
+) []u8 {
+    @memset(out, 0);
+    @memcpy(out[0..4], "GERO");
+    out[0x04] = @truncate(version & 0xFF);
+    out[0x05] = @truncate(version >> 8);
+    out[0x06] = @truncate(flags & 0xFF);
+    out[0x07] = @truncate(flags >> 8);
+    out[0x08] = @truncate(entry & 0xFF);
+    out[0x09] = @truncate(entry >> 8);
+    out[0x0A] = @truncate(image_size & 0xFF);
+    out[0x0B] = @truncate(image_size >> 8);
+    out[0x0C] = bank_count;
+    out[0x0D] = sram_bank_count;
+    // 0x0E..0x0F left zero
+    return out;
+}
+
+test "loader: rejects buffer shorter than the header" {
+    var tiny: [4]u8 = .{ 'G', 'E', 'R', 'O' };
+    try std.testing.expectError(error.TooSmall, gero.vm.parseGx(&tiny));
+}
+
+test "loader: rejects bad magic" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0001, 0, 0x1100, 0, 0, 0);
+    buf[0] = 'X';
+    try std.testing.expectError(error.BadMagic, gero.vm.parseGx(&buf));
+}
+
+test "loader: rejects future major version" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0100, 0, 0x1100, 0, 0, 0);
+    try std.testing.expectError(error.UnsupportedVersion, gero.vm.parseGx(&buf));
+}
+
+test "loader: accepts same-major higher-minor version" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0050, 0, 0x1100, 0, 0, 0);
+    const loaded = try gero.vm.parseGx(&buf);
+    try std.testing.expectEqual(@as(u16, 0x0050), loaded.header.version);
+}
+
+test "loader: rejects reserved flag bits" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0001, 0b1000_0000, 0x1100, 0, 0, 0);
+    try std.testing.expectError(error.ReservedBitsSet, gero.vm.parseGx(&buf));
+}
+
+test "loader: rejects non-zero reserved field at 0x0E" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0001, 0, 0x1100, 0, 0, 0);
+    buf[0x0E] = 0x42;
+    try std.testing.expectError(error.ReservedBitsSet, gero.vm.parseGx(&buf));
+}
+
+test "loader: rejects sram_bank_count > bank_count" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0001, 0, 0x1100, 0, 2, 3);
+    try std.testing.expectError(error.InvalidSramCount, gero.vm.parseGx(&buf));
+}
+
+test "loader: rejects image_size that doesn't fit" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0001, 0, 0x1100, 100, 0, 0);
+    // No bytes after header.
+    try std.testing.expectError(error.ImageSizeMismatch, gero.vm.parseGx(&buf));
+}
+
+test "loader: valid header + image returns the slice" {
+    var buf: [16 + 4]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0001, 0, 0x1100, 4, 0, 0);
+    buf[16] = 0xDE;
+    buf[17] = 0xAD;
+    buf[18] = 0xBE;
+    buf[19] = 0xEF;
+    const loaded = try gero.vm.parseGx(&buf);
+    try std.testing.expectEqual(@as(u16, 0x1100), loaded.header.entry_point);
+    try std.testing.expectEqual(@as(u16, 4), loaded.header.image_size);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xDE, 0xAD, 0xBE, 0xEF }, loaded.image);
+    try std.testing.expectEqual(@as(usize, 0), loaded.banks.len);
+}
+
+test "loader: banked flag requires bank section to fit" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0001, 0x0001, 0x1100, 0, 2, 0);
+    try std.testing.expectError(error.BanksSizeMismatch, gero.vm.parseGx(&buf));
+}
+
+test "loader: banked file returns the bank slice" {
+    var buf: [16 + 0x4000]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0001, 0x0001, 0x1100, 0, 1, 0);
+    buf[16] = 0x11; // marker at start of bank 0
+    const loaded = try gero.vm.parseGx(&buf);
+    try std.testing.expect(loaded.header.isBanked());
+    try std.testing.expectEqual(@as(usize, 0x4000), loaded.banks.len);
+    try std.testing.expectEqual(@as(u8, 0x11), loaded.banks[0]);
+}
+
+test "loader: debug-symbols flag returns the trailing slice" {
+    var buf: [16 + 4]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0001, 0x0002, 0x1100, 0, 0, 0);
+    buf[16] = 0x01;
+    buf[17] = 0x02;
+    buf[18] = 0x03;
+    buf[19] = 0x04;
+    const loaded = try gero.vm.parseGx(&buf);
+    try std.testing.expect(loaded.header.hasDebugSymbols());
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x02, 0x03, 0x04 }, loaded.debug);
+}
+
+// ---------- VM.boot ----------
+
+test "boot: copies the base image into RAM at 0x0000 and sets ip" {
+    var buf: [16 + 5]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0001, 0, 0x1100, 5, 0, 0);
+    // mov 0xABCD → r1 (4 bytes) + hlt (1 byte) — just data to copy.
+    buf[16] = 0x10;
+    buf[17] = 0xCD;
+    buf[18] = 0xAB;
+    buf[19] = 0x02;
+    buf[20] = 0xFF;
+    const loaded = try gero.vm.parseGx(&buf);
+
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try vm.boot(std.testing.allocator, loaded);
+
+    try std.testing.expectEqual(@as(u16, 0x1100), vm.regs.read(.ip));
+    try std.testing.expectEqual(@as(u8, 0x10), vm.mmap.mem.readByte(0x0000));
+    try std.testing.expectEqual(@as(u8, 0xFF), vm.mmap.mem.readByte(0x0004));
+}
+
+test "boot: banked program installs the bank pool" {
+    var buf: [16 + 2 + 0x4000 * 2]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0001, 0x0001, 0x0000, 2, 2, 1);
+    buf[16] = 0xFF; // image[0] = hlt
+    buf[17] = 0x00;
+    // Bank 0 marker.
+    buf[18 + 0] = 0xAA;
+    // Bank 1 marker (SRAM bank).
+    buf[18 + 0x4000] = 0xBB;
+    const loaded = try gero.vm.parseGx(&buf);
+
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try vm.boot(std.testing.allocator, loaded);
+
+    try std.testing.expect(vm.banks != null);
+    try std.testing.expectEqual(@as(u8, 2), vm.banks.?.bank_count);
+    try std.testing.expectEqual(@as(u8, 1), vm.banks.?.sram_bank_count);
+    try std.testing.expectEqual(@as(u8, 0xAA), vm.banks.?.readByte(0, 0xC000));
+    try std.testing.expectEqual(@as(u8, 0xBB), vm.banks.?.readByte(1, 0xC000));
+}
+
+test "boot + run: nop nop hlt program executes and halts" {
+    var buf: [16 + 3]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0001, 0, 0x0000, 3, 0, 0);
+    buf[16] = 0x91; // nop
+    buf[17] = 0x91; // nop
+    buf[18] = 0xFF; // hlt
+    const loaded = try gero.vm.parseGx(&buf);
+
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try vm.boot(std.testing.allocator, loaded);
+
+    try std.testing.expectEqual(gero.vm.StepResult.halted, gero.vm.run(&vm));
+    try std.testing.expectEqual(@as(u16, 0x0002), vm.regs.read(.ip));
+}
+
+// ---------- cycle counter ----------
+
+test "cycles: init starts at 0 and step increments by 1 each call" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    try std.testing.expectEqual(@as(u64, 0), vm.cycles);
+
+    vm.regs.write(.ip, 0x1100);
+    vm.mmap.writeByte(0x1100, 0x91); // nop
+    vm.mmap.writeByte(0x1101, 0x91);
+    vm.mmap.writeByte(0x1102, 0x91);
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u64, 1), vm.cycles);
+    _ = gero.vm.step(&vm);
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u64, 3), vm.cycles);
+}
+
+test "cycles: faulting steps still count" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_opcode), 0x3000);
+    vm.regs.write(.ip, 0x1100);
+    vm.mmap.writeByte(0x1100, 0x00); // gap byte → invalid-opcode fault
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u64, 1), vm.cycles);
+}
+
+test "cycles: run accumulates one per step including the terminating hlt" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.ip, 0x1100);
+    vm.mmap.writeByte(0x1100, 0x91); // nop
+    vm.mmap.writeByte(0x1101, 0xFF); // hlt
+    _ = gero.vm.run(&vm);
+    try std.testing.expectEqual(@as(u64, 2), vm.cycles);
+}


### PR DESCRIPTION
## Summary

Final piece of the v0.1 VM kernel.

- `src/vm/loader.zig` — `parseGx(bytes)` validates magic / version / flags / sram-count / image-size / banks-size and returns borrowed slices into the image / banks / debug sections. No allocation
- `VM.boot(allocator, loaded)` — copies the base image into RAM at `0x0000`, sets `ip` to the entry point, and installs zeroed bank storage when the program is banked. The host seeds SRAM via `sramSliceMut` afterward
- `VM.cycles: u64` — incremented once per `step` dispatch (faulting steps counted too); wraps via `+%` on overflow

## Acceptance (#30)

- [x] `.gx` with bad magic → `BadMagic` error
- [x] Future major version → `UnsupportedVersion` error
- [x] Valid `.gx`: image loaded at `0x0000`, `ip` set to `entry_point`
- [x] Banks loaded into the bank pool (verified via marker bytes in bank 0 + bank 1)
- [x] SRAM seeding from the host: covered by the round-trip mechanism in #29 — `boot` installs zeroed SRAM banks; host populates via `sramSliceMut`
- [x] Cycles incremented after each step (including faults; `run` accumulates through to the terminating `hlt`)
- [x] All four release modes pass + cross-target compile

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 18 tests in `tests/vm/loader.test.zig` covering: TooSmall / BadMagic / UnsupportedVersion / same-major higher-minor accepted / reserved-bit checks / InvalidSramCount / ImageSizeMismatch / BanksSizeMismatch / valid + image slice / banked + bank slice / debug-symbols trailing slice / boot image+ip / boot banks / boot+run nop nop hlt / cycles starts at 0 / cycles increment per step / faulting steps count / `run` accumulates

With this PR the VM kernel (#2) is complete: 90 opcodes, banking + SRAM, IVT + IRQ masking, loader + boot + cycle counter, all wired through one `step` / `run` API.

Closes #30.