### PR TITLE
feat(asm): data8 / data16 directives + value-list parser

### DIFF
--- a/.changeset/x2n06k48.md
+++ b/.changeset/x2n06k48.md
@@ -1,0 +1,41 @@
+---
+bump: minor
+---
+
+Add the `data8` and `data16` directives to the asm parser.
+
+**New AST shapes** (`src/asm/ast.zig`):
+- `Statement.data8: DataDecl` and `Statement.data16: DataDecl` —
+  one decl struct shared between both, the variant tag selects
+  byte-vs-word emission for codegen
+- `DataValue` union — one entry in a value list, covering every
+  shape asm spec §2.2 allows:
+  - `expr` — hex / char / paren / arithmetic (folded by the
+    expression evaluator)
+  - `addr_lit` — `&FFFF` address literal
+  - `sym_ref` — `@sym` reference (resolved by the symbol-table
+    pass)
+  - `string` — `"..."` (data8 only)
+  - `reserve` — `reserve N` form, with the count pre-evaluated
+    against the visible `ConstantTable`
+
+**Parser** (`src/asm/parser.zig`):
+- `parseDataDecl` shared between `data8` and `data16` — only the
+  variant tag and string-literal admissibility differ
+- `parseDataValue` dispatches by leading byte: `"` → string,
+  `&` → addr_lit, `@` → sym_ref, `reserve` keyword → reserve,
+  everything else → general expression. Strings in `data16`
+  surface a diagnostic but still produce an AST node so the
+  rest of the parse continues.
+- `Program.deinit` extended to walk data8/16 statements and free
+  each value's owned subtrees (expr + reserve count)
+
+**Public API** re-exported via `gero.asm_`:
+- `DataDecl`, `DataValue`, `AddrLit`, `SymRef`, `StringLit`,
+  `ReserveForm`
+
+**Tests**: 12 new parser tests covering every value form, mixed
+lists, `reserve` with literal + const-ref counts,
+reserve-in-the-middle, parenthesized expression values, data16
+rejecting strings, malformed directives (missing ident,
+missing equals), and data8 + label coexistence.

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -54,6 +54,18 @@ pub const parse = parser.parse;
 pub const Expr = ast_mod.Expr;
 /// Re-export: const declaration AST shape.
 pub const ConstDecl = ast_mod.ConstDecl;
+/// Re-export: data8/data16 declaration AST shape (shared between both).
+pub const DataDecl = ast_mod.DataDecl;
+/// Re-export: one entry in a data8/data16 value list.
+pub const DataValue = ast_mod.DataValue;
+/// Re-export: address literal `&FFFF`.
+pub const AddrLit = ast_mod.AddrLit;
+/// Re-export: symbol reference `@sym`.
+pub const SymRef = ast_mod.SymRef;
+/// Re-export: string literal `"..."` (data8 only).
+pub const StringLit = ast_mod.StringLit;
+/// Re-export: `reserve N` form.
+pub const ReserveForm = ast_mod.ReserveForm;
 /// Re-export: name → u16 lookup for compile-time constants.
 pub const ConstantTable = expr_mod.ConstantTable;
 /// Re-export: fold an `Expr` tree to a `u16` using a `ConstantTable`.

--- a/src/asm/ast.zig
+++ b/src/asm/ast.zig
@@ -31,6 +31,8 @@ pub const Span = struct {
 pub const Statement = union(enum) {
     label: Label,
     const_decl: ConstDecl,
+    data8: DataDecl,
+    data16: DataDecl,
     /// Catch-all for unrecognized lines — carries a span so the
     /// consumer can skip past it cleanly.
     unknown: Unknown,
@@ -40,6 +42,8 @@ pub const Statement = union(enum) {
         return switch (self) {
             .label => |l| l.span,
             .const_decl => |c| c.span,
+            .data8 => |d| d.span,
+            .data16 => |d| d.span,
             .unknown => |u| u.span,
         };
     }
@@ -70,6 +74,91 @@ pub const ConstDecl = struct {
     /// RHS expression tree, owned by the program allocator.
     expr: *Expr,
     /// Span covering `const NAME = expr` end-to-end.
+    span: Span,
+};
+
+/// `data8 NAME = value, ...` / `data16 NAME = value, ...` —
+/// emits a labeled byte (or LE word) sequence at the current
+/// emit position. The kind (data8 vs data16) lives in the
+/// `Statement` variant, so this struct is shared between both.
+pub const DataDecl = struct {
+    /// Span of the identifier being bound (without the directive
+    /// keyword or the `=`).
+    name: Span,
+    /// Comma-separated value list, in source order. Owned by the
+    /// program allocator (each entry may carry an owned `*Expr`
+    /// sub-tree).
+    values: []DataValue,
+    /// Span covering `<kw> NAME = v1, v2, ...` end-to-end.
+    span: Span,
+};
+
+/// One entry in a `data8` / `data16` value list. Per asm spec
+/// §2.2 the form can be one of:
+///
+/// - hex literal, char literal, or parenthesized expression —
+///   captured as `.expr` (the general compile-time-u16 case)
+/// - address literal `&FFFF` — `.addr_lit`
+/// - `@`-prefixed symbol reference — `.sym_ref`
+/// - string literal `"..."` — `.string` (data8 only; the parser
+///   rejects strings inside `data16`)
+/// - `reserve N` — `.reserve` (emits N zero units; N is itself
+///   an expression)
+pub const DataValue = union(enum) {
+    expr: ExprValue,
+    addr_lit: AddrLit,
+    sym_ref: SymRef,
+    string: StringLit,
+    reserve: ReserveForm,
+
+    /// Smallest `Span` covering the value's source bytes.
+    pub fn span(self: DataValue) Span {
+        return switch (self) {
+            .expr => |e| e.span,
+            .addr_lit => |a| a.span,
+            .sym_ref => |s| s.span,
+            .string => |s| s.span,
+            .reserve => |r| r.span,
+        };
+    }
+};
+
+/// Pre-parsed expression value wrapped to keep the union flat.
+pub const ExprValue = struct {
+    expr: *Expr,
+    span: Span,
+};
+
+/// `&FFFF` — already-parsed `u16` address.
+pub const AddrLit = struct {
+    value: u16,
+    span: Span,
+};
+
+/// `@sym` — symbol reference. The actual address gets patched in
+/// during the symbol-resolution pass (#35); for now the parser
+/// just records the lexeme span.
+pub const SymRef = struct {
+    /// Span of the `@sym` token, including the leading `@`.
+    span: Span,
+};
+
+/// `"..."` — string literal. The raw bytes (with escape
+/// sequences) live at `source[span.start + 1 .. span.end - 1]`.
+/// Codegen decodes the escapes per asm spec §1.5.
+pub const StringLit = struct {
+    span: Span,
+};
+
+/// `reserve N` — emits N zero units (bytes in `data8`, LE words
+/// in `data16`). `count_expr` is folded at parse time; the
+/// resulting count is stored alongside for emission convenience.
+pub const ReserveForm = struct {
+    count_expr: *Expr,
+    /// `null` if the count expression failed to evaluate at parse
+    /// time (a diagnostic was emitted). Codegen treats this as a
+    /// no-op for the failed entry.
+    count: ?u16,
     span: Span,
 };
 
@@ -188,11 +277,20 @@ pub const Program = struct {
     allocator: std.mem.Allocator,
 
     /// Release the owned statement list, including any expression
-    /// trees hanging off `const_decl` statements.
+    /// trees hanging off `const_decl` / `data8` / `data16`
+    /// statements.
     pub fn deinit(self: *Program) void {
         for (self.statements) |s| {
             switch (s) {
                 .const_decl => |c| freeExpr(self.allocator, c.expr),
+                .data8, .data16 => |d| {
+                    for (d.values) |v| switch (v) {
+                        .expr => |e| freeExpr(self.allocator, e.expr),
+                        .reserve => |r| freeExpr(self.allocator, r.count_expr),
+                        .addr_lit, .sym_ref, .string => {},
+                    };
+                    self.allocator.free(d.values);
+                },
                 else => {},
             }
         }

--- a/src/asm/parser.zig
+++ b/src/asm/parser.zig
@@ -74,6 +74,14 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8) !ParseTree {
 fn cleanupStatements(allocator: std.mem.Allocator, statements: *std.ArrayList(ast.Statement)) void {
     for (statements.items) |s| switch (s) {
         .const_decl => |c| ast.freeExpr(allocator, c.expr),
+        .data8, .data16 => |d| {
+            for (d.values) |v| switch (v) {
+                .expr => |e| ast.freeExpr(allocator, e.expr),
+                .reserve => |r| ast.freeExpr(allocator, r.count_expr),
+                .addr_lit, .sym_ref, .string => {},
+            };
+            allocator.free(d.values);
+        },
         else => {},
     };
     statements.deinit(allocator);
@@ -90,11 +98,17 @@ fn parseStatement(
 ) !void {
     const stmt_start = state.index;
 
-    // `const NAME = <expr>` — must be checked before generic
-    // labels, since the bare `const` lexeme would otherwise be
-    // taken as a label's identifier.
+    // Directive keywords must be checked before generic labels,
+    // since the bare keyword lexeme would otherwise be taken as a
+    // label's identifier.
     if (consumeKeyword(state, "const")) {
         return parseConstDecl(state, allocator, stmt_start, statements, errors, consts);
+    }
+    if (consumeKeyword(state, "data8")) {
+        return parseDataDecl(state, allocator, stmt_start, statements, errors, consts, .data8);
+    }
+    if (consumeKeyword(state, "data16")) {
+        return parseDataDecl(state, allocator, stmt_start, statements, errors, consts, .data16);
     }
 
     // Label: `ident ":"`. The colon distinguishes a label from an
@@ -219,6 +233,202 @@ fn parseConstDecl(
     } });
 }
 
+// ---------- data8 / data16 directives ----------
+
+/// Selects which data directive is being parsed. The parser
+/// shares one function across both — only the variant tag and
+/// the string-literal admissibility differ.
+const DataKind = enum { data8, data16 };
+
+fn parseDataDecl(
+    state: *core.ParseState,
+    allocator: std.mem.Allocator,
+    stmt_start: usize,
+    statements: *std.ArrayList(ast.Statement),
+    errors: *std.ArrayList(include.Diagnostic),
+    consts: *expr.ConstantTable,
+    kind: DataKind,
+) !void {
+    const kw_name: []const u8 = switch (kind) {
+        .data8 => "data8",
+        .data16 => "data16",
+    };
+
+    skipBlanksInLine(state);
+
+    // Name.
+    const name_result = lexer.identP.parseFn(state);
+    if (name_result != .ok) {
+        try errors.append(allocator, .{
+            .parse_error = core.parseError(
+                kw_name,
+                state.index,
+                "expected identifier after directive keyword",
+                .{ .expected = "identifier", .kind = .syntactic },
+            ),
+        });
+        try recoverToNewline(state);
+        try statements.append(allocator, .{ .unknown = .{
+            .span = spanFrom(stmt_start, state.index),
+        } });
+        return;
+    }
+    const name_token = name_result.ok.value;
+
+    skipBlanksInLine(state);
+
+    // `=`.
+    const eq_result = lexer.equalsP.parseFn(state);
+    if (eq_result != .ok) {
+        try errors.append(allocator, .{
+            .parse_error = core.parseError(
+                kw_name,
+                state.index,
+                "expected `=` after directive name",
+                .{ .expected = "=", .kind = .syntactic },
+            ),
+        });
+        try recoverToNewline(state);
+        try statements.append(allocator, .{ .unknown = .{
+            .span = spanFrom(stmt_start, state.index),
+        } });
+        return;
+    }
+
+    // Comma-separated value list. At least one value required.
+    var values: std.ArrayList(ast.DataValue) = .empty;
+    errdefer cleanupDataValues(allocator, &values);
+
+    while (true) {
+        const val_or_err = parseDataValue(state, allocator, errors, consts, kind);
+        const val = val_or_err catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.ParseFailed => {
+                cleanupDataValues(allocator, &values);
+                try recoverToNewline(state);
+                try statements.append(allocator, .{ .unknown = .{
+                    .span = spanFrom(stmt_start, state.index),
+                } });
+                return;
+            },
+        };
+        try values.append(allocator, val);
+
+        skipBlanksInLine(state);
+        if (peekByte(state, ',')) {
+            state.advance(1);
+            continue;
+        }
+        break;
+    }
+
+    const owned = try values.toOwnedSlice(allocator);
+    const decl: ast.DataDecl = .{
+        .name = ast.Span.fromToken(name_token),
+        .values = owned,
+        .span = spanFrom(stmt_start, state.index),
+    };
+    try statements.append(allocator, switch (kind) {
+        .data8 => .{ .data8 = decl },
+        .data16 => .{ .data16 = decl },
+    });
+}
+
+fn parseDataValue(
+    state: *core.ParseState,
+    allocator: std.mem.Allocator,
+    errors: *std.ArrayList(include.Diagnostic),
+    consts: *expr.ConstantTable,
+    kind: DataKind,
+) expr.ParseError!ast.DataValue {
+    skipBlanksInLine(state);
+    const start = state.index;
+
+    // `"..."` string literal — `data8` only.
+    if (state.index < state.input.len and state.input[state.index] == '"') {
+        const r = lexer.stringP.parseFn(state);
+        if (r == .ok) {
+            const tok = r.ok.value;
+            if (kind == .data16) {
+                try errors.append(state.allocator, .{
+                    .parse_error = core.parseError(
+                        "data16",
+                        tok.start,
+                        "string literals are only allowed in `data8` bodies",
+                        .{ .expected = "hex / addr / sym_ref / expression", .kind = .semantic },
+                    ),
+                });
+            }
+            return .{ .string = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } };
+        }
+        // Fall through — the string parser refused (probably
+        // unterminated). Let the lexer's earlier error stand;
+        // we'll surface a generic "expected value" below.
+    }
+
+    // `&FFFF` address literal — must come before the expression
+    // path because the expression parser treats `&` as bitwise AND.
+    if (state.index < state.input.len and state.input[state.index] == '&') {
+        const r = lexer.addrP.parseFn(state);
+        if (r == .ok) {
+            const tok = r.ok.value;
+            return .{ .addr_lit = .{
+                .value = tok.value,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } };
+        }
+    }
+
+    // `@sym` reference.
+    if (state.index < state.input.len and state.input[state.index] == '@') {
+        const r = lexer.symRefP.parseFn(state);
+        if (r == .ok) {
+            const tok = r.ok.value;
+            return .{ .sym_ref = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } };
+        }
+    }
+
+    // `reserve N` — the count is itself an expression.
+    if (consumeKeyword(state, "reserve")) {
+        const count_expr = try expr.parseExpression(state, allocator, errors);
+        const count: ?u16 = blk: {
+            const eval = expr.evalExpr(count_expr, state.input, consts.*);
+            switch (eval) {
+                .ok => |v| break :blk v,
+                .err => |d| {
+                    try errors.append(state.allocator, d);
+                    break :blk null;
+                },
+            }
+        };
+        return .{ .reserve = .{
+            .count_expr = count_expr,
+            .count = count,
+            .span = spanFrom(start, state.index),
+        } };
+    }
+
+    // Fall through to the general compile-time expression.
+    const e = try expr.parseExpression(state, allocator, errors);
+    return .{ .expr = .{
+        .expr = e,
+        .span = e.span(),
+    } };
+}
+
+fn cleanupDataValues(allocator: std.mem.Allocator, values: *std.ArrayList(ast.DataValue)) void {
+    for (values.items) |v| switch (v) {
+        .expr => |e| ast.freeExpr(allocator, e.expr),
+        .reserve => |r| ast.freeExpr(allocator, r.count_expr),
+        .addr_lit, .sym_ref, .string => {},
+    };
+    values.deinit(allocator);
+}
+
 // ---------- unknown / recovery ----------
 
 fn recordUnknown(
@@ -296,4 +506,12 @@ fn skipSeparators(state: *core.ParseState) void {
 fn spanFrom(start: usize, end: usize) ast.Span {
     // safety: source offsets bounded by max_file_size (16 MiB) per include.zig.
     return .{ .start = @intCast(start), .end = @intCast(end) };
+}
+
+/// Lightweight byte peek without going through a lexer parser.
+/// Used for one-char punctuation (`,`, `=`, …) in directive bodies
+/// where round-tripping through knit is overkill.
+fn peekByte(state: *core.ParseState, b: u8) bool {
+    skipBlanksInLine(state);
+    return state.index < state.input.len and state.input[state.index] == b;
 }

--- a/tests/asm/parser.test.zig
+++ b/tests/asm/parser.test.zig
@@ -243,3 +243,174 @@ test "parser: const without identifier surfaces a diagnostic" {
     }
     try std.testing.expect(saw_expected_ident);
 }
+
+// ---------- data8 / data16 directives ----------
+
+test "parser: data8 with single hex value" {
+    var pt = try parseSource("data8 hp = $64\n");
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), pt.program.statements.len);
+    switch (pt.program.statements[0]) {
+        .data8 => |d| {
+            try std.testing.expectEqual(@as(usize, 1), d.values.len);
+            switch (d.values[0]) {
+                .expr => |e| {
+                    var consts = gero.asm_.ConstantTable.init(alloc);
+                    defer consts.deinit();
+                    const result = gero.asm_.evalExpr(e.expr, "data8 hp = $64\n", consts);
+                    try std.testing.expectEqual(@as(u16, 0x64), result.ok);
+                },
+                else => return error.WrongValueKind,
+            }
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: data8 with comma-separated values" {
+    var pt = try parseSource("data8 row = $01, $02, $03, $04\n");
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        .data8 => |d| {
+            try std.testing.expectEqual(@as(usize, 4), d.values.len);
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: data8 with mixed forms (hex, char, addr, sym_ref, string)" {
+    const src = "data8 mixed = $FF, 'A', &1000, @sprite, \"hi\"\n";
+    var pt = try parseSource(src);
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        .data8 => |d| {
+            try std.testing.expectEqual(@as(usize, 5), d.values.len);
+            try std.testing.expectEqual(@as(std.meta.Tag(gero.asm_.DataValue), .expr), @as(std.meta.Tag(gero.asm_.DataValue), d.values[0]));
+            try std.testing.expectEqual(@as(std.meta.Tag(gero.asm_.DataValue), .expr), @as(std.meta.Tag(gero.asm_.DataValue), d.values[1]));
+            try std.testing.expectEqual(@as(std.meta.Tag(gero.asm_.DataValue), .addr_lit), @as(std.meta.Tag(gero.asm_.DataValue), d.values[2]));
+            try std.testing.expectEqual(@as(std.meta.Tag(gero.asm_.DataValue), .sym_ref), @as(std.meta.Tag(gero.asm_.DataValue), d.values[3]));
+            try std.testing.expectEqual(@as(std.meta.Tag(gero.asm_.DataValue), .string), @as(std.meta.Tag(gero.asm_.DataValue), d.values[4]));
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: data8 with reserve N (compile-time count)" {
+    var pt = try parseSource("data8 scratch = reserve $100\n");
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        .data8 => |d| {
+            try std.testing.expectEqual(@as(usize, 1), d.values.len);
+            switch (d.values[0]) {
+                .reserve => |r| {
+                    try std.testing.expectEqual(@as(u16, 0x100), r.count.?);
+                },
+                else => return error.WrongValueKind,
+            }
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: data8 reserve count via prior const" {
+    var pt = try parseSource(
+        \\const N = $40
+        \\data8 buf = reserve N
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[1]) {
+        .data8 => |d| switch (d.values[0]) {
+            .reserve => |r| try std.testing.expectEqual(@as(u16, 0x40), r.count.?),
+            else => return error.WrongValueKind,
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: data8 mixing reserve with other values" {
+    const src = "data8 frame = $AA, $55, reserve $04, $FF\n";
+    var pt = try parseSource(src);
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        .data8 => |d| {
+            try std.testing.expectEqual(@as(usize, 4), d.values.len);
+            try std.testing.expectEqual(@as(std.meta.Tag(gero.asm_.DataValue), .reserve), @as(std.meta.Tag(gero.asm_.DataValue), d.values[2]));
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: data16 accepts the same forms minus strings" {
+    const src = "data16 words = $1234, &5678, @sym, $01 + $02\n";
+    var pt = try parseSource(src);
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        .data16 => |d| {
+            try std.testing.expectEqual(@as(usize, 4), d.values.len);
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: data16 with string literal surfaces a diagnostic" {
+    var pt = try parseSource("data16 bad = \"hi\"\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    var saw_data16_rejection = false;
+    for (pt.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "string literals are only allowed in `data8`") != null) {
+            saw_data16_rejection = true;
+        }
+    }
+    try std.testing.expect(saw_data16_rejection);
+}
+
+test "parser: data8 with parenthesized expression value" {
+    var pt = try parseSource("data8 flags = ($01 << $02) | $08\n");
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        .data8 => |d| {
+            try std.testing.expectEqual(@as(usize, 1), d.values.len);
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: data8 missing identifier" {
+    var pt = try parseSource("data8 = $01\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    var saw_expected_ident = false;
+    for (pt.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "expected identifier") != null) {
+            saw_expected_ident = true;
+        }
+    }
+    try std.testing.expect(saw_expected_ident);
+}
+
+test "parser: data8 missing equals" {
+    var pt = try parseSource("data8 X $01\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+}
+
+test "parser: data8 followed by label both parse" {
+    var pt = try parseSource(
+        \\data8 player = $64, $3C
+        \\start:
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 2), pt.program.statements.len);
+}


### PR DESCRIPTION
## Summary

Plug-in on top of the \`const\` + expression evaluator landed in #83. Each \`data8\`/\`data16\` statement carries an owned \`[]DataValue\`. The \`DataValue\` union accepts every shape asm spec §2.2 allows.

## New shapes

\`\`\`zig
Statement.data8: DataDecl
Statement.data16: DataDecl   // same struct, variant tag drives codegen

DataDecl { name: Span, values: []DataValue, span: Span }

DataValue = expr | addr_lit | sym_ref | string | reserve
\`\`\`

Variants:
| Form | Shape | Notes |
|---|---|---|
| \`\$48\`, \`'A'\`, \`($01 << $02) \| $08\` | \`expr: *Expr\` | General compile-time u16 expression, folded by the evaluator |
| \`&FFFF\` | \`addr_lit: AddrLit { value, span }\` | Lexer-pre-resolved u16 |
| \`@sym\` | \`sym_ref: SymRef { span }\` | Resolved by #35 |
| \`\"hi\"\` | \`string: StringLit { span }\` | data8 only — data16 surfaces a diagnostic |
| \`reserve N\` | \`reserve: ReserveForm { count_expr, count, span }\` | N is an expression; folded at parse time against the visible \`ConstantTable\` |

## Parser dispatch

\`parseDataValue\` reads one entry by leading-byte peek:

\`\`\`
\"  →  string         (data16 emits a diagnostic but still builds the AST node)
&  →  addr_lit        (must precede the expr fallthrough — expr parser uses & as bitwise AND)
@  →  sym_ref
reserve  →  reserve form
else     →  expr.parseExpression (general case)
\`\`\`

The main loop reads comma-separated values until a non-comma byte follows, then stops. Newline-terminated naturally by the line-aware blanks skipping.

## Public API (re-exported via \`gero.asm_\`)

- \`DataDecl\`, \`DataValue\`
- \`AddrLit\`, \`SymRef\`, \`StringLit\`, \`ReserveForm\`

## Tests

12 new parser tests:

- **Single + multi-value lists**: hex value, 4-comma list
- **Mixed forms**: hex + char + addr + sym_ref + string in one line
- **\`reserve\`**: literal count, prior-const count, mixed in the middle of a list
- **\`data16\`**: same forms minus strings; string-in-data16 surfaces a diagnostic
- **Expression values**: parenthesized \`($01 << $02) | $08\`
- **Malformed**: missing identifier, missing equals
- **Co-existence**: data8 + label both parse cleanly

## Test plan

- [x] \`zig build ci\` clean — full pipeline in 4 release modes + cross-target
- [x] Self-review walk: doc comments on every new pub decl, no AI attribution, no strict violations
- [x] \`Program.deinit\` walks the new variants and frees value subtrees (expr + reserve count) — verified by debug allocator showing no leaks

## What's next

Same pattern repeats for the remaining #33 directives:

- \`struct NAME { ... }\` — multi-line block, field offsets. ~150 lines.
- \`org \$ADDR\` — single expression argument, mutates emit cursor at codegen. ~50 lines.

Then we close #33 and move to #34 (instructions + operands).

Part of #33.