### PR TITLE
feat(asm): codegen — closes #35 + #36, end-to-end assembler

### DIFF
--- a/.changeset/c7s5bp83.md
+++ b/.changeset/c7s5bp83.md
@@ -1,0 +1,79 @@
+---
+bump: minor
+---
+
+Implement the asm codegen pass. **This closes #35 + #36.** With
+this PR `gero asm program.gas` produces a runnable `.gx` file
+end-to-end.
+
+**New modules:**
+
+- `src/asm/symtab.zig` — `SymbolTable` maps names to
+  `(kind, u16 value)`. Kinds: `label`, `data`, `const_value`,
+  `struct_field`. Duplicate detection for label/data; const
+  values silently overwrite (parser already validated).
+- `src/asm/opcode_resolver.zig` — given a mnemonic + operand
+  `Kind` slice, return the matching opcode byte + total
+  encoded size. Hand-written shape table covering every v0.1
+  opcode (mov family, mov8 / movh / movl, block ops, stack,
+  arith, logical, shifts, cmp/tst, jumps, call/ret, misc,
+  flags, system).
+- `src/asm/codegen.zig` — two-pass orchestration:
+  - Pass 1 (layout): walk statements, compute sizes, populate
+    label / data / const addresses in `SymbolTable`. Org adjusts
+    the cursor; backward `org` raises E014. Duplicate labels
+    raise E005.
+  - Pass 2 (emit): walk statements again, emit bytes against
+    the now-populated table. Forward references resolve cleanly.
+    Undefined symbols raise E004.
+- `.gx` header per ISA §7.1: magic + version + flags +
+  entry_point + image_size + bank_count + sram_bank_count +
+  reserved. Bank emission deferred (v0.1 first cut).
+
+**Operand classification subtle bit:**
+
+A bare identifier in operand position (`label_ref`) can resolve
+to either a `const` (encodes as `imm16`) or a label / data
+symbol (encodes as `addr`). The classifier consults the
+`SymbolTable` to pick the right kind, which then drives opcode
+dispatch:
+
+- `cmp r1, TARGET` (TARGET = const) → 0x60 (cmp Reg, Imm16)
+- `jmp loop` (loop = label) → 0x70 (jmp Addr)
+
+Same source-level shape, different opcodes. The codegen passes
+the symbol table to both layout and emit classification so this
+disambiguation works in both directions.
+
+**Public API** re-exported via `gero.asm_`:
+- `SymbolTable`, `Symbol`, `SymbolKind`
+- `Codegen`, `CodegenOptions`, `assemble`
+
+**Tests** (`tests/asm/codegen.test.zig` — 20 cases):
+- Single-instruction smokes: `hlt`, `nop`, `mov` variants, `inc`,
+  `cmp`
+- Worked example §7 (count-up loop): assembles to the exact
+  14 documented bytes
+- Forward references resolve
+- `data8` / `data16` emit raw bytes + decoded strings + reserve
+- `org` zero-pads forward gaps; backward `org` errors
+- Header magic / version / entry / image_size / bank counts
+- Errors: duplicate label, undefined symbol, unknown mnemonic,
+  operand mismatch
+- Symbol table records const + data + struct entries
+
+Plus mirror tests for symtab.zig (7 cases) and
+opcode_resolver.zig (5 cases) covering operand classification
+edge cases (const-vs-label disambiguation).
+
+**Deferred to follow-ups:**
+
+- ZP-form auto-selection (`mov Imm16, ZP` etc.). Today every
+  address operand uses the 16-bit `addr` encoding.
+- Bank emission + SRAM banks.
+- Debug symbol section.
+- Indexed-store form (only indexed-load is in the ISA today).
+- Full E001..E016 alignment with #37 (today we use plain
+  diagnostic messages; #37 will format them as error codes).
+
+Closes #35 + #36.

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -12,6 +12,9 @@ const include = @import("asm/include.zig");
 const ast_mod = @import("asm/ast.zig");
 const parser = @import("asm/parser.zig");
 const expr_mod = @import("asm/expr.zig");
+const symtab_mod = @import("asm/symtab.zig");
+const codegen_mod = @import("asm/codegen.zig");
+const opres_mod = @import("asm/opcode_resolver.zig");
 
 /// Re-export: lexer token.
 pub const Token = lexer.Token;
@@ -92,6 +95,19 @@ pub const AddrExpr = ast_mod.AddrExpr;
 pub const IndexedAddr = ast_mod.IndexedAddr;
 /// Re-export: `<Type> @sym.field` cast operand.
 pub const CastOperand = ast_mod.CastOperand;
+
+/// Re-export: name → (kind, address) symbol table.
+pub const SymbolTable = symtab_mod.SymbolTable;
+/// Re-export: one entry in `SymbolTable`.
+pub const Symbol = symtab_mod.Symbol;
+/// Re-export: symbol classification.
+pub const SymbolKind = symtab_mod.SymbolKind;
+/// Re-export: codegen output — bytes + symbols + errors.
+pub const Codegen = codegen_mod.Codegen;
+/// Re-export: codegen options (entry point etc.).
+pub const CodegenOptions = codegen_mod.Options;
+/// Re-export: assemble a parsed program into a `.gx` byte image.
+pub const assemble = codegen_mod.assemble;
 /// Re-export: name → u16 lookup for compile-time constants.
 pub const ConstantTable = expr_mod.ConstantTable;
 /// Re-export: fold an `Expr` tree to a `u16` using a `ConstantTable`.

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -1,0 +1,644 @@
+/// Asm codegen — takes a parsed `ParseTree` and produces a
+/// complete `.gx` byte image (header + image bytes). Single-file,
+/// single-bank for the v0.1 first cut; banked emission lands later.
+///
+/// Two-pass model:
+///   Pass 1 (layout): walk statements, compute each statement's
+///     emit size via the opcode resolver, advance an emit cursor,
+///     record label / data addresses in the SymbolTable.
+///   Pass 2 (emit): walk statements again, emit opcode + operand
+///     bytes against the populated table. Forward references are
+///     resolvable now because pass 1 saw every label.
+///
+/// Org / forward gaps zero-pad between segments. Backward `org`
+/// (target < current emit address) raises E014.
+const std = @import("std");
+const knit = @import("knit");
+const core = knit.core;
+const ast = @import("ast.zig");
+const expr = @import("expr.zig");
+const include = @import("include.zig");
+const parser_mod = @import("parser.zig");
+const symtab = @import("symtab.zig");
+const opres = @import("opcode_resolver.zig");
+
+/// Output of the codegen pass — the complete `.gx` byte image
+/// (header + body), the symbol table for debuggers + downstream
+/// tools, and any diagnostics raised during layout / emit.
+pub const Codegen = struct {
+    /// The full `.gx` byte image, ready to write to disk.
+    image: []u8,
+    /// Populated symbol table.
+    symbols: symtab.SymbolTable,
+    /// Errors raised during codegen (E001..E016 per asm spec §8).
+    errors: []include.Diagnostic,
+    allocator: std.mem.Allocator,
+
+    /// Release the image buffer, symbol table, and error list.
+    pub fn deinit(self: *Codegen) void {
+        self.allocator.free(self.image);
+        self.symbols.deinit();
+        self.allocator.free(self.errors);
+    }
+
+    /// `true` when codegen surfaced at least one diagnostic.
+    pub fn hasErrors(self: Codegen) bool {
+        return self.errors.len > 0;
+    }
+};
+
+/// Configuration knobs for `assemble`. v0.1 just exposes the
+/// entry point; banking + SRAM land later.
+pub const Options = struct {
+    /// `ip` value at boot. Per ISA §7.1.
+    entry_point: u16 = 0x0000,
+};
+
+/// Run the full codegen pipeline against a parsed program.
+/// Never throws on grammar / semantic errors — those go into
+/// `errors` (E001..E016 per spec §8). Only `Allocator.Error`
+/// propagates.
+pub fn assemble(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    tree: parser_mod.ParseTree,
+    opts: Options,
+) !Codegen {
+    var symbols = symtab.SymbolTable.init(allocator);
+    errdefer symbols.deinit();
+    var errors: std.ArrayList(include.Diagnostic) = .empty;
+    errdefer errors.deinit(allocator);
+
+    // Pass 1: layout. Walk statements, compute sizes, populate
+    // symbol addresses. The emit cursor tracks where the next
+    // byte will land.
+    var image_size: u32 = 0;
+    try layoutPass(&symbols, &errors, source, tree, &image_size);
+
+    // Pass 2: emit. Project the populated symbol table down to a
+    // ConstantTable so the expression evaluator can resolve every
+    // symbol reference. Walk statements again, emit each byte.
+    var image_buf: std.ArrayList(u8) = .empty;
+    errdefer image_buf.deinit(allocator);
+
+    var resolved_consts = try symbols.toConstantTable();
+    defer resolved_consts.deinit();
+
+    try emitPass(allocator, &image_buf, &errors, source, tree, resolved_consts, &symbols, image_size);
+
+    // Prepend the .gx header per ISA §7.1.
+    const image_bytes = try image_buf.toOwnedSlice(allocator);
+    errdefer allocator.free(image_bytes);
+
+    const final = try buildArchive(allocator, image_bytes, opts);
+    allocator.free(image_bytes);
+
+    return .{
+        .image = final,
+        .symbols = symbols,
+        .errors = try errors.toOwnedSlice(allocator),
+        .allocator = allocator,
+    };
+}
+
+// ---------- operand classification ----------
+
+/// Classify an operand for layout / opcode selection, consulting
+/// the in-progress symbol table for `label_ref` operands. During
+/// layout, only forward-resolved consts can disambiguate;
+/// unknown names default to `.addr` (same byte width as `.imm16`,
+/// so sizing is correct either way).
+fn classifyForLayout(op: ast.Operand, source: []const u8, symbols: symtab.SymbolTable) opres.Kind {
+    return switch (op) {
+        .label_ref => |l| opres.labelRefKind(source[l.span.start..l.span.end], symbols),
+        else => opres.classify(op, null),
+    };
+}
+
+/// Same as `classifyForLayout` but used in the emit pass. By
+/// emit time, every label and const lives in the symbol table
+/// with its true kind, so `label_ref` resolves precisely.
+fn classifyForEmit(op: ast.Operand, source: []const u8, symbols: symtab.SymbolTable) opres.Kind {
+    return switch (op) {
+        .label_ref => |l| opres.labelRefKind(source[l.span.start..l.span.end], symbols),
+        else => opres.classify(op, null),
+    };
+}
+
+// ---------- pass 1: layout ----------
+
+fn layoutPass(
+    symbols: *symtab.SymbolTable,
+    errors: *std.ArrayList(include.Diagnostic),
+    source: []const u8,
+    tree: parser_mod.ParseTree,
+    out_image_size: *u32,
+) !void {
+    var cursor: u32 = 0;
+    for (tree.program.statements) |stmt| {
+        switch (stmt) {
+            .label => |l| {
+                const name = source[l.name.start..l.name.end];
+                // safety: cursor is bounded by max u16 image (the
+                //         ISA caps at 64k) — cast won't truncate.
+                const addr: u16 = @intCast(cursor);
+                symbols.putBorrowed(name, .{ .kind = .label, .value = addr }) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.Duplicate => try errors.append(symbols.allocator, .{
+                        .parse_error = core.parseError(
+                            "codegen",
+                            l.name.start,
+                            "duplicate label",
+                            .{ .expected = "unique label name", .actual = name, .kind = .semantic },
+                        ),
+                    }),
+                };
+            },
+            .const_decl => |c| {
+                // The parser already evaluated and stored this in
+                // its internal ConstantTable, but that table got
+                // dropped at end-of-parse. Re-eval here against
+                // the symbol table we're building up.
+                const name = source[c.name.start..c.name.end];
+                var consts = try symbols.toConstantTable();
+                defer consts.deinit();
+                const result = expr.evalExpr(c.expr, source, consts);
+                switch (result) {
+                    .ok => |v| symbols.putBorrowed(name, .{ .kind = .const_value, .value = v }) catch |err| switch (err) {
+                        error.OutOfMemory => return error.OutOfMemory,
+                        // safety: const_value never triggers Duplicate per putBorrowed's rules
+                        error.Duplicate => unreachable,
+                    },
+                    .err => |d| try errors.append(symbols.allocator, d),
+                }
+            },
+            .data8, .data16 => |d| {
+                const name = source[d.name.start..d.name.end];
+                const addr: u16 = @intCast(cursor);
+                symbols.putBorrowed(name, .{ .kind = .data, .value = addr }) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.Duplicate => try errors.append(symbols.allocator, .{
+                        .parse_error = core.parseError(
+                            "codegen",
+                            d.name.start,
+                            "duplicate data symbol",
+                            .{ .expected = "unique data name", .actual = name, .kind = .semantic },
+                        ),
+                    }),
+                };
+                const word_size: u32 = if (stmt == .data8) 1 else 2;
+                cursor += try sizeOfDataValues(d.values, word_size, source, symbols, errors);
+            },
+            .struct_decl => |sd| {
+                const struct_name = source[sd.name.start..sd.name.end];
+                for (sd.fields) |f| {
+                    const field_name = source[f.name.start..f.name.end];
+                    const qualified = try std.fmt.allocPrint(symbols.allocator, "{s}.{s}", .{ struct_name, field_name });
+                    errdefer symbols.allocator.free(qualified);
+                    try symbols.putOwned(qualified, .{ .kind = .struct_field, .value = f.offset });
+                }
+            },
+            .org => |o| {
+                if (o.addr) |target| {
+                    if (target < cursor) {
+                        try errors.append(symbols.allocator, .{
+                            .parse_error = core.parseError(
+                                "org",
+                                o.span.start,
+                                "backward `org` would overlap already-emitted bytes",
+                                .{ .expected = "addr ≥ current emit position", .kind = .semantic },
+                            ),
+                        });
+                    } else {
+                        cursor = target;
+                    }
+                }
+                // If `o.addr` is null the parser already emitted
+                // a diagnostic. Leave the cursor alone.
+            },
+            .instruction => |i| {
+                const mnem = source[i.mnemonic.start..i.mnemonic.end];
+                var kinds: [3]opres.Kind = undefined;
+                for (i.operands, 0..) |op, idx| kinds[idx] = classifyForLayout(op, source, symbols.*);
+                if (opres.resolve(mnem, kinds[0..i.operands.len])) |res| {
+                    cursor += res.size;
+                } else {
+                    // Unknown mnemonic OR operand-shape mismatch.
+                    const kind: []const u8 = if (opres.isKnownMnemonic(mnem)) "operand type mismatch" else "unknown mnemonic";
+                    try errors.append(symbols.allocator, .{
+                        .parse_error = core.parseError(
+                            "codegen",
+                            i.mnemonic.start,
+                            kind,
+                            .{ .expected = "valid instruction shape", .actual = mnem, .kind = .semantic },
+                        ),
+                    });
+                    // Best-effort cursor advance to keep subsequent
+                    // statements roughly aligned for layout.
+                    cursor += 1;
+                }
+            },
+            .unknown => {},
+        }
+    }
+    out_image_size.* = cursor;
+}
+
+fn sizeOfDataValues(
+    values: []const ast.DataValue,
+    word_size: u32,
+    source: []const u8,
+    symbols: *symtab.SymbolTable,
+    errors: *std.ArrayList(include.Diagnostic),
+) !u32 {
+    var total: u32 = 0;
+    for (values) |v| switch (v) {
+        .expr => total += word_size,
+        .addr_lit => total += word_size,
+        .sym_ref => total += word_size,
+        .string => |s| {
+            // The string token's lexeme is `"...escapes..."` so
+            // we need to decode escapes to get the byte count.
+            // (Identical logic to emit-time decoding; consolidate
+            // into a shared helper if it grows.)
+            const raw = source[s.span.start + 1 .. s.span.end - 1];
+            total += @intCast(decodedStringLen(raw) * word_size);
+        },
+        .reserve => |r| {
+            if (r.count) |n| {
+                // @as: widen u16 → u32 for the byte-count math (can't overflow — u16 max × 2 = 131070, fits in u32)
+                total += @as(u32, n) * word_size;
+            } else {
+                // Eval failed at parse time; re-try here against
+                // the current symbol table.
+                var consts = try symbols.toConstantTable();
+                defer consts.deinit();
+                const result = expr.evalExpr(r.count_expr, source, consts);
+                switch (result) {
+                    // @as: widen u16 → u32 for the byte-count math (can't overflow — u16 max × 2 = 131070, fits in u32)
+                    .ok => |n| total += @as(u32, n) * word_size,
+                    .err => |d| try errors.append(symbols.allocator, d),
+                }
+            }
+        },
+    };
+    return total;
+}
+
+fn decodedStringLen(raw: []const u8) usize {
+    var n: usize = 0;
+    var i: usize = 0;
+    while (i < raw.len) : (i += 1) {
+        if (raw[i] == '\\' and i + 1 < raw.len) i += 1;
+        n += 1;
+    }
+    return n;
+}
+
+// ---------- pass 2: emit ----------
+
+fn emitPass(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    errors: *std.ArrayList(include.Diagnostic),
+    source: []const u8,
+    tree: parser_mod.ParseTree,
+    consts: expr.ConstantTable,
+    symbols: *const symtab.SymbolTable,
+    image_size: u32,
+) !void {
+    var cursor: u32 = 0;
+    for (tree.program.statements) |stmt| {
+        switch (stmt) {
+            .label, .const_decl, .struct_decl, .unknown => {},
+            .data8, .data16 => |d| {
+                const word_size: u32 = if (stmt == .data8) 1 else 2;
+                try emitDataValues(allocator, image, errors, source, d.values, word_size, consts);
+                cursor = @intCast(image.items.len);
+            },
+            .org => |o| {
+                if (o.addr) |target| {
+                    if (target >= cursor) {
+                        // Pad gap with zeros.
+                        while (cursor < target) : (cursor += 1) {
+                            try image.append(allocator, 0);
+                        }
+                    }
+                    // Backward case already diagnosed in pass 1.
+                }
+            },
+            .instruction => |i| {
+                try emitInstruction(allocator, image, errors, source, i, consts, symbols);
+                cursor = @intCast(image.items.len);
+            },
+        }
+    }
+    // Ensure the image is at least `image_size` bytes (pass 1's
+    // layout target). Final pad if needed.
+    while (image.items.len < image_size) try image.append(allocator, 0);
+}
+
+fn emitDataValues(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    errors: *std.ArrayList(include.Diagnostic),
+    source: []const u8,
+    values: []const ast.DataValue,
+    word_size: u32,
+    consts: expr.ConstantTable,
+) !void {
+    for (values) |v| switch (v) {
+        .expr => |e| {
+            const result = expr.evalExpr(e.expr, source, consts);
+            switch (result) {
+                .ok => |val| try emitValue(allocator, image, val, word_size),
+                .err => |d| {
+                    try errors.append(allocator, d);
+                    try emitValue(allocator, image, 0, word_size); // zero placeholder
+                },
+            }
+        },
+        .addr_lit => |a| try emitValue(allocator, image, a.value, word_size),
+        .sym_ref => |s| {
+            const lex = source[s.span.start..s.span.end];
+            const name = if (lex.len > 0 and lex[0] == '@') lex[1..] else lex;
+            if (consts.get(name)) |val| {
+                try emitValue(allocator, image, val, word_size);
+            } else {
+                try errors.append(allocator, .{
+                    .parse_error = core.parseError(
+                        "codegen",
+                        s.span.start,
+                        "undefined symbol",
+                        .{ .expected = "a defined label / const", .actual = name, .kind = .semantic },
+                    ),
+                });
+                try emitValue(allocator, image, 0, word_size);
+            }
+        },
+        .string => |s| {
+            const raw = source[s.span.start + 1 .. s.span.end - 1];
+            try emitString(allocator, image, raw, word_size);
+        },
+        .reserve => |r| {
+            const n = if (r.count) |c| c else blk: {
+                const result = expr.evalExpr(r.count_expr, source, consts);
+                switch (result) {
+                    .ok => |folded| break :blk folded,
+                    .err => |d| {
+                        try errors.append(allocator, d);
+                        break :blk 0;
+                    },
+                }
+            };
+            var i: u32 = 0;
+            // @as: widen u16 → u32 for the byte-count math (can't overflow — u16 max × 2 = 131070, fits in u32)
+            const total = @as(u32, n) * word_size;
+            while (i < total) : (i += 1) try image.append(allocator, 0);
+        },
+    };
+}
+
+fn emitValue(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    value: u16,
+    width: u32,
+) !void {
+    if (width == 1) {
+        try image.append(allocator, @intCast(value & 0xFF));
+    } else {
+        try image.append(allocator, @intCast(value & 0xFF));
+        try image.append(allocator, @intCast((value >> 8) & 0xFF));
+    }
+}
+
+fn emitString(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    raw: []const u8,
+    word_size: u32,
+) !void {
+    var i: usize = 0;
+    while (i < raw.len) : (i += 1) {
+        var b: u8 = raw[i];
+        if (b == '\\' and i + 1 < raw.len) {
+            i += 1;
+            b = switch (raw[i]) {
+                '0' => 0x00,
+                'n' => 0x0A,
+                'r' => 0x0D,
+                't' => 0x09,
+                '\\' => 0x5C,
+                '"' => 0x22,
+                '\'' => 0x27,
+                // safety: lexer validated escapes — anything else
+                //         can't reach this branch.
+                else => unreachable,
+            };
+        }
+        try emitValue(allocator, image, b, word_size);
+    }
+}
+
+fn emitInstruction(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    errors: *std.ArrayList(include.Diagnostic),
+    source: []const u8,
+    inst: ast.Instruction,
+    consts: expr.ConstantTable,
+    symbols: *const symtab.SymbolTable,
+) !void {
+    const mnem = source[inst.mnemonic.start..inst.mnemonic.end];
+    var kinds: [3]opres.Kind = undefined;
+    for (inst.operands, 0..) |op, idx| kinds[idx] = classifyForEmit(op, source, symbols.*);
+    const res = opres.resolve(mnem, kinds[0..inst.operands.len]) orelse {
+        // Pass 1 already raised the diagnostic; emit a NOP-shape
+        // 1 byte (0xFF / `hlt`) so the cursor advances by the
+        // same amount we assumed for layout. Conservative but
+        // keeps subsequent label addresses correct enough that
+        // the rest of the diagnostics make sense.
+        try image.append(allocator, 0xFF);
+        return;
+    };
+
+    try image.append(allocator, res.opcode);
+
+    for (inst.operands) |op| switch (op) {
+        .register => |r| try image.append(allocator, @intFromEnum(r.id)),
+        .immediate => |e| {
+            const result = expr.evalExpr(e, source, consts);
+            const val: u16 = switch (result) {
+                .ok => |v| v,
+                .err => |d| blk: {
+                    try errors.append(allocator, d);
+                    break :blk 0;
+                },
+            };
+            try emitValue(allocator, image, val, 2);
+        },
+        .addr_lit => |a| try emitValue(allocator, image, a.value, 2),
+        .sym_ref => |s| try emitSymRef(allocator, image, errors, source, s, consts),
+        .label_ref => |l| try emitLabelRef(allocator, image, errors, source, l, consts),
+        .addr_expr => |a| {
+            const result = expr.evalExpr(a.expr, source, consts);
+            const val: u16 = switch (result) {
+                .ok => |v| v,
+                .err => |d| blk: {
+                    try errors.append(allocator, d);
+                    break :blk 0;
+                },
+            };
+            try emitValue(allocator, image, val, 2);
+        },
+        .cast => |c| try emitCast(allocator, image, errors, source, c, consts),
+        .indirect => |ind| try image.append(allocator, @intFromEnum(ind.reg.id)),
+        .indexed => |idx| {
+            const result = expr.evalExpr(idx.addr, source, consts);
+            const base: u16 = switch (result) {
+                .ok => |v| v,
+                .err => |d| blk: {
+                    try errors.append(allocator, d);
+                    break :blk 0;
+                },
+            };
+            try emitValue(allocator, image, base, 2);
+            try image.append(allocator, @intFromEnum(idx.reg.id));
+        },
+    };
+}
+
+fn emitSymRef(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    errors: *std.ArrayList(include.Diagnostic),
+    source: []const u8,
+    s: ast.SymRef,
+    consts: expr.ConstantTable,
+) !void {
+    const lex = source[s.span.start..s.span.end];
+    const name = if (lex.len > 0 and lex[0] == '@') lex[1..] else lex;
+    if (consts.get(name)) |val| {
+        try emitValue(allocator, image, val, 2);
+    } else {
+        try errors.append(allocator, .{
+            .parse_error = core.parseError(
+                "codegen",
+                s.span.start,
+                "undefined symbol",
+                .{ .expected = "defined label / const", .actual = name, .kind = .semantic },
+            ),
+        });
+        try emitValue(allocator, image, 0, 2);
+    }
+}
+
+fn emitLabelRef(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    errors: *std.ArrayList(include.Diagnostic),
+    source: []const u8,
+    l: ast.LabelRef,
+    consts: expr.ConstantTable,
+) !void {
+    const name = source[l.span.start..l.span.end];
+    if (consts.get(name)) |val| {
+        try emitValue(allocator, image, val, 2);
+    } else {
+        try errors.append(allocator, .{
+            .parse_error = core.parseError(
+                "codegen",
+                l.span.start,
+                "undefined symbol",
+                .{ .expected = "defined label / const", .actual = name, .kind = .semantic },
+            ),
+        });
+        try emitValue(allocator, image, 0, 2);
+    }
+}
+
+fn emitCast(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    errors: *std.ArrayList(include.Diagnostic),
+    source: []const u8,
+    c: ast.CastOperand,
+    consts: expr.ConstantTable,
+) !void {
+    // `<Type> @sym.field` desugars to `@sym + Type.field`.
+    const sym_lex = source[c.sym_ref.span.start..c.sym_ref.span.end];
+    const sym_name = if (sym_lex.len > 0 and sym_lex[0] == '@') sym_lex[1..] else sym_lex;
+    const type_name = source[c.type_name.start..c.type_name.end];
+    const field_name = source[c.field_name.start..c.field_name.end];
+
+    const sym_val: u16 = if (consts.get(sym_name)) |v| v else blk: {
+        try errors.append(allocator, .{
+            .parse_error = core.parseError(
+                "codegen",
+                c.sym_ref.span.start,
+                "undefined symbol in cast",
+                .{ .expected = "defined symbol", .actual = sym_name, .kind = .semantic },
+            ),
+        });
+        break :blk 0;
+    };
+
+    // Look up `Type.field` as one key in the table.
+    const qualified = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ type_name, field_name });
+    defer allocator.free(qualified);
+    const offset: u16 = if (consts.get(qualified)) |v| v else blk: {
+        try errors.append(allocator, .{
+            .parse_error = core.parseError(
+                "codegen",
+                c.field_name.start,
+                "unknown struct field",
+                .{ .expected = "a declared `struct` field", .actual = field_name, .kind = .semantic },
+            ),
+        });
+        break :blk 0;
+    };
+
+    try emitValue(allocator, image, sym_val +% offset, 2);
+}
+
+// ---------- header / archive ----------
+
+/// Magic bytes at the start of a `.gx` file — "GERO" in ASCII.
+const gx_magic = [4]u8{ 'G', 'E', 'R', 'O' };
+
+fn buildArchive(allocator: std.mem.Allocator, image_bytes: []const u8, opts: Options) ![]u8 {
+    // Header layout per ISA §7.1:
+    //   0x00..0x04  magic = "GERO"
+    //   0x04..0x06  u16le version = 0x0001
+    //   0x06..0x08  u16le flags
+    //   0x08..0x0A  u16le entry_point
+    //   0x0A..0x0C  u16le image_size
+    //   0x0C        u8 bank_count
+    //   0x0D        u8 sram_bank_count
+    //   0x0E..0x10  reserved (must be 0)
+    const header_size: usize = 16;
+    const total = header_size + image_bytes.len;
+    var out = try allocator.alloc(u8, total);
+
+    @memcpy(out[0..4], &gx_magic);
+    writeU16Le(out[4..6], 0x0001); // version
+    writeU16Le(out[6..8], 0x0000); // flags
+    writeU16Le(out[8..10], opts.entry_point);
+    // safety: image_size capped at 64 KiB by the ISA's 16-bit
+    //         address space; cart code larger than that needs
+    //         banking, which is a v0.1 follow-up.
+    writeU16Le(out[10..12], @intCast(image_bytes.len));
+    out[12] = 0; // bank_count
+    out[13] = 0; // sram_bank_count
+    writeU16Le(out[14..16], 0); // reserved
+
+    @memcpy(out[header_size..], image_bytes);
+    return out;
+}
+
+fn writeU16Le(dst: []u8, value: u16) void {
+    // safety: caller passes a 2-byte slice — bounds-checked by indexing.
+    dst[0] = @intCast(value & 0xFF);
+    dst[1] = @intCast((value >> 8) & 0xFF);
+}

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -1,0 +1,259 @@
+/// Resolves a parsed `ast.Instruction` to an ISA opcode + total
+/// encoded size. The matching is done by classifying each
+/// operand into a `Kind` (operand-encoding category) and looking
+/// up `(mnemonic, kinds...)` in a hand-written shape table.
+///
+/// ZP-form auto-selection is intentionally NOT implemented yet
+/// (PR #36 first cut — keep it simple). All address operands
+/// emit as 2-byte `addr`, never as 1-byte `zp`. A future
+/// peephole pass can downgrade `Addr` to `ZP` when the value
+/// fits in 0..0xFF.
+const std = @import("std");
+const ast = @import("ast.zig");
+const symtab = @import("symtab.zig");
+
+/// Operand-encoding category. Maps to one row in the ISA's
+/// opcode-schema. Each Kind has a known byte width.
+pub const Kind = enum {
+    /// 1-byte register index (`Reg` operand).
+    reg,
+    /// 1-byte immediate (`Imm8`).
+    imm8,
+    /// 2-byte little-endian immediate (`Imm16`).
+    imm16,
+    /// 2-byte little-endian address (`Addr`).
+    addr,
+    /// 1-byte zero-page address (`ZP`).
+    zp,
+    /// `[reg]` — indirect via register. Encodes as 1 reg byte.
+    reg_indirect,
+    /// `[addr + reg]` — indexed. Encodes as 2 addr bytes + 1 reg byte.
+    indexed,
+
+    /// Byte width when encoded.
+    pub fn width(self: Kind) u8 {
+        return switch (self) {
+            .reg, .imm8, .zp, .reg_indirect => 1,
+            .imm16, .addr => 2,
+            .indexed => 3,
+        };
+    }
+};
+
+/// One row of the dispatch table — what opcode matches a given
+/// mnemonic + operand-kinds tuple.
+const Shape = struct {
+    mnemonic: []const u8,
+    kinds: []const Kind,
+    opcode: u8,
+};
+
+/// Maximum operand count per instruction in v0.1 (`mov` indexed
+/// has 2 source-level operands; bcpy/bset have 3 register operands).
+const max_operands: usize = 3;
+
+/// The dispatch table. Order matters: more-specific shapes go
+/// first when shapes share a prefix (none in v0.1, but the rule
+/// is good hygiene). Mnemonics use lowercase, matching the lexer.
+const shapes: []const Shape = &.{
+    // mov family
+    .{ .mnemonic = "mov", .kinds = &.{ .imm16, .reg }, .opcode = 0x10 },
+    .{ .mnemonic = "mov", .kinds = &.{ .reg, .reg }, .opcode = 0x11 },
+    .{ .mnemonic = "mov", .kinds = &.{ .reg, .addr }, .opcode = 0x12 },
+    .{ .mnemonic = "mov", .kinds = &.{ .addr, .reg }, .opcode = 0x13 },
+    .{ .mnemonic = "mov", .kinds = &.{ .imm16, .addr }, .opcode = 0x14 },
+    .{ .mnemonic = "mov", .kinds = &.{ .reg, .reg_indirect }, .opcode = 0x15 },
+    .{ .mnemonic = "mov", .kinds = &.{ .reg_indirect, .reg }, .opcode = 0x16 },
+    .{ .mnemonic = "mov", .kinds = &.{ .indexed, .reg }, .opcode = 0x17 },
+    .{ .mnemonic = "mov", .kinds = &.{ .imm16, .reg_indirect }, .opcode = 0x18 },
+
+    // mov8 / movh / movl
+    .{ .mnemonic = "mov8", .kinds = &.{ .imm8, .addr }, .opcode = 0x20 },
+    .{ .mnemonic = "mov8", .kinds = &.{ .imm8, .reg }, .opcode = 0x21 },
+    .{ .mnemonic = "mov8", .kinds = &.{ .addr, .reg }, .opcode = 0x22 },
+    .{ .mnemonic = "mov8", .kinds = &.{ .reg, .reg_indirect }, .opcode = 0x23 },
+    .{ .mnemonic = "mov8", .kinds = &.{ .reg_indirect, .reg }, .opcode = 0x24 },
+    .{ .mnemonic = "movh", .kinds = &.{ .reg, .addr }, .opcode = 0x25 },
+    .{ .mnemonic = "movl", .kinds = &.{ .reg, .addr }, .opcode = 0x26 },
+
+    // block memory ops
+    .{ .mnemonic = "bcpy", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x27 },
+    .{ .mnemonic = "bset", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x28 },
+
+    // stack
+    .{ .mnemonic = "push", .kinds = &.{.imm16}, .opcode = 0x30 },
+    .{ .mnemonic = "push", .kinds = &.{.reg}, .opcode = 0x31 },
+    .{ .mnemonic = "pop", .kinds = &.{.reg}, .opcode = 0x32 },
+
+    // arithmetic
+    .{ .mnemonic = "add", .kinds = &.{ .imm16, .reg }, .opcode = 0x40 },
+    .{ .mnemonic = "add", .kinds = &.{ .reg, .reg }, .opcode = 0x41 },
+    .{ .mnemonic = "add", .kinds = &.{.reg}, .opcode = 0x42 },
+    .{ .mnemonic = "sub", .kinds = &.{ .imm16, .reg }, .opcode = 0x43 },
+    .{ .mnemonic = "sub", .kinds = &.{ .reg, .reg }, .opcode = 0x44 },
+    .{ .mnemonic = "sub", .kinds = &.{.reg}, .opcode = 0x45 },
+    .{ .mnemonic = "mul", .kinds = &.{ .imm16, .reg }, .opcode = 0x46 },
+    .{ .mnemonic = "mul", .kinds = &.{ .reg, .reg }, .opcode = 0x47 },
+    .{ .mnemonic = "inc", .kinds = &.{.reg}, .opcode = 0x48 },
+    .{ .mnemonic = "dec", .kinds = &.{.reg}, .opcode = 0x49 },
+    .{ .mnemonic = "neg", .kinds = &.{.reg}, .opcode = 0x4A },
+    .{ .mnemonic = "div", .kinds = &.{ .imm16, .reg }, .opcode = 0x4B },
+    .{ .mnemonic = "div", .kinds = &.{ .reg, .reg }, .opcode = 0x4C },
+    .{ .mnemonic = "divs", .kinds = &.{ .imm16, .reg }, .opcode = 0x4D },
+    .{ .mnemonic = "divs", .kinds = &.{ .reg, .reg }, .opcode = 0x4E },
+    .{ .mnemonic = "adc", .kinds = &.{ .imm16, .reg }, .opcode = 0x64 },
+    .{ .mnemonic = "adc", .kinds = &.{ .reg, .reg }, .opcode = 0x65 },
+    .{ .mnemonic = "sbc", .kinds = &.{ .imm16, .reg }, .opcode = 0x66 },
+    .{ .mnemonic = "sbc", .kinds = &.{ .reg, .reg }, .opcode = 0x67 },
+
+    // logical
+    .{ .mnemonic = "and", .kinds = &.{ .reg, .imm16 }, .opcode = 0x50 },
+    .{ .mnemonic = "and", .kinds = &.{ .reg, .reg }, .opcode = 0x51 },
+    .{ .mnemonic = "or", .kinds = &.{ .reg, .imm16 }, .opcode = 0x52 },
+    .{ .mnemonic = "or", .kinds = &.{ .reg, .reg }, .opcode = 0x53 },
+    .{ .mnemonic = "xor", .kinds = &.{ .reg, .imm16 }, .opcode = 0x54 },
+    .{ .mnemonic = "xor", .kinds = &.{ .reg, .reg }, .opcode = 0x55 },
+    .{ .mnemonic = "not", .kinds = &.{.reg}, .opcode = 0x56 },
+
+    // shifts + rotates
+    .{ .mnemonic = "shl", .kinds = &.{ .reg, .imm8 }, .opcode = 0x58 },
+    .{ .mnemonic = "shl", .kinds = &.{ .reg, .reg }, .opcode = 0x59 },
+    .{ .mnemonic = "shr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x5A },
+    .{ .mnemonic = "shr", .kinds = &.{ .reg, .reg }, .opcode = 0x5B },
+    .{ .mnemonic = "rol", .kinds = &.{ .reg, .imm8 }, .opcode = 0x5C },
+    .{ .mnemonic = "rol", .kinds = &.{ .reg, .reg }, .opcode = 0x5D },
+    .{ .mnemonic = "ror", .kinds = &.{ .reg, .imm8 }, .opcode = 0x5E },
+    .{ .mnemonic = "ror", .kinds = &.{ .reg, .reg }, .opcode = 0x5F },
+
+    // compare / test
+    .{ .mnemonic = "cmp", .kinds = &.{ .reg, .imm16 }, .opcode = 0x60 },
+    .{ .mnemonic = "cmp", .kinds = &.{ .reg, .reg }, .opcode = 0x61 },
+    .{ .mnemonic = "tst", .kinds = &.{ .reg, .imm16 }, .opcode = 0x62 },
+    .{ .mnemonic = "tst", .kinds = &.{ .reg, .reg }, .opcode = 0x63 },
+
+    // control flow
+    .{ .mnemonic = "jmp", .kinds = &.{.addr}, .opcode = 0x70 },
+    .{ .mnemonic = "jmp", .kinds = &.{.reg}, .opcode = 0x71 },
+    .{ .mnemonic = "jeq", .kinds = &.{.addr}, .opcode = 0x72 },
+    .{ .mnemonic = "jne", .kinds = &.{.addr}, .opcode = 0x73 },
+    .{ .mnemonic = "jlt", .kinds = &.{.addr}, .opcode = 0x74 },
+    .{ .mnemonic = "jle", .kinds = &.{.addr}, .opcode = 0x75 },
+    .{ .mnemonic = "jgt", .kinds = &.{.addr}, .opcode = 0x76 },
+    .{ .mnemonic = "jge", .kinds = &.{.addr}, .opcode = 0x77 },
+    .{ .mnemonic = "jcc", .kinds = &.{.addr}, .opcode = 0x78 },
+    .{ .mnemonic = "jcs", .kinds = &.{.addr}, .opcode = 0x79 },
+    .{ .mnemonic = "jvc", .kinds = &.{.addr}, .opcode = 0x7A },
+    .{ .mnemonic = "jvs", .kinds = &.{.addr}, .opcode = 0x7B },
+    .{ .mnemonic = "jz", .kinds = &.{.addr}, .opcode = 0x7C },
+    .{ .mnemonic = "jnz", .kinds = &.{.addr}, .opcode = 0x7D },
+    .{ .mnemonic = "djnz", .kinds = &.{ .reg, .addr }, .opcode = 0x7E },
+    .{ .mnemonic = "jr", .kinds = &.{.imm8}, .opcode = 0x7F },
+
+    // subroutines
+    .{ .mnemonic = "call", .kinds = &.{.addr}, .opcode = 0x80 },
+    .{ .mnemonic = "call", .kinds = &.{.reg}, .opcode = 0x81 },
+    .{ .mnemonic = "ret", .kinds = &.{}, .opcode = 0x82 },
+
+    // misc
+    .{ .mnemonic = "swap", .kinds = &.{ .reg, .reg }, .opcode = 0x90 },
+    .{ .mnemonic = "nop", .kinds = &.{}, .opcode = 0x91 },
+
+    // flag manipulation
+    .{ .mnemonic = "clc", .kinds = &.{}, .opcode = 0xA0 },
+    .{ .mnemonic = "sec", .kinds = &.{}, .opcode = 0xA1 },
+    .{ .mnemonic = "cli", .kinds = &.{}, .opcode = 0xA2 },
+    .{ .mnemonic = "sei", .kinds = &.{}, .opcode = 0xA3 },
+    .{ .mnemonic = "clv", .kinds = &.{}, .opcode = 0xA4 },
+
+    // system
+    .{ .mnemonic = "int", .kinds = &.{.imm8}, .opcode = 0xFC },
+    .{ .mnemonic = "rti", .kinds = &.{}, .opcode = 0xFD },
+    .{ .mnemonic = "brk", .kinds = &.{}, .opcode = 0xFE },
+    .{ .mnemonic = "hlt", .kinds = &.{}, .opcode = 0xFF },
+};
+
+/// Classify a parsed operand to its encoding `Kind`. Most
+/// operands map one-to-one; the exception is `.label_ref`
+/// (bare identifier) which can be either a `const` (encodes as
+/// `imm16`) or a label / data symbol (encodes as `addr`). The
+/// symbol table tells us which — pass `null` when the table
+/// isn't available yet (sizing pass with no label resolution)
+/// and `label_ref` falls back to `.addr` (size-equivalent to
+/// `.imm16`, so layout is correct either way).
+pub fn classify(op: ast.Operand, symbols: ?*const symtab.SymbolTable) Kind {
+    return switch (op) {
+        .register => .reg,
+        .immediate => .imm16,
+        .addr_lit, .sym_ref, .addr_expr, .cast => .addr,
+        .indirect => .reg_indirect,
+        .indexed => .indexed,
+        .label_ref => |l| classifyLabelRef(l, symbols),
+    };
+}
+
+fn classifyLabelRef(l: ast.LabelRef, symbols: ?*const symtab.SymbolTable) Kind {
+    if (symbols) |s| {
+        // The lexeme is stored by span; we don't have source bytes
+        // here. Caller uses the `*SymbolTable` directly via name.
+        // We can't extract the name without source — fall through
+        // to the default. (The `classifyByName` variant below
+        // takes the resolved lexeme.)
+        _ = s;
+    }
+    _ = l;
+    return .addr;
+}
+
+/// Resolve a `label_ref` operand's `Kind` given its lexeme and
+/// the populated `SymbolTable`. A `const` resolves to `imm16`;
+/// a label or data symbol resolves to `addr`; an unknown name
+/// (forward reference or genuine miss) defaults to `addr`.
+pub fn labelRefKind(name: []const u8, symbols: symtab.SymbolTable) Kind {
+    if (symbols.get(name)) |sym| {
+        return switch (sym.kind) {
+            .const_value, .struct_field => .imm16,
+            .label, .data => .addr,
+        };
+    }
+    return .addr;
+}
+
+/// Result of `resolve` — the opcode byte plus the total encoded
+/// instruction size (1 byte for the opcode + sum of operand widths).
+pub const Resolution = struct {
+    opcode: u8,
+    size: u8,
+};
+
+/// Resolve an instruction's mnemonic + operand kinds to an
+/// opcode. Returns `null` if no matching shape exists — the
+/// caller surfaces `E001` (unknown mnemonic) or `E003` (operand
+/// type mismatch) as appropriate.
+pub fn resolve(mnemonic: []const u8, kinds: []const Kind) ?Resolution {
+    for (shapes) |s| {
+        if (!std.mem.eql(u8, s.mnemonic, mnemonic)) continue;
+        if (s.kinds.len != kinds.len) continue;
+        var match = true;
+        for (s.kinds, kinds) |a, b| {
+            if (a != b) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            var size: u8 = 1;
+            for (s.kinds) |k| size += k.width();
+            return .{ .opcode = s.opcode, .size = size };
+        }
+    }
+    return null;
+}
+
+/// Check whether `mnemonic` is in the table at all (regardless
+/// of operand-kind match). Used to distinguish E001 from E003.
+pub fn isKnownMnemonic(mnemonic: []const u8) bool {
+    for (shapes) |s| {
+        if (std.mem.eql(u8, s.mnemonic, mnemonic)) return true;
+    }
+    return false;
+}

--- a/src/asm/symtab.zig
+++ b/src/asm/symtab.zig
@@ -1,0 +1,105 @@
+/// Symbol table for the asm codegen — accumulates label
+/// addresses, `const` values, struct-field offsets, and
+/// `data8`/`data16` data-symbol addresses as the codegen pass
+/// walks statements. The parser's `ConstantTable` (in `expr.zig`)
+/// handles parse-time refs to constants and struct fields; this
+/// table extends with the address-bearing entries codegen needs.
+const std = @import("std");
+const expr = @import("expr.zig");
+
+/// What a name maps to.
+pub const SymbolKind = enum {
+    /// A label declaration — `name:`. Value is the byte address.
+    label,
+    /// A `data8` / `data16` directive's name. Value is the byte
+    /// address where its bytes start.
+    data,
+    /// A `const NAME = <expr>` — value is the folded `u16`.
+    const_value,
+    /// A struct-field offset injected by `parseStructDecl`
+    /// (e.g., `Player.hp = 0`).
+    struct_field,
+};
+
+/// One entry in the table.
+pub const Symbol = struct {
+    kind: SymbolKind,
+    value: u16,
+};
+
+/// Name → Symbol lookup. Built incrementally by the codegen
+/// pass; consumed during operand resolution + diagnostics
+/// formatting (#37).
+pub const SymbolTable = struct {
+    entries: std.StringHashMap(Symbol),
+    /// Synthetic keys (Name.field for struct offsets) we allocated
+    /// ourselves and need to free on deinit.
+    owned_keys: std.ArrayList([]const u8),
+    allocator: std.mem.Allocator,
+
+    /// Build an empty table.
+    pub fn init(allocator: std.mem.Allocator) SymbolTable {
+        return .{
+            .entries = std.StringHashMap(Symbol).init(allocator),
+            .owned_keys = .empty,
+            .allocator = allocator,
+        };
+    }
+
+    /// Free owned keys + the backing map. Borrowed keys (slices
+    /// into the fused source) aren't freed.
+    pub fn deinit(self: *SymbolTable) void {
+        for (self.owned_keys.items) |k| self.allocator.free(k);
+        self.owned_keys.deinit(self.allocator);
+        self.entries.deinit();
+    }
+
+    /// Register a symbol with a **borrowed** key. Returns
+    /// `error.Duplicate` if a label or data symbol already exists
+    /// at this name (E005-shape). Const + struct fields silently
+    /// overwrite — the parser already validated their uniqueness.
+    pub fn putBorrowed(self: *SymbolTable, name: []const u8, sym: Symbol) !void {
+        if (sym.kind == .label or sym.kind == .data) {
+            if (self.entries.get(name)) |existing| {
+                if (existing.kind == .label or existing.kind == .data) {
+                    return error.Duplicate;
+                }
+            }
+        }
+        try self.entries.put(name, sym);
+    }
+
+    /// Register a symbol with an **owned** key (allocator-allocated).
+    /// Same duplicate rules as `putBorrowed`. On error, the caller
+    /// is responsible for freeing the key.
+    pub fn putOwned(self: *SymbolTable, name: []const u8, sym: Symbol) !void {
+        if (sym.kind == .label or sym.kind == .data) {
+            if (self.entries.get(name)) |existing| {
+                if (existing.kind == .label or existing.kind == .data) {
+                    return error.Duplicate;
+                }
+            }
+        }
+        try self.owned_keys.append(self.allocator, name);
+        try self.entries.put(name, sym);
+    }
+
+    /// Lookup; `null` if not bound.
+    pub fn get(self: SymbolTable, name: []const u8) ?Symbol {
+        return self.entries.get(name);
+    }
+
+    /// Project this table down to a `ConstantTable` so the
+    /// expression evaluator can use it. Keys + values are
+    /// borrowed — the returned table's lifetime is bounded by
+    /// `self`'s. Caller still owns / deinits the returned table.
+    pub fn toConstantTable(self: SymbolTable) !expr.ConstantTable {
+        var out = expr.ConstantTable.init(self.allocator);
+        errdefer out.deinit();
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            try out.put(entry.key_ptr.*, entry.value_ptr.value);
+        }
+        return out;
+    }
+};

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -1,0 +1,285 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+/// Assemble `source` end-to-end and return both the parse tree
+/// and codegen output. Tests deinit both.
+const Output = struct {
+    pt: gero.asm_.ParseTree,
+    cg: gero.asm_.Codegen,
+
+    fn deinit(self: *Output) void {
+        self.cg.deinit();
+        self.pt.deinit();
+    }
+
+    /// Slice into the codegen image, excluding the 16-byte header.
+    fn imageBody(self: Output) []const u8 {
+        return self.cg.image[16..];
+    }
+};
+
+fn assemble(source: []const u8, opts: gero.asm_.CodegenOptions) !Output {
+    var pt = try gero.asm_.parse(alloc, source);
+    errdefer pt.deinit();
+    const cg = try gero.asm_.assemble(alloc, source, pt, opts);
+    return .{ .pt = pt, .cg = cg };
+}
+
+// ---------- single-instruction smokes ----------
+
+test "codegen: bare hlt emits one 0xFF byte" {
+    var out = try assemble("hlt\n", .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    try std.testing.expectEqualSlices(u8, &.{0xFF}, out.imageBody());
+}
+
+test "codegen: nop emits 0x91" {
+    var out = try assemble("nop\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqualSlices(u8, &.{0x91}, out.imageBody());
+}
+
+test "codegen: mov imm16, reg → 0x10 LE imm reg" {
+    // r1 has reg-index 0x02.
+    var out = try assemble("mov $ABCD, r1\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqualSlices(u8, &.{ 0x10, 0xCD, 0xAB, 0x02 }, out.imageBody());
+}
+
+test "codegen: mov reg, reg → 0x11 dst src" {
+    var out = try assemble("mov r1, r2\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqualSlices(u8, &.{ 0x11, 0x02, 0x03 }, out.imageBody());
+}
+
+test "codegen: inc reg → 0x48 reg" {
+    var out = try assemble("inc r1\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqualSlices(u8, &.{ 0x48, 0x02 }, out.imageBody());
+}
+
+test "codegen: cmp reg, imm16 → 0x60 reg imm_lo imm_hi" {
+    var out = try assemble("cmp r1, $0010\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqualSlices(u8, &.{ 0x60, 0x02, 0x10, 0x00 }, out.imageBody());
+}
+
+// ---------- the §7 worked example ----------
+
+test "codegen: §7 worked example assembles to the spec'd 14 bytes" {
+    // Source from docs/asm.md §7 (count-up loop).
+    const src =
+        \\const TARGET = $10
+        \\
+        \\start:
+        \\  mov $00, r1
+        \\loop:
+        \\  inc r1
+        \\  cmp r1, TARGET
+        \\  jne loop
+        \\  hlt
+        \\
+    ;
+    var out = try assemble(src, .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+
+    // Documented bytecode at 0x0000:
+    //   10 00 00 02            mov $0000, r1
+    //   48 02                  inc r1                (loop: at 0x0004)
+    //   60 02 10 00            cmp r1, $0010
+    //   73 04 00               jne &0004
+    //   FF                     hlt
+    const expected = [_]u8{
+        0x10, 0x00, 0x00, 0x02,
+        0x48, 0x02, 0x60, 0x02,
+        0x10, 0x00, 0x73, 0x04,
+        0x00, 0xFF,
+    };
+    try std.testing.expectEqualSlices(u8, &expected, out.imageBody());
+}
+
+// ---------- forward references ----------
+
+test "codegen: forward label reference resolves" {
+    var out = try assemble(
+        \\jmp end
+        \\hlt
+        \\end:
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    // jmp Addr = opcode 0x70 + addr LE. `end` is at offset 4
+    // (jmp = 3 bytes, hlt = 1 byte). Encoding: 70 04 00.
+    try std.testing.expectEqualSlices(u8, &.{ 0x70, 0x04, 0x00, 0xFF, 0xFF }, out.imageBody());
+}
+
+// ---------- data directives ----------
+
+test "codegen: data8 with hex values emits raw bytes" {
+    var out = try assemble("data8 row = $01, $02, $03\n", .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    try std.testing.expectEqualSlices(u8, &.{ 0x01, 0x02, 0x03 }, out.imageBody());
+}
+
+test "codegen: data8 with string literal decodes escapes" {
+    var out = try assemble("data8 greet = \"Hi\\n\"\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqualSlices(u8, &.{ 'H', 'i', 0x0A }, out.imageBody());
+}
+
+test "codegen: data8 with reserve emits zero bytes" {
+    var out = try assemble("data8 buf = reserve $04\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0, 0 }, out.imageBody());
+}
+
+test "codegen: data16 emits LE words" {
+    var out = try assemble("data16 ws = $1234, $ABCD\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqualSlices(u8, &.{ 0x34, 0x12, 0xCD, 0xAB }, out.imageBody());
+}
+
+// ---------- org + zero-padding ----------
+
+test "codegen: org advances cursor and zero-pads the gap" {
+    var out = try assemble(
+        \\hlt
+        \\org $0004
+        \\hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    try std.testing.expectEqualSlices(u8, &.{ 0xFF, 0, 0, 0, 0xFF }, out.imageBody());
+}
+
+test "codegen: backward org raises E014-shape" {
+    var out = try assemble(
+        \\org $0010
+        \\hlt
+        \\org $0005
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var saw_backward = false;
+    for (out.cg.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "backward `org`") != null) saw_backward = true;
+    }
+    try std.testing.expect(saw_backward);
+}
+
+// ---------- header ----------
+
+test "codegen: header magic + version + entry_point + image_size" {
+    var out = try assemble("hlt\n", .{ .entry_point = 0x1100 });
+    defer out.deinit();
+    // Magic "GERO".
+    try std.testing.expectEqualSlices(u8, "GERO", out.cg.image[0..4]);
+    // Version = 0x0001 LE.
+    try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[4]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[5]);
+    // Entry point = 0x1100 LE.
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[8]);
+    try std.testing.expectEqual(@as(u8, 0x11), out.cg.image[9]);
+    // Image size = 1 byte (just the hlt).
+    try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[10]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[11]);
+    // bank_count = 0, sram_bank_count = 0.
+    try std.testing.expectEqual(@as(u8, 0), out.cg.image[12]);
+    try std.testing.expectEqual(@as(u8, 0), out.cg.image[13]);
+}
+
+// ---------- errors ----------
+
+test "codegen: duplicate label raises E005-shape" {
+    var out = try assemble(
+        \\foo:
+        \\foo:
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var saw_dup = false;
+    for (out.cg.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "duplicate label") != null) saw_dup = true;
+    }
+    try std.testing.expect(saw_dup);
+}
+
+test "codegen: undefined symbol in operand raises E004-shape" {
+    var out = try assemble("jmp nowhere\n", .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var saw_undefined = false;
+    for (out.cg.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "undefined symbol") != null) saw_undefined = true;
+    }
+    try std.testing.expect(saw_undefined);
+}
+
+test "codegen: unknown mnemonic raises E001-shape" {
+    var out = try assemble("foobar r1\n", .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var saw_unknown = false;
+    for (out.cg.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "unknown mnemonic") != null) saw_unknown = true;
+    }
+    try std.testing.expect(saw_unknown);
+}
+
+test "codegen: mnemonic with wrong operand shape raises E003-shape" {
+    // `add` has Imm16,Reg / Reg,Reg / Reg forms. `add addr, addr`
+    // doesn't match anything.
+    var out = try assemble("add &1000, &2000\n", .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var saw_mismatch = false;
+    for (out.cg.errors) |e| {
+        if (std.mem.indexOf(u8, e.parse_error.message, "operand type mismatch") != null) saw_mismatch = true;
+    }
+    try std.testing.expect(saw_mismatch);
+}
+
+// ---------- symbol table sanity ----------
+
+test "codegen: symbol table records labels at their addresses" {
+    var out = try assemble(
+        \\start:
+        \\  hlt
+        \\after:
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    const start = out.cg.symbols.get("start") orelse return error.SymbolMissing;
+    const after = out.cg.symbols.get("after") orelse return error.SymbolMissing;
+    try std.testing.expectEqual(@as(u16, 0x0000), start.value);
+    try std.testing.expectEqual(@as(u16, 0x0001), after.value);
+}
+
+test "codegen: symbol table records const + data + struct entries" {
+    var out = try assemble(
+        \\const N = $42
+        \\data8 buf = $01, $02
+        \\struct Player { hp: u16, mp: u16 }
+        \\hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    try std.testing.expectEqual(@as(u16, 0x42), out.cg.symbols.get("N").?.value);
+    try std.testing.expectEqual(@as(u16, 0x00), out.cg.symbols.get("buf").?.value);
+    try std.testing.expectEqual(@as(u16, 0x00), out.cg.symbols.get("Player.hp").?.value);
+    try std.testing.expectEqual(@as(u16, 0x02), out.cg.symbols.get("Player.mp").?.value);
+}

--- a/tests/asm/opcode_resolver.test.zig
+++ b/tests/asm/opcode_resolver.test.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+// The opcode resolver isn't directly re-exported through
+// `gero.asm_` since it's an implementation detail of codegen.
+// We exercise it indirectly via codegen — but the smoke tests
+// here verify a few intrinsic invariants of the table that
+// would otherwise require cross-file coverage to reveal.
+
+test "opres: mov reg,reg resolves to opcode 0x11" {
+    // Indirect proxy via codegen: assemble `mov r1, r2` and check
+    // the first byte of the body is 0x11.
+    var pt = try gero.asm_.parse(alloc, "mov r1, r2\n");
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, "mov r1, r2\n", pt, .{});
+    defer cg.deinit();
+    try std.testing.expect(!cg.hasErrors());
+    try std.testing.expectEqual(@as(u8, 0x11), cg.image[16]); // skip header
+}
+
+test "opres: hlt resolves to 0xFF (zero-operand sentinel)" {
+    var pt = try gero.asm_.parse(alloc, "hlt\n");
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, "hlt\n", pt, .{});
+    defer cg.deinit();
+    try std.testing.expectEqual(@as(u8, 0xFF), cg.image[16]);
+}
+
+test "opres: cmp reg, label_ref(const) uses imm16 form (0x60)" {
+    // `TARGET` is a const → label_ref resolves to imm16, picking
+    // 0x60 (cmp Reg, Imm16) over a hypothetical addr form.
+    const src =
+        \\const TARGET = $10
+        \\cmp r1, TARGET
+        \\
+    ;
+    var pt = try gero.asm_.parse(alloc, src);
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    defer cg.deinit();
+    try std.testing.expect(!cg.hasErrors());
+    try std.testing.expectEqual(@as(u8, 0x60), cg.image[16]);
+}
+
+test "opres: jmp label_ref(label) uses addr form (0x70)" {
+    const src =
+        \\target:
+        \\  hlt
+        \\jmp target
+        \\
+    ;
+    var pt = try gero.asm_.parse(alloc, src);
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    defer cg.deinit();
+    try std.testing.expect(!cg.hasErrors());
+    // image: hlt(0xFF) then jmp(0x70) + addr LE(00 00)
+    try std.testing.expectEqual(@as(u8, 0xFF), cg.image[16]);
+    try std.testing.expectEqual(@as(u8, 0x70), cg.image[17]);
+}
+
+test "opres: indexed addressing emits 3-byte operand (addr + reg)" {
+    const src = "mov [&2620 + r1], r2\n";
+    var pt = try gero.asm_.parse(alloc, src);
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    defer cg.deinit();
+    try std.testing.expect(!cg.hasErrors());
+    // 0x17 + addr LE (20 26) + idx_reg (r1 = 0x02) + dst_reg (r2 = 0x03)
+    try std.testing.expectEqualSlices(u8, &.{ 0x17, 0x20, 0x26, 0x02, 0x03 }, cg.image[16..]);
+}

--- a/tests/asm/symtab.test.zig
+++ b/tests/asm/symtab.test.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+test "symtab: empty table starts empty" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    try std.testing.expect(st.get("nope") == null);
+}
+
+test "symtab: putBorrowed + get round-trips" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    try st.putBorrowed("start", .{ .kind = .label, .value = 0x1100 });
+    const sym = st.get("start").?;
+    try std.testing.expectEqual(gero.asm_.SymbolKind.label, sym.kind);
+    try std.testing.expectEqual(@as(u16, 0x1100), sym.value);
+}
+
+test "symtab: duplicate label triggers error.Duplicate" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    try st.putBorrowed("foo", .{ .kind = .label, .value = 0x10 });
+    try std.testing.expectError(
+        error.Duplicate,
+        st.putBorrowed("foo", .{ .kind = .label, .value = 0x20 }),
+    );
+}
+
+test "symtab: duplicate data also triggers Duplicate" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    try st.putBorrowed("buf", .{ .kind = .data, .value = 0x10 });
+    try std.testing.expectError(
+        error.Duplicate,
+        st.putBorrowed("buf", .{ .kind = .data, .value = 0x20 }),
+    );
+}
+
+test "symtab: const_value silently overwrites" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    try st.putBorrowed("N", .{ .kind = .const_value, .value = 1 });
+    try st.putBorrowed("N", .{ .kind = .const_value, .value = 2 });
+    try std.testing.expectEqual(@as(u16, 2), st.get("N").?.value);
+}
+
+test "symtab: putOwned owns the key memory" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    const owned = try alloc.dupe(u8, "Player.hp");
+    try st.putOwned(owned, .{ .kind = .struct_field, .value = 0 });
+    try std.testing.expectEqual(@as(u16, 0), st.get("Player.hp").?.value);
+    // Cleanup via st.deinit() frees the owned key — no leak.
+}
+
+test "symtab: toConstantTable projects to expr.ConstantTable" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    try st.putBorrowed("start", .{ .kind = .label, .value = 0x1100 });
+    try st.putBorrowed("N", .{ .kind = .const_value, .value = 0x42 });
+
+    var ct = try st.toConstantTable();
+    defer ct.deinit();
+    try std.testing.expectEqual(@as(u16, 0x1100), ct.get("start").?);
+    try std.testing.expectEqual(@as(u16, 0x42), ct.get("N").?);
+}


### PR DESCRIPTION
## Summary

**Closes #35 + #36.** With this PR \`gero asm program.gas\` produces a runnable \`.gx\` end-to-end — the assembler is functionally complete for asm spec v0.1.

## Three new modules

\`\`\`
src/asm/symtab.zig          — SymbolTable (name → kind + u16 value)
src/asm/opcode_resolver.zig — mnemonic + operand-kinds → opcode byte + size
src/asm/codegen.zig         — two-pass orchestration + .gx header emit
\`\`\`

## Two-pass model

| Pass | Job |
|---|---|
| **1 — layout** | Walk statements, compute sizes, populate label / data / const addresses in \`SymbolTable\`. \`org\` adjusts the cursor; backward \`org\` raises E014. Duplicate labels raise E005. |
| **2 — emit** | Walk statements again, emit bytes against the populated table. Forward references resolve cleanly. Undefined symbols raise E004; unknown mnemonics E001; operand-shape mismatches E003. |

\`.gx\` header per ISA §7.1: magic + version + flags + entry_point + image_size + bank_count + sram_bank_count + reserved.

## Operand classification subtlety

A bare identifier (\`label_ref\`) can resolve to a \`const\` (encodes as \`imm16\`) or a label/data symbol (encodes as \`addr\`). The classifier consults the \`SymbolTable\` so:

\`\`\`asm
const TARGET = \$10
cmp r1, TARGET     ; → 0x60 (cmp Reg, Imm16) — TARGET is a const

target:
jmp target         ; → 0x70 (jmp Addr) — target is a label
\`\`\`

Same source shape, different opcodes. The codegen passes the symbol table to both layout and emit classification so this disambiguation works in both directions.

## Public API

Re-exported via \`gero.asm_\`:
- \`SymbolTable\`, \`Symbol\`, \`SymbolKind\`
- \`Codegen\`, \`CodegenOptions\`, \`assemble\`

## Tests (32 new cases)

**\`tests/asm/codegen.test.zig\` — 20 cases:**

- Single-instruction smokes: \`hlt\`, \`nop\`, \`mov\` variants, \`inc\`, \`cmp\`
- **Worked example §7** (count-up loop): assembles to the exact 14 documented bytes
- Forward references resolve
- \`data8\` / \`data16\` emit raw bytes + decoded strings + reserve
- \`org\` zero-pads forward gaps; backward \`org\` errors
- Header magic / version / entry_point / image_size / bank counts
- Errors: duplicate label, undefined symbol, unknown mnemonic, operand mismatch
- Symbol table records const + data + struct entries

**Mirror tests** (\`tests/asm/symtab.test.zig\` — 7 + \`tests/asm/opcode_resolver.test.zig\` — 5):
- SymbolTable round-trip / duplicate / overwrite semantics
- Operand classification edge cases (const-vs-label disambiguation, indexed encoding)

## Test plan

- [x] \`zig build ci\` clean — 1828 tests across 4 release modes + cross-target
- [x] §7 worked example produces the exact spec'd 14 bytes
- [x] Self-review walk: every new \`pub\` decl has a doc comment, every \`@as\` has an \`// @as:\` justification, no AI attribution, no leaks under debug allocator

## Deferred to follow-ups

- **ZP-form auto-selection** (\`mov Imm16, ZP\` etc.) — today every address operand uses the 16-bit \`addr\` encoding. ZP optimization can be added as a peephole pass without breaking anything.
- **Bank + SRAM emission** — header writes \`bank_count = 0\`, \`sram_bank_count = 0\`. Real banking lands when there's a banked program to test against.
- **Debug symbol section** — optional per spec §7.1; v0.1 strips them.
- **Indexed-store form** — only indexed-LOAD (opcode 0x17) exists in the ISA today. \`mov reg, [&addr + reg]\` (store direction) errors out cleanly. ISA gap to fix later.
- **E001-E016 error codes** — today we surface plain diagnostic messages. #37 will format them as the structured E-codes from spec §8.

## What this completes

| Phase 2 issue | Status |
|---|---|
| #31 knit dep + smoke | ✅ merged |
| #32 lexer | ✅ merged |
| #33 directives | ✅ merged |
| #34 instructions + operands | ✅ merged |
| **#35 symbol table** | ✅ **this PR** |
| **#36 codegen** | ✅ **this PR** |
| #37 error formatting | pending |
| #73, #76, #77 misc | ✅ all merged |

After #37 the asm + lexer + parser + codegen + diagnostics surface is fully spec'd at v0.1.