### PR TITLE
feat(asm): org directive — last slice of #33

### DIFF
--- a/.changeset/z4p28m60.md
+++ b/.changeset/z4p28m60.md
@@ -1,0 +1,44 @@
+---
+bump: minor
+---
+
+Add the `org $ADDR` directive to the asm parser. **This closes
+#33.**
+
+`org` relocates the codegen emit cursor — typically used to
+place IVT entries at their ISA-fixed address (`$1000`), then
+move back to user RAM for code. The RHS is a compile-time
+expression (hex literal, const reference, or arithmetic) and
+gets folded at parse time so codegen can consume `addr`
+directly.
+
+**New AST shape** (`src/asm/ast.zig`):
+- `Statement.org: OrgDecl` — `addr_expr: *Expr`, pre-evaluated
+  `addr: ?u16`, statement span
+
+**Parser** (`src/asm/parser.zig`):
+- `parseOrgDecl` reads the RHS via the shared expression parser
+  and folds against the visible `ConstantTable`. Unknown
+  identifiers surface a diagnostic but the statement still
+  emits (with `addr = null`) so the rest of the parse continues.
+- Backward-`org` overlap (E014) is **not** checked here — the
+  parser doesn't track emit position. Codegen catches it against
+  the actual emit cursor.
+
+**Bug fix as a bonus.** PR #85's `cleanupStatements` (the
+parser's errdefer cleanup path) was missing the `struct_decl`
+case from #85 itself. Both `struct_decl` and `org` are now
+wired so OOM-mid-parse releases their owned trees / slices
+correctly. `Program.deinit` was already correct.
+
+**Public API** re-exported via `gero.asm_`:
+- `OrgDecl`
+
+**Tests**: 6 new parser cases covering hex addr, const reference,
+arithmetic RHS, unknown identifier (diagnostic + null addr),
+missing expression, and the canonical IVT-setup pattern from
+asm spec §2.2.
+
+With this, every directive in asm spec §2.2 is now parsed:
+`const`, `data8`, `data16`, `struct`, `org` (plus `include`
+which the resolver handles pre-parse). **#33 is done.**

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -72,6 +72,8 @@ pub const StructDecl = ast_mod.StructDecl;
 pub const StructField = ast_mod.StructField;
 /// Re-export: field type (u8 / u16) per asm spec §2.2.
 pub const FieldType = ast_mod.FieldType;
+/// Re-export: `org $ADDR` directive AST shape.
+pub const OrgDecl = ast_mod.OrgDecl;
 /// Re-export: name → u16 lookup for compile-time constants.
 pub const ConstantTable = expr_mod.ConstantTable;
 /// Re-export: fold an `Expr` tree to a `u16` using a `ConstantTable`.

--- a/src/asm/ast.zig
+++ b/src/asm/ast.zig
@@ -34,6 +34,7 @@ pub const Statement = union(enum) {
     data8: DataDecl,
     data16: DataDecl,
     struct_decl: StructDecl,
+    org: OrgDecl,
     /// Catch-all for unrecognized lines — carries a span so the
     /// consumer can skip past it cleanly.
     unknown: Unknown,
@@ -46,6 +47,7 @@ pub const Statement = union(enum) {
             .data8 => |d| d.span,
             .data16 => |d| d.span,
             .struct_decl => |s| s.span,
+            .org => |o| o.span,
             .unknown => |u| u.span,
         };
     }
@@ -213,6 +215,23 @@ pub const FieldType = enum {
     }
 };
 
+/// `org $ADDR` — relocate the codegen emit cursor. The RHS is a
+/// compile-time expression (typically a hex literal or a const
+/// reference). The parser folds it eagerly so codegen can use
+/// `addr` directly. Backward-`org` checking (overlap → E014)
+/// happens at codegen against the actual emit position, not
+/// here.
+pub const OrgDecl = struct {
+    /// RHS expression tree, owned by the program allocator.
+    addr_expr: *Expr,
+    /// Folded address value, or `null` if eval failed (in which
+    /// case a diagnostic was emitted). Codegen treats `null` as
+    /// a no-op for the directive.
+    addr: ?u16,
+    /// Span covering `org <expr>` end-to-end.
+    span: Span,
+};
+
 /// Compile-time expression — what shows up on the RHS of `const`,
 /// inside `&[ ... ]` address expressions, and as `data8`/`data16`
 /// value-list entries. Walks via `expr.evalExpr` to a `u16` (or
@@ -343,6 +362,7 @@ pub const Program = struct {
                     self.allocator.free(d.values);
                 },
                 .struct_decl => |sd| self.allocator.free(sd.fields),
+                .org => |o| freeExpr(self.allocator, o.addr_expr),
                 else => {},
             }
         }

--- a/src/asm/parser.zig
+++ b/src/asm/parser.zig
@@ -82,6 +82,8 @@ fn cleanupStatements(allocator: std.mem.Allocator, statements: *std.ArrayList(as
             };
             allocator.free(d.values);
         },
+        .struct_decl => |sd| allocator.free(sd.fields),
+        .org => |o| ast.freeExpr(allocator, o.addr_expr),
         else => {},
     };
     statements.deinit(allocator);
@@ -112,6 +114,9 @@ fn parseStatement(
     }
     if (consumeKeyword(state, "struct")) {
         return parseStructDecl(state, allocator, stmt_start, statements, errors, consts);
+    }
+    if (consumeKeyword(state, "org")) {
+        return parseOrgDecl(state, allocator, stmt_start, statements, errors, consts);
     }
 
     // Label: `ident ":"`. The colon distinguishes a label from an
@@ -631,6 +636,51 @@ fn recoverToEndOfBlock(state: *core.ParseState) !void {
         state.advance(1);
         if (b == '}') return;
     }
+}
+
+// ---------- org directive ----------
+
+fn parseOrgDecl(
+    state: *core.ParseState,
+    allocator: std.mem.Allocator,
+    stmt_start: usize,
+    statements: *std.ArrayList(ast.Statement),
+    errors: *std.ArrayList(include.Diagnostic),
+    consts: *expr.ConstantTable,
+) !void {
+    skipBlanksInLine(state);
+
+    // RHS expression.
+    const rhs = expr.parseExpression(state, allocator, errors) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.ParseFailed => {
+            try recoverToNewline(state);
+            try statements.append(allocator, .{ .unknown = .{
+                .span = spanFrom(stmt_start, state.index),
+            } });
+            return;
+        },
+    };
+
+    // Fold against the visible constants. Backward-`org` overlap
+    // (E014) is a codegen-time check — the parser doesn't track
+    // the emit position, so it just records the address here.
+    const addr: ?u16 = blk: {
+        const eval = expr.evalExpr(rhs, state.input, consts.*);
+        switch (eval) {
+            .ok => |v| break :blk v,
+            .err => |d| {
+                try errors.append(allocator, d);
+                break :blk null;
+            },
+        }
+    };
+
+    try statements.append(allocator, .{ .org = .{
+        .addr_expr = rhs,
+        .addr = addr,
+        .span = spanFrom(stmt_start, state.index),
+    } });
 }
 
 // ---------- unknown / recovery ----------

--- a/tests/asm/parser.test.zig
+++ b/tests/asm/parser.test.zig
@@ -591,3 +591,90 @@ test "parser: expression with `Foo.` (missing field) surfaces an error" {
     defer pt.deinit();
     try std.testing.expect(pt.hasErrors());
 }
+
+// ---------- org directive ----------
+
+test "parser: org with hex literal evaluates eagerly" {
+    var pt = try parseSource("org $1000\n");
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), pt.program.statements.len);
+    switch (pt.program.statements[0]) {
+        .org => |o| try std.testing.expectEqual(@as(u16, 0x1000), o.addr.?),
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: org with const reference resolves" {
+    var pt = try parseSource(
+        \\const IVT_BASE = $1000
+        \\org IVT_BASE
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[1]) {
+        .org => |o| try std.testing.expectEqual(@as(u16, 0x1000), o.addr.?),
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: org with compile-time arithmetic" {
+    var pt = try parseSource("org ($10 << $08) + $24\n");
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    switch (pt.program.statements[0]) {
+        // (0x10 << 8) + 0x24 = 0x1024
+        .org => |o| try std.testing.expectEqual(@as(u16, 0x1024), o.addr.?),
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: org with unknown identifier surfaces a diagnostic" {
+    var pt = try parseSource("org NOPE\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    var saw_unknown_ident = false;
+    for (pt.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "unknown identifier") != null) {
+            saw_unknown_ident = true;
+        }
+    }
+    try std.testing.expect(saw_unknown_ident);
+    // The org statement is still recorded (with addr = null) so
+    // the parser keeps walking.
+    try std.testing.expectEqual(@as(usize, 1), pt.program.statements.len);
+    switch (pt.program.statements[0]) {
+        .org => |o| try std.testing.expect(o.addr == null),
+        else => return error.WrongStatementKind,
+    }
+}
+
+test "parser: org missing expression" {
+    var pt = try parseSource("org\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+}
+
+test "parser: classic IVT setup pattern" {
+    // The canonical use case from asm spec §2.2 — place data at
+    // the IVT base, then move the cursor for user code.
+    var pt = try parseSource(
+        \\org $1000
+        \\data16 ivt_keydown = $2000
+        \\org $1100
+        \\start:
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 4), pt.program.statements.len);
+    switch (pt.program.statements[0]) {
+        .org => |o| try std.testing.expectEqual(@as(u16, 0x1000), o.addr.?),
+        else => return error.WrongStatementKind,
+    }
+    switch (pt.program.statements[2]) {
+        .org => |o| try std.testing.expectEqual(@as(u16, 0x1100), o.addr.?),
+        else => return error.WrongStatementKind,
+    }
+}


### PR DESCRIPTION
## Summary

Closes #33. \`org \$ADDR\` relocates the codegen emit cursor — typically used to place IVT entries at \`\$1000\` (ISA-fixed) then move back to user RAM for code.

## New AST shape

\`\`\`zig
Statement.org: OrgDecl

OrgDecl {
    addr_expr: *Expr,    // RHS expression tree (owned)
    addr: ?u16,          // pre-evaluated; null on eval failure
    span: Span,
}
\`\`\`

## Parser

- \`parseOrgDecl\` reads the RHS via the shared expression parser and folds against the visible \`ConstantTable\`. Unknown identifiers surface a diagnostic but the statement still emits (with \`addr = null\`) so the rest of the parse continues.
- **Backward-org overlap (E014) is NOT checked here** — the parser doesn't track emit position. Codegen catches it against the actual emit cursor (#36's job).

## Bug fix bundled in

PR #85's \`cleanupStatements\` (the errdefer cleanup path in the parser) was missing the \`struct_decl\` case from its own PR. Both \`struct_decl\` and \`org\` are now wired so OOM-mid-parse releases their owned slices correctly. \`Program.deinit\` was already correct — only the parser's transient cleanup needed the patch.

## Public API (re-exported via \`gero.asm_\`)

- \`OrgDecl\`

## Tests

6 new parser cases:
- Hex literal addr (\`org \$1000\`)
- Const reference (\`const IVT_BASE = \$1000\\norg IVT_BASE\`)
- Arithmetic RHS (\`org (\$10 << \$08) + \$24\`)
- Unknown identifier → diagnostic + \`addr = null\`
- Missing expression → diagnostic + recovery
- Canonical IVT-setup pattern from asm spec §2.2

## Test plan

- [x] \`zig build ci\` clean — 1574+ tests pass across 4 modes + cross-target
- [x] Self-review walk: no strict violations, doc comments on every new pub decl, no AI attribution

## #33 status: DONE

Every directive in asm spec §2.2 is now parsed:

| Directive | PR |
|---|---|
| \`const\` + expression evaluator | #83 |
| \`data8\` / \`data16\` value lists | #84 |
| \`struct\` + qualified ident | #85 |
| \`org\` | this PR |
| \`include\` | #79 (pre-parse resolver) |

## What's next

#34 — instructions + operands. Mnemonic + operand-form recognition, indexed addressing (\`[&addr + r1]\`), indirect (\`[r1]\`), cast desugar (\`<Type> @sym.field\`). The expression machinery from #83 + this PR's directives are ready to consume.