### PR TITLE
feat(vm): add bcpy + bset block-memory opcodes

### DIFF
--- a/.changeset/v0l84i26.md
+++ b/.changeset/v0l84i26.md
@@ -1,0 +1,29 @@
+---
+bump: minor
+---
+
+Add two block-memory opcodes to the gero ISA:
+
+- **`0x27 bcpy dst_reg, src_reg, len_reg`** — block copy. Copies
+  `len` bytes from `mem[src]` to `mem[dst]` byte-by-byte from low
+  to high. Length is the third register's `u16` value (0..65535).
+  Overlapping ranges with `dst > src` produce corruption — split
+  or use disjoint regions. Address arithmetic wraps at the 16-bit
+  boundary. Doesn't touch flags.
+- **`0x28 bset addr_reg, len_reg, val_reg`** — block byte-fill.
+  Sets `len` bytes at `mem[addr..addr+len]` to `val.lo` (low byte
+  of the third register). Same wrap and flag semantics as `bcpy`.
+
+Use cases that motivated these:
+- Zero / pre-fill SRAM banks at boot
+- Copy sprite-sheet data between cart banks
+- Fast palette / LUT uploads to the gtx-16 host (via cart memory
+  buffer transfers)
+
+These are **ergonomic, not load-bearing** — every transfer they
+do could be hand-coded with a `mov` loop. They save instruction
+count + cart code size + (eventually) host-side memcpy
+optimization vs interpreted loop overhead.
+
+Opcode 0x29..0x2F remain reserved for future block ops if the
+family grows.

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -269,6 +269,8 @@ Useful for character buffers and packed data.
 | `0x24` | `mov8`   | `[Reg], Reg`    | reg.lo ← mem[ptr]; reg.hi ← 0 |
 | `0x25` | `movh`   | `Reg, Addr`     | mem[addr] ← reg.hi |
 | `0x26` | `movl`   | `Reg, Addr`     | mem[addr] ← reg.lo |
+| `0x27` | `bcpy`   | `Reg, Reg, Reg` | block copy: mem[dst..dst+len] ← mem[src..src+len]. Operand order: `dst, src, len` (Intel-style dst first). Length is the third register's `u16` value (0..65535 bytes). Copies low-to-high; overlapping ranges with `dst > src` produce corruption — split or use disjoint regions. Address arithmetic wraps. Doesn't touch flags. |
+| `0x28` | `bset`   | `Reg, Reg, Reg` | block byte-fill: mem[addr..addr+len] ← val.lo for each byte. Operand order: `addr, len, val`. Length is the second register's `u16` value; `val.lo` is the low byte of the third register. Address arithmetic wraps. Doesn't touch flags. |
 
 ### 5.3 Stack (`push`, `pop`)
 

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -95,6 +95,8 @@ pub const handler_table: [256]Handler = blk: {
     t[0x24] = mov.mov8PtrReg;
     t[0x25] = mov.movhRegAddr;
     t[0x26] = mov.movlRegAddr;
+    t[0x27] = mov.bcpyRegRegReg;
+    t[0x28] = mov.bsetRegRegReg;
 
     // stack
     t[0x30] = stack_handlers.pushImm16;

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -210,3 +210,48 @@ pub fn movlRegAddr(vm: *VM) StepResult {
     vm.writeByte(addr, @truncate(value));
     return ok;
 }
+
+/// `0x27` — `bcpy Reg, Reg, Reg` → block copy.
+/// `mem[dst..dst+len] ← mem[src..src+len]`, byte-by-byte from
+/// low to high (so overlapping ranges with `dst > src` will see
+/// corrupted bytes — callers should split or use disjoint
+/// regions). Reads three register indices: dst-addr, src-addr,
+/// length (in bytes, u16). Maximum transfer is 65535 bytes.
+/// Address arithmetic wraps at the 16-bit boundary.
+pub fn bcpyRegRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst_reg = vm.readByte(ip +% 1);
+    const src_reg = vm.readByte(ip +% 2);
+    const len_reg = vm.readByte(ip +% 3);
+    const dst_addr = vm.regs.readByIndex(dst_reg) orelse return fault(vm, .invalid_register);
+    const src_addr = vm.regs.readByIndex(src_reg) orelse return fault(vm, .invalid_register);
+    const len = vm.regs.readByIndex(len_reg) orelse return fault(vm, .invalid_register);
+    var i: u16 = 0;
+    while (i < len) : (i +%= 1) {
+        const b = vm.readByte(src_addr +% i);
+        vm.writeByte(dst_addr +% i, b);
+    }
+    return ok;
+}
+
+/// `0x28` — `bset Reg, Reg, Reg` → block byte-fill.
+/// `mem[addr..addr+len] ← val.lo` for each byte. Reads three
+/// register indices: dst-addr, length (u16), value (low byte
+/// used; high byte ignored). Address arithmetic wraps at the
+/// 16-bit boundary.
+pub fn bsetRegRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const addr_reg = vm.readByte(ip +% 1);
+    const len_reg = vm.readByte(ip +% 2);
+    const val_reg = vm.readByte(ip +% 3);
+    const addr = vm.regs.readByIndex(addr_reg) orelse return fault(vm, .invalid_register);
+    const len = vm.regs.readByIndex(len_reg) orelse return fault(vm, .invalid_register);
+    const val_word = vm.regs.readByIndex(val_reg) orelse return fault(vm, .invalid_register);
+    // safety: truncating to the low byte is the spec'd "val.lo" half
+    const val_byte: u8 = @truncate(val_word);
+    var i: u16 = 0;
+    while (i < len) : (i +%= 1) {
+        vm.writeByte(addr +% i, val_byte);
+    }
+    return ok;
+}

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -64,6 +64,10 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x25] = .{ .mnemonic = "movh", .operands = &.{ .reg, .addr } };
     t[0x26] = .{ .mnemonic = "movl", .operands = &.{ .reg, .addr } };
 
+    // block memory ops
+    t[0x27] = .{ .mnemonic = "bcpy", .operands = &.{ .reg, .reg, .reg } };
+    t[0x28] = .{ .mnemonic = "bset", .operands = &.{ .reg, .reg, .reg } };
+
     // stack
     t[0x30] = .{ .mnemonic = "push", .operands = &.{.imm16} };
     t[0x31] = .{ .mnemonic = "push", .operands = &.{.reg} };

--- a/tests/vm/handlers/mov.test.zig
+++ b/tests/vm/handlers/mov.test.zig
@@ -256,3 +256,156 @@ test "mov: invalid register index raises invalid-register fault" {
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
+
+// ---------- block memory ops (bcpy / bset) ----------
+
+test "bcpy 0x27: copies len bytes from src to dst" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // Seed source region.
+    vm.mmap.writeByte(0x2000, 0xDE);
+    vm.mmap.writeByte(0x2001, 0xAD);
+    vm.mmap.writeByte(0x2002, 0xBE);
+    vm.mmap.writeByte(0x2003, 0xEF);
+
+    vm.regs.write(.r1, 0x3000); // dst
+    vm.regs.write(.r2, 0x2000); // src
+    vm.regs.write(.r3, 0x0004); // len
+
+    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0x04 }); // bcpy r1, r2, r3
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(@as(u8, 0xDE), vm.mmap.readByte(0x3000));
+    try std.testing.expectEqual(@as(u8, 0xAD), vm.mmap.readByte(0x3001));
+    try std.testing.expectEqual(@as(u8, 0xBE), vm.mmap.readByte(0x3002));
+    try std.testing.expectEqual(@as(u8, 0xEF), vm.mmap.readByte(0x3003));
+    // Beyond the copied range is untouched (still 0).
+    try std.testing.expectEqual(@as(u8, 0x00), vm.mmap.readByte(0x3004));
+    try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
+}
+
+test "bcpy: len = 0 is a no-op" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.mmap.writeByte(0x2000, 0xAA);
+    vm.mmap.writeByte(0x3000, 0xBB);
+    vm.regs.write(.r1, 0x3000);
+    vm.regs.write(.r2, 0x2000);
+    vm.regs.write(.r3, 0x0000);
+    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0x04 });
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(@as(u8, 0xBB), vm.mmap.readByte(0x3000));
+}
+
+test "bcpy: address wraps at the 16-bit boundary" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    // Source straddles the wrap: bytes at 0xFFFE, 0xFFFF, 0x0000.
+    vm.mmap.writeByte(0xFFFE, 0x11);
+    vm.mmap.writeByte(0xFFFF, 0x22);
+    vm.mmap.writeByte(0x0000, 0x33);
+    vm.regs.write(.r1, 0x4000);
+    vm.regs.write(.r2, 0xFFFE);
+    vm.regs.write(.r3, 0x0003);
+    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0x04 });
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(@as(u8, 0x11), vm.mmap.readByte(0x4000));
+    try std.testing.expectEqual(@as(u8, 0x22), vm.mmap.readByte(0x4001));
+    try std.testing.expectEqual(@as(u8, 0x33), vm.mmap.readByte(0x4002));
+}
+
+test "bcpy: doesn't touch flags" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x3000);
+    vm.regs.write(.r2, 0x2000);
+    vm.regs.write(.r3, 0x0010);
+    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0x04 });
+    try expectFlagsUnchanged(&vm);
+}
+
+test "bcpy: invalid register index raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+    // bcpy r1, r2, <out-of-range>
+    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0xFF });
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}
+
+test "bset 0x28: fills len bytes with the value-register's low byte" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x3000); // addr
+    vm.regs.write(.r2, 0x0008); // len
+    vm.regs.write(.r3, 0xDEAD); // value (only 0xAD will be written)
+
+    loadProgram(&vm, &.{ 0x28, 0x02, 0x03, 0x04 }); // bset r1, r2, r3
+    _ = gero.vm.step(&vm);
+
+    var i: u16 = 0;
+    while (i < 8) : (i += 1) {
+        try std.testing.expectEqual(@as(u8, 0xAD), vm.mmap.readByte(0x3000 + i));
+    }
+    try std.testing.expectEqual(@as(u8, 0x00), vm.mmap.readByte(0x3008));
+    try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
+}
+
+test "bset: len = 0 is a no-op" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.mmap.writeByte(0x3000, 0xCC);
+    vm.regs.write(.r1, 0x3000);
+    vm.regs.write(.r2, 0x0000);
+    vm.regs.write(.r3, 0xFF);
+    loadProgram(&vm, &.{ 0x28, 0x02, 0x03, 0x04 });
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(@as(u8, 0xCC), vm.mmap.readByte(0x3000));
+}
+
+test "bset: address wraps at the 16-bit boundary" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0xFFFE);
+    vm.regs.write(.r2, 0x0003);
+    vm.regs.write(.r3, 0x5A);
+    loadProgram(&vm, &.{ 0x28, 0x02, 0x03, 0x04 });
+    _ = gero.vm.step(&vm);
+
+    try std.testing.expectEqual(@as(u8, 0x5A), vm.mmap.readByte(0xFFFE));
+    try std.testing.expectEqual(@as(u8, 0x5A), vm.mmap.readByte(0xFFFF));
+    try std.testing.expectEqual(@as(u8, 0x5A), vm.mmap.readByte(0x0000));
+}
+
+test "bset: doesn't touch flags" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x3000);
+    vm.regs.write(.r2, 0x0010);
+    vm.regs.write(.r3, 0x00);
+    loadProgram(&vm, &.{ 0x28, 0x02, 0x03, 0x04 });
+    try expectFlagsUnchanged(&vm);
+}
+
+test "bset: invalid register index raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+    loadProgram(&vm, &.{ 0x28, 0x02, 0xFF, 0x04 });
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -29,12 +29,12 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
-test "opcodes: table holds exactly 90 named entries" {
+test "opcodes: table holds exactly 92 named entries" {
     var count: usize = 0;
     for (table) |entry| if (entry != null) {
         count += 1;
     };
-    try std.testing.expectEqual(@as(usize, 90), count);
+    try std.testing.expectEqual(@as(usize, 92), count);
 }
 
 test "opcodes: every named entry has a non-empty mnemonic" {
@@ -104,7 +104,7 @@ test "opcodes: unused byte values are null" {
     // Spot-check several gaps in the spec's opcode space.
     try std.testing.expect(table[0x00] == null);
     try std.testing.expect(table[0x0F] == null);
-    try std.testing.expect(table[0x27] == null);
+    try std.testing.expect(table[0x29] == null);
     try std.testing.expect(table[0x33] == null);
     try std.testing.expect(table[0x57] == null);
     try std.testing.expect(table[0x68] == null);


### PR DESCRIPTION
## Summary

Two new opcodes in the mov family, closing the \"VM ergonomic additions for Picotron-class shift\" loose end from PR #81.

| Opcode | Mnemonic | Operands | Effect |
|--------|----------|----------|--------|
| \`0x27\` | \`bcpy\` | \`dst_reg, src_reg, len_reg\` | block copy: \`mem[dst..dst+len] ← mem[src..src+len]\` |
| \`0x28\` | \`bset\` | \`addr_reg, len_reg, val_reg\` | block byte-fill: \`mem[addr..addr+len] ← val.lo\` |

## Semantics

- **Encoding:** opcode + 3 register indices = 4 bytes per instruction
- **Operand order:** Intel-style \"dst first\" matching the rest of the mov family
- **Length:** the relevant register's u16 value, max 65535 bytes
- **Copy direction:** low to high — overlapping ranges with \`dst > src\` will see corrupted bytes. Callers split or use disjoint regions.
- **Address wrap:** the loop index uses \`+%=\` so transfers at the top of the address space wrap to zero
- **Flags:** untouched (block ops are conceptually moves)
- **Invalid register index:** raises the standard \`invalid_register\` fault

## Use cases

These were motivated by the Picotron-class shift in #81. Fast palette / LUT uploads (host reads cart memory in bulk; cart prepares the buffer with one \`bset\` or one \`bcpy\`), sprite-sheet bank transfers (move 1-2 KB chunks between cart banks for animation), SRAM zeroing at boot.

**They're ergonomic, not load-bearing.** Every transfer they do is expressible as a \`mov\` loop. The wins are:
- Cart code size (one instruction vs ~7-10 for a loop)
- Future host optimization (swap the byte loop for native \`memcpy\` without changing the contract)

## Test plan

- [x] \`zig build ci\` green locally — 1300+ tests pass in 4 release modes + cross-target
- [x] 12 new tests cover: happy path (multi-byte transfer / fill), \`len = 0\` no-op, address wrap at the 16-bit boundary, flag-immunity, and invalid-register fault for each opcode
- [x] Existing opcode-table assertions updated (the \"exactly 90 entries\" + null-spotcheck on \`0x27\`)
- [x] \`docs/isa.md\` §5.2 updated with both opcodes

## Reserved opcodes

\`0x29..0x2F\` remain unused — reserved for future block ops if the family grows (e.g. \`bcmp\` block compare, \`bxor\` block xor, \`bscan\` find-byte-in-range).