### PR TITLE
feat(apps/gero-cli): gero info — print .gx header

### DIFF
--- a/.changeset/n7e83c12.md
+++ b/.changeset/n7e83c12.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+`gero info <file.gx>` now prints the parsed `.gx` header in
+human form (path, on-disk size, magic, version, entry point,
+image size, bank count, SRAM count, debug-symbols presence).
+Uses the loader from #30 — no allocation beyond reading the
+file. Exit `0` on success, `1` on bad magic / file errors,
+`2` on missing path. The `gero disasm` half of #45 ships
+separately when `#38`–`#41` (disassembler) land.

--- a/apps/gero-cli/info.zig
+++ b/apps/gero-cli/info.zig
@@ -1,0 +1,136 @@
+/// `gero info` — print the `.gx` header in human-readable form.
+/// The formatter is pure (takes already-parsed values) so the
+/// host shell wires file I/O around it.
+const std = @import("std");
+const gero = @import("gero");
+
+/// All the values the formatter needs that aren't on the
+/// `Header` itself.
+pub const InfoContext = struct {
+    /// Path the user passed on the CLI — printed verbatim.
+    path: []const u8,
+    /// Total `.gx` size on disk in bytes.
+    file_size: usize,
+};
+
+/// Write the multi-line header summary to `out`. Matches the
+/// layout sketched in `cli.md` §3.7.
+pub fn format(
+    out: *std.Io.Writer,
+    ctx: InfoContext,
+    loaded: gero.vm.LoadedProgram,
+) std.Io.Writer.Error!void {
+    const h = loaded.header;
+    try out.print("file:    {s}\n", .{ctx.path});
+    try out.print("size:    {d} bytes\n", .{ctx.file_size});
+    try out.print("magic:   GERO\n", .{});
+    try out.print("version: 0x{X:0>4}\n", .{h.version});
+    try out.print("entry:   0x{X:0>4}\n", .{h.entry_point});
+    try out.print("image:   {d} bytes\n", .{h.image_size});
+    if (h.bank_count == 0) {
+        try out.print("banks:   none\n", .{});
+    } else {
+        try out.print("banks:   {d} \xC3\x97 16 KB\n", .{h.bank_count});
+    }
+    if (h.sram_bank_count == 0) {
+        try out.print("sram:    none\n", .{});
+    } else {
+        const noun: []const u8 = if (h.sram_bank_count == 1) "bank" else "banks";
+        try out.print("sram:    {d} {s} (battery-backed)\n", .{ h.sram_bank_count, noun });
+    }
+    try out.print("debug:   {s}\n", .{if (h.hasDebugSymbols()) "yes" else "no"});
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+/// Tests reuse the same buildGx helper shape as the loader tests.
+fn buildGx(
+    out: []u8,
+    flags: u16,
+    entry: u16,
+    image_size: u16,
+    bank_count: u8,
+    sram_bank_count: u8,
+) []u8 {
+    @memset(out, 0);
+    @memcpy(out[0..4], "GERO");
+    out[0x04] = 0x01;
+    out[0x05] = 0x00;
+    out[0x06] = @truncate(flags & 0xFF);
+    out[0x07] = @truncate(flags >> 8);
+    out[0x08] = @truncate(entry & 0xFF);
+    out[0x09] = @truncate(entry >> 8);
+    out[0x0A] = @truncate(image_size & 0xFF);
+    out[0x0B] = @truncate(image_size >> 8);
+    out[0x0C] = bank_count;
+    out[0x0D] = sram_bank_count;
+    return out;
+}
+
+test "format: unbanked program prints `banks: none` and `sram: none`" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0, 0x1100, 0, 0, 0);
+    const loaded = try gero.vm.parseGx(&buf);
+
+    var out_buf: [512]u8 = undefined;
+    var out: std.Io.Writer = .fixed(&out_buf);
+    try format(&out, .{ .path = "prog.gx", .file_size = buf.len }, loaded);
+    const written = out_buf[0..out.end];
+
+    try testing.expect(std.mem.indexOf(u8, written, "file:    prog.gx") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "size:    16 bytes") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "magic:   GERO") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "version: 0x0001") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "entry:   0x1100") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "image:   0 bytes") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "banks:   none") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "sram:    none") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "debug:   no") != null);
+}
+
+test "format: banked + sram + debug program renders all sections" {
+    // banked + debug flags; bank_count = 4, sram_count = 2.
+    var buf: [16 + 0x4000 * 4 + 2]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0003, 0x1100, 0, 4, 2);
+    @memset(buf[16..], 0); // image+banks+debug all zeroed (just need bytes to fit)
+    const loaded = try gero.vm.parseGx(&buf);
+
+    var out_buf: [512]u8 = undefined;
+    var out: std.Io.Writer = .fixed(&out_buf);
+    try format(&out, .{ .path = "game.gx", .file_size = buf.len }, loaded);
+    const written = out_buf[0..out.end];
+
+    try testing.expect(std.mem.indexOf(u8, written, "banks:   4 ") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "× 16 KB") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "sram:    2 banks (battery-backed)") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "debug:   yes") != null);
+}
+
+test "format: single SRAM bank uses singular noun" {
+    var buf: [16 + 0x4000]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0001, 0x0000, 0, 1, 1);
+    @memset(buf[16..], 0);
+    const loaded = try gero.vm.parseGx(&buf);
+
+    var out_buf: [512]u8 = undefined;
+    var out: std.Io.Writer = .fixed(&out_buf);
+    try format(&out, .{ .path = "x.gx", .file_size = buf.len }, loaded);
+
+    try testing.expect(std.mem.indexOf(u8, out_buf[0..out.end], "sram:    1 bank (battery-backed)") != null);
+}
+
+test "format: file size is the on-disk size, not just the image" {
+    var buf: [16 + 7]u8 = undefined;
+    _ = buildGx(buf[0..16], 0, 0x0000, 7, 0, 0);
+    @memset(buf[16..], 0xAB);
+    const loaded = try gero.vm.parseGx(&buf);
+
+    var out_buf: [512]u8 = undefined;
+    var out: std.Io.Writer = .fixed(&out_buf);
+    try format(&out, .{ .path = "x.gx", .file_size = buf.len }, loaded);
+
+    try testing.expect(std.mem.indexOf(u8, out_buf[0..out.end], "size:    23 bytes") != null);
+    try testing.expect(std.mem.indexOf(u8, out_buf[0..out.end], "image:   7 bytes") != null);
+}

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -1,9 +1,11 @@
 /// `gero` CLI entry point. Parses argv, dispatches to the
 /// per-subcommand modules, plumbs file-IO + stdio.
 const std = @import("std");
+const gero = @import("gero");
 const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const run_cmd = @import("run.zig");
+const info_cmd = @import("info.zig");
 
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
@@ -54,11 +56,40 @@ pub fn main(init: std.process.Init) !u8 {
 
     return switch (cmd) {
         .run => runDispatch(io, arena, parsed.options, stdout, &term),
+        .info => infoDispatch(io, arena, parsed.options, stdout, &term),
         else => blk: {
             try term.err("gero {s}: not yet implemented", .{cli.commandName(cmd)});
             break :blk 1;
         },
     };
+}
+
+fn infoDispatch(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+) !u8 {
+    const positionals = opts.positional();
+    if (positionals.len < 1) {
+        try term.err("gero info: missing .gx file path", .{});
+        return 2;
+    }
+    const gx_path = positionals[0];
+
+    const bytes = std.Io.Dir.cwd().readFileAlloc(io, gx_path, arena, .unlimited) catch |err| {
+        try term.err("gero info: cannot read {s} ({s})", .{ gx_path, @errorName(err) });
+        return 1;
+    };
+
+    const loaded = gero.vm.parseGx(bytes) catch |err| {
+        try term.err("gero info: invalid .gx file ({s})", .{@errorName(err)});
+        return 1;
+    };
+
+    try info_cmd.format(stdout, .{ .path = gx_path, .file_size = bytes.len }, loaded);
+    return 0;
 }
 
 fn toTermChoice(c: cli.ColorChoice) term_mod.ColorChoice {

--- a/build.zig
+++ b/build.zig
@@ -61,6 +61,16 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    const info_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/info.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    info_mod.addImport("gero", gero_mod);
+    const info_test = b.addTest(.{
+        .name = "test-cli-info",
+        .root_module = info_mod,
+    });
 
     // ----- Format ----------------------------------------------------------
 
@@ -90,6 +100,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(cli_test).step);
     test_step.dependOn(&b.addRunArtifact(run_cmd_test).step);
     test_step.dependOn(&b.addRunArtifact(term_test).step);
+    test_step.dependOn(&b.addRunArtifact(info_test).step);
     for (test_files) |rel| {
         const t = makeTest(b, gero_mod, rel, target, optimize);
         test_step.dependOn(&b.addRunArtifact(t).step);


### PR DESCRIPTION
## Summary

`gero info <file.gx>` reads the file, parses with the loader from #30, and renders a human-readable header summary:

```
$ gero info examples/hello.gx
file:    examples/hello.gx
size:    52 bytes
magic:   GERO
version: 0x0001
entry:   0x0000
image:   36 bytes
banks:   none
sram:    none
debug:   no
```

Banked + SRAM looks like:

```
banks:   2 × 16 KB
sram:    1 bank (battery-backed)
```

Singular / plural noun adapts to count.

Exit codes:
- `0` — success
- `1` — bad magic / version mismatch / file IO error
- `2` — missing positional

## Acceptance (#45 — info half)

- [x] `gero info game.gx` prints all header fields (path, size, magic, version, entry, image, banks, sram, debug)
- [x] Exit `1` on bad magic / read error
- [x] Exit `2` on missing path

The `gero disasm` half of #45 lands separately when the disassembler (#38–#41) is implemented.

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 4 tests in `apps/gero-cli/info.zig`: unbanked/no-debug / banked+sram+debug / singular-SRAM noun / file-size-vs-image-size distinction
- [x] Manual smoke: `gero info examples/hello.gx` (unbanked) and `gero info /tmp/save.gx` (2 banks, 1 SRAM)

Closes (info half of) #45.