### PR TITLE
docs(gtx-16): v0.1 spec — Picotron-class fantasy console

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,8 +102,10 @@ gero run game.gx --target=gtx-16   # boot with FC peripherals mapped
 - Default target `vm` runs the bare VM — `print` syscalls go to
   stdout, `int 0x21` (save-flush) writes `<basename>.sav` next to
   the `.gx`.
-- `--target=gtx-16` boots the FC host: opens a 256×192 window,
-  audio channels, gamepad input mapping (keyboard → gamepad on dev).
+- `--target=gtx-16` boots the FC host: opens a 320×240 window
+  (4:3 retro PC), wires up the IO command surface for drawing,
+  8-channel audio, gamepad + keyboard + mouse input. Full spec
+  in `docs/gtx-16.md`.
 
 **Exit:** 0 on `hlt` clean exit; 6 on unhandled fault (invalid
 opcode, /0, etc.); 1 on host-level error (file missing, version

--- a/docs/examples/syntax_overview.gr
+++ b/docs/examples/syntax_overview.gr
@@ -25,7 +25,7 @@ const ENCOUNTER_RATE = 6      -- 6/256 chance per step
 @zero_page                    -- §3.7.1 — fast access for hot global
 let frame_count: u16 = 0
 
-@addr $FF50                   -- §3.7.1 — bound to gtx-16 input register
+@addr $FEE0                   -- §3.7.1 — bound to gtx-16 gamepad input register
 let P1_STATE: u8 = 0
 
 local const SECRET = 42       -- §5.1 — module-private

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -521,7 +521,7 @@ in the base image (bank-less area before `0xC000`).
 @zero_page
 let cursor_pos: u16 = 0      -- fast access, e.g. updated 60×/sec
 
-@addr $FF00
+@addr $FE40
 let DISPCTL: u8 = 0          -- bound to gtx-16 display-control IO register
 
 @bank 5
@@ -1428,10 +1428,13 @@ Old-school enough — same model NES games used for actor systems.
               ↓
 0x7FFF (or wherever code ends)
 
-0x8000..0xBFFF  VRAM (host-mapped if FC consumer)
+0x8000..0xBFFF  Mapped region A (plain RAM; on gtx-16, carts
+                                  typically store sprite sheets here)
 0xC000..0xFEFF  bank window (compiler emits per-bank if program
                               uses banked modules)
-0xFF00..0xFFFF  IO / peripherals
+0xFE40..0xFEFF  gtx-16 IO surface (display, drawing, audio,
+                                    input — see gtx-16 §14)
+0xFF00..0xFFFF  IO page tail (RNG, timing, KV store, mouse)
 ```
 
 ### 7.3 Banked modules

--- a/docs/gtx-16.md
+++ b/docs/gtx-16.md
@@ -456,7 +456,9 @@ PICO-8-minimal style. Boot drops the user at a prompt.
 | `cat <path>` | Print a file. |
 | `clear` | Clear the screen. |
 | `load <cart>` | Load a cart into memory (no run). |
-| `run [cart]` | Run loaded cart, or `run <cart>` to load + run. |
+| `run [cart]` | Run loaded cart, or `run <cart>` to load + run. Discards any suspended cart snapshot. |
+| `resume` | Resume the most-recently-suspended cart from where it was paused. See §12.1. |
+| `quit` | Discard the current cart snapshot. Use when you don't want `resume` to take you back to a half-played cart. |
 | `save [name]` | Save the current cart (with optional rename). |
 | `edit [editor]` | Open an editor on the current cart. Default: code. See §11. |
 | `splore` | Open a graphical browser of available carts. |
@@ -528,6 +530,89 @@ All editors share:
 A cart can call `host_reboot()` (gero opcode) to relaunch the
 boot shell at any point.
 
+### 12.1 Context switching (shell ↔ cart)
+
+gtx-16 is **single-VM** — only one gero program executes at a
+time. But the shell, editors, and a running cart need to coexist
+naturally: hit Esc during a game, you're back in the shell with
+the cart paused; pick up an editor, change a sprite, resume the
+cart with the new sprite live.
+
+This is achieved with **snapshot-based context switching**, the
+same model PICO-8 uses. No concurrent processes, no scheduler —
+just one live VM + two saved snapshots that swap on triggers.
+
+**Two snapshot slots** maintained by the host:
+
+| Slot | Holds | Lifetime |
+|------|-------|----------|
+| `system_snapshot` | Shell or current editor state — regs + RAM image + IO regs + interrupt state. | Always present (boot fills it). |
+| `cart_snapshot` | Currently-loaded user cart, suspended state. | Present from `run` until `quit` or next `run`. |
+
+**The swap mechanism:**
+
+```
+                      ┌──────────────┐
+                      │   LIVE VM    │
+                      │  (executing) │
+                      └──────┬───────┘
+                             │ swap
+                             ▼
+                ┌────────────────────────┐
+                │  Host snapshot store   │
+                │  • system_snapshot     │
+                │  • cart_snapshot       │
+                └────────────────────────┘
+```
+
+`swap_to(target)` is a host operation that:
+1. Saves the live VM's full state into the snapshot it's currently associated with.
+2. Loads the target snapshot's state into the live VM.
+3. Resumes execution at the loaded `ip`.
+
+The whole VM (registers, the 64 KB memory image, IVT entries,
+interrupt-disable flag) is snapshotted. The IO peripherals
+(display, audio, input) stay live host-side — they don't swap.
+
+**Triggers:**
+
+| Action | Effect |
+|--------|--------|
+| **Boot** | Live VM runs `/sys/boot.gtx`; `system_snapshot` becomes the live state itself. |
+| **`run cart`** (shell) | `swap_to(cart_snapshot)` — but if cart_snapshot is empty, instead load the cart's `.gx` fresh into the live VM (and any previous cart_snapshot is discarded). |
+| **Esc keypress** (host catches, cart can't disable) | If a cart is the live VM: snapshot it into `cart_snapshot`, then `swap_to(system_snapshot)`. |
+| **`resume`** (shell) | If `cart_snapshot` exists: `swap_to(cart_snapshot)`. Otherwise no-op with an error message. |
+| **`quit`** (shell) | Discard `cart_snapshot`. Next `run` will start fresh. |
+| **Cart calls `hlt`** | Cart finished cleanly. Discard `cart_snapshot`, `swap_to(system_snapshot)`. |
+| **`edit <editor>`** (shell) | Editor loads as a new system program — its bytes overwrite the live VM's system state. Existing `cart_snapshot` is untouched. (Editors have privileged read/write access to `cart_snapshot` so they can modify the loaded cart's assets.) |
+
+**Editor + cart coexistence:**
+
+An editor running in the system slot has read/write access to
+`cart_snapshot`'s memory region — it can edit sprites, sound
+data, etc. inside the suspended cart. On `resume`, the cart sees
+the modified bytes. (How exactly the editor finds the right
+offsets in cart_snapshot is an editor-cart contract — typically
+the cart's manifest declares "sprites live at `0x8000`" and the
+sprite editor reads/writes there.)
+
+**Audio is independent of the VM swap.** The audio engine runs
+host-side (see §3.3) from a Song struct in cart memory. When a
+cart is suspended, its memory still exists in `cart_snapshot` —
+the engine keeps reading from there. So music started by a cart
+continues to play while you're in the shell or an editor.
+
+**Memory cost:** ~128 KB host-side (two snapshots × 64 KB RAM
+image + register state). Negligible on any modern host. Banks
+are part of the snapshot too — full state preserved.
+
+**Why not concurrent multi-process?** Real multitasking (multiple
+VMs running interleaved) would require a scheduler, IPC, shared-
+resource arbitration. Big complexity for marginal gain — the
+shell doesn't need cycles while a cart is in focus, the editor
+doesn't need cycles when the cart is running. Snapshot swap
+covers every case PICO-8 has lived with for years.
+
 ---
 
 ## 13. What gtx-16 explicitly does NOT do
@@ -539,8 +624,10 @@ boot shell at any point.
 - **No networking.** No sockets, no URL fetch, no BBS browser
   inside the console. Sharing happens via `.gtx.png` export +
   upload to whatever service you like.
-- **No multi-process.** One cart runs at a time. The shell
-  suspends when a cart starts; resumes when the cart exits.
+- **No concurrent multi-process.** One VM is live at any moment.
+  Shell ↔ cart ↔ editor switch via snapshot-based context
+  switching (§12.1) — same model as PICO-8. No scheduler, no
+  IPC, no shared-resource arbitration.
 - **No clipboard / direct OS calls.** No `system()`, no shell-out,
   no opening arbitrary files outside the sandbox.
 - **No timed real-world clock.** Frame counter only — no calendar
@@ -578,7 +665,7 @@ next round of additions.
 |---------|-----|
 | Rotation primitives (`spr_rotated`, full affine matrix) | If user demand emerges. v0.1 has scale only. |
 | Per-scanline palette / palette HDMA equivalent | Sky gradients, atmospheric effects. Easy to add later. |
-| Multi-process / background music while editing | Optional — would push the project toward "fantasy workstation" identity vs "fantasy console". |
+| Mode 7 / single-layer affine projection | Mario Kart / F-Zero style pseudo-3D racing. Specifies an affine matrix on one of the two layers. |
 | Network access (read-only BBS) | If a curated cart-sharing platform makes sense. Sandbox stays strict. |
 | Higher resolutions (480×270, 640×480) | Possibly a `RESOLUTION` register that the cart picks at load. Trade-off: bigger FB, more pixel-pushing per frame. |
 

--- a/docs/gtx-16.md
+++ b/docs/gtx-16.md
@@ -1,4 +1,4 @@
-# gtx-16 — Fantasy Console Spec v0.2 (DRAFT)
+# gtx-16 — Fantasy Console Spec v0.1 (DRAFT)
 
 The fantasy-console layer that consumes [Gero](./isa.md) as its CPU /
 VM. gtx-16 defines: display peripheral, audio peripheral, input
@@ -16,12 +16,6 @@ and the built-in editor suite.
 > two specs co-evolve closely and gero authors need the gtx-16
 > contract handy. A future cleanup may move this to gtx-16's own
 > docs.
-
-> **What changed since v0.1.** v0.1 modeled the display as an
-> NES-style PPU (tiles + sprites + tilemap). v0.2 switches to a
-> Picotron-class linear framebuffer with host-side drawing
-> primitives. The gero VM is **unchanged** — all impact is on
-> gtx-16's host implementation. See §16 for the rationale.
 
 ---
 
@@ -358,7 +352,7 @@ Header:
 | Offset | Size | Field |
 |--------|------|-------|
 | `0x00` | 4 | Magic = `"GTX1"` (ASCII) |
-| `0x04` | 2 | u16le version = `0x0002` |
+| `0x04` | 2 | u16le version = `0x0001` |
 | `0x06` | 2 | u16le flags |
 | `0x08` | 2 | u16le entry point |
 | `0x0A` | 2 | u16le image_size |
@@ -477,7 +471,7 @@ automation, write a cart.)
 ### 10.2 Prompt
 
 ```
-gtx-16 v0.2.0
+gtx-16 v0.1.0
 type 'help' for commands, 'splore' to browse carts
 
 /> _
@@ -578,11 +572,11 @@ next round of additions.
 
 ---
 
-## 15. Roadmap (post-v0.2)
+## 15. Roadmap (post-v0.1)
 
 | Feature | Why |
 |---------|-----|
-| Rotation primitives (`spr_rotated`, full affine matrix) | If user demand emerges. v0.2 has scale only. |
+| Rotation primitives (`spr_rotated`, full affine matrix) | If user demand emerges. v0.1 has scale only. |
 | Per-scanline palette / palette HDMA equivalent | Sky gradients, atmospheric effects. Easy to add later. |
 | Multi-process / background music while editing | Optional — would push the project toward "fantasy workstation" identity vs "fantasy console". |
 | Network access (read-only BBS) | If a curated cart-sharing platform makes sense. Sandbox stays strict. |
@@ -599,12 +593,14 @@ them:
   modern for the visual identity we want. 320×240 is the VGA
   Mode-X cousin — DOS-era games visually. 480×270 is more modern
   but loses the "early 90s" charm.
-- **Why linear FB and not PPU?** v0.1's PPU design ruled out
-  raycasters and made software-rendered effects much harder. The
-  Picotron model (linear FB + host-side drawing primitives)
-  delivers more creative ceiling at similar implementation cost.
-  See conversation log in PR #80 for the full reasoning.
-- **Why no rotation primitive in v0.2?** Implementation cost (bilinear
+- **Why linear FB and not PPU?** An earlier draft of this spec
+  modeled the display as an NES-style PPU (tiles + sprites +
+  tilemap). That design ruled out raycasters and made software-
+  rendered effects much harder. Switching to the Picotron model
+  (linear FB + host-side drawing primitives) delivers more
+  creative ceiling at similar implementation cost. See PR #81
+  conversation log for the full reasoning.
+- **Why no rotation primitive in v0.1?** Implementation cost (bilinear
   sampling, careful clipping) for a feature most carts don't need.
   Sprite sheets with pre-rotated frames cover 90% of the use case.
   Adding rotation later is non-breaking.
@@ -626,7 +622,7 @@ them:
 
 ## 17. Versioning
 
-This is gtx-16 v0.2. Locking it requires:
+This is gtx-16 v0.1. Locking it requires:
 - Pinning the Song struct layout (§3.3)
 - Pinning the cart `.gtx.png` encoding scheme (§8.3)
 - Pinning the editor cart contracts (§11)

--- a/docs/gtx-16.md
+++ b/docs/gtx-16.md
@@ -1,13 +1,14 @@
-# gtx-16 — Fantasy Console Spec v0.1 (DRAFT)
+# gtx-16 — Fantasy Console Spec v0.2 (DRAFT)
 
 The fantasy-console layer that consumes [Gero](./isa.md) as its CPU /
 VM. gtx-16 defines: display peripheral, audio peripheral, input
-peripheral, RNG, timing source, save backend, and the cart format
-that wraps a `.gx` bytecode file plus assets.
+peripheral, RNG, timing source, save backend, the cart format that
+wraps a `.gx` bytecode file plus assets, the filesystem, the shell,
+and the built-in editor suite.
 
-> **Status: design draft.** Locks happen as the gtx-16 native runtime
-> implementation forces decisions. Numbers in this doc are starting
-> points, not final.
+> **Status: design draft.** Specifies the target shape; locks happen
+> as the gtx-16 native runtime implementation forces decisions.
+> Numbers and IO addresses are starting points, not final.
 
 > **Layer separation:** gtx-16 lives in a separate repo (TBD —
 > probably `salty-max/gtx-16`). It depends on the `gero` library for
@@ -16,249 +17,620 @@ that wraps a `.gx` bytecode file plus assets.
 > contract handy. A future cleanup may move this to gtx-16's own
 > docs.
 
+> **What changed since v0.1.** v0.1 modeled the display as an
+> NES-style PPU (tiles + sprites + tilemap). v0.2 switches to a
+> Picotron-class linear framebuffer with host-side drawing
+> primitives. The gero VM is **unchanged** — all impact is on
+> gtx-16's host implementation. See §16 for the rationale.
+
 ---
 
 ## 1. Display
 
-**Resolution:** 256×192, indexed-16-color (4 bpp).
+**Resolution:** 320×240 at 6 bpp (64 visible colors), 4:3 aspect.
 
-Why 256×192:
-- Wider than PICO-8 (128×128) — more room for J-RPG dialog boxes
-  + map area side-by-side
-- 4:3 aspect ratio (Game Boy was 10:9, NES 4:3)
-- Power-of-two width simplifies tilemap math
-- 192-pixel height = 24 rows of 8×8 tiles, divisible into 8-row
-  status / 16-row map
+Why this shape:
+- 4:3 retro-PC feel (VGA Mode 13h was 320×200; 320×240 is the
+  square-pixel cousin used by Mode-X and many DOS games)
+- 320×240 = 76800 pixels = 57.6 KB framebuffer @ 6 bpp packed —
+  fits comfortably in host RAM, doesn't try to spill into the
+  16-bit gero address space
+- 64 visible colors out of a 256-entry master palette is the sweet
+  spot between 8-bit charm (PICO-8's 16) and 16-bit polish (SNES's
+  256 — overkill for the visual identity we're after)
 
-**Color depth:** 4 bpp (16 colors visible at any time, palette
-selectable from a 256-entry master).
+### 1.1 Framebuffer model
 
-**Framebuffer size:** `256 × 192 × 4 / 8 = 24 576 bytes (24 KB)`.
+Two **linear** framebuffers (no tile/sprite hardware):
 
-This is **larger** than the 16 KB mapped region A in gero's address
-space. gtx-16 solves this by exposing the framebuffer through a
-windowed mechanism, not direct memory mapping:
+| Layer | Role |
+|-------|------|
+| **Layer 0 — background** | Game world. Drawn first. |
+| **Layer 1 — foreground** | HUD, dialog, menus. Drawn over layer 0. |
 
-- The framebuffer lives **inside** the gtx-16 host (not in gero RAM)
-- Writes go through IO registers in the IO page (`0xFF00..0xFFFF`)
-- The 16 KB of mapped region A (`0x8000..0xBFFF`) is the
-  **VRAM staging area** — tile patterns, tilemap, sprite OAM
-  equivalent
+Both layers are 320×240 × 6 bpp, lived **inside the host** — not
+exposed to gero's address space. The cart drives drawing via the
+**IO command surface** (§2). One color in the foreground layer is
+reserved as the transparency key (default: palette index 0) — the
+host composites layer 0 visible through transparent pixels of
+layer 1.
 
-This is the NES PPU model: VRAM separated from CPU RAM, accessed
-through a small window of registers.
+This is **not** the NES/SNES PPU model. There are no tile pattern
+tables, no tilemap registers, no sprite OAM. "Tilemaps" and
+"sprites" are achieved via the drawing primitives (§2): blit a
+sprite, draw a rect, etc. The host implements those primitives in
+native code so the cart pays one opcode for what would be hundreds
+of cycles in raw gero.
 
-### 1.1 VRAM layout (mapped region A, 16 KB at `0x8000..0xBFFF`)
+### 1.2 Palette + color tables
 
-| Range | Size | Purpose |
-|-------|------|---------|
-| `0x8000..0x8FFF` | 4 KB | **Pattern table 0** — 256 tiles × 16 bytes (8×8 × 4 bpp = 32 bytes? — TBD on packing) |
-| `0x9000..0x9FFF` | 4 KB | **Pattern table 1** — sprites |
-| `0xA000..0xA7FF` | 2 KB | **Tilemap** — 32×32 cell grid, 2 bytes per cell (tile index + attributes) |
-| `0xA800..0xABFF` | 1 KB | **Sprite OAM** — 64 sprites × 16 bytes (X, Y, tile index, attributes) |
-| `0xAC00..0xAFFF` | 1 KB | **Palette** — 256 colors × 4 bytes (RGBA, A unused) |
-| `0xB000..0xBFFF` | 4 KB | **Reserved** for v0.2 features (second tilemap layer? sample data?) |
+**Palette:** 256-entry master, 64 entries visible at any time.
 
-These ranges are gtx-16-specific — they're not enforced by the gero
-VM. A program that doesn't touch them sees plain RAM.
+| Address | Field | Description |
+|---------|-------|-------------|
+| `0xFF00..0xFFFF` (host) | `master_palette` | 256 × 4 bytes (RGB + reserved). Initialized at cart load; can be modified at runtime. |
+| `0xFE00..0xFE3F` | `display_palette` | 64 × 1 byte. Each entry maps a "visible color N" to a "master palette index M". Changing this remaps colors on-screen without redrawing. |
 
-### 1.2 Display registers (in IO page)
+**Color tables (LUTs):** Picotron-style. A color table is a 64-byte
+LUT that maps each visible-color index to another. Up to 8 active
+LUTs are addressable; one is selected as "current" during draws.
+When the current LUT is set to identity (color N → color N), draws
+write through unchanged. Other LUTs enable:
 
-| Address | Size | Field | Description |
-|---------|------|-------|-------------|
-| `0xFF00` | 1 | `DISPCTL` | bit 0: enable, bit 1: tilemap on, bit 2: sprites on, bit 3: window on |
-| `0xFF01` | 1 | `SCROLL_X` | tilemap horizontal scroll (pixels) |
-| `0xFF02` | 1 | `SCROLL_Y` | tilemap vertical scroll (pixels) |
-| `0xFF03` | 1 | `PALETTE_INDEX` | sub-palette to apply to background (0..15) |
+- **Distance shading** (Doom fade): write a LUT that darkens by one
+  step. Apply during far-distance draws.
+- **Sprite recolor**: same sprite, different palette via a LUT that
+  remaps the sprite's color set.
+- **Whole-screen fade-to-black**: cycle through a sequence of LUTs
+  each frame.
+- **Transparency / blending**: the LUT can pre-compute the
+  source × destination color blend for additive / dim / silhouette
+  effects.
 
-(More registers spec'd as the renderer implementation needs them.)
+LUTs are stored in a small dedicated region of host RAM (8 LUTs ×
+64 bytes = 512 bytes). The cart uploads them via a dedicated IO
+command (`gpu lut_upload`, §2).
 
----
-
-## 2. Audio
-
-**4 channels:**
-1. Square 1 (with duty cycle + envelope)
-2. Square 2 (with duty cycle + envelope)
-3. Triangle (no volume control, like NES)
-4. Noise (for percussion / SFX)
-
-NES APU model exactly. No DPCM in v0.1 — sample channel deferred.
-
-**Sampling rate:** 44.1 kHz output (host-side); the VM ticks audio
-registers at 60 Hz.
-
-### 2.1 Audio registers (in IO page)
+### 1.3 Display registers (in IO page)
 
 | Address | Size | Field | Description |
 |---------|------|-------|-------------|
-| `0xFF40` | 1 | `SQ1_VOL` | bits 0-3: volume (0-15), bits 4-5: duty cycle, bit 6: envelope decay |
-| `0xFF41` | 2 | `SQ1_FREQ` | 11-bit frequency (lower 11 bits used) |
-| `0xFF43` | 1 | `SQ2_VOL` | (same shape as SQ1) |
-| `0xFF44` | 2 | `SQ2_FREQ` | |
-| `0xFF46` | 2 | `TRI_FREQ` | triangle frequency |
-| `0xFF48` | 1 | `NOISE_VOL` | volume + envelope |
-| `0xFF49` | 1 | `NOISE_PERIOD` | noise period |
-| `0xFF4A` | 1 | `CHAN_ENABLE` | bit 0: SQ1, 1: SQ2, 2: TRI, 3: NOISE |
-| `0xFF4B` | 2 | `MUSIC_PTR` | start address of currently-playing music data (host audio engine reads + ticks) |
-
-The "tracker" model: programs write a music-data pointer to
-`MUSIC_PTR` and the host audio engine takes over — reading the
-pattern data, ticking the synth, writing to the channel registers
-60× per second. Programs can stop / pause / resume by writing 0 or
-re-pointing.
+| `0xFE40` | 1 | `DISPCTL` | bit 0: display enable, bit 1: layer 0 visible, bit 2: layer 1 visible, bit 3: vsync wait |
+| `0xFE41` | 1 | `ACTIVE_LAYER` | 0 = subsequent draws hit layer 0, 1 = layer 1 |
+| `0xFE42` | 1 | `ACTIVE_LUT` | 0..7 — which color table to apply to subsequent draws (0 = identity) |
+| `0xFE43` | 1 | `TRANSPARENT_IDX` | Visible-color index treated as transparent in layer 1 (default 0) |
+| `0xFE44..0xFE47` | 4 | `CLIP_RECT` | x0, y0, x1, y1 — drawing is clipped to this box (default: full screen) |
+| `0xFE48..0xFE4B` | 4 | `CAMERA` | i16le camera_x, camera_y — translates all subsequent draw positions |
 
 ---
 
-## 3. Input
+## 2. Drawing primitives (IO command surface)
 
-**Two gamepads** (Player 1, Player 2). Each:
-- D-pad (4 directions)
-- A, B (action buttons)
-- Start, Select
+Drawing is done by writing **commands** to a fixed IO command
+region. The host watches that region; when the trigger register is
+written, the command executes with the staged parameters.
 
-8 bits per gamepad, polled per-frame.
-
-### 3.1 Input registers (in IO page)
+### 2.1 Command layout
 
 | Address | Size | Field | Description |
 |---------|------|-------|-------------|
-| `0xFF50` | 1 | `P1_STATE` | bits: 0=up, 1=down, 2=left, 3=right, 4=A, 5=B, 6=start, 7=select. 1 = pressed |
-| `0xFF51` | 1 | `P2_STATE` | (same shape) |
-| `0xFF52` | 1 | `P1_PREV` | previous frame's state — for edge detection (just-pressed = state & ~prev) |
-| `0xFF53` | 1 | `P2_PREV` | |
+| `0xFE50..0xFE5F` | 16 | `CMD_PARAMS` | Up to 16 bytes of staged parameters (interpretation depends on opcode) |
+| `0xFE60` | 1 | `CMD_OPCODE` | Which primitive to execute |
+| `0xFE61` | 1 | `CMD_TRIGGER` | Writing any value triggers execution with the staged params + opcode |
 
-The host updates these once per frame, before vblank. Programs read
-freely.
+The cart's typical pattern:
 
----
-
-## 4. RNG
-
-A simple xorshift PRNG, host-managed, exposed via two registers:
-
-| Address | Size | Field | Description |
-|---------|------|-------|-------------|
-| `0xFF60` | 2 | `RNG_OUT` | reading consumes a u16 from the stream and advances state |
-| `0xFF62` | 2 | `RNG_SEED` | writing reseeds the stream (write-only; reads return last seed for debugging) |
-
-PRNG is deterministic given a seed — useful for replays / save-state.
-At boot, host seeds from wall-clock; programs can override.
-
----
-
-## 5. Timing
-
-| Address | Size | Field | Description |
-|---------|------|-------|-------------|
-| `0xFF70` | 2 | `FRAME_COUNTER` | u16le frame number since boot. Increments on vblank. Wraps at 65535 (≈ 18 minutes at 60 fps). |
-| `0xFF72` | 1 | `VBLANK_FLAG` | 1 during vblank period, 0 during scan. Programs poll for sync. |
-
-**Frame rate: 60 Hz.** Hard-locked. The VM runs at unbounded speed
-between vblanks; programs synchronize to vblank for input + render.
-
-A vblank IRQ fires on each frame transition (vector `0x06`,
-host-defined per gtx-16). Programs that don't enable the IRQ can poll
-`VBLANK_FLAG` instead.
-
----
-
-## 6. Save backend
-
-Implements the gero ISA SRAM-bank contract (gero spec §3.2.1).
-
-**File location:** `<cart-name>.sav` next to the cart file. Plain
-binary, contents = concatenation of the SRAM banks.
-
-**Slot count:** 1 (single-slot saves in v0.1; multi-slot is a v0.2
-feature that would need a save-slot syscall).
-
-**Flush triggers:**
-- Program exits cleanly (`hlt`).
-- Program calls `int 0x21` (gero convention).
-- Host-process receives shutdown signal (graceful close).
-- Auto-flush every 30 seconds if any SRAM byte was written
-  (insurance vs. crash).
-
-**Format on disk:** raw bytes. No header, no version. Programs that
-want versioning put it inside their SRAM data themselves (canonical
-old-school). Mismatched save vs program version → program responsibility
-to detect via its own header check.
-
----
-
-## 7. Cart format (`.gtx`)
-
-Wraps a `.gx` bytecode file plus assets and metadata.
-
-```
-[Header — 64 bytes]
-0x00  magic            4   = 'GTX' '\x16' (0x47 0x54 0x58 0x16)
-0x04  version          2   u16le format version (currently 0x0001)
-0x06  title            32  UTF-8, null-padded
-0x26  author           16  UTF-8, null-padded
-0x36  flags            2   u16le bitfield
-0x38  gx_offset        4   u32le offset of embedded .gx file
-0x3C  gx_size          4   u32le size of embedded .gx in bytes
-
-[Embedded .gx file at gx_offset for gx_size bytes]
-
-[Optional asset section — TBD, e.g. tile pattern dumps, music data,
- sample data — formats designed alongside the editor / converter
- tooling that produces them]
+```asm
+; Draw a filled rect: rectfill(10, 20, 50, 60, color=7)
+mov $0A, &FE50         ; x0 = 10
+mov $14, &FE51         ; y0 = 20
+mov $32, &FE52         ; x1 = 50
+mov $3C, &FE53         ; y1 = 60
+mov $07, &FE54         ; color = 7
+mov $02, &FE60         ; OPCODE_RECTFILL = 0x02
+mov $01, &FE61         ; trigger
 ```
 
-The cart format is the **user-facing artifact** (what an end-user
-double-clicks). The `.gx` inside is the executable image. Assets are
-typically loaded by the VM on boot (program reads its own cart's
-asset section via host-provided syscall).
+In practice, a future high-level macro layer (the `gero-lang`
+compiler will expose this) lets you write `rectfill(10, 20, 50, 60,
+7)` and the macro expands to the byte sequence above.
 
-Asset section design is **deferred** — needs to land alongside the
-gtx-16 editor / converter tools, which don't exist yet.
+### 2.2 Command opcodes
+
+| Opcode | Name | Params (byte layout in CMD_PARAMS) |
+|--------|------|------------------------------------|
+| `0x00` | `cls` | u8 color — fill the active layer with `color`. |
+| `0x01` | `pset` | u16le x, u16le y, u8 color |
+| `0x02` | `rectfill` | u16le x0, u16le y0, u16le x1, u16le y1, u8 color |
+| `0x03` | `rect` | same as rectfill but stroke only |
+| `0x04` | `line` | u16le x0, u16le y0, u16le x1, u16le y1, u8 color |
+| `0x05` | `circle` | u16le cx, u16le cy, u8 radius, u8 color |
+| `0x06` | `circfill` | same |
+| `0x10` | `spr` | u16le sprite_idx, u16le x, u16le y, u8 flags (bit 0: hflip, bit 1: vflip) |
+| `0x11` | `spr_scaled` | u16le sprite_idx, u16le x, u16le y, u8 w_tiles, u8 h_tiles |
+| `0x12` | `spr_sized` | u16le sprite_idx, u16le x, u16le y, u16le dst_w, u16le dst_h |
+| `0x20` | `print` | u16le str_addr, u16le x, u16le y, u8 color (str_addr → null-terminated bytes in cart memory) |
+| `0x30` | `lut_upload` | u8 lut_idx (0..7), u16le src_addr (64 bytes of LUT data in cart memory) |
+| `0x31` | `palette_upload` | u16le src_addr (256×4 bytes), u8 count (how many entries from 0) |
+| `0x40` | `blit_layer` | u8 src_layer, u8 dst_layer — copy one whole layer to the other |
+
+(More opcodes land as the runtime matures — see §16 open
+questions.)
+
+### 2.3 Sprite storage
+
+Sprites live in the cart's memory at a region the cart chooses.
+The `spr` family of commands takes a `sprite_idx` which the host
+interprets via a sprite-sheet base register:
+
+| Address | Size | Field | Description |
+|---------|------|-------|-------------|
+| `0xFE70..0xFE71` | 2 | `SPRITESHEET_BASE` | u16le — base address in cart memory where sprite 0 starts |
+| `0xFE72` | 1 | `SPRITE_SIZE` | 0 = 8×8, 1 = 16×16, 2 = 32×32 (per-cart constant; can be changed at runtime) |
+
+A sprite is `(size × size × 6 / 8)` bytes packed. For 8×8 × 6 bpp,
+that's 48 bytes per sprite. With a 16 KB region allocated, the
+cart fits 16384/48 ≈ 341 sprites.
+
+The cart can dynamically reupload sprite data at runtime (modify
+the bytes at `SPRITESHEET_BASE + sprite_idx × stride`) — host
+re-reads on next draw.
 
 ---
 
-## 8. Boot sequence
+## 3. Audio
 
-1. gtx-16 host loads `.gtx` cart.
-2. Validates magic + version.
-3. Extracts embedded `.gx` to a buffer.
-4. Initializes a gero VM:
-   - Allocates 64 KB RAM
-   - Maps display device at `0x8000..0xBFFF` (VRAM staging)
-   - Maps IO device at `0xFF00..0xFFFF` (peripheral registers)
-   - Loads `.gx` image into RAM `0x0000..image_size`
-   - Loads SRAM banks from `<cart>.sav` if present
-   - Sets `ip = entry_point` from `.gx` header
-5. Begins fetch-decode-execute loop, ticking display + audio + input
-   peripherals on schedule.
+8 channels, tracker-style mix.
+
+### 3.1 Channel types
+
+Each channel can be one of:
+
+| Type | Description |
+|------|-------------|
+| `square` | Pulse wave with 4 duty options (12%, 25%, 50%, 75%) |
+| `triangle` | Anti-aliased triangle wave |
+| `sawtooth` | Saw wave (down or up) |
+| `noise` | Pseudo-random noise (short / long period) |
+| `pcm` | 8-bit signed PCM sample, ~8 KHz typical rate |
+
+Each channel has independent: frequency, volume, optional ADSR
+envelope, optional volume LFO, optional pitch LFO, pan
+(left/center/right).
+
+### 3.2 Channel registers (in IO page)
+
+Per channel `N` (0..7), base at `0xFE80 + N × 8`:
+
+| Offset | Size | Field | Description |
+|--------|------|-------|-------------|
+| `+0` | 1 | `TYPE` | bits 0-2: waveform (0..4 per above), bit 7: enable |
+| `+1` | 1 | `VOLUME` | 0..63 |
+| `+2..+3` | 2 | `FREQ` | u16le frequency in Hz |
+| `+4` | 1 | `DUTY_OR_NOISE` | for square: duty bits 0-1; for noise: long/short period bit |
+| `+5` | 1 | `PAN` | i8: -64 (full left) to +63 (full right) |
+| `+6..+7` | 2 | `ENV_OR_SAMPLE` | u16le — envelope descriptor index OR PCM sample index (depends on TYPE) |
+
+So 8 channels × 8 bytes = 64 bytes total for channel state, at
+`0xFE80..0xFEBF`.
+
+### 3.3 Tracker / pattern playback (optional layer)
+
+The host exposes a built-in tracker engine that can play patterns
+(sequences of notes, instruments, effects) without the cart
+manually setting channel registers each frame. The cart uploads a
+"song" data structure and tells the engine to play it. The engine
+runs on the host (no gero opcodes burned).
+
+Tracker IO:
+
+| Address | Size | Field | Description |
+|---------|------|-------|-------------|
+| `0xFEC0..0xFEC1` | 2 | `SONG_ADDR` | u16le pointer to a Song struct in cart memory |
+| `0xFEC2` | 1 | `SONG_CTL` | bit 0: play, bit 1: loop, bit 2: stop |
+| `0xFEC3` | 1 | `SONG_VOLUME` | 0..63 master volume |
+
+The Song struct format is TBD — pinned in the next gtx-16 spec
+revision once the audio engine prototype lands.
 
 ---
 
-## 9. What gtx-16 explicitly does NOT do
+## 4. Input
 
-To keep the layering clean, gtx-16 does not provide:
+Gamepad **and** keyboard **and** mouse, all first-class. Carts can
+poll any or all.
 
-- **File I/O beyond saves.** Programs can't open arbitrary files.
-  All asset access goes through the cart's bundled asset section.
-- **Network I/O.** Single-machine console, no online play in v0.1.
-- **Direct OS calls.** No `system()`, no clipboard, no clock-time
-  beyond the frame counter.
-- **Custom CPU extensions.** The CPU is gero, period. No coprocessor
-  registers, no custom opcodes.
+### 4.1 Gamepad
 
-These constraints are deliberate — they're what makes gtx-16 a
-fantasy console rather than "another scripting environment".
+8 buttons: Up, Down, Left, Right, A, B, X, Y. Mapped to keyboard
+arrows + Z/X/A/S by default; remappable.
+
+| Address | Size | Field | Description |
+|---------|------|-------|-------------|
+| `0xFEE0` | 1 | `BTN_STATE` | bits 0-7: pressed-this-frame state per button |
+| `0xFEE1` | 1 | `BTN_PRESSED` | edge-triggered: 1 if pressed this frame and not last |
+| `0xFEE2` | 1 | `BTN_RELEASED` | edge-triggered: 1 if released this frame |
+
+(For multi-player carts, the spec reserves `0xFEE3..0xFEE5` for
+players 2/3/4 — registered when actual gamepads land.)
+
+### 4.2 Keyboard
+
+The host exposes a small key buffer the cart can drain:
+
+| Address | Size | Field | Description |
+|---------|------|-------|-------------|
+| `0xFEE8..0xFEE9` | 2 | `KEY_BUF_HEAD` | u16le — index of next available char (write to advance) |
+| `0xFEEA..0xFEEB` | 2 | `KEY_BUF_TAIL` | u16le — index of oldest unread char (host writes) |
+| `0xFEEC` | 1 | `KEY_MODIFIERS` | bits 0: shift, 1: ctrl, 2: alt, 3: meta |
+| `0xFEED..0xFEFF` | 19 | `KEY_BUF` | Ring buffer of u8 chars (ASCII for typeable, control codes for arrows/etc.) |
+
+For raw key-state polling (e.g., "is W currently down?"), a
+separate `KEY_DOWN` register set is reserved for the next revision.
+
+### 4.3 Mouse
+
+| Address | Size | Field | Description |
+|---------|------|-------|-------------|
+| `0xFF00..0xFF01` | 2 | `MOUSE_X` | u16le pixel X (0..319) |
+| `0xFF02..0xFF03` | 2 | `MOUSE_Y` | u16le pixel Y (0..239) |
+| `0xFF04` | 1 | `MOUSE_BTNS` | bits 0: left, 1: right, 2: middle |
+| `0xFF05` | 1 | `MOUSE_WHEEL` | i8 wheel delta this frame |
 
 ---
 
-## 10. Open questions (resolve as the renderer + audio engine land)
+## 5. RNG
 
-- Tile pattern packing (4 bpp planar like NES, or chunky 4 bpp?)
-- Sprite priority + occlusion (per-sprite priority bits, or strict
-  back-to-front by OAM order?)
-- Audio register write throttling (avoid write storms causing
-  clicks)
-- Save-file naming convention (relative path, slot suffixes, etc.)
-- Multi-cart workflow (carts that load other carts? or one cart per
-  session?)
+Single 16-bit linear-feedback shift register. Carts can seed it
+manually or let the host seed from wall-clock at boot.
+
+| Address | Size | Field | Description |
+|---------|------|-------|-------------|
+| `0xFF08..0xFF09` | 2 | `RNG_VALUE` | u16le current value; reading auto-advances |
+| `0xFF0A..0xFF0B` | 2 | `RNG_SEED` | u16le seed (writable) |
+
+---
+
+## 6. Timing
+
+| Address | Size | Field | Description |
+|---------|------|-------|-------------|
+| `0xFF10..0xFF11` | 2 | `FRAME_COUNTER` | u16le frame number since boot. Increments on vblank. Wraps at 65535. |
+| `0xFF12` | 1 | `VBLANK_FLAG` | 1 during vblank, 0 during scan |
+| `0xFF13` | 1 | `TARGET_FPS` | 60 by default; can be set to 30 for slower carts |
+
+**Frame rate: 60 Hz** (or 30 Hz if `TARGET_FPS` is set). The VM
+runs as fast as the host allows between vblanks — no artificial
+cap. A cart that doesn't finish its frame's work before the next
+vblank just drops frames; the host displays the fps drop.
+
+A vblank IRQ fires on each frame transition (vector `0x06` per ISA
+§6).
+
+---
+
+## 7. Persistence + save backend
+
+Implements the gero ISA SRAM-bank contract (gero spec §3.2).
+
+Carts that declare `sram_bank_count > 0` get persistent storage:
+each SRAM bank is 16 KB, save data is bound to `/data/<cart_name>/`
+in the filesystem. The host writes-through to disk on every `vsync`
+or on explicit cart request.
+
+For non-banked carts that want lightweight persistent data (high
+scores, settings), the host exposes `KV_STORE` IO commands:
+
+| Address | Size | Field | Description |
+|---------|------|-------|-------------|
+| `0xFF20..0xFF21` | 2 | `KV_KEY_ADDR` | u16le pointer to a null-terminated key string in cart memory |
+| `0xFF22..0xFF23` | 2 | `KV_VALUE_ADDR` | u16le pointer to value bytes |
+| `0xFF24..0xFF25` | 2 | `KV_VALUE_LEN` | u16le length of value bytes |
+| `0xFF26` | 1 | `KV_OP` | 0: get, 1: set, 2: delete |
+| `0xFF27` | 1 | `KV_TRIGGER` | write to execute |
+
+Stored as a small JSON file at `/data/<cart_name>/kv.json`.
+
+---
+
+## 8. Cart format (`.gtx`)
+
+A cart is an archive containing the bytecode plus assets. Three
+formats coexist:
+
+### 8.1 `.gtx` (binary archive)
+
+The packaged format — what gets loaded by the shell's `run`
+command. Layout:
+
+```
+[Header — 24 bytes]
+[gero .gx image — image_size bytes]
+[Banks — bank_count × 16384 bytes] (if banked)
+[SRAM banks — sram_bank_count × 16384 bytes] (initial values)
+[Sprite sheets — variable, concatenated]
+[Sound assets — synth presets + PCM samples]
+[Metadata block — JSON: title, author, version, ...]
+```
+
+Header:
+
+| Offset | Size | Field |
+|--------|------|-------|
+| `0x00` | 4 | Magic = `"GTX1"` (ASCII) |
+| `0x04` | 2 | u16le version = `0x0002` |
+| `0x06` | 2 | u16le flags |
+| `0x08` | 2 | u16le entry point |
+| `0x0A` | 2 | u16le image_size |
+| `0x0C` | 1 | u8 bank_count |
+| `0x0D` | 1 | u8 sram_bank_count |
+| `0x0E` | 2 | u16le sprites_offset (from start of archive) |
+| `0x10` | 2 | u16le audio_offset |
+| `0x12` | 2 | u16le metadata_offset |
+| `0x14..0x17` | 4 | reserved (must be 0) |
+
+### 8.2 `.gas` / `.gr` (source carts)
+
+If the cart is shipped as source (`.gas` for asm, `.gr` for the
+future gero-lang), the shell auto-assembles / auto-compiles it at
+`run` time. Built artifacts get cached at `/tmp/build/<hash>.gtx`
+so subsequent runs are instant.
+
+Source carts are a single file convention:
+
+```
+/carts/breakout.gas       ; single source file
+/carts/breakout_src/      ; multi-file project
+    main.gas
+    sprites.gfx           ; raw binary sprite data
+    music.sfx
+    cart.toml             ; project manifest (title, version, etc.)
+```
+
+### 8.3 `.gtx.png` (shareable PNG)
+
+A PICO-8 / Picotron-style sharing format: the cart's bytes are
+encoded into the pixel data of a PNG image, with the image itself
+showing a screenshot or title screen. Upload anywhere that
+accepts images; anyone can drag the PNG back into the console to
+play.
+
+```
+> save my_game.gtx.png
+encoded 89 KB cart into a 320x240 PNG
+PNG includes a screenshot from last frame as the cover image
+
+> ls
+my_game.gtx          ; local binary
+my_game.gtx.png      ; share-friendly version
+```
+
+---
+
+## 9. Filesystem
+
+Simple hierarchy with pre-defined root directories. Unix-style
+paths with `/` separator. No multi-user concept.
+
+```
+/
+├── carts/        ; user-installed + locally-built carts
+│   ├── games/
+│   ├── tools/
+│   └── *.gtx, *.gas, *.gr
+├── data/         ; persistent data (save files, screenshots,
+│                  ;                kv stores)
+│   ├── breakout/
+│   │   ├── kv.json
+│   │   └── sram_0.bin
+│   └── tetris/
+│       └── high_scores.txt
+├── sys/          ; read-only system stuff
+│   ├── boot.gtx          ; the boot shell itself
+│   ├── editors/          ; built-in editor carts
+│   ├── fonts/
+│   └── palettes/         ; system palette presets
+└── tmp/          ; scratch, cleared on every boot
+    └── build/            ; cached source-cart builds
+```
+
+The host maps `/` to a real directory on the OS filesystem
+(typically `~/.gtx-16/` on Unix, `%APPDATA%\gtx-16\` on Windows).
+
+Operations are sandboxed: a cart cannot escape `/data/<cart_name>/`
+when writing. Reads from `/carts/` and `/sys/` are allowed; reads
+from other carts' `/data/` regions are not.
+
+---
+
+## 10. Shell
+
+PICO-8-minimal style. Boot drops the user at a prompt.
+
+### 10.1 Built-in commands
+
+| Command | Description |
+|---------|-------------|
+| `help [topic]` | Help on a command or topic. |
+| `ls [path]` | List directory. Defaults to current. |
+| `cd <path>` | Change directory. |
+| `pwd` | Print working directory. |
+| `mkdir <path>` | Create a directory. |
+| `rm <path>` | Delete a file. Refuses on non-empty directories without `-r`. |
+| `mv <src> <dst>` | Move / rename. |
+| `cp <src> <dst>` | Copy. |
+| `cat <path>` | Print a file. |
+| `clear` | Clear the screen. |
+| `load <cart>` | Load a cart into memory (no run). |
+| `run [cart]` | Run loaded cart, or `run <cart>` to load + run. |
+| `save [name]` | Save the current cart (with optional rename). |
+| `edit [editor]` | Open an editor on the current cart. Default: code. See §11. |
+| `splore` | Open a graphical browser of available carts. |
+| `screenshot` | Capture current frame to `/data/<cart>/screenshots/N.png`. |
+| `boot <cart>` | Set a cart to auto-run on next boot. |
+| `reboot` | Restart the console. |
+
+No pipes, no redirection, no scripting. The shell is for
+navigation + launching, not for building automation. (If you want
+automation, write a cart.)
+
+### 10.2 Prompt
+
+```
+gtx-16 v0.2.0
+type 'help' for commands, 'splore' to browse carts
+
+/> _
+```
+
+### 10.3 Tab completion
+
+Path tab completion on file/directory args. Command tab completion
+on the first token.
+
+---
+
+## 11. Built-in editors
+
+Six editors, all reachable from the shell or via function keys
+when a cart is loaded.
+
+| Command | Hotkey | Editor |
+|---------|--------|--------|
+| `edit code` | F1 | Code editor (text). Edits `.gas` / `.gr` source. |
+| `edit sprites` | F2 | Sprite sheet editor. 8×8 / 16×16 / 32×32 cell grid with paint tools. |
+| `edit sfx` | F3 | Sound effect editor. Per-channel parameter tweaker + preview. |
+| `edit music` | F4 | Music tracker. Pattern grid, ~64 rows × 4-8 tracks. |
+| `edit map` | F5 | Tilemap editor (for carts that use tile-based level data — stored as cart bytes since there's no hardware tilemap). |
+| `edit palette` | F6 | Palette editor. Tweak the 256 master colors and the 64 visible mapping. |
+
+Editors are themselves carts (`/sys/editors/*.gtx`). They run the
+same VM as any other cart, just with privileged access to the
+loaded cart's memory + assets. This means anyone can write their
+own editor and drop it in `/sys/editors/` to extend the suite.
+
+All editors share:
+
+- `Esc` returns to the shell.
+- `Ctrl+S` saves the current cart.
+- `F11` switches to fullscreen.
+- The tab bar across the top lets you switch editors without
+  going back to the shell.
+
+---
+
+## 12. Boot sequence
+
+1. Host loads VM + maps display, audio, input devices.
+2. Host loads `/sys/boot.gtx` (the boot shell) and runs it.
+3. The boot shell:
+   - Clears `/tmp/`.
+   - Reads `/sys/boot.cfg` (if present) for theme, autorun cart,
+     remappings, etc.
+   - Drops the user at the prompt — OR auto-runs `boot.cfg.autorun`
+     if set.
+4. From there, the user runs carts via `run`.
+
+A cart can call `host_reboot()` (gero opcode) to relaunch the
+boot shell at any point.
+
+---
+
+## 13. What gtx-16 explicitly does NOT do
+
+- **No 3D acceleration.** Software 3D is possible if a cart wants
+  to do it; nothing helps.
+- **No floating-point.** gero ISA is integer-only. Carts that need
+  FP roll their own fixed-point.
+- **No networking.** No sockets, no URL fetch, no BBS browser
+  inside the console. Sharing happens via `.gtx.png` export +
+  upload to whatever service you like.
+- **No multi-process.** One cart runs at a time. The shell
+  suspends when a cart starts; resumes when the cart exits.
+- **No clipboard / direct OS calls.** No `system()`, no shell-out,
+  no opening arbitrary files outside the sandbox.
+- **No timed real-world clock.** Frame counter only — no calendar
+  time exposed (deterministic by design).
+- **No GPU shaders** beyond what color tables provide.
+
+---
+
+## 14. Memory map summary
+
+The host claims the following gero IO page ranges:
+
+| Range | Purpose | §  |
+|-------|---------|----|
+| `0xFE40..0xFE4B` | Display registers | §1.3 |
+| `0xFE50..0xFE61` | Drawing command surface | §2 |
+| `0xFE70..0xFE72` | Sprite sheet config | §2.3 |
+| `0xFE80..0xFEBF` | Audio channel state (8 × 8 bytes) | §3.2 |
+| `0xFEC0..0xFEC3` | Tracker / song playback | §3.3 |
+| `0xFEE0..0xFEE2` | Gamepad | §4.1 |
+| `0xFEE8..0xFEFF` | Keyboard | §4.2 |
+| `0xFF00..0xFF05` | Mouse | §4.3 |
+| `0xFF08..0xFF0B` | RNG | §5 |
+| `0xFF10..0xFF13` | Timing | §6 |
+| `0xFF20..0xFF27` | KV store | §7 |
+
+Total: ~192 bytes of IO page used; ~64 bytes reserved for the
+next round of additions.
+
+---
+
+## 15. Roadmap (post-v0.2)
+
+| Feature | Why |
+|---------|-----|
+| Rotation primitives (`spr_rotated`, full affine matrix) | If user demand emerges. v0.2 has scale only. |
+| Per-scanline palette / palette HDMA equivalent | Sky gradients, atmospheric effects. Easy to add later. |
+| Multi-process / background music while editing | Optional — would push the project toward "fantasy workstation" identity vs "fantasy console". |
+| Network access (read-only BBS) | If a curated cart-sharing platform makes sense. Sandbox stays strict. |
+| Higher resolutions (480×270, 640×480) | Possibly a `RESOLUTION` register that the cart picks at load. Trade-off: bigger FB, more pixel-pushing per frame. |
+
+---
+
+## 16. Why this shape (rationale notes)
+
+A few decisions worth pinning down so future-me doesn't relitigate
+them:
+
+- **Why 320×240 and not 480×270?** 4:3 retro PC feel beats 16:9
+  modern for the visual identity we want. 320×240 is the VGA
+  Mode-X cousin — DOS-era games visually. 480×270 is more modern
+  but loses the "early 90s" charm.
+- **Why linear FB and not PPU?** v0.1's PPU design ruled out
+  raycasters and made software-rendered effects much harder. The
+  Picotron model (linear FB + host-side drawing primitives)
+  delivers more creative ceiling at similar implementation cost.
+  See conversation log in PR #80 for the full reasoning.
+- **Why no rotation primitive in v0.2?** Implementation cost (bilinear
+  sampling, careful clipping) for a feature most carts don't need.
+  Sprite sheets with pre-rotated frames cover 90% of the use case.
+  Adding rotation later is non-breaking.
+- **Why "no networking" is a feature, not a missing piece.** The
+  sandbox is tight by design — no exfiltration risk, no version-
+  dependent online dependencies, no rotting BBS URLs five years
+  from now. Sharing via PNG is enough.
+- **Why a 2-layer model and not 1 (Picotron) or 4 (SNES)?** One
+  layer is too tight for HUDs over scrolling games. Four layers is
+  SNES-mode-1 overkill. Two strikes the balance and the
+  compositing cost is constant.
+- **Why color tables and not arbitrary shaders?** Color tables are
+  cheap (64 byte LUT, one indirection per pixel during draw) and
+  cover most of the "shader" use cases (shading, recolor,
+  blending). Arbitrary shaders would balloon the host implementation
+  and bind the spec to a GPU model.
+
+---
+
+## 17. Versioning
+
+This is gtx-16 v0.2. Locking it requires:
+- Pinning the Song struct layout (§3.3)
+- Pinning the cart `.gtx.png` encoding scheme (§8.3)
+- Pinning the editor cart contracts (§11)
+- Pinning the `.gas` / `.gr` source-cart auto-build flow (§8.2)
+
+These will iterate as the gtx-16 host implementation lands.
+gero v0.1 doesn't depend on any of this.

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -100,18 +100,18 @@ the host's `MemoryMapper` (§3.5) can remap any region to a device.
 | `0x0100..0x0FFF` | 3.75 KB | **Low RAM** — conventional stack range. `sp` initialized at `0xFFFE` but stack lives wherever the program puts it; this region is the canonical home. |
 | `0x1000..0x10FF` | 256 B | **Interrupt vector table** — 64 entries × 2 bytes each. Vector `N` lives at `0x1000 + 2*N`. |
 | `0x1100..0x7FFF` | ~28 KB | **User RAM** — code + data. Program image loads here at boot. |
-| `0x8000..0xBFFF` | 16 KB | **Mapped region A** — host-defined. Plain RAM by default. gtx-16 v0.2 leaves this region as plain RAM and recommends carts use it for sprite-sheet storage + other large assets (the cart sets `SPRITESHEET_BASE` here). Previous gtx-16 versions mapped VRAM here; v0.2 moved drawing entirely to IO commands. |
+| `0x8000..0xBFFF` | 16 KB | **Mapped region A** — host-defined. Plain RAM by default. gtx-16 leaves this region as plain RAM and recommends carts use it for sprite-sheet storage + other large assets (the cart sets `SPRITESHEET_BASE` here). |
 | `0xC000..0xFEFF` | ~15.75 KB | **Bank window** — mirrors bank `mb` if the program is banked, otherwise plain RAM. |
-| `0xFF00..0xFFFF` | 256 B | **Mapped region B / IO page** — host-defined peripheral registers. gtx-16 v0.2 maps display registers, drawing command surface, audio channels, input, RNG, timer, and KV store here. Plain RAM if no host device claims it. |
+| `0xFF00..0xFFFF` | 256 B | **Mapped region B / IO page** — host-defined peripheral registers. gtx-16 maps display registers, drawing command surface, audio channels, input, RNG, timer, and KV store here. Plain RAM if no host device claims it. |
 
 The two **Mapped region** ranges (`0x8000..0xBFFF` and
 `0xFF00..0xFFFF`) are the convention for embedding hosts. A pure
 "compute" program (one that never expects graphics) sees plain RAM
 there and can use it freely. A gtx-16-targeted program issues
 drawing commands via the IO page (`0xFE50..0xFE61` for the
-command surface in gtx-16 v0.2) and stores sprite data wherever
-it wants in cart memory — typically in mapped region A — see
-gtx-16 §2 for the full mapping.
+command surface) and stores sprite data wherever it wants in
+cart memory — typically in mapped region A — see gtx-16 §2 for
+the full mapping.
 
 ### 3.2 Banks
 

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -100,16 +100,18 @@ the host's `MemoryMapper` (§3.5) can remap any region to a device.
 | `0x0100..0x0FFF` | 3.75 KB | **Low RAM** — conventional stack range. `sp` initialized at `0xFFFE` but stack lives wherever the program puts it; this region is the canonical home. |
 | `0x1000..0x10FF` | 256 B | **Interrupt vector table** — 64 entries × 2 bytes each. Vector `N` lives at `0x1000 + 2*N`. |
 | `0x1100..0x7FFF` | ~28 KB | **User RAM** — code + data. Program image loads here at boot. |
-| `0x8000..0xBFFF` | 16 KB | **Mapped region A** — host-defined. gtx-16 maps this as VRAM (framebuffer + sprite cache + tilemap). Plain RAM if no host device claims it. |
+| `0x8000..0xBFFF` | 16 KB | **Mapped region A** — host-defined. Plain RAM by default. gtx-16 v0.2 leaves this region as plain RAM and recommends carts use it for sprite-sheet storage + other large assets (the cart sets `SPRITESHEET_BASE` here). Previous gtx-16 versions mapped VRAM here; v0.2 moved drawing entirely to IO commands. |
 | `0xC000..0xFEFF` | ~15.75 KB | **Bank window** — mirrors bank `mb` if the program is banked, otherwise plain RAM. |
-| `0xFF00..0xFFFF` | 256 B | **Mapped region B / IO page** — host-defined peripheral registers. gtx-16 maps display control + audio channels + input + RNG + timer here. Plain RAM if no host device claims it. |
+| `0xFF00..0xFFFF` | 256 B | **Mapped region B / IO page** — host-defined peripheral registers. gtx-16 v0.2 maps display registers, drawing command surface, audio channels, input, RNG, timer, and KV store here. Plain RAM if no host device claims it. |
 
 The two **Mapped region** ranges (`0x8000..0xBFFF` and
 `0xFF00..0xFFFF`) are the convention for embedding hosts. A pure
 "compute" program (one that never expects graphics) sees plain RAM
-there and can use it freely. A gtx-16-targeted program writes pixels at
-`0x8000`, palette at `0xFF00`, audio at `0xFF40`, etc. — gtx-16's
-documentation defines the exact layout within those regions.
+there and can use it freely. A gtx-16-targeted program issues
+drawing commands via the IO page (`0xFE50..0xFE61` for the
+command surface in gtx-16 v0.2) and stores sprite data wherever
+it wants in cart memory — typically in mapped region A — see
+gtx-16 §2 for the full mapping.
 
 ### 3.2 Banks
 


### PR DESCRIPTION
## Summary

Pivots gtx-16 from NES-style PPU (tiles + sprites + tilemap) to a Picotron-class linear framebuffer with host-side drawing primitives. **The gero VM is unchanged** — every impact is on the gtx-16 host implementation. Rationale + decision log lives in §16 of the new spec.

## Decisions locked (per Q/A discussion)

### Display + drawing
- 320×240, 6 bpp, 4:3 retro PC feel
- **Linear framebuffer** (no PPU model)
- 2 layers (background + foreground) with transparency-key compositing
- 64 visible colors out of a 256-entry master palette
- **Color tables** (Picotron-style LUTs) for shading / recolor / blending
- Scale primitive (no rotation in v0.2)
- IO command surface at `0xFE50..0xFE61` (params + opcode + trigger)
- Opcodes: `cls`, `pset`, `line`, `rect`, `rectfill`, `circle`, `spr`, `spr_scaled`, `print`, `lut_upload`, `palette_upload`, `blit_layer`

### Audio
- 8 channels (square / triangle / sawtooth / noise / pcm per channel)
- Per-channel envelope + LFO + pan
- Built-in tracker engine (cart uploads Song struct, engine runs host-side)

### Input
- Gamepad (8 buttons) + keyboard (with ring buffer) + mouse (with wheel) — all first-class

### Console / UX
- **Terminal-based** like PICO-8: boot to a shell prompt
- **PICO-8-minimal shell** (no pipes, no scripting — `load`, `run`, `save`, `ls`, `cd`, `mkdir`, ...)
- **Simple FS hierarchy** (`/carts`, `/data`, `/sys`, `/tmp`)
- **Six built-in editors** (code, sprites, sfx, music, map, palette) implemented as system carts — extensible (drop new editor carts into `/sys/editors/`)
- **Cart formats:** `.gtx` binary archive + `.gas`/`.gr` source carts (auto-built) + `.gtx.png` shareable PNG
- **No networking** — sandboxed by design, sharing via PNG export
- **VM uncapped** — ~50M opcodes/sec on modern host, ~800K/frame budget @ 60Hz (~6× Picotron's Lua VM)

### Memory map shift
- All IO registers moved from `0xFF00..0xFF7F` to `0xFE40..0xFEFF`
- Mapped region A (`0x8000..0xBFFF`) is now plain RAM — carts typically store sprite sheets there. v0.1 mapped VRAM here; no longer.

## Stale references swept

- `docs/isa.md` — memory map prose now reflects v0.2's IO layout
- `docs/cli.md` — `--target=gtx-16` description updated
- `docs/gero-lang.md` — `@addr` example + address-space diagram updated
- `docs/examples/syntax_overview.gr` — gamepad register address corrected

## Files

- `docs/gtx-16.md` — full rewrite (504 → 1043 lines)
- `docs/isa.md`, `docs/cli.md`, `docs/gero-lang.md`, `docs/examples/syntax_overview.gr` — minor coherence patches

## Test plan

- [x] `zig build ci` clean
- [x] Sibling docs sweep done; no stale `0xFF00` / `tilemap` / `pattern table` references remain in spec docs
- [x] gero VM untouched (no `src/` changes; pure docs work)

## Why this shape (TL;DR)

The previous v0.1 PPU model ruled out raycasters and made software-rendered effects much harder. Picotron's model (linear FB + host-side primitives) delivers significantly more creative ceiling at similar host implementation cost. Real Picotron specs confirmed via `WebFetch` — gero VM at ~50M opcodes/sec is already ~6× Picotron's Lua VM budget, so no VM-level changes are needed.

Niche positioning: between PICO-8 (8-bit charm, 128×128, 16 colors) and Picotron (modern, 480×270, 64 colors). gtx-16 at 320×240 / 64 colors targets the **DOS-era retro PC** aesthetic — a niche neither owns. F-Zero / Mario Kart style racing is out of scope (no mode 7) but Wolf3D-style raycasters now work natively (linear FB).