### PR TITLE
feat(asm): include resolution phase (textual splice)

### DIFF
--- a/.changeset/t8j61h09.md
+++ b/.changeset/t8j61h09.md
@@ -6,9 +6,10 @@ Implement `include` resolution per asm spec §2.2. New module
 `src/asm/include.zig` walks the include graph from a root `.gas`
 file and fuses every reachable file's tokens into one stream.
 
-- **Dedup (`pragma once`):** each canonical path resolves at most
-  once. A diamond `main → {a, b} → utils` reads `utils.gas` once
-  and includes its tokens once.
+- **Textual splice (NASM tradition):** every `include` emits the
+  target's tokens every time. A diamond `main → {a, b} → utils`
+  emits `utils.gas` twice — the user controls dedup through their
+  include graph or (post-v0.1) conditional assembly guards.
 - **Cycle detection** → `E012` (asm spec §8). Error is pinned to
   the include statement that closes the cycle, not the root.
 - **Depth cap** at 32 nested includes → `E013`.

--- a/.changeset/t8j61h09.md
+++ b/.changeset/t8j61h09.md
@@ -1,0 +1,30 @@
+---
+bump: minor
+---
+
+Implement `include` resolution per asm spec §2.2. New module
+`src/asm/include.zig` walks the include graph from a root `.gas`
+file and fuses every reachable file's tokens into one stream.
+
+- **Dedup (`pragma once`):** each canonical path resolves at most
+  once. A diamond `main → {a, b} → utils` reads `utils.gas` once
+  and includes its tokens once.
+- **Cycle detection** → `E012` (asm spec §8). Error is pinned to
+  the include statement that closes the cycle, not the root.
+- **Depth cap** at 32 nested includes → `E013`.
+- **Missing file** → `E015`, pinned to the including file's
+  `include` statement.
+- **File-aware diagnostics:** new `Diagnostic { file_id,
+  parse_error }` wraps every error with its originating file.
+  `formatDiagnostic` emits `<path>:<line>:<col>: <message>`.
+
+`Token` gains a `file_id: u16` (default `0`) — the standalone
+lexer leaves it untouched; the resolver overwrites it as it
+fuses streams. Backwards-compatible for existing callers of
+`tokenize`.
+
+Public surface re-exported through `gero.asm_`:
+
+- `FileInfo`, `FileTable`, `Diagnostic`, `FusedSource`
+- `resolveIncludes(io, allocator, root_path)`
+- `formatDiagnostic(writer, file_table, diagnostic)`

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -306,10 +306,9 @@ include "sound.gas"
 include "level1.gas"
 ```
 
-Resolves another `.gas` file at this point and inlines its tokens.
-Path is relative to the including file. Borrows from the C/Rust
-`#pragma once` / `mod` tradition rather than the literal-splice
-NASM tradition — see "Re-include semantics" below.
+Resolves another `.gas` file at this point and inlines its tokens
+**textually** — same model as NASM `%include`, ca65 `.include`,
+6502 / z80 assemblers. Path is relative to the including file.
 
 Rules:
 
@@ -323,20 +322,25 @@ Rules:
   doing the include. No search path / no system include directory
   in v0.1.
 
-**Re-include semantics (`pragma once`):** each unique file is
-resolved at most once per assembly run. If two files both include
-`utils.gas`, `utils.gas` is read and lexed once, and its tokens
-appear once in the fused stream. The second `include "utils.gas"`
-is a silent no-op.
+**Re-include semantics:** every `include` directive splices in
+the target's tokens, every time. If two files both `include
+"utils.gas"`, the bytes from `utils.gas` are emitted twice. This
+matches the asm tradition and gives hand-writers a way to repeat
+parametric blocks before macros (post-v0.1) land.
 
-Path identity is determined by canonical form (resolved symlinks,
-normalized separators). `./utils.gas`, `utils.gas`, and
-`../current/utils.gas` are all the same file.
+When you want a header to appear at most once, wrap it in an
+include guard at the top of the file — same pattern as NASM:
 
-This trades the NASM "splice every time + write your own include
-guards" model for a guard-free experience. Code that needs
-"emit-this-block-N-times" should use other directives (or v-next
-macros) rather than `include`.
+```asm
+; ----- utils.gas -----
+;ifndef UTILS_GAS    ; (planned syntax — TBD)
+;  ... shared definitions here ...
+;endif
+```
+
+(Conditional assembly is post-v0.1; until it lands, hand-writers
+either control the include graph manually or accept the duplicate
+emission for repeated sections.)
 
 ### 2.3 Instructions
 

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -306,10 +306,10 @@ include "sound.gas"
 include "level1.gas"
 ```
 
-Textually splices another `.gas` file at this point — 6502 / z80
-convention. The included file's tokens are parsed in-place as if
-they had been typed at the include site. Path is relative to the
-including file.
+Resolves another `.gas` file at this point and inlines its tokens.
+Path is relative to the including file. Borrows from the C/Rust
+`#pragma once` / `mod` tradition rather than the literal-splice
+NASM tradition — see "Re-include semantics" below.
 
 Rules:
 
@@ -322,6 +322,21 @@ Rules:
 - Paths are resolved relative to the directory of the `.gas` file
   doing the include. No search path / no system include directory
   in v0.1.
+
+**Re-include semantics (`pragma once`):** each unique file is
+resolved at most once per assembly run. If two files both include
+`utils.gas`, `utils.gas` is read and lexed once, and its tokens
+appear once in the fused stream. The second `include "utils.gas"`
+is a silent no-op.
+
+Path identity is determined by canonical form (resolved symlinks,
+normalized separators). `./utils.gas`, `utils.gas`, and
+`../current/utils.gas` are all the same file.
+
+This trades the NASM "splice every time + write your own include
+guards" model for a guard-free experience. Code that needs
+"emit-this-block-N-times" should use other directives (or v-next
+macros) rather than `include`.
 
 ### 2.3 Instructions
 

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const knit = @import("knit");
 const gero = @import("gero.zig");
 const lexer = @import("asm/lexer.zig");
+const include = @import("asm/include.zig");
 
 /// Re-export: lexer token.
 pub const Token = lexer.Token;
@@ -15,6 +16,19 @@ pub const Token = lexer.Token;
 pub const TokenStream = lexer.TokenStream;
 /// Re-export: `.gas` tokenizer.
 pub const tokenize = lexer.tokenize;
+
+/// Re-export: one file in the fused image (canonical path + raw content).
+pub const FileInfo = include.FileInfo;
+/// Re-export: the per-build file registry.
+pub const FileTable = include.FileTable;
+/// Re-export: diagnostic with originating file pinned.
+pub const Diagnostic = include.Diagnostic;
+/// Re-export: result of `resolveIncludes` — fused token stream + file table + errors.
+pub const FusedSource = include.FusedSource;
+/// Re-export: walk the include graph, return a single fused stream.
+pub const resolveIncludes = include.resolveIncludes;
+/// Re-export: format one `Diagnostic` as `<path>:<line>:<col>: <msg>`.
+pub const formatDiagnostic = include.formatDiagnostic;
 
 /// Errors the assembler can emit. Restricted while the smoke
 /// parser is the only producer; the real assembler will grow

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -1,0 +1,361 @@
+/// `include` resolution phase — walks the asm source graph,
+/// fusing tokens from every reachable file into one stream the
+/// downstream parser can consume directly. Implements the
+/// `pragma once` semantics from asm spec §2.2 (each file resolves
+/// at most once per assembly), cycle detection (E012), depth cap
+/// (E013), and file-not-found (E015).
+const std = @import("std");
+const knit = @import("knit");
+const core = knit.core;
+const lexer = @import("lexer.zig");
+
+const Io = std.Io;
+const Dir = Io.Dir;
+
+/// Hard cap on the include chain depth — bounds recursion so a
+/// pathological graph can't blow the stack.
+const max_include_depth: u8 = 32;
+
+/// 16 MiB ceiling on an individual `.gas` file. Real source is
+/// orders of magnitude smaller; this guards against
+/// runaway file descriptors / accidental binary reads.
+const max_file_size: usize = 16 * 1024 * 1024;
+
+/// One source file in the fused image — canonicalized path plus
+/// raw content. `FileTable` owns both buffers. `path` is
+/// sentinel-terminated because `realPathFileAlloc` returns
+/// `[:0]u8` and we need to keep the sentinel info for the
+/// allocator to free the right size on `deinit`.
+pub const FileInfo = struct {
+    path: [:0]const u8,
+    content: []const u8,
+};
+
+/// Indexed registry of every file pulled into the build. Token
+/// `file_id` fields point here. Errors are also keyed by file_id
+/// so the formatter can derive the right line/col.
+pub const FileTable = struct {
+    files: std.ArrayList(FileInfo),
+    allocator: std.mem.Allocator,
+
+    /// Free every owned path + content buffer and the backing list.
+    pub fn deinit(self: *FileTable) void {
+        for (self.files.items) |f| {
+            self.allocator.free(f.path);
+            self.allocator.free(f.content);
+        }
+        self.files.deinit(self.allocator);
+    }
+
+    /// Look up the FileInfo for a given file_id. Caller's job to
+    /// pass a valid id (in `[0, files.len)`).
+    pub fn get(self: FileTable, id: u16) FileInfo {
+        return self.files.items[id];
+    }
+
+    fn append(self: *FileTable, path: [:0]const u8, content: []const u8) !u16 {
+        // safety: FileTable is build-once, append-only; u16 caps
+        // the count at 65k files which is far above any sane
+        // assembly project.
+        const id: u16 = @intCast(self.files.items.len);
+        try self.files.append(self.allocator, .{ .path = path, .content = content });
+        return id;
+    }
+};
+
+/// Diagnostic with its originating file pinned. Wraps the raw
+/// `knit.ParseError` so downstream formatting can resolve the
+/// `<file>:<line>:<col>` prefix.
+pub const Diagnostic = struct {
+    file_id: u16,
+    parse_error: core.ParseError,
+};
+
+/// Output of `resolveIncludes` — everything the parser needs to
+/// see a single project as one stream.
+pub const FusedSource = struct {
+    file_table: FileTable,
+    tokens: []lexer.Token,
+    errors: []Diagnostic,
+    allocator: std.mem.Allocator,
+
+    /// Release the file table, token buffer, and diagnostics list.
+    pub fn deinit(self: *FusedSource) void {
+        self.file_table.deinit();
+        self.allocator.free(self.tokens);
+        self.allocator.free(self.errors);
+    }
+
+    /// `true` when at least one diagnostic was recorded during resolution.
+    pub fn hasErrors(self: FusedSource) bool {
+        return self.errors.len > 0;
+    }
+};
+
+/// Mutable working state threaded through every recursive call.
+const Context = struct {
+    io: Io,
+    allocator: std.mem.Allocator,
+    file_table: *FileTable,
+    tokens: *std.ArrayList(lexer.Token),
+    errors: *std.ArrayList(Diagnostic),
+    /// Canonical paths currently being resolved — cycle detection.
+    /// Entries reference path strings owned by `file_table`.
+    in_progress: *std.ArrayList([]const u8),
+    /// Canonical paths that have finished resolving — dedup
+    /// (`pragma once` semantics). Entries reference path strings
+    /// owned by `file_table`.
+    resolved: *std.StringHashMap(u16),
+};
+
+/// Resolve `root_path` and every file it includes (transitively)
+/// into a single fused token stream. Diagnostics are collected,
+/// not thrown — caller drains `.errors` to see all problems.
+///
+/// Returns an allocator error only if the build can't even start
+/// (root file can't be read, OOM, etc.). All include-time
+/// problems (cycle, depth, missing target) show up as
+/// `Diagnostic`s on the returned `FusedSource`.
+pub fn resolveIncludes(
+    io: Io,
+    allocator: std.mem.Allocator,
+    root_path: []const u8,
+) !FusedSource {
+    var file_table: FileTable = .{ .files = .empty, .allocator = allocator };
+    errdefer file_table.deinit();
+
+    var tokens: std.ArrayList(lexer.Token) = .empty;
+    errdefer tokens.deinit(allocator);
+
+    var errors: std.ArrayList(Diagnostic) = .empty;
+    errdefer errors.deinit(allocator);
+
+    var resolved = std.StringHashMap(u16).init(allocator);
+    defer resolved.deinit();
+
+    var in_progress: std.ArrayList([]const u8) = .empty;
+    defer in_progress.deinit(allocator);
+
+    var ctx = Context{
+        .io = io,
+        .allocator = allocator,
+        .file_table = &file_table,
+        .tokens = &tokens,
+        .errors = &errors,
+        .in_progress = &in_progress,
+        .resolved = &resolved,
+    };
+
+    try resolveOne(&ctx, root_path, null, 0, 0, 0);
+
+    return .{
+        .file_table = file_table,
+        .tokens = try tokens.toOwnedSlice(allocator),
+        .errors = try errors.toOwnedSlice(allocator),
+        .allocator = allocator,
+    };
+}
+
+fn resolveOne(
+    ctx: *Context,
+    requested: []const u8,
+    base_dir: ?[]const u8,
+    depth: u8,
+    include_site_file_id: u16,
+    include_site_offset: usize,
+) !void {
+    if (depth > max_include_depth) {
+        try ctx.errors.append(ctx.allocator, .{
+            .file_id = include_site_file_id,
+            .parse_error = core.parseError(
+                "include",
+                include_site_offset,
+                "include depth exceeds 32 — likely runaway recursion",
+                .{ .expected = "shorter include chain", .kind = .semantic },
+            ),
+        });
+        return;
+    }
+
+    // Resolve requested to an absolute path (relative-to base_dir
+    // or absolute-as-given). We can't use realpath directly on a
+    // relative path because realpath's behavior depends on the
+    // process cwd, and we want predictable resolution rooted at
+    // the including file's directory.
+    const absolute = if (std.fs.path.isAbsolute(requested))
+        try ctx.allocator.dupe(u8, requested)
+    else if (base_dir) |dir|
+        try std.fs.path.join(ctx.allocator, &.{ dir, requested })
+    else
+        try std.fs.path.join(ctx.allocator, &.{ ".", requested });
+    defer ctx.allocator.free(absolute);
+
+    // Canonicalize so symlinks / `..` / `.` segments / casing
+    // converge to the same key for dedup + cycle detection.
+    // realPathFileAlloc returns a null-terminated owned slice; we
+    // keep ownership of it through to the file_table.append below.
+    const canonical = Dir.cwd().realPathFileAlloc(ctx.io, absolute, ctx.allocator) catch |err| switch (err) {
+        error.FileNotFound => {
+            try ctx.errors.append(ctx.allocator, .{
+                .file_id = include_site_file_id,
+                .parse_error = core.parseError(
+                    "include",
+                    include_site_offset,
+                    "include target file not found",
+                    .{
+                        .expected = "existing .gas file",
+                        .actual = requested,
+                        .kind = .semantic,
+                    },
+                ),
+            });
+            return;
+        },
+        else => return err,
+    };
+
+    // pragma-once: already fully resolved, skip silently. Need to
+    // free the canonical we just allocated since we won't be
+    // registering this file.
+    if (ctx.resolved.contains(canonical)) {
+        ctx.allocator.free(canonical);
+        return;
+    }
+
+    // Cycle: same path currently being resolved further up the
+    // chain. Borrowing the canonical path string is safe because
+    // every in_progress entry points into file_table-owned memory.
+    for (ctx.in_progress.items) |p| {
+        if (std.mem.eql(u8, p, canonical)) {
+            try ctx.errors.append(ctx.allocator, .{
+                .file_id = include_site_file_id,
+                .parse_error = core.parseError(
+                    "include",
+                    include_site_offset,
+                    "include cycle detected",
+                    .{
+                        .expected = "non-cyclic include graph",
+                        .actual = requested,
+                        .kind = .semantic,
+                    },
+                ),
+            });
+            ctx.allocator.free(canonical);
+            return;
+        }
+    }
+
+    // Read the file. On success, ownership of `content` transfers
+    // to the file_table.
+    const content = Dir.cwd().readFileAlloc(ctx.io, canonical, ctx.allocator, Io.Limit.limited(max_file_size)) catch |err| {
+        ctx.allocator.free(canonical);
+        return err;
+    };
+
+    const file_id = ctx.file_table.append(canonical, content) catch |err| {
+        ctx.allocator.free(canonical);
+        ctx.allocator.free(content);
+        return err;
+    };
+
+    try ctx.in_progress.append(ctx.allocator, canonical);
+    defer _ = ctx.in_progress.pop();
+
+    var ts = try lexer.tokenize(ctx.allocator, content);
+    defer ts.deinit();
+
+    var i: usize = 0;
+    var prev_was_newline = true; // start-of-file counts as a statement boundary
+    while (i < ts.tokens.len) : (i += 1) {
+        const t = ts.tokens[i];
+        if (t.kind == .eof) break;
+
+        const is_stmt_start = prev_was_newline;
+        prev_was_newline = (t.kind == .newline);
+
+        if (is_stmt_start and t.kind == .ident) {
+            const ident_lex = content[t.start..t.end];
+            if (std.mem.eql(u8, ident_lex, "include")) {
+                if (i + 1 < ts.tokens.len and ts.tokens[i + 1].kind == .string) {
+                    const path_tok = ts.tokens[i + 1];
+                    const raw = content[path_tok.start..path_tok.end];
+                    // Strip the surrounding quote bytes. Escape
+                    // processing in include paths is out of scope
+                    // for v0.1 — file system paths in practice
+                    // don't need it.
+                    const path_str = raw[1 .. raw.len - 1];
+
+                    const this_dir = std.fs.path.dirname(canonical) orelse ".";
+
+                    try resolveOne(
+                        ctx,
+                        path_str,
+                        this_dir,
+                        depth + 1,
+                        file_id,
+                        t.start,
+                    );
+
+                    // Skip the consumed `include "path"` pair plus
+                    // the trailing newline if present, so the
+                    // include statement doesn't leak through into
+                    // the fused stream.
+                    i += 1; // skip the string
+                    if (i + 1 < ts.tokens.len and ts.tokens[i + 1].kind == .newline) {
+                        i += 1;
+                    }
+                    prev_was_newline = true;
+                    continue;
+                }
+                // Malformed: `include` without a following string.
+                // Let the parser surface the syntax error — emit
+                // the ident as a regular token below.
+            }
+        }
+
+        var copied = t;
+        copied.file_id = file_id;
+        try ctx.tokens.append(ctx.allocator, copied);
+    }
+
+    // Lexer errors from this file get tagged with our file_id so
+    // the formatter resolves them back to the right source.
+    for (ts.errors) |e| {
+        try ctx.errors.append(ctx.allocator, .{ .file_id = file_id, .parse_error = e });
+    }
+
+    try ctx.resolved.put(canonical, file_id);
+}
+
+/// Format one `Diagnostic` as `<path>:<line>:<col>: <message>` —
+/// the minimum prefix asm spec §8 mandates. The full multi-error
+/// + caret-snippet treatment lives in #37 (`error formatting via
+/// knit`); this helper is just enough to test that include
+/// errors reference the right file.
+pub fn formatDiagnostic(
+    writer: anytype,
+    file_table: FileTable,
+    err: Diagnostic,
+) !void {
+    const file = file_table.get(err.file_id);
+    const lc = computeLineCol(file.content, err.parse_error.index);
+    try writer.print("{s}:{d}:{d}: {s}\n", .{ file.path, lc.line, lc.col, err.parse_error.message });
+}
+
+const LineCol = struct { line: usize, col: usize };
+
+fn computeLineCol(source: []const u8, offset: usize) LineCol {
+    var line: usize = 1;
+    var col: usize = 1;
+    var i: usize = 0;
+    const end = @min(offset, source.len);
+    while (i < end) : (i += 1) {
+        if (source[i] == '\n') {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    return .{ .line = line, .col = col };
+}

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -1,9 +1,10 @@
 /// `include` resolution phase — walks the asm source graph,
 /// fusing tokens from every reachable file into one stream the
-/// downstream parser can consume directly. Implements the
-/// `pragma once` semantics from asm spec §2.2 (each file resolves
-/// at most once per assembly), cycle detection (E012), depth cap
-/// (E013), and file-not-found (E015).
+/// downstream parser can consume directly. Splice is textual per
+/// asm spec §2.2 (each `include` emits the target's tokens every
+/// time — NASM tradition). Cycle detection bounds runaway
+/// recursion (E012); depth cap (E013) guards pathological graphs;
+/// missing target (E015) is a per-include diagnostic.
 const std = @import("std");
 const knit = @import("knit");
 const core = knit.core;
@@ -100,12 +101,10 @@ const Context = struct {
     tokens: *std.ArrayList(lexer.Token),
     errors: *std.ArrayList(Diagnostic),
     /// Canonical paths currently being resolved — cycle detection.
-    /// Entries reference path strings owned by `file_table`.
-    in_progress: *std.ArrayList([]const u8),
-    /// Canonical paths that have finished resolving — dedup
-    /// (`pragma once` semantics). Entries reference path strings
-    /// owned by `file_table`.
-    resolved: *std.StringHashMap(u16),
+    /// Entries reference path strings owned by `file_table` (each
+    /// entry is the canonical path that's been registered there
+    /// for the duration of its recursive call).
+    in_progress: *std.ArrayList([:0]const u8),
 };
 
 /// Resolve `root_path` and every file it includes (transitively)
@@ -130,10 +129,7 @@ pub fn resolveIncludes(
     var errors: std.ArrayList(Diagnostic) = .empty;
     errdefer errors.deinit(allocator);
 
-    var resolved = std.StringHashMap(u16).init(allocator);
-    defer resolved.deinit();
-
-    var in_progress: std.ArrayList([]const u8) = .empty;
+    var in_progress: std.ArrayList([:0]const u8) = .empty;
     defer in_progress.deinit(allocator);
 
     var ctx = Context{
@@ -143,7 +139,6 @@ pub fn resolveIncludes(
         .tokens = &tokens,
         .errors = &errors,
         .in_progress = &in_progress,
-        .resolved = &resolved,
     };
 
     try resolveOne(&ctx, root_path, null, 0, 0, 0);
@@ -213,14 +208,6 @@ fn resolveOne(
         },
         else => return err,
     };
-
-    // pragma-once: already fully resolved, skip silently. Need to
-    // free the canonical we just allocated since we won't be
-    // registering this file.
-    if (ctx.resolved.contains(canonical)) {
-        ctx.allocator.free(canonical);
-        return;
-    }
 
     // Cycle: same path currently being resolved further up the
     // chain. Borrowing the canonical path string is safe because
@@ -323,8 +310,6 @@ fn resolveOne(
     for (ts.errors) |e| {
         try ctx.errors.append(ctx.allocator, .{ .file_id = file_id, .parse_error = e });
     }
-
-    try ctx.resolved.put(canonical, file_id);
 }
 
 /// Format one `Diagnostic` as `<path>:<line>:<col>: <message>` —

--- a/src/asm/lexer.zig
+++ b/src/asm/lexer.zig
@@ -9,14 +9,20 @@ const knit = @import("knit");
 const core = knit.core;
 
 /// One syntactic atom. `start..end` are byte offsets into the
-/// original source; numeric tokens also carry the parsed value.
+/// source file identified by `file_id`; numeric tokens also carry
+/// the parsed value.
 pub const Token = struct {
     kind: Kind,
     start: u32,
     end: u32,
     /// `0` for non-numeric tokens; the parsed `u16` for `.hex`
-    /// and `.addr`.
+    /// and `.addr`; the resolved byte for `.char`.
     value: u16,
+    /// Source-file ID — `0` for tokens emitted by the standalone
+    /// lexer (no include resolution). The include resolver
+    /// (`src/asm/include.zig`) overwrites this with the right
+    /// `FileTable` index when it fuses streams across files.
+    file_id: u16 = 0,
 
     /// Token classes the lexer emits.
     pub const Kind = enum {

--- a/tests/asm/include.test.zig
+++ b/tests/asm/include.test.zig
@@ -121,9 +121,9 @@ test "include: nested 3-deep include resolves in order" {
     try std.testing.expectEqualStrings("a_ident", idents[2]);
 }
 
-// ---------- pragma-once dedup ----------
+// ---------- textual splice (re-include emits every time) ----------
 
-test "include: diamond include — utils is resolved once even when reached twice" {
+test "include: diamond — utils is spliced TWICE per asm tradition" {
     var fx = Fixture.init();
     defer fx.deinit();
     try fx.write("utils.gas", "u_ident\n");
@@ -148,27 +148,26 @@ test "include: diamond include — utils is resolved once even when reached twic
     defer fused.deinit();
 
     try std.testing.expect(!fused.hasErrors());
-    // 4 files in the table (main, a, b, utils) — utils appears exactly once.
-    try std.testing.expectEqual(@as(usize, 4), fused.file_table.files.items.len);
-    // u_ident should appear ONCE in the fused stream, not twice.
+    // utils.gas gets a FileTable entry per inclusion — the file table
+    // tracks each splice, not each unique file.
+    try std.testing.expect(fused.file_table.files.items.len >= 4);
+    // u_ident should appear TWICE in the fused stream (textual splice).
     var u_ident_count: usize = 0;
     for (fused.tokens) |t| {
         if (t.kind != .ident) continue;
         const f = fused.file_table.get(t.file_id);
         if (std.mem.eql(u8, f.content[t.start..t.end], "u_ident")) u_ident_count += 1;
     }
-    try std.testing.expectEqual(@as(usize, 1), u_ident_count);
+    try std.testing.expectEqual(@as(usize, 2), u_ident_count);
 }
 
-test "include: same file referenced via different relative paths still dedups" {
+test "include: two direct includes of the same file emit its tokens twice" {
     var fx = Fixture.init();
     defer fx.deinit();
-    try fx.mkdir("sub");
-    try fx.write("utils.gas", "u_ident\n");
-    try fx.write("sub/inner.gas", "include \"../utils.gas\"\n");
+    try fx.write("shared.gas", "s_ident\n");
     try fx.write("main.gas",
-        \\include "utils.gas"
-        \\include "sub/inner.gas"
+        \\include "shared.gas"
+        \\include "shared.gas"
         \\
     );
 
@@ -179,15 +178,13 @@ test "include: same file referenced via different relative paths still dedups" {
     defer fused.deinit();
 
     try std.testing.expect(!fused.hasErrors());
-    // utils.gas must appear once even though the second include
-    // names it via `../utils.gas` from inside sub/.
-    var u_ident_count: usize = 0;
+    var s_count: usize = 0;
     for (fused.tokens) |t| {
         if (t.kind != .ident) continue;
         const f = fused.file_table.get(t.file_id);
-        if (std.mem.eql(u8, f.content[t.start..t.end], "u_ident")) u_ident_count += 1;
+        if (std.mem.eql(u8, f.content[t.start..t.end], "s_ident")) s_count += 1;
     }
-    try std.testing.expectEqual(@as(usize, 1), u_ident_count);
+    try std.testing.expectEqual(@as(usize, 2), s_count);
 }
 
 // ---------- cycle / depth / missing ----------

--- a/tests/asm/include.test.zig
+++ b/tests/asm/include.test.zig
@@ -1,0 +1,395 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+/// Bundle a `tmpDir` plus a few helpers so tests stay readable.
+const Fixture = struct {
+    tmp: std.testing.TmpDir,
+
+    fn init() Fixture {
+        return .{ .tmp = std.testing.tmpDir(.{}) };
+    }
+
+    fn deinit(self: *Fixture) void {
+        self.tmp.cleanup();
+    }
+
+    fn write(self: *Fixture, name: []const u8, body: []const u8) !void {
+        try self.tmp.dir.writeFile(std.testing.io, .{ .sub_path = name, .data = body });
+    }
+
+    fn mkdir(self: *Fixture, name: []const u8) !void {
+        try self.tmp.dir.createDirPath(std.testing.io, name);
+    }
+
+    fn pathOf(self: *Fixture, name: []const u8) ![:0]u8 {
+        return self.tmp.dir.realPathFileAlloc(std.testing.io, name, alloc);
+    }
+};
+
+fn countKind(tokens: []const gero.asm_.Token, kind: gero.asm_.Token.Kind) usize {
+    var n: usize = 0;
+    for (tokens) |t| if (t.kind == kind) {
+        n += 1;
+    };
+    return n;
+}
+
+// ---------- happy path ----------
+
+test "include: root file with no includes round-trips its token kinds" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("main.gas", "hlt\n");
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), fused.file_table.files.items.len);
+
+    // Should see: ident(hlt), newline. (eof isn't copied by the resolver.)
+    try std.testing.expectEqual(@as(usize, 1), countKind(fused.tokens, .ident));
+    try std.testing.expectEqual(@as(usize, 1), countKind(fused.tokens, .newline));
+    try std.testing.expectEqual(@as(u16, 0), fused.tokens[0].file_id);
+}
+
+test "include: single include splices the target's tokens, drops the include statement" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("lib.gas", "nop\n");
+    try fx.write("main.gas",
+        \\include "lib.gas"
+        \\hlt
+        \\
+    );
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    try std.testing.expectEqual(@as(usize, 2), fused.file_table.files.items.len);
+    // Two ident tokens: `nop` from lib, `hlt` from main. The `include`
+    // and `"lib.gas"` themselves are consumed by the resolver.
+    try std.testing.expectEqual(@as(usize, 2), countKind(fused.tokens, .ident));
+    try std.testing.expectEqual(@as(usize, 0), countKind(fused.tokens, .string));
+}
+
+test "include: nested 3-deep include resolves in order" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("c.gas", "c_ident\n");
+    try fx.write("b.gas",
+        \\include "c.gas"
+        \\b_ident
+        \\
+    );
+    try fx.write("a.gas",
+        \\include "b.gas"
+        \\a_ident
+        \\
+    );
+
+    const a_path = try fx.pathOf("a.gas");
+    defer alloc.free(a_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, a_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    try std.testing.expectEqual(@as(usize, 3), fused.file_table.files.items.len);
+
+    // Walking the token stream we should hit c_ident, b_ident, a_ident in that order.
+    var idents: [3][]const u8 = undefined;
+    var idx: usize = 0;
+    for (fused.tokens) |t| {
+        if (t.kind != .ident) continue;
+        const f = fused.file_table.get(t.file_id);
+        idents[idx] = f.content[t.start..t.end];
+        idx += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 3), idx);
+    try std.testing.expectEqualStrings("c_ident", idents[0]);
+    try std.testing.expectEqualStrings("b_ident", idents[1]);
+    try std.testing.expectEqualStrings("a_ident", idents[2]);
+}
+
+// ---------- pragma-once dedup ----------
+
+test "include: diamond include — utils is resolved once even when reached twice" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("utils.gas", "u_ident\n");
+    try fx.write("a.gas",
+        \\include "utils.gas"
+        \\
+    );
+    try fx.write("b.gas",
+        \\include "utils.gas"
+        \\
+    );
+    try fx.write("main.gas",
+        \\include "a.gas"
+        \\include "b.gas"
+        \\
+    );
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    // 4 files in the table (main, a, b, utils) — utils appears exactly once.
+    try std.testing.expectEqual(@as(usize, 4), fused.file_table.files.items.len);
+    // u_ident should appear ONCE in the fused stream, not twice.
+    var u_ident_count: usize = 0;
+    for (fused.tokens) |t| {
+        if (t.kind != .ident) continue;
+        const f = fused.file_table.get(t.file_id);
+        if (std.mem.eql(u8, f.content[t.start..t.end], "u_ident")) u_ident_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), u_ident_count);
+}
+
+test "include: same file referenced via different relative paths still dedups" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.mkdir("sub");
+    try fx.write("utils.gas", "u_ident\n");
+    try fx.write("sub/inner.gas", "include \"../utils.gas\"\n");
+    try fx.write("main.gas",
+        \\include "utils.gas"
+        \\include "sub/inner.gas"
+        \\
+    );
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    // utils.gas must appear once even though the second include
+    // names it via `../utils.gas` from inside sub/.
+    var u_ident_count: usize = 0;
+    for (fused.tokens) |t| {
+        if (t.kind != .ident) continue;
+        const f = fused.file_table.get(t.file_id);
+        if (std.mem.eql(u8, f.content[t.start..t.end], "u_ident")) u_ident_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), u_ident_count);
+}
+
+// ---------- cycle / depth / missing ----------
+
+test "include: direct self-include detected as cycle (E012)" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("main.gas", "include \"main.gas\"\n");
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(fused.hasErrors());
+    var saw_cycle = false;
+    for (fused.errors) |e| {
+        if (std.mem.eql(u8, e.parse_error.parser, "include") and
+            std.mem.indexOf(u8, e.parse_error.message, "cycle") != null) saw_cycle = true;
+    }
+    try std.testing.expect(saw_cycle);
+}
+
+test "include: indirect cycle a→b→a detected (E012)" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("a.gas", "include \"b.gas\"\n");
+    try fx.write("b.gas", "include \"a.gas\"\n");
+
+    const a_path = try fx.pathOf("a.gas");
+    defer alloc.free(a_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, a_path);
+    defer fused.deinit();
+
+    try std.testing.expect(fused.hasErrors());
+    var saw_cycle = false;
+    for (fused.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "cycle") != null) saw_cycle = true;
+    }
+    try std.testing.expect(saw_cycle);
+}
+
+test "include: missing target produces E015-shape error pointing at including file" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("main.gas", "include \"nope.gas\"\n");
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(fused.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), fused.errors.len);
+    const e = fused.errors[0];
+    try std.testing.expect(std.mem.indexOf(u8, e.parse_error.message, "not found") != null);
+    // Error should be attached to main (the file doing the include),
+    // not the missing target.
+    const main_info = fused.file_table.get(e.file_id);
+    try std.testing.expect(std.mem.endsWith(u8, main_info.path, "main.gas"));
+}
+
+test "include: deep chain exceeding 32 levels is rejected (E013)" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    // Build 34 files where file_N includes file_{N+1}.
+    var name_buf: [32]u8 = undefined;
+    var next_buf: [32]u8 = undefined;
+    var i: usize = 0;
+    while (i < 34) : (i += 1) {
+        const name = try std.fmt.bufPrint(&name_buf, "f{d}.gas", .{i});
+        if (i < 33) {
+            const next = try std.fmt.bufPrint(&next_buf, "f{d}.gas", .{i + 1});
+            const body = try std.fmt.allocPrint(alloc, "include \"{s}\"\n", .{next});
+            defer alloc.free(body);
+            try fx.write(name, body);
+        } else {
+            try fx.write(name, "leaf\n");
+        }
+    }
+
+    const root_path = try fx.pathOf("f0.gas");
+    defer alloc.free(root_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, root_path);
+    defer fused.deinit();
+
+    try std.testing.expect(fused.hasErrors());
+    var saw_depth = false;
+    for (fused.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "depth") != null) saw_depth = true;
+    }
+    try std.testing.expect(saw_depth);
+}
+
+// ---------- error-site preservation ----------
+
+test "include: lexer error in an included file references that file's path + line" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    // `$ABCDE` is a 5-digit hex literal — rejected by the lexer.
+    // Put it on line 2 of the included file so we can check line/col.
+    try fx.write("bad.gas",
+        \\hlt
+        \\mov $ABCDE, r1
+        \\
+    );
+    try fx.write("main.gas", "include \"bad.gas\"\n");
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(fused.hasErrors());
+
+    // Find the lexer error (parser == "hexLiteral") and check the
+    // file pinned on it is bad.gas, not main.gas.
+    var saw_in_bad = false;
+    for (fused.errors) |e| {
+        if (std.mem.eql(u8, e.parse_error.parser, "hexLiteral")) {
+            const info = fused.file_table.get(e.file_id);
+            if (std.mem.endsWith(u8, info.path, "bad.gas")) saw_in_bad = true;
+        }
+    }
+    try std.testing.expect(saw_in_bad);
+}
+
+test "include: formatDiagnostic produces path:line:col prefix" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("bad.gas",
+        \\hlt
+        \\$ABCDE
+        \\
+    );
+    try fx.write("main.gas", "include \"bad.gas\"\n");
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    defer allocating.deinit();
+
+    // Find the hex-literal error and format it.
+    for (fused.errors) |e| {
+        if (std.mem.eql(u8, e.parse_error.parser, "hexLiteral")) {
+            try gero.asm_.formatDiagnostic(&allocating.writer, fused.file_table, e);
+            break;
+        }
+    }
+
+    const out = allocating.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "bad.gas") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, ":2:") != null); // line 2
+}
+
+// ---------- token stream invariants ----------
+
+test "include: token file_ids match the files they came from" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("lib.gas", "lib_token\n");
+    try fx.write("main.gas",
+        \\include "lib.gas"
+        \\main_token
+        \\
+    );
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    for (fused.tokens) |t| {
+        if (t.kind != .ident) continue;
+        const f = fused.file_table.get(t.file_id);
+        const lex = f.content[t.start..t.end];
+        if (std.mem.eql(u8, lex, "lib_token")) {
+            try std.testing.expect(std.mem.endsWith(u8, f.path, "lib.gas"));
+        } else if (std.mem.eql(u8, lex, "main_token")) {
+            try std.testing.expect(std.mem.endsWith(u8, f.path, "main.gas"));
+        }
+    }
+}
+
+test "include: standalone tokenize still emits file_id = 0" {
+    // The lexer is file-agnostic — only the resolver sets file_id.
+    // Anyone calling `tokenize` directly (e.g., tests, smoke tools)
+    // should still see the default.
+    var ts = try gero.asm_.tokenize(alloc, "hlt\n");
+    defer ts.deinit();
+    for (ts.tokens) |t| {
+        try std.testing.expectEqual(@as(u16, 0), t.file_id);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `include` resolution per asm spec §2.2 — textual splice in 6502 / NASM / ca65 tradition. A new pre-parse pass (\`src/asm/include.zig\`) walks the include graph from a root \`.gas\` file and hands the rest of the pipeline a single fused token stream — no parser changes needed.

## Three commits

1. **\`docs(asm): clarify include is dedup'd (pragma-once)\`** — initial spec patch, now reversed.
2. **\`feat(asm): include resolution phase\`** — initial implementation with pragma-once dedup.
3. **\`refactor(asm): switch include semantics from pragma-once to textual splice\`** — reverses the dedup decision after recognizing asm and lang are sibling compilers (neither sits on top of the other), so the asm needs its own parametric-repetition story. Textual splice + future include guards (post-v0.1 conditional assembly) matches 6502 / NASM / ca65 idioms.

The final state (after commit 3) is what gets reviewed.

## Design choices (final)

- **Token-level fusion** (not text concat). The resolver runs the existing lexer once per file, then walks the token stream and recurses on \`ident(\"include\") string\`. Lexer stays file-agnostic.
- **\`file_id: u16\` on \`Token\`** (default \`0\`). The lexer leaves it alone; the resolver overwrites it during fusion. Backwards-compatible with existing \`tokenize\` callers.
- **Textual splice** — every include emits the target's tokens every time. Cycle detection bounds runaway recursion. Future conditional assembly (\`;ifndef\` guards) will be the dedup mechanism.
- **Format helper in this PR** (minimal \`<path>:<line>:<col>: <msg>\`) so the \"error references the included file\" acceptance criterion is testable without waiting for #37.

## Public API (re-exported via \`gero.asm_\`)

\`\`\`zig
FileInfo { path: [:0]const u8, content: []const u8 }
FileTable { ... }
Diagnostic { file_id: u16, parse_error: core.ParseError }
FusedSource { file_table, tokens, errors, ... }

resolveIncludes(io, allocator, root_path) → FusedSource
formatDiagnostic(writer, file_table, diagnostic)
\`\`\`

## Acceptance walk (#77)

| Criterion | Test |
|---|---|
| Single include resolves | \`single include splices the target's tokens, drops the include statement\` |
| Nested 3-deep | \`nested 3-deep include resolves in order\` |
| Cycle a→b→a → E012 | \`direct self-include detected as cycle (E012)\`, \`indirect cycle a→b→a detected (E012)\` |
| Depth > 32 → E013 | \`deep chain exceeding 32 levels is rejected (E013)\` |
| Missing → E015 | \`missing target produces E015-shape error pointing at including file\` |
| Error in included file → right path + line | \`lexer error in an included file references that file's path + line\`, \`formatDiagnostic produces path:line:col prefix\` |
| Global namespace | implicit by construction (one flat token stream) |
| All four release modes | CI green |

Plus textual-splice invariants: \`diamond — utils is spliced twice\`, \`two direct includes emit twice\`, \`standalone tokenize emits file_id = 0\`.

## Test plan

- [x] \`zig build ci\` green locally — 1240 tests pass across 4 modes + cross-target.
- [x] 13 include tests cover every #77 acceptance + the textual-splice contract.
- [x] Existing lexer tests unaffected.
- [x] Self-review walk done.

Closes #77.