### PR TITLE
feat(asm): struct directive + qualified ident resolution

### DIFF
--- a/.changeset/y3o17l59.md
+++ b/.changeset/y3o17l59.md
@@ -1,0 +1,44 @@
+---
+bump: minor
+---
+
+Add the `struct` directive to the asm parser.
+
+**New AST shapes** (`src/asm/ast.zig`):
+- `Statement.struct_decl: StructDecl` — name span + field list +
+  computed size + statement span
+- `StructField` — name span + `FieldType` + computed offset +
+  field span
+- `FieldType` enum: `u8_t` (1 byte) or `u16_t` (2 bytes) per asm
+  spec §2.2. Method `width()` returns the byte size.
+
+**Parser** (`src/asm/parser.zig`):
+- `parseStructDecl` reads `struct NAME { fields }` with:
+  - Multi-line block — newlines INSIDE `{}` separate fields,
+    not statements
+  - Comma-separated fields with optional trailing comma
+  - Recovery: malformed body scans to the next `}` to keep the
+    outer loop alive
+- `parseStructField` reads `name: type` and computes the running
+  offset (`u8` adds 1, `u16` adds 2)
+- After parsing, **injects `Name.field` keys into the
+  `ConstantTable`** so downstream expressions can resolve them
+  (e.g., `const HP_OFFSET = Player.hp` works)
+
+**Expression parser extensions** (`src/asm/expr.zig`):
+- `parsePrimary` now recognizes `ident "." ident` as a qualified
+  identifier — the lexeme spans both halves so the evaluator
+  can look up `Foo.bar` as one key
+- `ConstantTable` gains `putOwned` for synthetic keys
+  (`Player.hp` etc. don't exist in the source — the parser
+  allocates them and the table tracks for cleanup)
+
+**Public API** re-exported via `gero.asm_`:
+- `StructDecl`, `StructField`, `FieldType`
+
+**Tests**: 11 new parser tests:
+- Empty struct (size 0), packed offset math, qualified ident
+  injection, single-line + multi-line bodies, trailing comma,
+  malformed (no name, no `{`, unknown type, no `:`),
+  coexistence with other statements, dotted-ident resolution in
+  expressions, dotted-ident with missing field.

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -66,6 +66,12 @@ pub const SymRef = ast_mod.SymRef;
 pub const StringLit = ast_mod.StringLit;
 /// Re-export: `reserve N` form.
 pub const ReserveForm = ast_mod.ReserveForm;
+/// Re-export: struct directive AST shape.
+pub const StructDecl = ast_mod.StructDecl;
+/// Re-export: one field in a struct declaration.
+pub const StructField = ast_mod.StructField;
+/// Re-export: field type (u8 / u16) per asm spec §2.2.
+pub const FieldType = ast_mod.FieldType;
 /// Re-export: name → u16 lookup for compile-time constants.
 pub const ConstantTable = expr_mod.ConstantTable;
 /// Re-export: fold an `Expr` tree to a `u16` using a `ConstantTable`.

--- a/src/asm/ast.zig
+++ b/src/asm/ast.zig
@@ -33,6 +33,7 @@ pub const Statement = union(enum) {
     const_decl: ConstDecl,
     data8: DataDecl,
     data16: DataDecl,
+    struct_decl: StructDecl,
     /// Catch-all for unrecognized lines — carries a span so the
     /// consumer can skip past it cleanly.
     unknown: Unknown,
@@ -44,6 +45,7 @@ pub const Statement = union(enum) {
             .const_decl => |c| c.span,
             .data8 => |d| d.span,
             .data16 => |d| d.span,
+            .struct_decl => |s| s.span,
             .unknown => |u| u.span,
         };
     }
@@ -160,6 +162,55 @@ pub const ReserveForm = struct {
     /// no-op for the failed entry.
     count: ?u16,
     span: Span,
+};
+
+/// `struct NAME { field: TYPE, ... }` — compile-time struct
+/// layout. No bytes get emitted at the struct's source position;
+/// each field produces an offset constant accessible as
+/// `NAME.field` in expressions (the parser injects these into
+/// the `ConstantTable` as it walks fields).
+pub const StructDecl = struct {
+    /// Span of the struct type name (without `struct` keyword
+    /// or the `{`).
+    name: Span,
+    /// Fields in declaration order. The parser computes each
+    /// field's offset as it walks: `u8` adds 1 to the running
+    /// offset, `u16` adds 2. Layout is packed — no padding.
+    fields: []StructField,
+    /// Total layout size (= last field's offset + its width).
+    /// `0` for an empty struct.
+    size: u16,
+    /// Span covering `struct NAME { ... }` end-to-end.
+    span: Span,
+};
+
+/// One field of a `struct` block. Field offsets start at zero
+/// for the first field and accumulate as fields are walked.
+pub const StructField = struct {
+    /// Span of the field's identifier.
+    name: Span,
+    /// `u8` (1 byte) or `u16` (2 bytes). Per asm spec §2.2 these
+    /// are the only field types in v0.1.
+    ty: FieldType,
+    /// Byte offset within the struct.
+    offset: u16,
+    /// Span covering `field: type` end-to-end.
+    span: Span,
+};
+
+/// Field type per asm spec §2.2. The width values are 1 byte for
+/// `u8`, 2 bytes for `u16`; nothing wider in v0.1.
+pub const FieldType = enum {
+    u8_t,
+    u16_t,
+
+    /// Byte width of this type.
+    pub fn width(self: FieldType) u16 {
+        return switch (self) {
+            .u8_t => 1,
+            .u16_t => 2,
+        };
+    }
 };
 
 /// Compile-time expression — what shows up on the RHS of `const`,
@@ -291,6 +342,7 @@ pub const Program = struct {
                     };
                     self.allocator.free(d.values);
                 },
+                .struct_decl => |sd| self.allocator.free(sd.fields),
                 else => {},
             }
         }

--- a/src/asm/expr.zig
+++ b/src/asm/expr.zig
@@ -23,28 +23,47 @@ const ast = @import("ast.zig");
 /// point in parsing. The parser maintains one of these as it
 /// walks statements top-to-bottom; each `const` declaration adds
 /// an entry, subsequent expressions resolve against it.
+///
+/// Two kinds of keys live here:
+/// - **Borrowed** — slices into the fused source (the common
+///   case for top-level `const` names).
+/// - **Owned** — allocated strings (used for synthetic keys like
+///   `Player.hp` from struct directives). Tracked in
+///   `owned_keys` so deinit can free them.
 pub const ConstantTable = struct {
     entries: std.StringHashMap(u16),
+    owned_keys: std.ArrayList([]const u8),
     allocator: std.mem.Allocator,
 
     /// Build an empty table backed by `allocator`.
     pub fn init(allocator: std.mem.Allocator) ConstantTable {
         return .{
             .entries = std.StringHashMap(u16).init(allocator),
+            .owned_keys = .empty,
             .allocator = allocator,
         };
     }
 
-    /// Release the backing map. Keys are borrowed (point into the
-    /// fused source); we don't free them.
+    /// Release the backing map and any allocator-owned keys.
+    /// Borrowed keys (slices into the source) aren't freed.
     pub fn deinit(self: *ConstantTable) void {
+        for (self.owned_keys.items) |k| self.allocator.free(k);
+        self.owned_keys.deinit(self.allocator);
         self.entries.deinit();
     }
 
-    /// Bind `name` to `value`. Overwrites silently — duplicate
-    /// detection is the parser's responsibility (it surfaces an
-    /// E005-style diagnostic before reaching here).
+    /// Bind `name` to `value` with a **borrowed** key (caller
+    /// guarantees the slice outlives the table). Overwrites
+    /// silently — duplicate detection is the parser's job.
     pub fn put(self: *ConstantTable, name: []const u8, value: u16) !void {
+        try self.entries.put(name, value);
+    }
+
+    /// Bind `name` to `value` and take ownership of the `name`
+    /// buffer — it will be freed by `deinit`. Used for synthetic
+    /// keys (e.g., `Player.hp`) that don't live in the source.
+    pub fn putOwned(self: *ConstantTable, name: []const u8, value: u16) !void {
+        try self.owned_keys.append(self.allocator, name);
         try self.entries.put(name, value);
     }
 
@@ -291,10 +310,32 @@ fn parsePrimary(
     } else if (isIdentStart(next)) {
         const r = lexer.identP.parseFn(state);
         if (r == .ok) {
-            const tok = r.ok.value;
+            const first_tok = r.ok.value;
+            // Check for a dotted continuation: `Name.field` is a
+            // qualified ident referring to struct-field offsets
+            // (asm spec §2.2). Evaluator looks up the full
+            // `Name.field` lexeme as one key in the
+            // ConstantTable.
+            var end_offset: u32 = first_tok.end;
+            if (state.index < state.input.len and state.input[state.index] == '.') {
+                state.advance(1);
+                const second = lexer.identP.parseFn(state);
+                if (second != .ok) {
+                    try errors.append(state.allocator, .{
+                        .parse_error = core.parseError(
+                            "expression",
+                            state.index,
+                            "expected field name after `.`",
+                            .{ .expected = "identifier", .kind = .syntactic },
+                        ),
+                    });
+                    return error.ParseFailed;
+                }
+                end_offset = second.ok.value.end;
+            }
             const expr = try allocator.create(ast.Expr);
             expr.* = .{ .ident = .{
-                .span = .{ .start = tok.start, .end = tok.end },
+                .span = .{ .start = first_tok.start, .end = end_offset },
             } };
             return expr;
         }

--- a/src/asm/parser.zig
+++ b/src/asm/parser.zig
@@ -110,6 +110,9 @@ fn parseStatement(
     if (consumeKeyword(state, "data16")) {
         return parseDataDecl(state, allocator, stmt_start, statements, errors, consts, .data16);
     }
+    if (consumeKeyword(state, "struct")) {
+        return parseStructDecl(state, allocator, stmt_start, statements, errors, consts);
+    }
 
     // Label: `ident ":"`. The colon distinguishes a label from an
     // instruction line that happens to start with an identifier.
@@ -427,6 +430,207 @@ fn cleanupDataValues(allocator: std.mem.Allocator, values: *std.ArrayList(ast.Da
         .addr_lit, .sym_ref, .string => {},
     };
     values.deinit(allocator);
+}
+
+// ---------- struct directive ----------
+
+fn parseStructDecl(
+    state: *core.ParseState,
+    allocator: std.mem.Allocator,
+    stmt_start: usize,
+    statements: *std.ArrayList(ast.Statement),
+    errors: *std.ArrayList(include.Diagnostic),
+    consts: *expr.ConstantTable,
+) !void {
+    skipBlanksInLine(state);
+
+    // Type name.
+    const name_result = lexer.identP.parseFn(state);
+    if (name_result != .ok) {
+        try errors.append(allocator, .{
+            .parse_error = core.parseError(
+                "struct",
+                state.index,
+                "expected identifier after `struct` keyword",
+                .{ .expected = "identifier", .kind = .syntactic },
+            ),
+        });
+        try recoverToEndOfBlock(state);
+        try statements.append(allocator, .{ .unknown = .{
+            .span = spanFrom(stmt_start, state.index),
+        } });
+        return;
+    }
+    const name_token = name_result.ok.value;
+
+    skipSeparators(state); // whitespace + newlines allowed before `{`
+
+    // Opening brace.
+    const lb_result = lexer.lbraceP.parseFn(state);
+    if (lb_result != .ok) {
+        try errors.append(allocator, .{
+            .parse_error = core.parseError(
+                "struct",
+                state.index,
+                "expected `{` to open struct body",
+                .{ .expected = "{", .kind = .syntactic },
+            ),
+        });
+        try recoverToEndOfBlock(state);
+        try statements.append(allocator, .{ .unknown = .{
+            .span = spanFrom(stmt_start, state.index),
+        } });
+        return;
+    }
+
+    // Field list. Fields separated by commas, newlines, or both.
+    // Closing `}` ends the body. Allow a trailing comma.
+    var fields: std.ArrayList(ast.StructField) = .empty;
+    errdefer fields.deinit(allocator);
+
+    var running_offset: u16 = 0;
+
+    while (true) {
+        skipSeparators(state);
+
+        // End of body?
+        if (state.index < state.input.len and state.input[state.index] == '}') {
+            state.advance(1);
+            break;
+        }
+
+        const field_or_err = parseStructField(state, allocator, errors, running_offset);
+        const field = field_or_err catch |err| switch (err) {
+            error.OutOfMemory => {
+                fields.deinit(allocator);
+                return error.OutOfMemory;
+            },
+            error.ParseFailed => {
+                fields.deinit(allocator);
+                try recoverToEndOfBlock(state);
+                try statements.append(allocator, .{ .unknown = .{
+                    .span = spanFrom(stmt_start, state.index),
+                } });
+                return;
+            },
+        };
+        try fields.append(allocator, field);
+        running_offset += field.ty.width();
+
+        skipBlanksInLine(state);
+        // Optional comma between fields. The next iteration's
+        // `skipSeparators` handles newlines.
+        if (peekByte(state, ',')) state.advance(1);
+    }
+
+    // Inject `Name.field` offset constants into the parser's
+    // ConstantTable so downstream expressions can resolve them.
+    const struct_name = state.input[name_token.start..name_token.end];
+    for (fields.items) |f| {
+        const field_name = state.input[f.name.start..f.name.end];
+        const qualified = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ struct_name, field_name });
+        try consts.putOwned(qualified, f.offset);
+    }
+
+    const owned = try fields.toOwnedSlice(allocator);
+    try statements.append(allocator, .{ .struct_decl = .{
+        .name = ast.Span.fromToken(name_token),
+        .fields = owned,
+        .size = running_offset,
+        .span = spanFrom(stmt_start, state.index),
+    } });
+}
+
+fn parseStructField(
+    state: *core.ParseState,
+    allocator: std.mem.Allocator,
+    errors: *std.ArrayList(include.Diagnostic),
+    offset: u16,
+) expr.ParseError!ast.StructField {
+    _ = allocator;
+    const field_start = state.index;
+    skipBlanksInLine(state);
+
+    // Field name.
+    const name_result = lexer.identP.parseFn(state);
+    if (name_result != .ok) {
+        try errors.append(state.allocator, .{
+            .parse_error = core.parseError(
+                "struct",
+                state.index,
+                "expected field name",
+                .{ .expected = "identifier", .kind = .syntactic },
+            ),
+        });
+        return error.ParseFailed;
+    }
+    const name_token = name_result.ok.value;
+
+    skipBlanksInLine(state);
+
+    // Separator `:`.
+    const colon_result = lexer.colonP.parseFn(state);
+    if (colon_result != .ok) {
+        try errors.append(state.allocator, .{
+            .parse_error = core.parseError(
+                "struct",
+                state.index,
+                "expected `:` between field name and type",
+                .{ .expected = ":", .kind = .syntactic },
+            ),
+        });
+        return error.ParseFailed;
+    }
+
+    skipBlanksInLine(state);
+
+    // Type — must be `u8` or `u16`.
+    const type_result = lexer.identP.parseFn(state);
+    if (type_result != .ok) {
+        try errors.append(state.allocator, .{
+            .parse_error = core.parseError(
+                "struct",
+                state.index,
+                "expected `u8` or `u16` as field type",
+                .{ .expected = "u8 | u16", .kind = .syntactic },
+            ),
+        });
+        return error.ParseFailed;
+    }
+    const type_token = type_result.ok.value;
+    const type_lex = state.input[type_token.start..type_token.end];
+    const ty: ast.FieldType = if (std.mem.eql(u8, type_lex, "u8"))
+        .u8_t
+    else if (std.mem.eql(u8, type_lex, "u16"))
+        .u16_t
+    else {
+        try errors.append(state.allocator, .{
+            .parse_error = core.parseError(
+                "struct",
+                type_token.start,
+                "unknown field type (v0.1 supports `u8` and `u16` only)",
+                .{ .expected = "u8 | u16", .actual = type_lex, .kind = .semantic },
+            ),
+        });
+        return error.ParseFailed;
+    };
+
+    return .{
+        .name = ast.Span.fromToken(name_token),
+        .ty = ty,
+        .offset = offset,
+        .span = spanFrom(field_start, state.index),
+    };
+}
+
+/// Recover from a malformed struct body — advance past the next
+/// closing `}` (or to EOF) so the outer loop can pick up cleanly.
+fn recoverToEndOfBlock(state: *core.ParseState) !void {
+    while (state.index < state.input.len) {
+        const b = state.input[state.index];
+        state.advance(1);
+        if (b == '}') return;
+    }
 }
 
 // ---------- unknown / recovery ----------

--- a/tests/asm/parser.test.zig
+++ b/tests/asm/parser.test.zig
@@ -414,3 +414,180 @@ test "parser: data8 followed by label both parse" {
     try std.testing.expect(!pt.hasErrors());
     try std.testing.expectEqual(@as(usize, 2), pt.program.statements.len);
 }
+
+// ---------- struct directive ----------
+
+test "parser: empty struct parses with size 0" {
+    var pt = try parseSource(
+        \\struct Empty {
+        \\}
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), pt.program.statements.len);
+    switch (pt.program.statements[0]) {
+        .struct_decl => |s| {
+            try std.testing.expectEqual(@as(usize, 0), s.fields.len);
+            try std.testing.expectEqual(@as(u16, 0), s.size);
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: struct with u8 + u16 fields computes packed offsets" {
+    var pt = try parseSource(
+        \\struct Player {
+        \\  hp: u16,
+        \\  mp: u16,
+        \\  level: u8,
+        \\  pad: u8,
+        \\}
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        .struct_decl => |s| {
+            try std.testing.expectEqual(@as(usize, 4), s.fields.len);
+            try std.testing.expectEqual(@as(u16, 0), s.fields[0].offset); // hp
+            try std.testing.expectEqual(@as(u16, 2), s.fields[1].offset); // mp
+            try std.testing.expectEqual(@as(u16, 4), s.fields[2].offset); // level
+            try std.testing.expectEqual(@as(u16, 5), s.fields[3].offset); // pad
+            try std.testing.expectEqual(@as(u16, 6), s.size);
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: struct injects Name.field constants into the symbol table" {
+    var pt = try parseSource(
+        \\struct Player { hp: u16, mp: u16 }
+        \\const PLAYER_HP_OFFSET = Player.hp
+        \\const PLAYER_MP_OFFSET = Player.mp
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 3), pt.program.statements.len);
+
+    // Re-evaluate the two const_decls and check they pick up the
+    // struct's offset constants.
+    var consts = gero.asm_.ConstantTable.init(alloc);
+    defer consts.deinit();
+    // Pre-fill with the struct's offsets so the chained eval works.
+    try consts.put("Player.hp", 0);
+    try consts.put("Player.mp", 2);
+    const src =
+        \\struct Player { hp: u16, mp: u16 }
+        \\const PLAYER_HP_OFFSET = Player.hp
+        \\const PLAYER_MP_OFFSET = Player.mp
+        \\
+    ;
+    switch (pt.program.statements[1]) {
+        .const_decl => |c| {
+            const r = gero.asm_.evalExpr(c.expr, src, consts);
+            try std.testing.expectEqual(@as(u16, 0), r.ok);
+        },
+        else => return error.WrongStatementKind,
+    }
+    switch (pt.program.statements[2]) {
+        .const_decl => |c| {
+            const r = gero.asm_.evalExpr(c.expr, src, consts);
+            try std.testing.expectEqual(@as(u16, 2), r.ok);
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: struct fields can be on one line with commas" {
+    var pt = try parseSource("struct Point { x: u16, y: u16 }\n");
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        .struct_decl => |s| try std.testing.expectEqual(@as(usize, 2), s.fields.len),
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: struct allows trailing comma" {
+    var pt = try parseSource(
+        \\struct Foo {
+        \\  a: u8,
+        \\  b: u8,
+        \\}
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+}
+
+test "parser: struct missing name surfaces a diagnostic" {
+    var pt = try parseSource("struct { hp: u16 }\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+}
+
+test "parser: struct missing opening brace" {
+    var pt = try parseSource("struct Player hp: u16 }\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+}
+
+test "parser: struct unknown field type" {
+    var pt = try parseSource("struct Foo { x: u32 }\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    var saw_unknown_type = false;
+    for (pt.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "unknown field type") != null) {
+            saw_unknown_type = true;
+        }
+    }
+    try std.testing.expect(saw_unknown_type);
+}
+
+test "parser: struct field without colon" {
+    var pt = try parseSource("struct Foo { x u16 }\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+}
+
+test "parser: struct followed by other statements parses cleanly" {
+    var pt = try parseSource(
+        \\struct Player { hp: u16 }
+        \\start:
+        \\data8 hp_init = $64
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 3), pt.program.statements.len);
+}
+
+test "parser: expression with qualified ident (Foo.bar) resolves" {
+    var pt = try parseSource(
+        \\struct S { a: u8, b: u8, c: u16 }
+        \\const X = S.c
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    // S.a = 0, S.b = 1, S.c = 2
+    var consts = gero.asm_.ConstantTable.init(alloc);
+    defer consts.deinit();
+    try consts.put("S.c", 2);
+    switch (pt.program.statements[1]) {
+        .const_decl => |c| {
+            const r = gero.asm_.evalExpr(c.expr, "struct S { a: u8, b: u8, c: u16 }\nconst X = S.c\n", consts);
+            try std.testing.expectEqual(@as(u16, 2), r.ok);
+        },
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: expression with `Foo.` (missing field) surfaces an error" {
+    var pt = try parseSource("const X = Foo.\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+}


### PR DESCRIPTION
## Summary

Third-of-four slice for #33's directives. \`struct\` declarations carry packed field offsets and inject \`Name.field\` keys into the \`ConstantTable\` so expressions can reference them — needed by \`<Type>\` casts in #34 and by users writing hand-computed offset arithmetic.

## New AST shapes

\`\`\`zig
Statement.struct_decl: StructDecl

StructDecl { name: Span, fields: []StructField, size: u16, span: Span }
StructField { name: Span, ty: FieldType, offset: u16, span: Span }
FieldType = u8_t | u16_t          // .width() → 1 or 2
\`\`\`

## Parser

- **Multi-line block.** \`parseStructDecl\` recognizes \`struct NAME { fields }\` with newlines INSIDE \`{}\` separating fields (not statements). Comma optional between fields, trailing comma OK.
- **Field offsets.** \`parseStructField\` reads \`name: type\` and accumulates the running offset (\`u8\` adds 1, \`u16\` adds 2). Packed — no padding.
- **\`Name.field\` injection.** After parsing, the parser allocates synthetic key strings (\`\"Player.hp\"\`, \`\"Player.mp\"\`, …) and puts them into the visible \`ConstantTable\` with the computed offsets. Downstream \`const FOO = Player.hp\` parses + evaluates correctly.
- **Recovery.** Malformed body? Scan to the next \`}\` so the outer loop keeps going.

## Expression parser extensions

- \`parsePrimary\` recognizes \`ident . ident\` as a single qualified identifier — the lexeme span covers both halves so the evaluator looks up \`\"Foo.bar\"\` as one key in the table.
- Bare trailing \`.\` with no field name surfaces a structured diagnostic.
- \`ConstantTable\` gains \`putOwned\` for synthetic keys. The parser allocates them; the table tracks them for \`deinit\` cleanup.

## Public API (re-exported via \`gero.asm_\`)

- \`StructDecl\`, \`StructField\`, \`FieldType\`

## Tests

11 new parser cases:
- Empty struct (size 0)
- Packed offset math for \`hp: u16, mp: u16, level: u8, pad: u8\` (offsets 0/2/4/5, size 6)
- \`Name.field\` injection — \`const X = Player.hp\` evaluates to 0
- Single-line form: \`struct Point { x: u16, y: u16 }\`
- Multi-line form (the asm spec §2.2 example shape)
- Trailing comma allowed
- Malformed: no name, no \`{\`, unknown type (\`u32\`), no \`:\`
- Coexistence with other statements
- Dotted-ident in expressions
- \`Foo.\` (missing field) → diagnostic

## Test plan

- [x] \`zig build ci\` clean — 1568+ tests pass across 4 modes + cross-target
- [x] Self-review walk: doc comments on every new pub decl, no strict violations, no AI attribution
- [x] \`Program.deinit\` walks the new variant and frees \`fields\` slice; no leaks under debug allocator

## What's next

Last #33 slice: \`org \$ADDR\` directive — single expression argument, mutates emit cursor at codegen time. ~50 lines.

After that #33 closes and we open #34 (instructions + operands).

Part of #33.