### PR TITLE
feat(asm/lexer): add char literal token

### DIFF
--- a/.changeset/s7h45f02.md
+++ b/.changeset/s7h45f02.md
@@ -1,0 +1,13 @@
+---
+bump: minor
+---
+
+Add the `.gas` char literal token to the lexer per asm spec §1.4:
+single-quoted byte with C-style escapes (`\0 \n \r \t \\ \" \'`).
+The resolved byte lives in `Token.value`. Empty `''` or
+multi-byte `'AB'` is `.lexical` (E016-shape); unterminated `'A`
+or `'A\n` is `.incomplete`; unknown escape `'\q'` is `.lexical`.
+
+`\'` is added to the shared escape table so strings can also
+escape an embedded apostrophe (harmless extension to §1.5; was
+needed anyway to express the byte `0x27` inside a char literal).

--- a/src/asm/lexer.zig
+++ b/src/asm/lexer.zig
@@ -55,6 +55,9 @@ pub const Token = struct {
         ampersand,
         /// `"..."` literal with C-style escapes per asm spec §1.5.
         string,
+        /// `'A'` literal — single byte with C-style escapes per
+        /// asm spec §1.4. `value` carries the resolved byte.
+        char,
         eof,
     };
 
@@ -282,6 +285,7 @@ const ltP = parserOf(punctThunk('<', .lt, "lt"));
 const gtP = parserOf(punctThunk('>', .gt, "gt"));
 const dotP = parserOf(punctThunk('.', .dot, "dot"));
 const stringP = parserOf(stringThunk);
+const charP = parserOf(charThunk);
 fn shiftThunk(comptime byte: u8, comptime kind: Token.Kind, comptime name: []const u8) fn (*core.ParseState) core.ParseResult(Token) {
     return struct {
         fn parse(state: *core.ParseState) core.ParseResult(Token) {
@@ -309,6 +313,7 @@ fn decodeEscape(b: u8) u16 {
         't' => 0x09,
         '\\' => 0x5C,
         '"' => 0x22,
+        '\'' => 0x27,
         else => decodedEscapeMissing,
     };
 }
@@ -370,6 +375,96 @@ fn stringThunk(state: *core.ParseState) core.ParseResult(Token) {
     }) };
 }
 
+/// Match a single-quoted character literal per asm spec §1.4 —
+/// exactly one byte (raw or backslash-escaped via the §1.5 table
+/// plus `\'`), then a closing `'`. The resolved byte lives in
+/// `Token.value`. Empty `''` or multi-byte `'AB'` is `E016`-shape;
+/// unterminated is `.incomplete`; bad escape is `.lexical`.
+fn charThunk(state: *core.ParseState) core.ParseResult(Token) {
+    const start = state.index;
+    const rem = state.remaining();
+    if (rem.len == 0 or rem[0] != '\'') {
+        return .{ .err = core.parseError("char", start, "expected '\\''", .{
+            .expected = "'",
+            .kind = .syntactic,
+        }) };
+    }
+    if (rem.len < 2) {
+        return .{ .err = core.parseError("char", start + 1, "unterminated char literal at end of input", .{
+            .expected = "byte then '",
+            .kind = .incomplete,
+        }) };
+    }
+    if (rem[1] == '\'') {
+        // Error index past the opening quote so this beats every
+        // other parser's index-0 refusal in `choice()`'s
+        // furthest-progress comparison — otherwise `newlineP` (first
+        // in the table) wins the tie and we report a misleading
+        // "newline" error for an empty char literal.
+        return .{ .err = core.parseError("char", start + 1, "empty char literal", .{
+            .expected = "exactly one byte between the quotes",
+            .kind = .lexical,
+        }) };
+    }
+    if (rem[1] == '\n' or rem[1] == '\r') {
+        return .{ .err = core.parseError("char", start + 1, "unterminated char literal (newline before closing ')", .{
+            .expected = "'",
+            .kind = .incomplete,
+        }) };
+    }
+
+    var value: u16 = 0;
+    var body_len: usize = 0;
+    if (rem[1] == '\\') {
+        if (rem.len < 3) {
+            return .{ .err = core.parseError("char", start + 1, "unterminated escape at end of input", .{
+                .expected = "escape character",
+                .kind = .incomplete,
+            }) };
+        }
+        const decoded = decodeEscape(rem[2]);
+        if (decoded == decodedEscapeMissing) {
+            return .{ .err = core.parseError("char", start + 1, "unknown escape sequence", .{
+                .expected = "\\0 \\n \\r \\t \\\\ \\\" \\'",
+                .kind = .lexical,
+            }) };
+        }
+        value = decoded;
+        body_len = 2;
+    } else {
+        value = rem[1];
+        body_len = 1;
+    }
+
+    const closing = 1 + body_len;
+    if (rem.len <= closing) {
+        return .{ .err = core.parseError("char", start + closing, "unterminated char literal at end of input", .{
+            .expected = "'",
+            .kind = .incomplete,
+        }) };
+    }
+    if (rem[closing] != '\'') {
+        if (rem[closing] == '\n' or rem[closing] == '\r') {
+            return .{ .err = core.parseError("char", start + closing, "unterminated char literal (newline before closing ')", .{
+                .expected = "'",
+                .kind = .incomplete,
+            }) };
+        }
+        return .{ .err = core.parseError("char", start + closing, "char literal must be exactly one byte", .{
+            .expected = "'",
+            .kind = .lexical,
+        }) };
+    }
+
+    state.advance(closing + 1);
+    return core.ok(Token{
+        .kind = .char,
+        .start = u32At(start),
+        .end = u32At(state.index),
+        .value = value,
+    }, state.index);
+}
+
 /// Bare `&` only — refuses when followed by a hex digit so the
 /// `addrLiteral` parser (which DOES want hex digits) handles
 /// `&FFFF` and any over-length-but-still-hex variants like
@@ -413,12 +508,12 @@ const ampersandP = parserOf(ampersandThunk);
 //     so the two-byte shift operators win over the single-byte
 //     comparisons.
 const oneToken = knit.choice(Token, &[_]core.Parser(Token){
-    newlineP, hexP,    addrP,   symRefP,    identP,
-    stringP,  colonP,  commaP,  equalsP,    lbraceP,
-    rbraceP,  lparenP, rparenP, lbracketP,  rbracketP,
-    plusP,    minusP,  starP,   slashP,     percentP,
-    pipeP,    caretP,  tildeP,  shlP,       shrP,
-    ltP,      gtP,     dotP,    ampersandP,
+    newlineP,  hexP,    addrP,   symRefP, identP,
+    stringP,   charP,   colonP,  commaP,  equalsP,
+    lbraceP,   rbraceP, lparenP, rparenP, lbracketP,
+    rbracketP, plusP,   minusP,  starP,   slashP,
+    percentP,  pipeP,   caretP,  tildeP,  shlP,
+    shrP,      ltP,     gtP,     dotP,    ampersandP,
 });
 
 // ---------- whitespace + comment skipping (between tokens) ----------

--- a/tests/asm/lexer.test.zig
+++ b/tests/asm/lexer.test.zig
@@ -320,6 +320,96 @@ test "lex: data8 directive accepts mixed bytes + string" {
     });
 }
 
+// ---------- char literals ----------
+
+test "lex: 'A' char literal carries the byte value" {
+    var ts = try tokenize("'A'");
+    defer ts.deinit();
+    try std.testing.expectEqual(Token.Kind.char, ts.tokens[0].kind);
+    try std.testing.expectEqual(@as(u16, 0x41), ts.tokens[0].value);
+    try std.testing.expect(!ts.hasErrors());
+}
+
+test "lex: ' ' (space) char literal" {
+    var ts = try tokenize("' '");
+    defer ts.deinit();
+    try std.testing.expectEqual(Token.Kind.char, ts.tokens[0].kind);
+    try std.testing.expectEqual(@as(u16, 0x20), ts.tokens[0].value);
+}
+
+test "lex: char literal escapes resolve to bytes" {
+    const cases = [_]struct { src: []const u8, value: u16 }{
+        .{ .src = "'\\0'", .value = 0x00 },
+        .{ .src = "'\\n'", .value = 0x0A },
+        .{ .src = "'\\r'", .value = 0x0D },
+        .{ .src = "'\\t'", .value = 0x09 },
+        .{ .src = "'\\\\'", .value = 0x5C },
+        .{ .src = "'\\\"'", .value = 0x22 },
+        .{ .src = "'\\''", .value = 0x27 },
+    };
+    for (cases) |c| {
+        var ts = try tokenize(c.src);
+        defer ts.deinit();
+        try std.testing.expectEqual(Token.Kind.char, ts.tokens[0].kind);
+        try std.testing.expectEqual(c.value, ts.tokens[0].value);
+        try std.testing.expect(!ts.hasErrors());
+    }
+}
+
+test "lex: empty char literal '' errors as lexical" {
+    var ts = try tokenize("''");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqualStrings("char", ts.errors[0].parser);
+    try std.testing.expect(ts.errors[0].kind == .lexical);
+}
+
+test "lex: multi-byte 'AB' errors as lexical" {
+    var ts = try tokenize("'AB'");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqualStrings("char", ts.errors[0].parser);
+    try std.testing.expect(ts.errors[0].kind == .lexical);
+}
+
+test "lex: unterminated char literal at EOF errors as incomplete" {
+    var ts = try tokenize("'A");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqualStrings("char", ts.errors[0].parser);
+    try std.testing.expect(ts.errors[0].kind == .incomplete);
+}
+
+test "lex: unterminated char literal before newline errors as incomplete" {
+    var ts = try tokenize("'A\n");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqualStrings("char", ts.errors[0].parser);
+    try std.testing.expect(ts.errors[0].kind == .incomplete);
+}
+
+test "lex: unknown char escape errors as lexical" {
+    var ts = try tokenize("'\\q'");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expectEqualStrings("char", ts.errors[0].parser);
+    try std.testing.expect(ts.errors[0].kind == .lexical);
+}
+
+test "lex: char in operand position next to mnemonic" {
+    try expectKinds("cmp r1, 'A'", &.{
+        .ident, .ident, .comma, .char,
+    });
+}
+
+test "lex: char alongside string literal still both work" {
+    const src = "data8 ch = 'A'\ndata8 hi = \"Hi\"\n";
+    try expectKinds(src, &.{
+        .ident, .ident, .equals, .char,   .newline,
+        .ident, .ident, .equals, .string, .newline,
+    });
+}
+
 // ---------- realistic programs ----------
 
 test "lex: labelled instruction with operands and comment" {


### PR DESCRIPTION
## Summary

Adds the `char` token introduced in PR #75's spec sweep. Single-quoted byte literals per asm §1.4, mirroring the `string` thunk shape but constrained to exactly one byte (raw or backslash-escaped) between the quotes.

## Behavior

| Input | Outcome |
|---|---|
| `'A'` | `.char` with `value = 0x41` |
| `' '`, `'7'`, etc. | `.char` with the ASCII byte |
| `'\0' '\n' '\r' '\t' '\\\\' '\\\"' '\\''` | resolved per §1.5 escape table (extended with `\'` for the apostrophe byte) |
| `''` | `.lexical` — empty char literal |
| `'AB'` | `.lexical` — must be exactly one byte |
| `'A` (EOF) | `.incomplete` — unterminated at end of input |
| `'A\\n` (newline before closing) | `.incomplete` — unterminated before newline |
| `'\\q'` | `.lexical` — unknown escape |

## Two subtle bugs caught during self-review

1. **Empty `''` was reporting a `newline` error.** The empty-char error was emitted at index 0 — tied with every other parser refusing at index 0 — and `choice()`'s tie-break pulls the first alternative (`newlineP`). Fixed by advancing the error index past the opening quote so `charP` wins the furthest-progress comparison.
2. **`'A\\n` was reporting `.lexical` instead of `.incomplete`.** The newline at the closing position originally fell through the generic "multi-byte" branch. Now special-cased to `.incomplete`, matching the intent (user forgot the closing quote).

## Files

- `src/asm/lexer.zig` — `Token.Kind.char`, `decodeEscape` gets `\'` → `0x27`, new `charThunk` + `charP`, choice table order.
- `tests/asm/lexer.test.zig` — 10 new tests covering every #76 acceptance item plus operand-position and string-coexistence smokes.
- `.changeset/s7h45f02.md`.

Closes #76.

## Test plan

- [x] `zig build ci` clean — 59 lexer tests pass in all 4 release modes + cross-target.
- [x] Each #76 acceptance criterion has at least one dedicated test.
- [x] Existing string-literal tests still pass (no regression from sharing the escape table).