### PR TITLE
feat(apps/gero-cli): scaffold the gero binary + arg parser

### DIFF
--- a/.changeset/l9c4e5a1.md
+++ b/.changeset/l9c4e5a1.md
@@ -1,0 +1,15 @@
+---
+bump: minor
+---
+
+Scaffold the `gero` CLI binary. New `apps/gero-cli/` builds
+`zig-out/bin/gero` via `zig build`. Subcommand dispatcher
+recognizes the v0.1 set (`asm` / `compile` / `run` / `test` /
+`bench` / `fmt` / `check` / `build` / `disasm` / `info`); each
+prints `not yet implemented` and exits `1` for now. The arg
+parser is fully wired — common flags (`--help` / `-h`,
+`--quiet` / `-q`, `--verbose` / `-v`, `--target`, `--optimize`,
+`--out` / `-o`, `--` terminator) populate an `Options` struct
+the real subcommand implementations will read. `gero --help`
+lists subcommands; `gero <cmd> --help` shows per-command help;
+unknown subcommands / flags exit `2`.

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -1,0 +1,397 @@
+/// Argument parser + subcommand dispatcher for the `gero`
+/// binary. The parser doesn't allocate — it borrows from the
+/// caller's argv slice. Each known subcommand is currently a
+/// stub that prints "not yet implemented" and exits 1; flag
+/// parsing is fully wired so the eventual implementations only
+/// need to read `Options`.
+const std = @import("std");
+
+/// Recognized subcommands.
+pub const Command = enum {
+    asm_,
+    compile,
+    run,
+    test_,
+    bench,
+    fmt,
+    check,
+    build,
+    disasm,
+    info,
+};
+
+/// `--target` values per `cli.md` §2.
+pub const Target = enum { vm, gtx_16 };
+
+/// `--optimize` values per `cli.md` §2.
+pub const Optimize = enum { debug, release, size };
+
+/// Maximum positional args a single invocation can hold. v0.1
+/// commands top out at 1-2; keep it generous to absorb future
+/// `gero build` multi-source forms without re-architecting.
+pub const max_positionals: usize = 16;
+
+/// Parsed common flags + the collected positional tail.
+pub const Options = struct {
+    help: bool = false,
+    quiet: bool = false,
+    verbose: bool = false,
+    target: Target = .vm,
+    optimize: Optimize = .debug,
+    out: ?[]const u8 = null,
+    positional_buf: [max_positionals][]const u8 = undefined,
+    positional_count: usize = 0,
+
+    /// Borrow the slice of positional args actually written.
+    pub fn positional(self: *const Options) []const []const u8 {
+        return self.positional_buf[0..self.positional_count];
+    }
+};
+
+/// Result of `parse`.
+pub const Parsed = struct {
+    command: ?Command,
+    options: Options,
+};
+
+/// Errors the parser can emit.
+pub const ParseError = error{
+    UnknownCommand,
+    UnknownFlag,
+    MissingFlagValue,
+    InvalidEnumValue,
+    /// More than `max_positionals` non-flag tokens after the
+    /// subcommand. Real commands shouldn't hit this.
+    TooManyPositionals,
+};
+
+fn commandFromStr(s: []const u8) ?Command {
+    if (std.mem.eql(u8, s, "asm")) return .asm_;
+    if (std.mem.eql(u8, s, "compile")) return .compile;
+    if (std.mem.eql(u8, s, "run")) return .run;
+    if (std.mem.eql(u8, s, "test")) return .test_;
+    if (std.mem.eql(u8, s, "bench")) return .bench;
+    if (std.mem.eql(u8, s, "fmt")) return .fmt;
+    if (std.mem.eql(u8, s, "check")) return .check;
+    if (std.mem.eql(u8, s, "build")) return .build;
+    if (std.mem.eql(u8, s, "disasm")) return .disasm;
+    if (std.mem.eql(u8, s, "info")) return .info;
+    return null;
+}
+
+fn commandName(cmd: Command) []const u8 {
+    return switch (cmd) {
+        .asm_ => "asm",
+        .compile => "compile",
+        .run => "run",
+        .test_ => "test",
+        .bench => "bench",
+        .fmt => "fmt",
+        .check => "check",
+        .build => "build",
+        .disasm => "disasm",
+        .info => "info",
+    };
+}
+
+fn commandSummary(cmd: Command) []const u8 {
+    return switch (cmd) {
+        .asm_ => "Assemble a .gas file into a .gx image",
+        .compile => "Compile a gero-lang module into a .gx",
+        .run => "Execute a .gx",
+        .test_ => "Run asm-level tests",
+        .bench => "Run benchmarks",
+        .fmt => "Format .gas / .gr source",
+        .check => "Type-check without producing output",
+        .build => "Resolve + asm + compile a project",
+        .disasm => "Disassemble a .gx into asm",
+        .info => "Print the .gx file header",
+    };
+}
+
+/// Top-level help text. Printed for `gero` (no args) and
+/// `gero --help`.
+pub fn topHelp(out: *std.Io.Writer) std.Io.Writer.Error!void {
+    try out.print("gero — VM + asm + lang toolchain\n\n", .{});
+    try out.print("USAGE\n  gero <subcommand> [flags] [args]\n\n", .{});
+    try out.print("SUBCOMMANDS\n", .{});
+    inline for (std.meta.fields(Command)) |f| {
+        const cmd: Command = @enumFromInt(f.value);
+        try out.print("  {s:<8} {s}\n", .{ commandName(cmd), commandSummary(cmd) });
+    }
+    try out.print("\nRun `gero <subcommand> --help` for per-command flags.\n", .{});
+}
+
+/// Per-subcommand help. Currently the same template; concrete
+/// flag lists land with each subcommand's real implementation.
+pub fn commandHelp(out: *std.Io.Writer, cmd: Command) std.Io.Writer.Error!void {
+    try out.print("gero {s} — {s}\n\n", .{ commandName(cmd), commandSummary(cmd) });
+    try out.print("USAGE\n  gero {s} [flags] [args]\n\n", .{commandName(cmd)});
+    try out.print("COMMON FLAGS\n", .{});
+    try out.print("  --help / -h      Print this help.\n", .{});
+    try out.print("  --quiet / -q     Suppress non-error output.\n", .{});
+    try out.print("  --verbose / -v   Extra diagnostics.\n", .{});
+    try out.print("  --target=<spec>  vm (default) or gtx-16.\n", .{});
+    try out.print("  --optimize=<m>   debug (default) / release / size.\n", .{});
+    try out.print("  --out=<path>     Output destination for file-producing commands.\n", .{});
+}
+
+fn parseTarget(s: []const u8) ParseError!Target {
+    if (std.mem.eql(u8, s, "vm")) return .vm;
+    if (std.mem.eql(u8, s, "gtx-16")) return .gtx_16;
+    return error.InvalidEnumValue;
+}
+
+fn parseOptimize(s: []const u8) ParseError!Optimize {
+    if (std.mem.eql(u8, s, "debug")) return .debug;
+    if (std.mem.eql(u8, s, "release")) return .release;
+    if (std.mem.eql(u8, s, "size")) return .size;
+    return error.InvalidEnumValue;
+}
+
+const FlagKind = enum { help, quiet, verbose, target, optimize, out };
+
+fn longFlag(s: []const u8) ?FlagKind {
+    if (std.mem.eql(u8, s, "help")) return .help;
+    if (std.mem.eql(u8, s, "quiet")) return .quiet;
+    if (std.mem.eql(u8, s, "verbose")) return .verbose;
+    if (std.mem.eql(u8, s, "target")) return .target;
+    if (std.mem.eql(u8, s, "optimize")) return .optimize;
+    if (std.mem.eql(u8, s, "out")) return .out;
+    return null;
+}
+
+fn shortFlag(s: []const u8) ?FlagKind {
+    if (std.mem.eql(u8, s, "h")) return .help;
+    if (std.mem.eql(u8, s, "q")) return .quiet;
+    if (std.mem.eql(u8, s, "v")) return .verbose;
+    if (std.mem.eql(u8, s, "o")) return .out;
+    return null;
+}
+
+fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void {
+    switch (kind) {
+        .help => opts.help = true,
+        .quiet => opts.quiet = true,
+        .verbose => opts.verbose = true,
+        .target => opts.target = try parseTarget(value orelse return error.MissingFlagValue),
+        .optimize => opts.optimize = try parseOptimize(value orelse return error.MissingFlagValue),
+        .out => opts.out = value orelse return error.MissingFlagValue,
+    }
+}
+
+fn needsValue(kind: FlagKind) bool {
+    return switch (kind) {
+        .target, .optimize, .out => true,
+        else => false,
+    };
+}
+
+/// Parse `argv[1..]` into a `Parsed`. The first non-flag token
+/// is the subcommand; everything after it is forwarded to the
+/// command (positional args / its own flags get re-parsed by
+/// the subcommand). The first argument may also be `--help` /
+/// `-h` to request top-level help — that's surfaced via
+/// `Options.help` and `command == null`.
+pub fn parse(args: []const []const u8) ParseError!Parsed {
+    var opts: Options = .{};
+    var cmd: ?Command = null;
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const a = args[i];
+        if (a.len == 0) continue;
+
+        if (std.mem.eql(u8, a, "--")) {
+            // Everything after `--` is positional, even tokens
+            // that look like flags.
+            for (args[i + 1 ..]) |rest_arg| {
+                if (opts.positional_count >= max_positionals) return error.TooManyPositionals;
+                opts.positional_buf[opts.positional_count] = rest_arg;
+                opts.positional_count += 1;
+            }
+            break;
+        }
+
+        if (a[0] != '-') {
+            if (cmd == null) {
+                cmd = commandFromStr(a) orelse return error.UnknownCommand;
+                continue;
+            }
+            if (opts.positional_count >= max_positionals) return error.TooManyPositionals;
+            opts.positional_buf[opts.positional_count] = a;
+            opts.positional_count += 1;
+            continue;
+        }
+
+        if (std.mem.startsWith(u8, a, "--")) {
+            const rest = a[2..];
+            const eq = std.mem.indexOfScalar(u8, rest, '=');
+            const name = if (eq) |p| rest[0..p] else rest;
+            const inline_value: ?[]const u8 = if (eq) |p| rest[p + 1 ..] else null;
+            const kind = longFlag(name) orelse return error.UnknownFlag;
+            if (needsValue(kind)) {
+                const v = inline_value orelse blk: {
+                    i += 1;
+                    if (i >= args.len) return error.MissingFlagValue;
+                    break :blk args[i];
+                };
+                try applyFlag(&opts, kind, v);
+            } else {
+                if (inline_value != null) return error.InvalidEnumValue;
+                try applyFlag(&opts, kind, null);
+            }
+        } else if (a.len > 1) {
+            const rest = a[1..];
+            const kind = shortFlag(rest) orelse return error.UnknownFlag;
+            if (needsValue(kind)) {
+                i += 1;
+                if (i >= args.len) return error.MissingFlagValue;
+                try applyFlag(&opts, kind, args[i]);
+            } else {
+                try applyFlag(&opts, kind, null);
+            }
+        } else return error.UnknownFlag;
+    }
+
+    return .{ .command = cmd, .options = opts };
+}
+
+/// Drive a parsed invocation: emits help / runs the stub for
+/// the requested subcommand / surfaces usage errors. Returns
+/// the process exit code (0 = success, 1 = stub or file error,
+/// 2 = bad usage).
+pub fn run(parsed: Parsed, stdout: *std.Io.Writer, stderr: *std.Io.Writer) std.Io.Writer.Error!u8 {
+    if (parsed.command == null) {
+        try topHelp(stdout);
+        return 0;
+    }
+    const cmd = parsed.command.?;
+    if (parsed.options.help) {
+        try commandHelp(stdout, cmd);
+        return 0;
+    }
+    try stderr.print("gero {s}: not yet implemented\n", .{commandName(cmd)});
+    return 1;
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "parse: no args → no command, help false" {
+    const args = [_][]const u8{};
+    const p = try parse(&args);
+    try testing.expect(p.command == null);
+    try testing.expect(!p.options.help);
+}
+
+test "parse: --help with no subcommand" {
+    const args = [_][]const u8{"--help"};
+    const p = try parse(&args);
+    try testing.expect(p.command == null);
+    try testing.expect(p.options.help);
+}
+
+test "parse: subcommand recognized" {
+    const args = [_][]const u8{"run"};
+    const p = try parse(&args);
+    try testing.expectEqual(@as(?Command, .run), p.command);
+}
+
+test "parse: unknown subcommand" {
+    const args = [_][]const u8{"frobnicate"};
+    try testing.expectError(error.UnknownCommand, parse(&args));
+}
+
+test "parse: --help after subcommand routes to per-command help" {
+    const args = [_][]const u8{ "run", "--help" };
+    const p = try parse(&args);
+    try testing.expectEqual(@as(?Command, .run), p.command);
+    try testing.expect(p.options.help);
+}
+
+test "parse: long flag with =value" {
+    const args = [_][]const u8{ "asm", "--out=build/", "src.gas" };
+    const p = try parse(&args);
+    try testing.expectEqual(@as(?Command, .asm_), p.command);
+    try testing.expectEqualStrings("build/", p.options.out.?);
+    try testing.expectEqual(@as(usize, 1), p.options.positional().len);
+    try testing.expectEqualStrings("src.gas", p.options.positional()[0]);
+}
+
+test "parse: long flag with separate value" {
+    const args = [_][]const u8{ "run", "--target", "gtx-16", "game.gx" };
+    const p = try parse(&args);
+    try testing.expectEqual(Target.gtx_16, p.options.target);
+    try testing.expectEqualStrings("game.gx", p.options.positional()[0]);
+}
+
+test "parse: short flags" {
+    const args = [_][]const u8{ "run", "-q", "-v", "-o", "out.gx", "game.gx" };
+    const p = try parse(&args);
+    try testing.expect(p.options.quiet);
+    try testing.expect(p.options.verbose);
+    try testing.expectEqualStrings("out.gx", p.options.out.?);
+    try testing.expectEqualStrings("game.gx", p.options.positional()[0]);
+}
+
+test "parse: -- terminator captures trailing positionals" {
+    const args = [_][]const u8{ "run", "--", "--game.gx" };
+    const p = try parse(&args);
+    try testing.expectEqual(@as(?Command, .run), p.command);
+    try testing.expectEqual(@as(usize, 1), p.options.positional().len);
+    try testing.expectEqualStrings("--game.gx", p.options.positional()[0]);
+}
+
+test "parse: unknown flag errors" {
+    const args = [_][]const u8{ "run", "--zoinks" };
+    try testing.expectError(error.UnknownFlag, parse(&args));
+}
+
+test "parse: --target with bad value errors" {
+    const args = [_][]const u8{ "run", "--target=mainframe" };
+    try testing.expectError(error.InvalidEnumValue, parse(&args));
+}
+
+test "parse: --target without a value errors" {
+    const args = [_][]const u8{ "run", "--target" };
+    try testing.expectError(error.MissingFlagValue, parse(&args));
+}
+
+test "parse: --optimize=release accepted" {
+    const args = [_][]const u8{ "asm", "--optimize=release" };
+    const p = try parse(&args);
+    try testing.expectEqual(Optimize.release, p.options.optimize);
+}
+
+test "run: no command prints top help, exit 0" {
+    var out_buf: [4096]u8 = undefined;
+    var err_buf: [256]u8 = undefined;
+    var out: std.Io.Writer = .fixed(&out_buf);
+    var err: std.Io.Writer = .fixed(&err_buf);
+    const code = try run(.{ .command = null, .options = .{} }, &out, &err);
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expect(std.mem.indexOf(u8, out_buf[0..out.end], "USAGE") != null);
+}
+
+test "run: --help on a subcommand prints per-command help, exit 0" {
+    var out_buf: [4096]u8 = undefined;
+    var err_buf: [256]u8 = undefined;
+    var out: std.Io.Writer = .fixed(&out_buf);
+    var err: std.Io.Writer = .fixed(&err_buf);
+    const opts: Options = .{ .help = true };
+    const code = try run(.{ .command = .run, .options = opts }, &out, &err);
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expect(std.mem.indexOf(u8, out_buf[0..out.end], "gero run") != null);
+}
+
+test "run: subcommand stub exits 1" {
+    var out_buf: [256]u8 = undefined;
+    var err_buf: [256]u8 = undefined;
+    var out: std.Io.Writer = .fixed(&out_buf);
+    var err: std.Io.Writer = .fixed(&err_buf);
+    const code = try run(.{ .command = .run, .options = .{} }, &out, &err);
+    try testing.expectEqual(@as(u8, 1), code);
+    try testing.expect(std.mem.indexOf(u8, err_buf[0..err.end], "not yet implemented") != null);
+}

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -1,0 +1,38 @@
+/// `gero` CLI entry point. Wires argv + stdio into the
+/// dispatcher in `cli.zig`, which carries all the testable
+/// logic.
+const std = @import("std");
+const cli = @import("cli.zig");
+
+pub fn main(init: std.process.Init) !u8 {
+    const io = init.io;
+    const arena = init.arena.allocator();
+
+    var stdout_buf: [4096]u8 = undefined;
+    var stderr_buf: [1024]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buf);
+    var stderr_writer = std.Io.File.stderr().writer(io, &stderr_buf);
+    const stdout = &stdout_writer.interface;
+    const stderr = &stderr_writer.interface;
+
+    const raw_args = try init.minimal.args.toSlice(arena);
+    const args = try arena.alloc([]const u8, raw_args.len);
+    for (raw_args, 0..) |a, i| args[i] = a;
+
+    const parsed = cli.parse(args[1..]) catch |err| {
+        switch (err) {
+            error.UnknownCommand => try stderr.print("gero: unknown subcommand\nrun `gero --help` for the list\n", .{}),
+            error.UnknownFlag => try stderr.print("gero: unknown flag\n", .{}),
+            error.MissingFlagValue => try stderr.print("gero: flag is missing its value\n", .{}),
+            error.InvalidEnumValue => try stderr.print("gero: flag value is not recognized\n", .{}),
+            error.TooManyPositionals => try stderr.print("gero: too many positional args (max 16)\n", .{}),
+        }
+        try stderr.flush();
+        return 2;
+    };
+
+    const code = try cli.run(parsed, stdout, stderr);
+    try stdout.flush();
+    try stderr.flush();
+    return code;
+}

--- a/build.zig
+++ b/build.zig
@@ -19,16 +19,41 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(lib);
 
+    // ----- CLI binary ------------------------------------------------------
+
+    const cli_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cli_mod.addImport("gero", gero_mod);
+
+    const cli_exe = b.addExecutable(.{
+        .name = "gero",
+        .root_module = cli_mod,
+    });
+    b.installArtifact(cli_exe);
+
+    // Tests embedded in the CLI source — wire them into `zig build test`.
+    const cli_test = b.addTest(.{
+        .name = "test-cli",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("apps/gero-cli/cli.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     // ----- Format ----------------------------------------------------------
 
     const fmt = b.addFmt(.{
-        .paths = &.{ "src", "tests", "build.zig" },
+        .paths = &.{ "src", "tests", "apps", "build.zig" },
         .check = false,
     });
     b.step("fmt", "Format every .zig file in place").dependOn(&fmt.step);
 
     const fmt_check = b.addFmt(.{
-        .paths = &.{ "src", "tests", "build.zig" },
+        .paths = &.{ "src", "tests", "apps", "build.zig" },
         .check = true,
     });
     b.step("fmt-check", "Check formatting without writing").dependOn(&fmt_check.step);
@@ -44,6 +69,7 @@ pub fn build(b: *std.Build) void {
     // ----- Native tests, default optimize ----------------------------------
 
     const test_step = b.step("test", "Run native tests");
+    test_step.dependOn(&b.addRunArtifact(cli_test).step);
     for (test_files) |rel| {
         const t = makeTest(b, gero_mod, rel, target, optimize);
         test_step.dependOn(&b.addRunArtifact(t).step);


### PR DESCRIPTION
## Summary

`zig build` now produces `zig-out/bin/gero`. The binary dispatches to the v0.1 subcommand set (`asm` / `compile` / `run` / `test` / `bench` / `fmt` / `check` / `build` / `disasm` / `info`) — each is a stub that prints "not yet implemented" and exits `1`. Follow-up issues fill them in (`gero run` → #44, `gero info` → half of #45, etc.).

The arg parser is fully wired so the real implementations only need to read `Options`:

- `--help` / `-h` (top-level lists subcommands; per-command shows that command's help)
- `--quiet` / `-q`, `--verbose` / `-v`
- `--target=<vm|gtx-16>`, `--optimize=<debug|release|size>`
- `--out=<path>` / `-o`
- `--` terminator captures the rest as positional even if it looks like flags
- Flags can appear before or after positionals (e.g. `gero asm src.gas -o build/`)
- Unknown subcommand / flag / bad enum value / missing flag value → exit `2`

## Acceptance (#42)

- [x] `gero --help` lists all subcommands
- [x] `gero <cmd> --help` shows per-subcommand help
- [x] Unknown subcommand: exit `2` with helpful message
- [x] Common flags accepted by every subcommand
- [x] Built and installed via `zig build`

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 16 parser unit tests in `apps/gero-cli/cli.zig` (no-args / --help variants / subcommand recognition / unknown subcommand / long flag with `=value` / long flag with separate value / short flags / `--` terminator / unknown flag / bad enum / missing value / `--optimize=release` accepted / `run` dispatch paths)
- [x] Manual smoke: `gero --help`, `gero run --help`, `gero frobnicate` (exit 2), `gero run --zoinks` (exit 2), `gero asm src.gas -o build/` (interleaved positional+flag → dispatch reaches stub)

Closes #42.