### PR TITLE
feat(cli): gero asm subcommand + imm8 narrowing

### DIFF
--- a/.changeset/b9k74u02.md
+++ b/.changeset/b9k74u02.md
@@ -1,0 +1,41 @@
+---
+bump: minor
+---
+
+Wire up `gero asm` and unblock the imm8-only opcode subset — closes #43.
+
+**`gero asm <file.gas>`** (`apps/gero-cli/asm.zig`):
+- Drives the assembler end-to-end via `resolveIncludes` + `parse` +
+  `assemble`, prints diagnostics with `formatPretty` (caret snippets).
+- Default output `<basename>.gx` next to the source.
+- `-o <dir>/` or `--out=<dir>/` redirects into a directory.
+- `-o <file>` writes verbatim to that path.
+- `--quiet` suppresses the `(N bytes, M banks, debug: yes/no)` summary.
+- Exit codes per cli.md §3.1: `0` success, `3` parse/assembly error,
+  `1` host IO error, `2` missing argument.
+
+**`imm8` narrowing in `src/asm/`** — prerequisite caught by the
+end-to-end smoke: opcodes that only accept `Imm8` (`int`, `shl/shr/
+rol/ror`, `mov8`, `jr`) couldn't assemble before because the
+classifier always returned `.imm16` for hex literals.
+
+- `codegen` now folds every `.immediate` operand at classify time
+  (both layout and emit passes) and returns `.imm8` when the value
+  fits in `u8`, `.imm16` otherwise. Forward refs that don't fold
+  keep the wider `.imm16`.
+- `opres.resolve` adds a second pass that allows `.imm8 → .imm16`
+  widening when no exact match exists. Narrowing in the other
+  direction is never attempted.
+- `Resolution` carries the matched shape's `kinds`, so the emit pass
+  knows the on-wire width even when widening picked a wider shape.
+
+**Tests** (5 new in `tests/asm/`):
+- `int $10` produces `[0xFC, 0x10]` (1-byte imm8 operand).
+- `shl r1, $03` uses the imm8 shape `[0x58, reg, imm8]`.
+- `mov $00, r1` still widens to imm16 form `[0x10, lo, hi, reg]`.
+- `int $1234` errors with E003 (no imm16 form of `int` exists).
+- `mov8 $42, r1` resolves to the imm8 shape directly.
+
+Plus 4 unit tests for `gxBasename` + `endsWithSep` helpers in
+`apps/gero-cli/asm.zig` (wired into `zig build test` as
+`test-cli-asm`).

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -1,0 +1,155 @@
+/// `gero asm` — drive the assembler from a `.gas` source file
+/// down to a `.gx` image on disk. Includes are resolved through
+/// `gero.asm_.resolveIncludes`; parse + codegen run end-to-end;
+/// diagnostics print with caret snippets via `formatPretty`.
+///
+/// Exit code per cli.md §3.1: `0` on success, `3` on parse /
+/// assembly error, `1` on host IO problems.
+const std = @import("std");
+const gero = @import("gero");
+const cli = @import("cli.zig");
+const term_mod = @import("term.zig");
+
+/// Run the full `gero asm` flow against `opts.positional()[0]`.
+/// Caller owns `arena`; everything we allocate is short-lived.
+pub fn execute(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+) !u8 {
+    const positionals = opts.positional();
+    if (positionals.len < 1) {
+        try term.err("gero asm: missing .gas file path", .{});
+        return 2;
+    }
+    const src_path = positionals[0];
+
+    var fused = gero.asm_.resolveIncludes(io, arena, src_path) catch |err| {
+        try term.err("gero asm: cannot read {s} ({s})", .{ src_path, @errorName(err) });
+        return 1;
+    };
+    defer fused.deinit();
+
+    if (fused.errors.len > 0) {
+        try printDiagnostics(stdout, fused.source_map, fused.errors);
+        return 3;
+    }
+
+    var pt = try gero.asm_.parse(arena, fused.source);
+    defer pt.deinit();
+    if (pt.hasErrors()) {
+        try printDiagnostics(stdout, fused.source_map, pt.errors);
+        return 3;
+    }
+
+    var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
+    defer cg.deinit();
+    if (cg.hasErrors()) {
+        try printDiagnostics(stdout, fused.source_map, cg.errors);
+        return 3;
+    }
+
+    const out_path = try resolveOutputPath(io, arena, src_path, opts.out);
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = out_path, .data = cg.image }) catch |err| {
+        try term.err("gero asm: cannot write {s} ({s})", .{ out_path, @errorName(err) });
+        return 1;
+    };
+
+    if (!opts.quiet) {
+        const loaded = gero.vm.parseGx(cg.image) catch unreachable; // allow-strict: codegen just emitted these bytes — they're well-formed by construction
+        try stdout.print("{s} ({d} bytes, {d} banks, debug: {s})\n", .{
+            out_path,
+            cg.image.len,
+            loaded.header.bank_count,
+            if (loaded.header.hasDebugSymbols()) "yes" else "no",
+        });
+    }
+
+    return 0;
+}
+
+/// Pretty-print every diagnostic against the fused-source map.
+fn printDiagnostics(
+    stdout: *std.Io.Writer,
+    source_map: gero.asm_.SourceMap,
+    errors: []const gero.asm_.Diagnostic,
+) !void {
+    for (errors) |d| try gero.asm_.formatPretty(stdout, source_map, d);
+}
+
+/// Resolve the `.gx` output path from `--out` plus the source.
+/// `--out` may be unset (defaults to `<basename>.gx` next to the
+/// source), an existing directory (`<dir>/<basename>.gx`), or a
+/// concrete file path (used verbatim, duped into `arena`).
+fn resolveOutputPath(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    src_path: []const u8,
+    out_opt: ?[]const u8,
+) ![]const u8 {
+    const base = try gxBasename(arena, src_path);
+    if (out_opt) |out| {
+        if (isDirLike(io, out)) {
+            return std.fs.path.join(arena, &.{ out, base });
+        }
+        return arena.dupe(u8, out);
+    }
+    const dir = std.fs.path.dirname(src_path) orelse "";
+    if (dir.len == 0) return base;
+    return std.fs.path.join(arena, &.{ dir, base });
+}
+
+/// `foo/bar.gas` → owned `"bar.gx"`. If the input already ends
+/// in `.gx` we keep its basename; otherwise we strip whatever
+/// extension is there and append `.gx`.
+fn gxBasename(arena: std.mem.Allocator, src_path: []const u8) ![]const u8 {
+    const file = std.fs.path.basename(src_path);
+    if (std.mem.endsWith(u8, file, ".gx")) return arena.dupe(u8, file);
+    const stem = if (std.mem.lastIndexOfScalar(u8, file, '.')) |dot| file[0..dot] else file;
+    return std.fmt.allocPrint(arena, "{s}.gx", .{stem});
+}
+
+/// True when `path` resolves to a directory on disk, or syntactically
+/// ends with a path separator (covers the `-o build/` shape even
+/// when `build/` doesn't exist yet — though we don't auto-create).
+fn isDirLike(io: std.Io, path: []const u8) bool {
+    if (endsWithSep(path)) return true;
+    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch return false;
+    return stat.kind == .directory;
+}
+
+/// Trailing-separator check pulled out for unit testability — the
+/// stat path needs real IO so we can't cover it in pure tests.
+fn endsWithSep(path: []const u8) bool {
+    return path.len > 0 and (path[path.len - 1] == '/' or path[path.len - 1] == std.fs.path.sep);
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "asm: gxBasename drops directory + swaps extension" {
+    const out = try gxBasename(testing.allocator, "src/foo.gas");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("foo.gx", out);
+}
+
+test "asm: gxBasename keeps an existing .gx basename verbatim" {
+    const out = try gxBasename(testing.allocator, "build/foo.gx");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("foo.gx", out);
+}
+
+test "asm: gxBasename appends .gx when no extension is present" {
+    const out = try gxBasename(testing.allocator, "noext");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("noext.gx", out);
+}
+
+test "asm: endsWithSep recognizes trailing slash" {
+    try testing.expect(endsWithSep("build/"));
+    try testing.expect(!endsWithSep("build"));
+    try testing.expect(!endsWithSep(""));
+}

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -6,6 +6,7 @@ const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const run_cmd = @import("run.zig");
 const info_cmd = @import("info.zig");
+const asm_cmd = @import("asm.zig");
 
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
@@ -55,6 +56,7 @@ pub fn main(init: std.process.Init) !u8 {
     }
 
     return switch (cmd) {
+        .asm_ => asm_cmd.execute(io, arena, parsed.options, stdout, &term),
         .run => runDispatch(io, arena, parsed.options, stdout, &term),
         .info => infoDispatch(io, arena, parsed.options, stdout, &term),
         else => blk: {

--- a/build.zig
+++ b/build.zig
@@ -75,6 +75,16 @@ pub fn build(b: *std.Build) void {
         .name = "test-cli-info",
         .root_module = info_mod,
     });
+    const asm_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/asm.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    asm_mod.addImport("gero", gero_mod);
+    const asm_test = b.addTest(.{
+        .name = "test-cli-asm",
+        .root_module = asm_mod,
+    });
 
     // ----- Format ----------------------------------------------------------
 
@@ -105,6 +115,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(run_cmd_test).step);
     test_step.dependOn(&b.addRunArtifact(term_test).step);
     test_step.dependOn(&b.addRunArtifact(info_test).step);
+    test_step.dependOn(&b.addRunArtifact(asm_test).step);
     for (test_files) |rel| {
         const t = makeTest(b, gero_mod, rel, target, optimize);
         test_step.dependOn(&b.addRunArtifact(t).step);

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -111,6 +111,7 @@ pub fn assemble(
 fn classifyForLayout(op: ast.Operand, source: []const u8, symbols: symtab.SymbolTable) opres.Kind {
     return switch (op) {
         .label_ref => |l| opres.labelRefKind(source[l.span.start..l.span.end], symbols),
+        .immediate => |e| narrowImm(e, source, symbols),
         else => opres.classify(op, null),
     };
 }
@@ -121,7 +122,21 @@ fn classifyForLayout(op: ast.Operand, source: []const u8, symbols: symtab.Symbol
 fn classifyForEmit(op: ast.Operand, source: []const u8, symbols: symtab.SymbolTable) opres.Kind {
     return switch (op) {
         .label_ref => |l| opres.labelRefKind(source[l.span.start..l.span.end], symbols),
+        .immediate => |e| narrowImm(e, source, symbols),
         else => opres.classify(op, null),
+    };
+}
+
+/// Pick the narrowest immediate kind that fits the folded value.
+/// Forward refs (anything that doesn't fold) keep the wider
+/// `.imm16` so layout sizing stays safe; `resolve()`'s widening
+/// pass picks up the wider shape if no `.imm8` form exists.
+fn narrowImm(e: *ast.Expr, source: []const u8, symbols: symtab.SymbolTable) opres.Kind {
+    var consts = symbols.toConstantTable() catch return .imm16;
+    defer consts.deinit();
+    return switch (expr.evalExpr(e, source, consts)) {
+        .ok => |v| if (v <= 0xFF) .imm8 else .imm16,
+        .err => .imm16,
     };
 }
 
@@ -471,7 +486,7 @@ fn emitInstruction(
 
     try image.append(allocator, res.opcode);
 
-    for (inst.operands) |op| switch (op) {
+    for (inst.operands, 0..) |op, op_idx| switch (op) {
         .register => |r| try image.append(allocator, @intFromEnum(r.id)),
         .immediate => |e| {
             const result = expr.evalExpr(e, source, consts);
@@ -482,7 +497,10 @@ fn emitInstruction(
                     break :blk 0;
                 },
             };
-            try emitValue(allocator, image, val, 2);
+            // Resolved shape decides the on-wire width: imm8 → 1 byte,
+            // imm16 → 2 bytes (default).
+            const width: u32 = if (res.kinds[op_idx] == .imm8) 1 else 2;
+            try emitValue(allocator, image, val, width);
         },
         .addr_lit => |a| try emitValue(allocator, image, a.value, 2),
         .sym_ref => |s| try emitSymRef(allocator, image, errors, source, s, consts),

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -218,18 +218,29 @@ pub fn labelRefKind(name: []const u8, symbols: symtab.SymbolTable) Kind {
     return .addr;
 }
 
-/// Result of `resolve` — the opcode byte plus the total encoded
-/// instruction size (1 byte for the opcode + sum of operand widths).
+/// Result of `resolve` — the opcode byte, total encoded size
+/// (1 byte for the opcode + sum of operand widths), and the
+/// matched shape's kinds so emit can write each operand at the
+/// canonical width even when widening kicked in.
 pub const Resolution = struct {
     opcode: u8,
     size: u8,
+    /// The matched shape's kinds. May differ from the caller's
+    /// kinds when an `.imm8` user-kind widened to `.imm16` to
+    /// match a shape that only has the wider form.
+    kinds: []const Kind,
 };
 
 /// Resolve an instruction's mnemonic + operand kinds to an
-/// opcode. Returns `null` if no matching shape exists — the
-/// caller surfaces `E001` (unknown mnemonic) or `E003` (operand
-/// type mismatch) as appropriate.
+/// opcode. Tries exact match first; if none, retries with each
+/// user-side `.imm8` widened to `.imm16` (safe — every `Imm8`
+/// value fits in `Imm16`). Narrowing in the other direction is
+/// never attempted — a caller-supplied `.imm16` only matches a
+/// shape's `.imm16`. Returns `null` if no matching shape exists —
+/// the caller surfaces `E001` (unknown mnemonic) or `E003`
+/// (operand type mismatch) as appropriate.
 pub fn resolve(mnemonic: []const u8, kinds: []const Kind) ?Resolution {
+    // Pass 1: exact match.
     for (shapes) |s| {
         if (!std.mem.eql(u8, s.mnemonic, mnemonic)) continue;
         if (s.kinds.len != kinds.len) continue;
@@ -240,13 +251,28 @@ pub fn resolve(mnemonic: []const u8, kinds: []const Kind) ?Resolution {
                 break;
             }
         }
-        if (match) {
-            var size: u8 = 1;
-            for (s.kinds) |k| size += k.width();
-            return .{ .opcode = s.opcode, .size = size };
+        if (match) return resolutionFor(s);
+    }
+    // Pass 2: allow `.imm8` → `.imm16` widening at each position.
+    for (shapes) |s| {
+        if (!std.mem.eql(u8, s.mnemonic, mnemonic)) continue;
+        if (s.kinds.len != kinds.len) continue;
+        var match = true;
+        for (s.kinds, kinds) |a, b| {
+            if (a == b) continue;
+            if (a == .imm16 and b == .imm8) continue;
+            match = false;
+            break;
         }
+        if (match) return resolutionFor(s);
     }
     return null;
+}
+
+fn resolutionFor(s: Shape) Resolution {
+    var size: u8 = 1;
+    for (s.kinds) |k| size += k.width();
+    return .{ .opcode = s.opcode, .size = size, .kinds = s.kinds };
 }
 
 /// Check whether `mnemonic` is in the table at all (regardless

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -67,6 +67,40 @@ test "codegen: cmp reg, imm16 → 0x60 reg imm_lo imm_hi" {
     try std.testing.expectEqualSlices(u8, &.{ 0x60, 0x02, 0x10, 0x00 }, out.imageBody());
 }
 
+test "codegen: int $10 narrows to 1-byte imm8 operand (0xFC 0x10)" {
+    var out = try assemble("int $10\n", .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    try std.testing.expectEqualSlices(u8, &.{ 0xFC, 0x10 }, out.imageBody());
+}
+
+test "codegen: shl r1, $03 uses imm8 shape (0x58 reg imm8)" {
+    var out = try assemble("shl r1, $03\n", .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    try std.testing.expectEqualSlices(u8, &.{ 0x58, 0x02, 0x03 }, out.imageBody());
+}
+
+test "codegen: mov $00, r1 widens imm8 → imm16 (4 bytes, not 3)" {
+    var out = try assemble("mov $00, r1\n", .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    // mov has no Imm8,Reg shape — only Imm16,Reg. Widening picks
+    // 0x10 with 2-byte LE imm + reg.
+    try std.testing.expectEqualSlices(u8, &.{ 0x10, 0x00, 0x00, 0x02 }, out.imageBody());
+}
+
+test "codegen: int $1234 errors — imm16 won't narrow to imm8 shape" {
+    var out = try assemble("int $1234\n", .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var saw_mismatch = false;
+    for (out.cg.errors) |e| {
+        if (e.code == .operand_type_mismatch) saw_mismatch = true;
+    }
+    try std.testing.expect(saw_mismatch);
+}
+
 // ---------- the §7 worked example ----------
 
 test "codegen: §7 worked example assembles to the spec'd 14 bytes" {

--- a/tests/asm/opcode_resolver.test.zig
+++ b/tests/asm/opcode_resolver.test.zig
@@ -71,3 +71,15 @@ test "opres: indexed addressing emits 3-byte operand (addr + reg)" {
     // 0x17 + addr LE (20 26) + idx_reg (r1 = 0x02) + dst_reg (r2 = 0x03)
     try std.testing.expectEqualSlices(u8, &.{ 0x17, 0x20, 0x26, 0x02, 0x03 }, cg.image[16..]);
 }
+
+test "opres: imm8 narrowing — mov8 picks Imm8 shape over widening" {
+    // `mov8 $42, r1` — value fits u8, mov8 has an Imm8,Reg shape
+    // exactly. Total 3 bytes: opcode + imm8 + reg.
+    const src = "mov8 $42, r1\n";
+    var pt = try gero.asm_.parse(alloc, src);
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    defer cg.deinit();
+    try std.testing.expect(!cg.hasErrors());
+    try std.testing.expectEqualSlices(u8, &.{ 0x21, 0x42, 0x02 }, cg.image[16..]);
+}


### PR DESCRIPTION
## Summary

Wires `gero asm <file.gas>` end-to-end per cli.md §3.1, and fixes a real-codegen bug surfaced by the smoke test (no imm8-only opcode was assemblable).

- **Commit 1 — `feat(asm): imm8 narrowing`**: classify every immediate at codegen time; if it folds and fits in `u8` return `.imm8`, else `.imm16`. `resolve()` adds a second pass allowing `.imm8 → .imm16` widening; `Resolution` carries the matched shape's kinds so emit knows the on-wire width.
- **Commit 2 — `feat(cli): gero asm`**: full asm flow + caret-style diagnostics + `-o <dir>/` and `-o <file>` output redirects + `--quiet`. Exit codes per spec (`0`/`1`/`2`/`3`).

## Real-conditions smoke

```bash
$ cat > /tmp/hello.gas <<'EOF2'
mov \$48, r1
int \$10
mov \$69, r1
int \$10
mov \$0A, r1
int \$10
hlt
EOF2

$ gero asm /tmp/hello.gas
/tmp/hello.gx (35 bytes, 0 banks, debug: no)

$ gero info /tmp/hello.gx
file:    /tmp/hello.gx
size:    35 bytes
...
debug:   no

$ gero run /tmp/hello.gx
Hi
```

Error path:

```
$ gero asm broken.gas
broken.gas:2:5: [E004] undefined symbol
   2 | jmp nowhere
     |     ^
[exit=3]
```

## Test plan
- [x] `zig build ci` green
- [x] 5 new codegen tests for imm8 narrowing (int / shl / mov widening / int overflow / mov8)
- [x] 4 new unit tests for `gxBasename` + `endsWithSep` in the CLI module
- [x] Manual smoke: `gero asm` → `gero info` → `gero run` prints `Hi\n`
- [x] `-o build/` and `-o build/named.gx` both produce the expected files
- [x] Error path: undefined symbol shows caret + `[E004]` + exit 3

Closes #43.