### PR TITLE
feat(asm/lexer): apply v0.1-final spec — @sym + operators + strings

### DIFF
--- a/.changeset/r5g23e91.md
+++ b/.changeset/r5g23e91.md
@@ -1,0 +1,18 @@
+---
+bump: minor
+---
+
+Apply the v0.1-final asm spec to the `.gas` lexer:
+
+- Symbol references now use `@` instead of `!` (e.g. `@hasFrame`).
+  Bare `!` is no longer recognized by the lexer.
+- Five new single-byte operator tokens for compile-time
+  expressions per spec §1.7: `/` (`slash`), `%` (`percent`),
+  `|` (`pipe`), `^` (`caret`), `~` (`tilde`).
+- Two new multi-byte shift tokens with longest-match: `<<`
+  (`shl`) and `>>` (`shr`). `< x` (single `<` with whitespace)
+  still lexes as `lt` + `ident`.
+- New `string` token for `data8` bodies per spec §1.5. C-style
+  escapes (`\0 \n \r \t \\ \"`) are validated at lex time;
+  unterminated literals surface a `ParseError` with
+  `kind=.incomplete` and unknown escapes with `kind=.lexical`.

--- a/src/asm/lexer.zig
+++ b/src/asm/lexer.zig
@@ -37,6 +37,15 @@ pub const Token = struct {
         plus,
         minus,
         star,
+        slash,
+        percent,
+        pipe,
+        caret,
+        tilde,
+        /// `<<` — two bytes, longest-match before `lt`.
+        shl,
+        /// `>>` — two bytes, longest-match before `gt`.
+        shr,
         lt,
         gt,
         dot,
@@ -44,6 +53,8 @@ pub const Token = struct {
         /// digit (so the parser sees the building blocks of
         /// `&r1` register-pointer or `&[ ]` address-expression).
         ampersand,
+        /// `"..."` literal with C-style escapes per asm spec §1.5.
+        string,
         eof,
     };
 
@@ -147,14 +158,14 @@ const addrThunk = numericThunk('&', "addrLiteral", .addr);
 fn symRefThunk(state: *core.ParseState) core.ParseResult(Token) {
     const start = state.index;
     const rem = state.remaining();
-    if (rem.len == 0 or rem[0] != '!') {
-        return .{ .err = core.parseError("symRef", start, "expected '!'", .{
-            .expected = "!",
+    if (rem.len == 0 or rem[0] != '@') {
+        return .{ .err = core.parseError("symRef", start, "expected '@'", .{
+            .expected = "@",
             .kind = .syntactic,
         }) };
     }
     if (rem.len < 2 or !isIdentStart(rem[1])) {
-        return .{ .err = core.parseError("symRef", start + 1, "expected identifier after '!'", .{
+        return .{ .err = core.parseError("symRef", start + 1, "expected identifier after '@'", .{
             .expected = "letter or '_'",
             .kind = .syntactic,
         }) };
@@ -260,9 +271,105 @@ const rbracketP = parserOf(punctThunk(']', .rbracket, "rbracket"));
 const plusP = parserOf(punctThunk('+', .plus, "plus"));
 const minusP = parserOf(punctThunk('-', .minus, "minus"));
 const starP = parserOf(punctThunk('*', .star, "star"));
+const slashP = parserOf(punctThunk('/', .slash, "slash"));
+const percentP = parserOf(punctThunk('%', .percent, "percent"));
+const pipeP = parserOf(punctThunk('|', .pipe, "pipe"));
+const caretP = parserOf(punctThunk('^', .caret, "caret"));
+const tildeP = parserOf(punctThunk('~', .tilde, "tilde"));
+const shlP = parserOf(shiftThunk('<', .shl, "shl"));
+const shrP = parserOf(shiftThunk('>', .shr, "shr"));
 const ltP = parserOf(punctThunk('<', .lt, "lt"));
 const gtP = parserOf(punctThunk('>', .gt, "gt"));
 const dotP = parserOf(punctThunk('.', .dot, "dot"));
+const stringP = parserOf(stringThunk);
+fn shiftThunk(comptime byte: u8, comptime kind: Token.Kind, comptime name: []const u8) fn (*core.ParseState) core.ParseResult(Token) {
+    return struct {
+        fn parse(state: *core.ParseState) core.ParseResult(Token) {
+            const start = state.index;
+            const rem = state.remaining();
+            if (rem.len < 2 or rem[0] != byte or rem[1] != byte) {
+                return .{ .err = core.parseError(name, start, "expected shift operator", .{
+                    .expected = &[_]u8{ byte, byte },
+                    .kind = .syntactic,
+                }) };
+            }
+            state.advance(2);
+            return core.ok(Token{ .kind = kind, .start = u32At(start), .end = u32At(state.index), .value = 0 }, state.index);
+        }
+    }.parse;
+}
+
+const decodedEscapeMissing: u16 = 0xFFFF;
+
+fn decodeEscape(b: u8) u16 {
+    return switch (b) {
+        '0' => 0x00,
+        'n' => 0x0A,
+        'r' => 0x0D,
+        't' => 0x09,
+        '\\' => 0x5C,
+        '"' => 0x22,
+        else => decodedEscapeMissing,
+    };
+}
+
+/// Match a double-quoted string literal with C-style escapes.
+/// The token's span covers from the opening `"` to the closing
+/// `"` (inclusive). Body decoding lives at codegen time; the
+/// lexer only validates that every escape is legal and that the
+/// literal closes before EOF / newline.
+fn stringThunk(state: *core.ParseState) core.ParseResult(Token) {
+    const start = state.index;
+    const rem = state.remaining();
+    if (rem.len == 0 or rem[0] != '"') {
+        return .{ .err = core.parseError("string", start, "expected '\"'", .{
+            .expected = "\"",
+            .kind = .syntactic,
+        }) };
+    }
+    var j: usize = 1;
+    while (j < rem.len) {
+        const b = rem[j];
+        if (b == '"') {
+            j += 1;
+            state.advance(j);
+            return core.ok(Token{
+                .kind = .string,
+                .start = u32At(start),
+                .end = u32At(state.index),
+                .value = 0,
+            }, state.index);
+        }
+        if (b == '\n' or b == '\r') {
+            return .{ .err = core.parseError("string", start + j, "unterminated string literal (newline before closing '\"')", .{
+                .expected = "\"",
+                .kind = .incomplete,
+            }) };
+        }
+        if (b == '\\') {
+            if (j + 1 >= rem.len) {
+                return .{ .err = core.parseError("string", start + j, "unterminated escape at end of input", .{
+                    .expected = "escape character",
+                    .kind = .incomplete,
+                }) };
+            }
+            if (decodeEscape(rem[j + 1]) == decodedEscapeMissing) {
+                return .{ .err = core.parseError("string", start + j, "unknown escape sequence", .{
+                    .expected = "\\0 \\n \\r \\t \\\\ \\\"",
+                    .kind = .lexical,
+                }) };
+            }
+            j += 2;
+            continue;
+        }
+        j += 1;
+    }
+    return .{ .err = core.parseError("string", start + j, "unterminated string literal (EOF before closing '\"')", .{
+        .expected = "\"",
+        .kind = .incomplete,
+    }) };
+}
+
 /// Bare `&` only — refuses when followed by a hex digit so the
 /// `addrLiteral` parser (which DOES want hex digits) handles
 /// `&FFFF` and any over-length-but-still-hex variants like
@@ -299,15 +406,19 @@ const ampersandP = parserOf(ampersandThunk);
 // back to the first alternative. Putting `newlineP` at the front
 // makes bare `\r` surface as a "newline" lexical error instead of
 // whatever the first prefix-checker would have said.
-// Order matters: `addrP` must come before `ampersandP` so
-// `&FFFF` is recognized as an address literal before the bare
-// `&` punct gets a chance.
+// Order also matters in two longest-match cases:
+//   - `addrP` before `ampersandP` so `&FFFF` is an address literal
+//     before the bare `&` punct gets a chance.
+//   - `shlP` / `shrP` (`<<` / `>>`) before `ltP` / `gtP` (`<` / `>`)
+//     so the two-byte shift operators win over the single-byte
+//     comparisons.
 const oneToken = knit.choice(Token, &[_]core.Parser(Token){
-    newlineP,   hexP,    addrP,     symRefP,   identP,
-    colonP,     commaP,  equalsP,   lbraceP,   rbraceP,
-    lparenP,    rparenP, lbracketP, rbracketP, plusP,
-    minusP,     starP,   ltP,       gtP,       dotP,
-    ampersandP,
+    newlineP, hexP,    addrP,   symRefP,    identP,
+    stringP,  colonP,  commaP,  equalsP,    lbraceP,
+    rbraceP,  lparenP, rparenP, lbracketP,  rbracketP,
+    plusP,    minusP,  starP,   slashP,     percentP,
+    pipeP,    caretP,  tildeP,  shlP,       shrP,
+    ltP,      gtP,     dotP,    ampersandP,
 });
 
 // ---------- whitespace + comment skipping (between tokens) ----------

--- a/tests/asm/lexer.test.zig
+++ b/tests/asm/lexer.test.zig
@@ -137,26 +137,36 @@ test "lex: identifier can't start with a digit — emits an error then resumes" 
     try std.testing.expectEqualStrings("bad", ts.tokens[0].lexeme("9bad"));
 }
 
-test "lex: !sym_ref" {
-    var ts = try tokenize("!hasFrame");
+test "lex: @sym_ref" {
+    var ts = try tokenize("@hasFrame");
     defer ts.deinit();
     try std.testing.expectEqual(Token.Kind.sym_ref, ts.tokens[0].kind);
-    try std.testing.expectEqualStrings("!hasFrame", ts.tokens[0].lexeme("!hasFrame"));
+    try std.testing.expectEqualStrings("@hasFrame", ts.tokens[0].lexeme("@hasFrame"));
 }
 
-test "lex: bare ! rejected" {
-    var ts = try tokenize("!");
+test "lex: bare @ rejected" {
+    var ts = try tokenize("@");
     defer ts.deinit();
     try std.testing.expect(ts.hasErrors());
     try std.testing.expectEqualStrings("symRef", ts.errors[0].parser);
 }
 
-test "lex: ! followed by digit rejected — both bytes flagged" {
-    var ts = try tokenize("!9");
+test "lex: @ followed by digit rejected — both bytes flagged" {
+    var ts = try tokenize("@9");
     defer ts.deinit();
     try std.testing.expect(ts.hasErrors());
-    // The '!' errors via symRef; then '9' errors via the fall-through.
+    // The '@' errors via symRef; then '9' errors via the fall-through.
     try std.testing.expect(ts.errors.len >= 1);
+}
+
+test "lex: legacy '!sym' no longer recognized after spec revision" {
+    // '!' is no longer the sym-ref prefix (replaced by '@' in v0.1-final).
+    // The bare '!' surfaces as an unknown byte; the rest still lexes.
+    var ts = try tokenize("!hasFrame");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqual(Token.Kind.ident, ts.tokens[0].kind);
+    try std.testing.expectEqualStrings("hasFrame", ts.tokens[0].lexeme("!hasFrame"));
 }
 
 // ---------- punctuation ----------
@@ -171,8 +181,49 @@ test "lex: all punctuation tokens" {
     });
 }
 
+test "lex: arithmetic operator tokens (/ % | ^ ~)" {
+    try expectKinds("/ % | ^ ~", &.{
+        .slash, .percent, .pipe, .caret, .tilde,
+    });
+}
+
+test "lex: << longest-match wins over two lt" {
+    try expectKinds("<<", &.{.shl});
+}
+
+test "lex: >> longest-match wins over two gt" {
+    try expectKinds(">>", &.{.shr});
+}
+
+test "lex: shift mixed with comparisons" {
+    try expectKinds("x << $01 > $00", &.{
+        .ident, .shl, .hex, .gt, .hex,
+    });
+}
+
+test "lex: space-separated < stays as lt (no shift glue)" {
+    try expectKinds("< <", &.{ .lt, .lt });
+}
+
+test "lex: '< x' lexes as lt + ident (whitespace breaks longest-match)" {
+    try expectKinds("< x", &.{ .lt, .ident });
+}
+
+test "lex: compile-time expression with full operator set" {
+    const src = "$01 + $02 * $03 - $04 / $05 % $06 | $07 ^ $08 ~ $09 << $0A >> $0B";
+    try expectKinds(src, &.{
+        .hex,     .plus,  .hex,
+        .star,    .hex,   .minus,
+        .hex,     .slash, .hex,
+        .percent, .hex,   .pipe,
+        .hex,     .caret, .hex,
+        .tilde,   .hex,   .shl,
+        .hex,     .shr,   .hex,
+    });
+}
+
 test "lex: arithmetic expression inside &[ ]" {
-    const src = "mov &[!t + r1 * STRIDE - $02], acu";
+    const src = "mov &[@t + r1 * STRIDE - $02], acu";
     try expectKinds(src, &.{
         .ident,   .ampersand, .lbracket,
         .sym_ref, .plus,      .ident,
@@ -190,7 +241,7 @@ test "lex: cast syntax <Type> obj.field" {
 }
 
 test "lex: field access in addr expression" {
-    const src = "mov acu, &[!player + Player.mp]";
+    const src = "mov acu, &[@player + Player.mp]";
     try expectKinds(src, &.{
         .ident,     .ident,    .comma,
         .ampersand, .lbracket, .sym_ref,
@@ -208,6 +259,65 @@ test "lex: &FFFF stays as addr literal (addr wins over ampersand)" {
     defer ts.deinit();
     try std.testing.expectEqual(Token.Kind.addr, ts.tokens[0].kind);
     try std.testing.expectEqual(@as(u16, 0xFFFF), ts.tokens[0].value);
+}
+
+// ---------- string literals ----------
+
+test "lex: empty string literal" {
+    var ts = try tokenize("\"\"");
+    defer ts.deinit();
+    try std.testing.expectEqual(Token.Kind.string, ts.tokens[0].kind);
+    try std.testing.expectEqualStrings("\"\"", ts.tokens[0].lexeme("\"\""));
+    try std.testing.expect(!ts.hasErrors());
+}
+
+test "lex: plain string literal" {
+    var ts = try tokenize("\"hello\"");
+    defer ts.deinit();
+    try std.testing.expectEqual(Token.Kind.string, ts.tokens[0].kind);
+    try std.testing.expectEqualStrings("\"hello\"", ts.tokens[0].lexeme("\"hello\""));
+    try std.testing.expect(!ts.hasErrors());
+}
+
+test "lex: string literal with every supported escape" {
+    const src = "\"a\\0b\\nc\\rd\\te\\\\f\\\"g\"";
+    var ts = try tokenize(src);
+    defer ts.deinit();
+    try std.testing.expectEqual(Token.Kind.string, ts.tokens[0].kind);
+    try std.testing.expect(!ts.hasErrors());
+}
+
+test "lex: unterminated string literal at EOF errors" {
+    var ts = try tokenize("\"oops");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqualStrings("string", ts.errors[0].parser);
+    try std.testing.expect(ts.errors[0].kind == .incomplete);
+}
+
+test "lex: unterminated string literal before newline errors" {
+    var ts = try tokenize("\"oops\n");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqualStrings("string", ts.errors[0].parser);
+    try std.testing.expect(ts.errors[0].kind == .incomplete);
+}
+
+test "lex: unknown escape sequence flagged as lexical" {
+    var ts = try tokenize("\"\\q\"");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqualStrings("string", ts.errors[0].parser);
+    try std.testing.expect(ts.errors[0].kind == .lexical);
+}
+
+test "lex: data8 directive accepts mixed bytes + string" {
+    const src = "data8 greeting = { \"hi\", $00 }\n";
+    try expectKinds(src, &.{
+        .ident,   .ident, .equals, .lbrace,
+        .string,  .comma, .hex,    .rbrace,
+        .newline,
+    });
 }
 
 // ---------- realistic programs ----------
@@ -246,7 +356,7 @@ test "lex: exported constant directive" {
 // ---------- error recovery + multi-error ----------
 
 test "lex: two unknown bytes in one line surface as two errors" {
-    var ts = try tokenize("hlt @ # foo");
+    var ts = try tokenize("hlt # ? foo");
     defer ts.deinit();
     try std.testing.expectEqual(@as(usize, 2), ts.errors.len);
     // The valid tokens around the bad bytes still made it through.
@@ -255,7 +365,7 @@ test "lex: two unknown bytes in one line surface as two errors" {
 }
 
 test "lex: bad byte doesn't poison the rest of the stream" {
-    var ts = try tokenize("@ hlt\n");
+    var ts = try tokenize("# hlt\n");
     defer ts.deinit();
     try std.testing.expect(ts.hasErrors());
     try std.testing.expectEqual(Token.Kind.ident, ts.tokens[0].kind); // hlt


### PR DESCRIPTION
## Summary

Follow-up to #71 (closed #32) that applies the three lexer-touching decisions from the v0.1-final spec revision (PR #72):

- **Symbol refs** — `!sym` → `@sym`. Bare `!` is no longer recognized.
- **Operators** — adds `/` `%` `|` `^` `~` (single-byte) and `<<` `>>` (longest-match shifts) for compile-time expressions per spec §1.7.
- **String literals** — new `string` token for `data8` bodies per spec §1.5. C-style escapes validated at lex time; unterminated → `kind=.incomplete`, bad escape → `kind=.lexical`.

The choice() order is now documented for two longest-match cases (`addrP` before `ampersandP`, `shlP`/`shrP` before `ltP`/`gtP`).

Closes #73.

## Test plan

- [ ] 49 lexer tests pass in all four release modes (Debug, ReleaseSafe, ReleaseFast, ReleaseSmall)
- [ ] `zig build ci` clean (lint + strict + mirror + naming + cross-target)
- [ ] Acceptance criteria from #73 walked line-by-line:
  - `@hasFrame` → `sym_ref`, `!hasFrame` errors (covered by "legacy '!sym' no longer recognized" test)
  - Each new operator token (`/`, `%`, `|`, `^`, `~`) covered
  - `<<` / `>>` longest-match; `< x` (space) stays as `lt` + `ident`
  - String literal happy path, every supported escape, unterminated (EOF + newline), bad escape