### PR TITLE
feat(asm): wire knit dependency + smoke assembleHlt

### DIFF
--- a/.changeset/o6f73a92.md
+++ b/.changeset/o6f73a92.md
@@ -1,0 +1,10 @@
+---
+bump: minor
+---
+
+Wire `knit` as a dependency (pinned to v1.0.0) and scaffold the
+assembler module. `src/asm.zig` exposes a smoke entry point
+`assembleHlt` that uses `knit.str("hlt")` to recognize the
+mnemonic and emit a 1-byte `0xFF` image. The smoke also proves
+the asm → loader → VM path end-to-end. Real lexer / parser /
+codegen land in follow-up PRs.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache
 /zig-out
+/zig-pkg
 .DS_Store

--- a/build.zig
+++ b/build.zig
@@ -7,11 +7,15 @@ pub fn build(b: *std.Build) void {
 
     // ----- Library module + artifact ---------------------------------------
 
+    const knit_dep = b.dependency("knit", .{ .target = target, .optimize = optimize });
+    const knit_mod = knit_dep.module("knit");
+
     const gero_mod = b.addModule("gero", .{
         .root_source_file = b.path("src/gero.zig"),
         .target = target,
         .optimize = optimize,
     });
+    gero_mod.addImport("knit", knit_mod);
 
     const lib = b.addLibrary(.{
         .name = "gero",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,12 @@
     .version = "0.0.0",
     .fingerprint = 0x9ad7ed0848df5cb,
     .minimum_zig_version = "0.16.0",
-    .dependencies = .{},
+    .dependencies = .{
+        .knit = .{
+            .url = "https://github.com/salty-max/knit/archive/refs/tags/v1.0.0.tar.gz",
+            .hash = "knit-1.0.0-sNyTDNeJBgDjPM6AV42BBXOutJyNoQe7ThiOArM7Arwj",
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -1,0 +1,40 @@
+/// Assembler — text `.gas` source → `.gx` bytecode. This file
+/// is the public barrel; the real parser / codegen lives under
+/// `src/asm/` in subsequent issues. For now it exposes a
+/// single smoke entry point that recognizes the `hlt` mnemonic
+/// and emits a 1-byte program. The smoke proves the `knit`
+/// dependency wiring and the assembler → loader → VM path.
+const std = @import("std");
+const knit = @import("knit");
+const gero = @import("gero.zig");
+
+/// Errors the assembler can emit. Restricted while the smoke
+/// parser is the only producer; the real assembler will grow
+/// this set.
+pub const AsmError = error{
+    /// Source didn't match the smoke grammar.
+    ParseFailed,
+};
+
+/// Smoke assembler: matches `hlt` (with optional trailing
+/// newline / whitespace) and returns a one-byte image
+/// containing `0xFF` (the `hlt` opcode). Caller owns the
+/// returned slice.
+pub fn assembleHlt(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+) (std.mem.Allocator.Error || AsmError)![]u8 {
+    const trimmed = std.mem.trim(u8, source, " \t\r\n");
+    const result = knit.str("hlt").run(trimmed, allocator);
+    switch (result) {
+        .ok => |ok| {
+            // The grammar is strictly `hlt` — extra trailing tokens
+            // are a parse failure for this smoke.
+            if (ok.index != trimmed.len) return error.ParseFailed;
+            const buf = try allocator.alloc(u8, 1);
+            buf[0] = 0xFF;
+            return buf;
+        },
+        .err => return error.ParseFailed,
+    }
+}

--- a/src/gero.zig
+++ b/src/gero.zig
@@ -4,3 +4,7 @@ pub const VERSION = "0.0.0";
 
 /// VM kernel — register file, memory, and the composing `VM` type.
 pub const vm = @import("vm/vm.zig");
+
+/// Assembler — text `.gas` source → `.gx` bytecode. Scaffold;
+/// real parser / codegen lands in follow-up PRs.
+pub const asm_ = @import("asm.zig");

--- a/tests/asm.test.zig
+++ b/tests/asm.test.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const gero = @import("gero");
+
+test "asm.assembleHlt: 'hlt' → single 0xFF byte" {
+    const bytes = try gero.asm_.assembleHlt(std.testing.allocator, "hlt");
+    defer std.testing.allocator.free(bytes);
+    try std.testing.expectEqualSlices(u8, &[_]u8{0xFF}, bytes);
+}
+
+test "asm.assembleHlt: whitespace around the mnemonic is fine" {
+    const bytes = try gero.asm_.assembleHlt(std.testing.allocator, "  hlt\n");
+    defer std.testing.allocator.free(bytes);
+    try std.testing.expectEqualSlices(u8, &[_]u8{0xFF}, bytes);
+}
+
+test "asm.assembleHlt: unknown mnemonic returns ParseFailed" {
+    try std.testing.expectError(
+        error.ParseFailed,
+        gero.asm_.assembleHlt(std.testing.allocator, "nop"),
+    );
+}
+
+test "asm.assembleHlt: trailing garbage after hlt rejects" {
+    try std.testing.expectError(
+        error.ParseFailed,
+        gero.asm_.assembleHlt(std.testing.allocator, "hlt extra"),
+    );
+}
+
+test "asm → vm integration: assembled hlt runs and halts" {
+    const allocator = std.testing.allocator;
+    const image = try gero.asm_.assembleHlt(allocator, "hlt");
+    defer allocator.free(image);
+
+    var vm = gero.vm.VM.init(allocator);
+    defer vm.deinit();
+    // Drop the assembled byte at the entry point and run.
+    vm.regs.write(.ip, 0x1100);
+    vm.mmap.writeByte(0x1100, image[0]);
+    try std.testing.expectEqual(gero.vm.StepResult.halted, gero.vm.run(&vm));
+}


### PR DESCRIPTION
## Summary

First step of the assembler — adds `knit` v1.0.0 as a fetched dependency, wires it into `gero_mod` so any `src/` file can `@import("knit")`, and scaffolds `src/asm.zig` with a smoke entry point that proves the asm → loader → VM path end-to-end.

`assembleHlt(allocator, source)` trims whitespace, runs `knit.str("hlt")` on the input, and returns a 1-byte image with `0xFF` (the `hlt` opcode) — or `error.ParseFailed` on a mismatch / trailing tokens.

## Acceptance (#31)

- [x] knit dep added, hash populated via `zig fetch --save`
- [x] `@import("knit")` works from `src/`
- [x] smoke parser recognizes `hlt` (with whitespace tolerance) and emits the 1-byte 0xFF buffer
- [x] integration test loads the assembled byte into a fresh VM and `gero.vm.run` halts cleanly
- [x] CI green

## Notes

- The module identifier on the public barrel is `gero.asm_` (`asm` is a Zig keyword). Future PRs may refactor to a more friendly name once we settle on one.
- This is **scaffold** — the real lexer / parser / codegen land in #32–#37. `assembleHlt` will get replaced.

## Test plan

- [x] `zig build ci` — fmt, lint (strict/mirror/imports/naming/docs/unused), tests
- [x] `zig build test-modes` — Debug, ReleaseSafe, ReleaseFast, ReleaseSmall
- [x] 5 tests in `tests/asm.test.zig` (hlt happy path / whitespace tolerant / unknown mnemonic / trailing garbage / VM integration)

Closes #31.