### PR TITLE
fix: kitchen-sink gap fixes — closes #92

### DIFF
--- a/.changeset/c2m83v15.md
+++ b/.changeset/c2m83v15.md
@@ -1,0 +1,32 @@
+---
+bump: minor
+---
+
+Kitchen-sink end-to-end testing surfaced five distinct gaps in v0.1.
+All fixed here — closes #92.
+
+**asm-side:**
+- `int CONST` narrows to imm8 when const value ≤ `0xFF`, same as
+  literal immediates.
+- `main:` label is auto-detected as entry point in the `.gx` header
+  when `Options.entry_point` is null (the new default). Explicit
+  overrides still win.
+- Lexer-level diagnostics (hex overflow, unknown escape, unterminated
+  string, char-literal size) propagate with their `[E006]` / `[E010]`
+  / `[E011]` / `[E016]` codes instead of the generic
+  "expected a hex literal..." fallback.
+- Local labels: `.foo:` declares a sub-label of the most recent
+  global label (mangled to `parent.foo`). `.foo` in operand position
+  resolves the same way. Same local name can recur across distinct
+  global scopes. Local labels with no enclosing global surface E004.
+- The stale "directives + instructions arrive in follow-up PRs"
+  parser message is gone — they're all implemented now.
+
+**vm + isa:**
+- New opcode `0x29 mov8 [Addr + Reg], Reg` for byte-level indexed
+  loads. The existing `0x17 mov` form reads a `u16` word, which is
+  wrong for stepping byte-by-byte through `data8` arrays. Spec
+  table in docs/isa.md gains the new row.
+
+E-code coverage in the formatter is now 12/16 (up from 8). E002,
+E007, E008, E013 remain untagged — orthogonal scope.

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -36,8 +36,9 @@ pub fn execute(
     // full picture in one run. Include errors that can't be
     // recovered from (no fused source = no parse) short-circuit
     // before parse.
+    const style: gero.asm_.Style = if (term.color) .ansi else .plain;
     if (fused.errors.len > 0) {
-        try printDiagnostics(stdout, fused.source_map, fused.errors);
+        try printDiagnostics(stdout, fused.source_map, fused.errors, style);
         return 3;
     }
 
@@ -54,7 +55,7 @@ pub fn execute(
 
     const had_errors = pt.hasErrors() or cg.hasErrors();
     if (had_errors) {
-        try printAllDiagnostics(arena, stdout, fused.source_map, pt.errors, cg.errors);
+        try printAllDiagnostics(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
         return 3;
     }
 
@@ -82,30 +83,78 @@ fn printDiagnostics(
     stdout: *std.Io.Writer,
     source_map: gero.asm_.SourceMap,
     errors: []const gero.asm_.Diagnostic,
+    style: gero.asm_.Style,
 ) !void {
-    for (errors) |d| try gero.asm_.formatPretty(stdout, source_map, d);
+    for (errors) |d| try gero.asm_.formatPretty(stdout, source_map, d, style);
 }
 
-/// Merge parse + codegen diagnostics, sort by fused-source offset
-/// so the user sees errors in source order regardless of which
-/// pass raised them.
+/// Augment each diagnostic with its resolved file path so we can
+/// group + sort by (path, fused_index) — diagnostics from the same
+/// file land in one section, sorted by source position.
+const KeyedDiag = struct {
+    diag: gero.asm_.Diagnostic,
+    path: []const u8,
+};
+
+/// Merge parse + codegen diagnostics, group by file, sort each
+/// group by fused-source offset, print a summary header + one
+/// section per file. `<unknown>` (rare — source-map miss) groups
+/// last under a single bucket.
 fn printAllDiagnostics(
     arena: std.mem.Allocator,
     stdout: *std.Io.Writer,
     source_map: gero.asm_.SourceMap,
     parse_errors: []const gero.asm_.Diagnostic,
     codegen_errors: []const gero.asm_.Diagnostic,
+    style: gero.asm_.Style,
 ) !void {
     const total = parse_errors.len + codegen_errors.len;
-    const all = try arena.alloc(gero.asm_.Diagnostic, total);
-    @memcpy(all[0..parse_errors.len], parse_errors);
-    @memcpy(all[parse_errors.len..], codegen_errors);
-    std.mem.sort(gero.asm_.Diagnostic, all, {}, byIndex);
-    try printDiagnostics(stdout, source_map, all);
+    const keyed = try arena.alloc(KeyedDiag, total);
+    for (parse_errors, 0..) |d, i| keyed[i] = .{ .diag = d, .path = pathOf(source_map, d) };
+    for (codegen_errors, 0..) |d, j| keyed[parse_errors.len + j] = .{ .diag = d, .path = pathOf(source_map, d) };
+    std.mem.sort(KeyedDiag, keyed, {}, byPathThenIndex);
+
+    // Count distinct files for the summary header.
+    var file_count: usize = 0;
+    var prev_path: []const u8 = "";
+    for (keyed) |k| {
+        if (!std.mem.eql(u8, k.path, prev_path)) {
+            file_count += 1;
+            prev_path = k.path;
+        }
+    }
+    try writeSummaryHeader(stdout, style, total, file_count);
+
+    // Emit per-file sections — blank line before each new file.
+    prev_path = "";
+    for (keyed) |k| {
+        if (!std.mem.eql(u8, k.path, prev_path)) {
+            try stdout.writeByte('\n');
+            prev_path = k.path;
+        }
+        try gero.asm_.formatPretty(stdout, source_map, k.diag, style);
+    }
 }
 
-fn byIndex(_: void, a: gero.asm_.Diagnostic, b: gero.asm_.Diagnostic) bool {
-    return a.parse_error.index < b.parse_error.index;
+fn writeSummaryHeader(stdout: *std.Io.Writer, style: gero.asm_.Style, errors: usize, files: usize) !void {
+    const error_noun: []const u8 = if (errors == 1) "error" else "errors";
+    const file_noun: []const u8 = if (files == 1) "file" else "files";
+    // Reuse Style.code for the count label so it pops in red like
+    // the per-line [Exxx] markers.
+    try stdout.print("{s}{d} {s}{s} in {d} {s}\n", .{ style.code, errors, error_noun, style.reset, files, file_noun });
+}
+
+fn pathOf(source_map: gero.asm_.SourceMap, d: gero.asm_.Diagnostic) []const u8 {
+    // @as: ParseError indexes fit in u32 — bounded by max_file_size (16 MiB).
+    const offset: u32 = @as(u32, @intCast(d.parse_error.index));
+    if (source_map.lookup(offset)) |loc| return loc.file.path;
+    return "<unknown>";
+}
+
+fn byPathThenIndex(_: void, a: KeyedDiag, b: KeyedDiag) bool {
+    const path_cmp = std.mem.order(u8, a.path, b.path);
+    if (path_cmp != .eq) return path_cmp == .lt;
+    return a.diag.parse_error.index < b.diag.parse_error.index;
 }
 
 /// Resolve the `.gx` output path from `--out` plus the source.

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -27,11 +27,13 @@ pub fn execute(
     }
     const src_path = positionals[0];
 
+    const t_phase_start_include = std.Io.Timestamp.now(io, .awake);
     var fused = gero.asm_.resolveIncludes(io, arena, src_path) catch |err| {
         try term.err("gero asm: cannot read {s} ({s})", .{ src_path, @errorName(err) });
         return 1;
     };
     defer fused.deinit();
+    const t_after_include = std.Io.Timestamp.now(io, .awake);
 
     // Collect diagnostics across every phase so the user sees the
     // full picture in one run. Include errors that can't be
@@ -51,9 +53,11 @@ pub fn execute(
     // statements still surface in the same run.
     var pt = try gero.asm_.parse(arena, fused.source);
     defer pt.deinit();
+    const t_after_parse = std.Io.Timestamp.now(io, .awake);
 
     var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
     defer cg.deinit();
+    const t_after_codegen = std.Io.Timestamp.now(io, .awake);
 
     const had_errors = pt.hasErrors() or cg.hasErrors();
     if (had_errors) {
@@ -67,6 +71,7 @@ pub fn execute(
         try term.err("gero asm: cannot write {s} ({s})", .{ out_path, @errorName(err) });
         return 1;
     };
+    const t_after_write = std.Io.Timestamp.now(io, .awake);
 
     if (!opts.quiet) {
         const loaded = gero.vm.parseGx(cg.image) catch unreachable; // allow-strict: codegen just emitted these bytes — they're well-formed by construction
@@ -76,10 +81,39 @@ pub fn execute(
             loaded.header.bank_count,
             if (loaded.header.hasDebugSymbols()) "yes" else "no",
         });
+        if (opts.verbose) {
+            try writePhaseTimings(stdout, style, .{
+                .include = t_phase_start_include.durationTo(t_after_include).nanoseconds,
+                .parse = t_after_include.durationTo(t_after_parse).nanoseconds,
+                .codegen = t_after_parse.durationTo(t_after_codegen).nanoseconds,
+                .write = t_after_codegen.durationTo(t_after_write).nanoseconds,
+            });
+        }
         try writeFooter(stdout, io, style, t_start, .ok);
     }
 
     return 0;
+}
+
+const PhaseTimings = struct {
+    include: i96,
+    parse: i96,
+    codegen: i96,
+    write: i96,
+};
+
+fn writePhaseTimings(stdout: *std.Io.Writer, style: gero.asm_.Style, t: PhaseTimings) !void {
+    const phases = [_]struct { label: []const u8, ns: i96 }{
+        .{ .label = "    include", .ns = t.include },
+        .{ .label = "    parse  ", .ns = t.parse },
+        .{ .label = "    codegen", .ns = t.codegen },
+        .{ .label = "    write  ", .ns = t.write },
+    };
+    for (phases) |p| {
+        try stdout.print("{s}{s}{s} ", .{ style.gutter, p.label, style.reset });
+        try writeDuration(stdout, p.ns);
+        try stdout.writeByte('\n');
+    }
 }
 
 /// Whether `gero asm` produced a `.gx` or bailed on errors.

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -19,6 +19,7 @@ pub fn execute(
     stdout: *std.Io.Writer,
     term: *term_mod.Term,
 ) !u8 {
+    const t_start = std.Io.Timestamp.now(io, .awake);
     const positionals = opts.positional();
     if (positionals.len < 1) {
         try term.err("gero asm: missing .gas file path", .{});
@@ -39,6 +40,7 @@ pub fn execute(
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
     if (fused.errors.len > 0) {
         try printDiagnostics(stdout, fused.source_map, fused.errors, style);
+        try writeFooter(stdout, io, style, t_start, .failed);
         return 3;
     }
 
@@ -56,6 +58,7 @@ pub fn execute(
     const had_errors = pt.hasErrors() or cg.hasErrors();
     if (had_errors) {
         try printAllDiagnostics(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
+        try writeFooter(stdout, io, style, t_start, .failed);
         return 3;
     }
 
@@ -73,9 +76,55 @@ pub fn execute(
             loaded.header.bank_count,
             if (loaded.header.hasDebugSymbols()) "yes" else "no",
         });
+        try writeFooter(stdout, io, style, t_start, .ok);
     }
 
     return 0;
+}
+
+/// Whether `gero asm` produced a `.gx` or bailed on errors.
+const Outcome = enum { ok, failed };
+
+/// Cargo-style footer with elapsed wall time.
+///
+/// ```text
+///     Finished in 12.3 ms
+///     Failed in 4.1 ms
+/// ```
+fn writeFooter(stdout: *std.Io.Writer, io: std.Io, style: gero.asm_.Style, t_start: std.Io.Timestamp, outcome: Outcome) !void {
+    const t_end = std.Io.Timestamp.now(io, .awake);
+    const elapsed_ns: i96 = t_start.durationTo(t_end).nanoseconds;
+    const label = switch (outcome) {
+        .ok => "    Finished in ",
+        .failed => "    Failed in ",
+    };
+    const label_style = switch (outcome) {
+        .ok => style.location, // bold — same as path headers
+        .failed => style.code, // red — same as [Exxx]
+    };
+    try stdout.print("{s}{s}{s}", .{ label_style, label, style.reset });
+    try writeDuration(stdout, elapsed_ns);
+    try stdout.writeByte('\n');
+}
+
+fn writeDuration(stdout: *std.Io.Writer, ns: i96) !void {
+    const ns_per_ms: i96 = std.time.ns_per_ms;
+    const ns_per_s: i96 = std.time.ns_per_s;
+    if (ns >= ns_per_s) {
+        // safety: caller passes a non-negative duration; the cast
+        //         to u64 just lets {d} format unsigned without the
+        //         leading-sign business that confuses the spec.
+        const whole: u64 = @intCast(@divFloor(ns, ns_per_s));
+        const tenths: u64 = @intCast(@divFloor(@mod(ns, ns_per_s), ns_per_ms * 100));
+        try stdout.print("{d}.{d} s", .{ whole, tenths });
+    } else if (ns >= ns_per_ms) {
+        // @as: see above — non-negative ns by construction.
+        const whole: u64 = @intCast(@divFloor(ns, ns_per_ms));
+        const tenths: u64 = @intCast(@divFloor(@mod(ns, ns_per_ms), 100_000));
+        try stdout.print("{d}.{d} ms", .{ whole, tenths });
+    } else {
+        try stdout.writeAll("< 1 ms");
+    }
 }
 
 /// Pretty-print every diagnostic against the fused-source map.

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -125,14 +125,16 @@ fn printAllDiagnostics(
     }
     try writeSummaryHeader(stdout, style, total, file_count);
 
-    // Emit per-file sections — blank line before each new file.
+    // Emit per-file sections: blank line + `<path>:` header for
+    // each new file, then each diagnostic body (no path prefix).
     prev_path = "";
     for (keyed) |k| {
         if (!std.mem.eql(u8, k.path, prev_path)) {
             try stdout.writeByte('\n');
+            try stdout.print("{s}{s}{s}\n", .{ style.location, k.path, style.reset });
             prev_path = k.path;
         }
-        try gero.asm_.formatPretty(stdout, source_map, k.diag, style);
+        try gero.asm_.formatPrettyBody(stdout, source_map, k.diag, style);
     }
 }
 

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -32,22 +32,29 @@ pub fn execute(
     };
     defer fused.deinit();
 
+    // Collect diagnostics across every phase so the user sees the
+    // full picture in one run. Include errors that can't be
+    // recovered from (no fused source = no parse) short-circuit
+    // before parse.
     if (fused.errors.len > 0) {
         try printDiagnostics(stdout, fused.source_map, fused.errors);
         return 3;
     }
 
+    // Parse always returns a tree (statement-level recovery means
+    // `Unknown` nodes stand in for failed statements). We run
+    // codegen even when parse surfaced errors so codegen-level
+    // diagnostics (E001/E003/E004/E005/E014) for the well-formed
+    // statements still surface in the same run.
     var pt = try gero.asm_.parse(arena, fused.source);
     defer pt.deinit();
-    if (pt.hasErrors()) {
-        try printDiagnostics(stdout, fused.source_map, pt.errors);
-        return 3;
-    }
 
     var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
     defer cg.deinit();
-    if (cg.hasErrors()) {
-        try printDiagnostics(stdout, fused.source_map, cg.errors);
+
+    const had_errors = pt.hasErrors() or cg.hasErrors();
+    if (had_errors) {
+        try printAllDiagnostics(arena, stdout, fused.source_map, pt.errors, cg.errors);
         return 3;
     }
 
@@ -77,6 +84,28 @@ fn printDiagnostics(
     errors: []const gero.asm_.Diagnostic,
 ) !void {
     for (errors) |d| try gero.asm_.formatPretty(stdout, source_map, d);
+}
+
+/// Merge parse + codegen diagnostics, sort by fused-source offset
+/// so the user sees errors in source order regardless of which
+/// pass raised them.
+fn printAllDiagnostics(
+    arena: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    source_map: gero.asm_.SourceMap,
+    parse_errors: []const gero.asm_.Diagnostic,
+    codegen_errors: []const gero.asm_.Diagnostic,
+) !void {
+    const total = parse_errors.len + codegen_errors.len;
+    const all = try arena.alloc(gero.asm_.Diagnostic, total);
+    @memcpy(all[0..parse_errors.len], parse_errors);
+    @memcpy(all[parse_errors.len..], codegen_errors);
+    std.mem.sort(gero.asm_.Diagnostic, all, {}, byIndex);
+    try printDiagnostics(stdout, source_map, all);
+}
+
+fn byIndex(_: void, a: gero.asm_.Diagnostic, b: gero.asm_.Diagnostic) bool {
+    return a.parse_error.index < b.parse_error.index;
 }
 
 /// Resolve the `.gx` output path from `--out` plus the source.

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -37,6 +37,7 @@ pub const max_positionals: usize = 16;
 /// Parsed common flags + the collected positional tail.
 pub const Options = struct {
     help: bool = false,
+    version: bool = false,
     quiet: bool = false,
     verbose: bool = false,
     target: Target = .vm,
@@ -124,6 +125,7 @@ pub fn topHelp(out: *std.Io.Writer) std.Io.Writer.Error!void {
         try out.print("  {s:<8} {s}\n", .{ commandName(cmd), commandSummary(cmd) });
     }
     try out.print("\nRun `gero <subcommand> --help` for per-command flags.\n", .{});
+    try out.print("Run `gero --version` to print the build version.\n", .{});
 }
 
 /// Per-subcommand help. Currently the same template; concrete
@@ -132,14 +134,20 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command) std.Io.Writer.Error!void {
     try out.print("gero {s} — {s}\n\n", .{ commandName(cmd), commandSummary(cmd) });
     try out.print("USAGE\n  gero {s} [flags] [args]\n\n", .{commandName(cmd)});
     try out.print("COMMON FLAGS\n", .{});
-    try out.print("  --help / -h      Print this help.\n", .{});
-    try out.print("  --quiet / -q     Suppress non-error output.\n", .{});
-    try out.print("  --verbose / -v   Extra diagnostics.\n", .{});
-    try out.print("  --target=<spec>  vm (default) or gtx-16.\n", .{});
-    try out.print("  --optimize=<m>   debug (default) / release / size.\n", .{});
-    try out.print("  --out=<path>     Output destination for file-producing commands.\n", .{});
-    try out.print("  --color=<mode>   auto (default) / always / never.\n", .{});
-    try out.print("  --no-color       Shortcut for --color=never.\n", .{});
+    try out.print("  --help / -h         Print this help.\n", .{});
+    try out.print("  --version / -V      Print build version.\n", .{});
+    try out.print("  --quiet / -q        Suppress non-error output.\n", .{});
+    try out.print("  --verbose / -v      Extra diagnostics + per-phase timings.\n", .{});
+    try out.print("  --target / -t=<s>   vm (default) or gtx-16.\n", .{});
+    try out.print("  --optimize / -O=<m> debug (default) / release / size.\n", .{});
+    try out.print("  --out / -o=<path>   Output destination for file-producing commands.\n", .{});
+    try out.print("  --color / -c=<m>    auto (default) / always / never.\n", .{});
+    try out.print("  --no-color          Shortcut for --color=never.\n", .{});
+}
+
+/// Print the version line consumed by `gero --version` / `gero -V`.
+pub fn printVersion(out: *std.Io.Writer) std.Io.Writer.Error!void {
+    try out.print("gero {s}\n", .{version_string});
 }
 
 fn parseTarget(s: []const u8) ParseError!Target {
@@ -162,10 +170,11 @@ fn parseColor(s: []const u8) ParseError!ColorChoice {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, quiet, verbose, target, optimize, out, color, no_color };
+const FlagKind = enum { help, version, quiet, verbose, target, optimize, out, color, no_color };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
+    if (std.mem.eql(u8, s, "version")) return .version;
     if (std.mem.eql(u8, s, "quiet")) return .quiet;
     if (std.mem.eql(u8, s, "verbose")) return .verbose;
     if (std.mem.eql(u8, s, "target")) return .target;
@@ -178,15 +187,20 @@ fn longFlag(s: []const u8) ?FlagKind {
 
 fn shortFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "h")) return .help;
+    if (std.mem.eql(u8, s, "V")) return .version; // upper-case — convention from rustc / clang
     if (std.mem.eql(u8, s, "q")) return .quiet;
     if (std.mem.eql(u8, s, "v")) return .verbose;
+    if (std.mem.eql(u8, s, "t")) return .target;
+    if (std.mem.eql(u8, s, "O")) return .optimize; // upper-case — convention from clang / gcc
     if (std.mem.eql(u8, s, "o")) return .out;
+    if (std.mem.eql(u8, s, "c")) return .color;
     return null;
 }
 
 fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void {
     switch (kind) {
         .help => opts.help = true,
+        .version => opts.version = true,
         .quiet => opts.quiet = true,
         .verbose => opts.verbose = true,
         .target => opts.target = try parseTarget(value orelse return error.MissingFlagValue),
@@ -203,6 +217,10 @@ fn needsValue(kind: FlagKind) bool {
         else => false,
     };
 }
+
+/// Build-time-captured semver from `build.zig.zon`. Stamped into
+/// `gero --version` output. Bumped via `zig build version`.
+pub const version_string: []const u8 = "0.0.0";
 
 /// Parse `argv[1..]` into a `Parsed`. The first non-flag token
 /// is the subcommand; everything after it is forwarded to the

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -114,35 +114,126 @@ fn commandSummary(cmd: Command) []const u8 {
     };
 }
 
-/// Top-level help text. Printed for `gero` (no args) and
-/// `gero --help`.
-pub fn topHelp(out: *std.Io.Writer) std.Io.Writer.Error!void {
-    try out.print("gero — VM + asm + lang toolchain\n\n", .{});
-    try out.print("USAGE\n  gero <subcommand> [flags] [args]\n\n", .{});
-    try out.print("SUBCOMMANDS\n", .{});
-    inline for (std.meta.fields(Command)) |f| {
-        const cmd: Command = @enumFromInt(f.value);
-        try out.print("  {s:<8} {s}\n", .{ commandName(cmd), commandSummary(cmd) });
-    }
-    try out.print("\nRun `gero <subcommand> --help` for per-command flags.\n", .{});
-    try out.print("Run `gero --version` to print the build version.\n", .{});
+/// True for subcommands that have a real implementation today.
+/// The rest are intentionally listed in help so the surface is
+/// discoverable, but split into a separate "planned" section.
+fn commandIsImplemented(cmd: Command) bool {
+    return switch (cmd) {
+        .asm_, .run, .info => true,
+        .compile, .test_, .bench, .fmt, .check, .build, .disasm => false,
+    };
 }
 
-/// Per-subcommand help. Currently the same template; concrete
-/// flag lists land with each subcommand's real implementation.
-pub fn commandHelp(out: *std.Io.Writer, cmd: Command) std.Io.Writer.Error!void {
-    try out.print("gero {s} — {s}\n\n", .{ commandName(cmd), commandSummary(cmd) });
-    try out.print("USAGE\n  gero {s} [flags] [args]\n\n", .{commandName(cmd)});
-    try out.print("COMMON FLAGS\n", .{});
-    try out.print("  --help / -h         Print this help.\n", .{});
-    try out.print("  --version / -V      Print build version.\n", .{});
-    try out.print("  --quiet / -q        Suppress non-error output.\n", .{});
-    try out.print("  --verbose / -v      Extra diagnostics + per-phase timings.\n", .{});
-    try out.print("  --target / -t=<s>   vm (default) or gtx-16.\n", .{});
-    try out.print("  --optimize / -O=<m> debug (default) / release / size.\n", .{});
-    try out.print("  --out / -o=<path>   Output destination for file-producing commands.\n", .{});
-    try out.print("  --color / -c=<m>    auto (default) / always / never.\n", .{});
-    try out.print("  --no-color          Shortcut for --color=never.\n", .{});
+/// ANSI helpers used only inside the help text. Kept inline so
+/// `cli.zig` doesn't have to pull in the asm-side `Style` struct.
+const HelpAnsi = struct {
+    bold: []const u8,
+    dim: []const u8,
+    cyan: []const u8,
+    yellow: []const u8,
+    reset: []const u8,
+
+    fn pick(color: bool) HelpAnsi {
+        return if (color) .{
+            .bold = "\x1b[1m",
+            .dim = "\x1b[2m",
+            .cyan = "\x1b[36m",
+            .yellow = "\x1b[33m",
+            .reset = "\x1b[0m",
+        } else .{
+            .bold = "",
+            .dim = "",
+            .cyan = "",
+            .yellow = "",
+            .reset = "",
+        };
+    }
+};
+
+/// Top-level help text. Printed for `gero` (no args) and
+/// `gero --help`. `color` toggles ANSI escapes for section
+/// headers and key terms.
+pub fn topHelp(out: *std.Io.Writer, color: bool) std.Io.Writer.Error!void {
+    const a = HelpAnsi.pick(color);
+
+    try out.print("{s}gero{s} — 16-bit VM + asm + lang toolchain  {s}(v{s}){s}\n\n", .{ a.bold, a.reset, a.dim, version_string, a.reset });
+
+    try out.print("{s}USAGE{s}\n", .{ a.yellow, a.reset });
+    try out.print("  {s}gero{s} <subcommand> [flags] [args]\n", .{ a.cyan, a.reset });
+    try out.print("  {s}gero{s} --version\n", .{ a.cyan, a.reset });
+    try out.print("  {s}gero{s} --help\n\n", .{ a.cyan, a.reset });
+
+    try out.print("{s}SUBCOMMANDS{s}\n", .{ a.yellow, a.reset });
+    inline for (std.meta.fields(Command)) |f| {
+        const cmd: Command = @enumFromInt(f.value);
+        if (commandIsImplemented(cmd))
+            try out.print("  {s}{s:<8}{s} {s}\n", .{ a.cyan, commandName(cmd), a.reset, commandSummary(cmd) });
+    }
+
+    try out.print("\n{s}PLANNED{s} {s}(not yet implemented){s}\n", .{ a.yellow, a.reset, a.dim, a.reset });
+    inline for (std.meta.fields(Command)) |f| {
+        const cmd: Command = @enumFromInt(f.value);
+        if (!commandIsImplemented(cmd))
+            try out.print("  {s}{s:<8}{s} {s}{s}{s}\n", .{ a.dim, commandName(cmd), a.reset, a.dim, commandSummary(cmd), a.reset });
+    }
+
+    try out.print("\n{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
+    try out.print("  {s}gero asm prog.gas{s}                Assemble to prog.gx (next to source)\n", .{ a.cyan, a.reset });
+    try out.print("  {s}gero asm prog.gas -o build/{s}      Output into a directory\n", .{ a.cyan, a.reset });
+    try out.print("  {s}gero asm prog.gas -v{s}             Verbose — print per-phase timings\n", .{ a.cyan, a.reset });
+    try out.print("  {s}gero info prog.gx{s}                Print the .gx header\n", .{ a.cyan, a.reset });
+    try out.print("  {s}gero run prog.gx{s}                 Boot the VM and execute\n", .{ a.cyan, a.reset });
+
+    try out.print("\nRun `{s}gero <subcommand> --help{s}` for per-command flags.\n", .{ a.cyan, a.reset });
+}
+
+/// Per-subcommand help. Implemented commands get a tailored
+/// usage line + example; planned commands print a one-liner
+/// reminder so the user isn't left wondering.
+pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer.Error!void {
+    const a = HelpAnsi.pick(color);
+
+    try out.print("{s}gero {s}{s} — {s}\n\n", .{ a.bold, commandName(cmd), a.reset, commandSummary(cmd) });
+
+    if (!commandIsImplemented(cmd)) {
+        try out.print("{s}Not yet implemented{s} in this build (v{s}).\n", .{ a.yellow, a.reset, version_string });
+        try out.print("Track progress: {s}https://github.com/salty-max/gero/issues{s}\n", .{ a.cyan, a.reset });
+        return;
+    }
+
+    try out.print("{s}USAGE{s}\n", .{ a.yellow, a.reset });
+    switch (cmd) {
+        .asm_ => {
+            try out.print("  {s}gero asm{s} <file.gas> [-o <path>] [-v] [--quiet]\n\n", .{ a.cyan, a.reset });
+            try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
+            try out.print("  {s}gero asm prog.gas{s}                {s}# → prog.gx{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero asm prog.gas -o build/{s}      {s}# → build/prog.gx{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero asm prog.gas -o named.gx{s}    {s}# → named.gx{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero asm prog.gas -v{s}             {s}# per-phase timings{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+        },
+        .run => {
+            try out.print("  {s}gero run{s} <file.gx> [--quiet]\n\n", .{ a.cyan, a.reset });
+            try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
+            try out.print("  {s}gero run prog.gx{s}                 {s}# boot + execute until hlt{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+        },
+        .info => {
+            try out.print("  {s}gero info{s} <file.gx>\n\n", .{ a.cyan, a.reset });
+            try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
+            try out.print("  {s}gero info prog.gx{s}                {s}# print the .gx header{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+        },
+        else => unreachable, // allow-strict: commandIsImplemented() filtered above
+    }
+
+    try out.print("\n{s}COMMON FLAGS{s}\n", .{ a.yellow, a.reset });
+    try out.print("  {s}--help / -h{s}         Print this help.\n", .{ a.cyan, a.reset });
+    try out.print("  {s}--version / -V{s}      Print build version.\n", .{ a.cyan, a.reset });
+    try out.print("  {s}--quiet / -q{s}        Suppress non-error output.\n", .{ a.cyan, a.reset });
+    try out.print("  {s}--verbose / -v{s}      Extra diagnostics + per-phase timings.\n", .{ a.cyan, a.reset });
+    try out.print("  {s}--target / -t=<s>{s}   vm (default) or gtx-16.\n", .{ a.cyan, a.reset });
+    try out.print("  {s}--optimize / -O=<m>{s} debug (default) / release / size.\n", .{ a.cyan, a.reset });
+    try out.print("  {s}--out / -o=<path>{s}   Output destination for file-producing commands.\n", .{ a.cyan, a.reset });
+    try out.print("  {s}--color / -c=<m>{s}    auto (default) / always / never.\n", .{ a.cyan, a.reset });
+    try out.print("  {s}--no-color{s}          Shortcut for --color=never.\n", .{ a.cyan, a.reset });
 }
 
 /// Print the version line consumed by `gero --version` / `gero -V`.
@@ -298,12 +389,12 @@ pub fn parse(args: []const []const u8) ParseError!Parsed {
 /// 2 = bad usage).
 pub fn run(parsed: Parsed, stdout: *std.Io.Writer, stderr: *std.Io.Writer) std.Io.Writer.Error!u8 {
     if (parsed.command == null) {
-        try topHelp(stdout);
+        try topHelp(stdout, false);
         return 0;
     }
     const cmd = parsed.command.?;
     if (parsed.options.help) {
-        try commandHelp(stdout, cmd);
+        try commandHelp(stdout, cmd, false);
         return 0;
     }
     try stderr.print("gero {s}: not yet implemented\n", .{commandName(cmd)});

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -45,6 +45,10 @@ pub fn main(init: std.process.Init) !u8 {
     );
     var term = term_mod.Term{ .out = stderr, .color = stderr_color };
 
+    if (parsed.options.version) {
+        try cli.printVersion(stdout);
+        return 0;
+    }
     if (parsed.command == null) {
         try cli.topHelp(stdout);
         return 0;

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -45,17 +45,25 @@ pub fn main(init: std.process.Init) !u8 {
     );
     var term = term_mod.Term{ .out = stderr, .color = stderr_color };
 
+    // Help + version write to stdout, so resolve color against
+    // stdout's TTY (a user piping to less expects no escapes).
+    const stdout_color = term_mod.resolve(
+        toTermChoice(parsed.options.color),
+        envFlag(init.environ_map, "NO_COLOR"),
+        std.Io.File.stdout().isTty(io) catch false,
+    );
+
     if (parsed.options.version) {
         try cli.printVersion(stdout);
         return 0;
     }
     if (parsed.command == null) {
-        try cli.topHelp(stdout);
+        try cli.topHelp(stdout, stdout_color);
         return 0;
     }
     const cmd = parsed.command.?;
     if (parsed.options.help) {
-        try cli.commandHelp(stdout, cmd);
+        try cli.commandHelp(stdout, cmd, stdout_color);
         return 0;
     }
 

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -267,6 +267,7 @@ Useful for character buffers and packed data.
 | `0x22` | `mov8`   | `Addr, Reg`     | reg.lo ← mem[addr]; reg.hi ← 0 |
 | `0x23` | `mov8`   | `Reg, [Reg]`    | mem[ptr] ← reg.lo |
 | `0x24` | `mov8`   | `[Reg], Reg`    | reg.lo ← mem[ptr]; reg.hi ← 0 |
+| `0x29` | `mov8`   | `[Addr + Reg], Reg` | reg.lo ← mem[addr + idx]; reg.hi ← 0 (byte-level indexed load — useful for stepping through `data8` arrays) |
 | `0x25` | `movh`   | `Reg, Addr`     | mem[addr] ← reg.hi |
 | `0x26` | `movl`   | `Reg, Addr`     | mem[addr] ← reg.lo |
 | `0x27` | `bcpy`   | `Reg, Reg, Reg` | block copy: mem[dst..dst+len] ← mem[src..src+len]. Operand order: `dst, src, len` (Intel-style dst first). Length is the third register's `u16` value (0..65535 bytes). Copies low-to-high; overlapping ranges with `dst > src` produce corruption — split or use disjoint regions. Address arithmetic wraps. Doesn't touch flags. |

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -41,6 +41,8 @@ pub const resolveIncludes = include.resolveIncludes;
 pub const formatDiagnostic = include.formatDiagnostic;
 /// Re-export: pretty-format a `Diagnostic` with a caret-style snippet.
 pub const formatPretty = include.formatPretty;
+/// Re-export: `formatPretty` without the path prefix — caller emits a file header.
+pub const formatPrettyBody = include.formatPrettyBody;
 /// Re-export: ANSI escape strings the formatter wraps around colored pieces.
 pub const Style = include.Style;
 

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -41,6 +41,8 @@ pub const resolveIncludes = include.resolveIncludes;
 pub const formatDiagnostic = include.formatDiagnostic;
 /// Re-export: pretty-format a `Diagnostic` with a caret-style snippet.
 pub const formatPretty = include.formatPretty;
+/// Re-export: ANSI escape strings the formatter wraps around colored pieces.
+pub const Style = include.Style;
 
 /// Re-export: source span — `{start, end}` byte offsets in the fused source.
 pub const Span = ast_mod.Span;

--- a/src/asm/ast.zig
+++ b/src/asm/ast.zig
@@ -60,6 +60,9 @@ pub const Statement = union(enum) {
 /// Resolution (forward refs, duplicates) lives in #35.
 pub const Label = struct {
     /// Span of the bare identifier (without the trailing colon).
+    /// For a local label `.foo:`, this covers `.foo` (the leading
+    /// dot is the marker codegen uses to mangle against the most
+    /// recent global label).
     name: Span,
     /// Span covering both the identifier and the colon.
     span: Span,
@@ -323,6 +326,9 @@ pub const IndirectReg = struct {
 /// (`jmp loop`) or a previously-defined `const`. The symbol pass
 /// (#35) resolves it; the parser just records the lexeme span.
 pub const LabelRef = struct {
+    /// The lexeme span. For a local-label ref `.foo`, the span
+    /// covers `.foo` and codegen mangles via the most recent
+    /// global label.
     span: Span,
 };
 

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -50,8 +50,11 @@ pub const Codegen = struct {
 /// Configuration knobs for `assemble`. v0.1 just exposes the
 /// entry point; banking + SRAM land later.
 pub const Options = struct {
-    /// `ip` value at boot. Per ISA §7.1.
-    entry_point: u16 = 0x0000,
+    /// `ip` value at boot per ISA §7.1. `null` (default) triggers
+    /// auto-detection: if the program defines a `main:` label, its
+    /// address is used; otherwise the entry point is `0x0000`
+    /// (start of image). Set explicitly to override.
+    entry_point: ?u16 = null,
 };
 
 /// Run the full codegen pipeline against a parsed program.
@@ -86,11 +89,20 @@ pub fn assemble(
 
     try emitPass(allocator, &image_buf, &errors, source, tree, resolved_consts, &symbols, image_size);
 
-    // Prepend the .gx header per ISA §7.1.
+    // Prepend the .gx header per ISA §7.1. Resolve the entry
+    // point: explicit option wins; otherwise prefer a `main:`
+    // label if present, else default to `0x0000`.
     const image_bytes = try image_buf.toOwnedSlice(allocator);
     errdefer allocator.free(image_bytes);
 
-    const final = try buildArchive(allocator, image_bytes, opts);
+    const resolved_entry: u16 = opts.entry_point orelse blk: {
+        if (symbols.get("main")) |sym| {
+            if (sym.kind == .label) break :blk sym.value;
+        }
+        break :blk 0x0000;
+    };
+
+    const final = try buildArchive(allocator, image_bytes, resolved_entry);
     allocator.free(image_bytes);
 
     return .{
@@ -108,9 +120,20 @@ pub fn assemble(
 /// layout, only forward-resolved consts can disambiguate;
 /// unknown names default to `.addr` (same byte width as `.imm16`,
 /// so sizing is correct either way).
-fn classifyForLayout(op: ast.Operand, source: []const u8, symbols: symtab.SymbolTable) opres.Kind {
+fn classifyForLayout(
+    op: ast.Operand,
+    source: []const u8,
+    symbols: symtab.SymbolTable,
+    parent_label: ?[]const u8,
+    scratch: std.mem.Allocator,
+) opres.Kind {
     return switch (op) {
-        .label_ref => |l| opres.labelRefKind(source[l.span.start..l.span.end], symbols),
+        .label_ref => |l| blk: {
+            const lex = source[l.span.start..l.span.end];
+            const resolved = resolveLabelKey(lex, parent_label, scratch) catch break :blk .addr;
+            defer if (resolved.owned) scratch.free(resolved.key);
+            break :blk opres.labelRefKind(resolved.key, symbols);
+        },
         .immediate => |e| narrowImm(e, source, symbols),
         else => opres.classify(op, null),
     };
@@ -119,12 +142,44 @@ fn classifyForLayout(op: ast.Operand, source: []const u8, symbols: symtab.Symbol
 /// Same as `classifyForLayout` but used in the emit pass. By
 /// emit time, every label and const lives in the symbol table
 /// with its true kind, so `label_ref` resolves precisely.
-fn classifyForEmit(op: ast.Operand, source: []const u8, symbols: symtab.SymbolTable) opres.Kind {
+fn classifyForEmit(
+    op: ast.Operand,
+    source: []const u8,
+    symbols: symtab.SymbolTable,
+    parent_label: ?[]const u8,
+    scratch: std.mem.Allocator,
+) opres.Kind {
     return switch (op) {
-        .label_ref => |l| opres.labelRefKind(source[l.span.start..l.span.end], symbols),
+        .label_ref => |l| blk: {
+            const lex = source[l.span.start..l.span.end];
+            const resolved = resolveLabelKey(lex, parent_label, scratch) catch break :blk .addr;
+            defer if (resolved.owned) scratch.free(resolved.key);
+            break :blk opres.labelRefKind(resolved.key, symbols);
+        },
         .immediate => |e| narrowImm(e, source, symbols),
         else => opres.classify(op, null),
     };
+}
+
+/// Result of expanding a label-style lexeme into its symbol-table
+/// key. Local labels (`.foo`) get prefixed with the most recent
+/// global label; `owned == true` means the caller frees `key`.
+const ResolvedKey = struct {
+    key: []const u8,
+    owned: bool,
+};
+
+/// If `name` starts with `.`, mangle it to `parent.name` using
+/// `scratch`; otherwise return the name verbatim (borrowed).
+/// Returns an error if a local label appears with no enclosing
+/// parent — caller can fall back to a plain lookup.
+fn resolveLabelKey(name: []const u8, parent: ?[]const u8, scratch: std.mem.Allocator) !ResolvedKey {
+    if (name.len > 0 and name[0] == '.') {
+        const p = parent orelse return error.NoParentLabel;
+        const joined = try std.fmt.allocPrint(scratch, "{s}{s}", .{ p, name });
+        return .{ .key = joined, .owned = true };
+    }
+    return .{ .key = name, .owned = false };
 }
 
 /// Pick the narrowest immediate kind that fits the folded value.
@@ -150,6 +205,7 @@ fn layoutPass(
     out_image_size: *u32,
 ) !void {
     var cursor: u32 = 0;
+    var parent_label: ?[]const u8 = null;
     for (tree.program.statements) |stmt| {
         switch (stmt) {
             .label => |l| {
@@ -157,18 +213,51 @@ fn layoutPass(
                 // safety: cursor is bounded by max u16 image (the
                 //         ISA caps at 64k) — cast won't truncate.
                 const addr: u16 = @intCast(cursor);
-                symbols.putBorrowed(name, .{ .kind = .label, .value = addr }) catch |err| switch (err) {
-                    error.OutOfMemory => return error.OutOfMemory,
-                    error.Duplicate => try errors.append(symbols.allocator, .{
-                        .code = .duplicate_label,
-                        .parse_error = core.parseError(
-                            "codegen",
-                            l.name.start,
-                            "duplicate label",
-                            .{ .expected = "unique label name", .actual = name, .kind = .semantic },
-                        ),
-                    }),
-                };
+                if (name.len > 0 and name[0] == '.') {
+                    // Local label: register as `parent.name`.
+                    if (parent_label) |p| {
+                        const qualified = try std.fmt.allocPrint(symbols.allocator, "{s}{s}", .{ p, name });
+                        symbols.putOwned(qualified, .{ .kind = .label, .value = addr }) catch |err| switch (err) {
+                            error.OutOfMemory => return error.OutOfMemory,
+                            error.Duplicate => {
+                                symbols.allocator.free(qualified);
+                                try errors.append(symbols.allocator, .{
+                                    .code = .duplicate_label,
+                                    .parse_error = core.parseError(
+                                        "codegen",
+                                        l.name.start,
+                                        "duplicate local label",
+                                        .{ .expected = "unique local-label name within the enclosing global label", .actual = name, .kind = .semantic },
+                                    ),
+                                });
+                            },
+                        };
+                    } else {
+                        try errors.append(symbols.allocator, .{
+                            .code = .undefined_symbol,
+                            .parse_error = core.parseError(
+                                "codegen",
+                                l.name.start,
+                                "local label has no enclosing global label",
+                                .{ .expected = "preceding global label", .actual = name, .kind = .semantic },
+                            ),
+                        });
+                    }
+                } else {
+                    symbols.putBorrowed(name, .{ .kind = .label, .value = addr }) catch |err| switch (err) {
+                        error.OutOfMemory => return error.OutOfMemory,
+                        error.Duplicate => try errors.append(symbols.allocator, .{
+                            .code = .duplicate_label,
+                            .parse_error = core.parseError(
+                                "codegen",
+                                l.name.start,
+                                "duplicate label",
+                                .{ .expected = "unique label name", .actual = name, .kind = .semantic },
+                            ),
+                        }),
+                    };
+                    parent_label = name;
+                }
             },
             .const_decl => |c| {
                 // The parser already evaluated and stored this in
@@ -237,7 +326,7 @@ fn layoutPass(
             .instruction => |i| {
                 const mnem = source[i.mnemonic.start..i.mnemonic.end];
                 var kinds: [3]opres.Kind = undefined;
-                for (i.operands, 0..) |op, idx| kinds[idx] = classifyForLayout(op, source, symbols.*);
+                for (i.operands, 0..) |op, idx| kinds[idx] = classifyForLayout(op, source, symbols.*, parent_label, symbols.allocator);
                 if (opres.resolve(mnem, kinds[0..i.operands.len])) |res| {
                     cursor += res.size;
                 } else {
@@ -328,9 +417,14 @@ fn emitPass(
     image_size: u32,
 ) !void {
     var cursor: u32 = 0;
+    var parent_label: ?[]const u8 = null;
     for (tree.program.statements) |stmt| {
         switch (stmt) {
-            .label, .const_decl, .struct_decl, .unknown => {},
+            .label => |l| {
+                const name = source[l.name.start..l.name.end];
+                if (name.len == 0 or name[0] != '.') parent_label = name;
+            },
+            .const_decl, .struct_decl, .unknown => {},
             .data8, .data16 => |d| {
                 const word_size: u32 = if (stmt == .data8) 1 else 2;
                 try emitDataValues(allocator, image, errors, source, d.values, word_size, consts);
@@ -348,7 +442,7 @@ fn emitPass(
                 }
             },
             .instruction => |i| {
-                try emitInstruction(allocator, image, errors, source, i, consts, symbols);
+                try emitInstruction(allocator, image, errors, source, i, consts, symbols, parent_label);
                 cursor = @intCast(image.items.len);
             },
         }
@@ -470,10 +564,11 @@ fn emitInstruction(
     inst: ast.Instruction,
     consts: expr.ConstantTable,
     symbols: *const symtab.SymbolTable,
+    parent_label: ?[]const u8,
 ) !void {
     const mnem = source[inst.mnemonic.start..inst.mnemonic.end];
     var kinds: [3]opres.Kind = undefined;
-    for (inst.operands, 0..) |op, idx| kinds[idx] = classifyForEmit(op, source, symbols.*);
+    for (inst.operands, 0..) |op, idx| kinds[idx] = classifyForEmit(op, source, symbols.*, parent_label, allocator);
     const res = opres.resolve(mnem, kinds[0..inst.operands.len]) orelse {
         // Pass 1 already raised the diagnostic; emit a NOP-shape
         // 1 byte (0xFF / `hlt`) so the cursor advances by the
@@ -504,7 +599,10 @@ fn emitInstruction(
         },
         .addr_lit => |a| try emitValue(allocator, image, a.value, 2),
         .sym_ref => |s| try emitSymRef(allocator, image, errors, source, s, consts),
-        .label_ref => |l| try emitLabelRef(allocator, image, errors, source, l, consts),
+        .label_ref => |l| {
+            const width: u32 = if (res.kinds[op_idx] == .imm8) 1 else 2;
+            try emitLabelRef(allocator, image, errors, source, l, consts, width, parent_label);
+        },
         .addr_expr => |a| {
             const result = expr.evalExpr(a.expr, source, consts);
             const val: u16 = switch (result) {
@@ -566,10 +664,26 @@ fn emitLabelRef(
     source: []const u8,
     l: ast.LabelRef,
     consts: expr.ConstantTable,
+    width: u32,
+    parent_label: ?[]const u8,
 ) !void {
-    const name = source[l.span.start..l.span.end];
-    if (consts.get(name)) |val| {
-        try emitValue(allocator, image, val, 2);
+    const lex = source[l.span.start..l.span.end];
+    const resolved = resolveLabelKey(lex, parent_label, allocator) catch {
+        try errors.append(allocator, .{
+            .code = .undefined_symbol,
+            .parse_error = core.parseError(
+                "codegen",
+                l.span.start,
+                "local label reference has no enclosing global label",
+                .{ .expected = "preceding global label", .actual = lex, .kind = .semantic },
+            ),
+        });
+        try emitValue(allocator, image, 0, width);
+        return;
+    };
+    defer if (resolved.owned) allocator.free(resolved.key);
+    if (consts.get(resolved.key)) |val| {
+        try emitValue(allocator, image, val, width);
     } else {
         try errors.append(allocator, .{
             .code = .undefined_symbol,
@@ -577,10 +691,10 @@ fn emitLabelRef(
                 "codegen",
                 l.span.start,
                 "undefined symbol",
-                .{ .expected = "defined label / const", .actual = name, .kind = .semantic },
+                .{ .expected = "defined label / const", .actual = resolved.key, .kind = .semantic },
             ),
         });
-        try emitValue(allocator, image, 0, 2);
+        try emitValue(allocator, image, 0, width);
     }
 }
 
@@ -635,7 +749,7 @@ fn emitCast(
 /// Magic bytes at the start of a `.gx` file — "GERO" in ASCII.
 const gx_magic = [4]u8{ 'G', 'E', 'R', 'O' };
 
-fn buildArchive(allocator: std.mem.Allocator, image_bytes: []const u8, opts: Options) ![]u8 {
+fn buildArchive(allocator: std.mem.Allocator, image_bytes: []const u8, entry_point: u16) ![]u8 {
     // Header layout per ISA §7.1:
     //   0x00..0x04  magic = "GERO"
     //   0x04..0x06  u16le version = 0x0001
@@ -652,7 +766,7 @@ fn buildArchive(allocator: std.mem.Allocator, image_bytes: []const u8, opts: Opt
     @memcpy(out[0..4], &gx_magic);
     writeU16Le(out[4..6], 0x0001); // version
     writeU16Le(out[6..8], 0x0000); // flags
-    writeU16Le(out[8..10], opts.entry_point);
+    writeU16Le(out[8..10], entry_point);
     // safety: image_size capped at 64 KiB by the ISA's 16-bit
     //         address space; cart code larger than that needs
     //         banking, which is a v0.1 follow-up.

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -264,17 +264,20 @@ fn layoutPass(
                 // its internal ConstantTable, but that table got
                 // dropped at end-of-parse. Re-eval here against
                 // the symbol table we're building up.
+                // On eval failure we stay silent: the parser
+                // already surfaced the same diagnostic when it
+                // tried to fold this expression. Re-raising would
+                // duplicate the user-facing error.
                 const name = source[c.name.start..c.name.end];
                 var consts = try symbols.toConstantTable();
                 defer consts.deinit();
-                const result = expr.evalExpr(c.expr, source, consts);
-                switch (result) {
+                switch (expr.evalExpr(c.expr, source, consts)) {
                     .ok => |v| symbols.putBorrowed(name, .{ .kind = .const_value, .value = v }) catch |err| switch (err) {
                         error.OutOfMemory => return error.OutOfMemory,
                         // safety: const_value never triggers Duplicate per putBorrowed's rules
                         error.Duplicate => unreachable,
                     },
-                    .err => |d| try errors.append(symbols.allocator, d),
+                    .err => {},
                 }
             },
             .data8, .data16 => |d| {

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -430,7 +430,7 @@ fn emitPass(
             .const_decl, .struct_decl, .unknown => {},
             .data8, .data16 => |d| {
                 const word_size: u32 = if (stmt == .data8) 1 else 2;
-                try emitDataValues(allocator, image, errors, source, d.values, word_size, consts);
+                try emitDataValues(allocator, image, errors, source, d.values, word_size, consts, symbols);
                 cursor = @intCast(image.items.len);
             },
             .org => |o| {
@@ -463,6 +463,7 @@ fn emitDataValues(
     values: []const ast.DataValue,
     word_size: u32,
     consts: expr.ConstantTable,
+    symbols: *const symtab.SymbolTable,
 ) !void {
     for (values) |v| switch (v) {
         .expr => |e| {
@@ -484,6 +485,7 @@ fn emitDataValues(
             } else {
                 try errors.append(allocator, .{
                     .code = .undefined_symbol,
+                    .note = symbols.suggestSimilar(name),
                     .parse_error = core.parseError(
                         "codegen",
                         s.span.start,
@@ -601,10 +603,10 @@ fn emitInstruction(
             try emitValue(allocator, image, val, width);
         },
         .addr_lit => |a| try emitValue(allocator, image, a.value, 2),
-        .sym_ref => |s| try emitSymRef(allocator, image, errors, source, s, consts),
+        .sym_ref => |s| try emitSymRef(allocator, image, errors, source, s, consts, symbols),
         .label_ref => |l| {
             const width: u32 = if (res.kinds[op_idx] == .imm8) 1 else 2;
-            try emitLabelRef(allocator, image, errors, source, l, consts, width, parent_label);
+            try emitLabelRef(allocator, image, errors, source, l, consts, width, parent_label, symbols);
         },
         .addr_expr => |a| {
             const result = expr.evalExpr(a.expr, source, consts);
@@ -617,7 +619,7 @@ fn emitInstruction(
             };
             try emitValue(allocator, image, val, 2);
         },
-        .cast => |c| try emitCast(allocator, image, errors, source, c, consts),
+        .cast => |c| try emitCast(allocator, image, errors, source, c, consts, symbols),
         .indirect => |ind| try image.append(allocator, @intFromEnum(ind.reg.id)),
         .indexed => |idx| {
             const result = expr.evalExpr(idx.addr, source, consts);
@@ -641,6 +643,7 @@ fn emitSymRef(
     source: []const u8,
     s: ast.SymRef,
     consts: expr.ConstantTable,
+    symbols: *const symtab.SymbolTable,
 ) !void {
     const lex = source[s.span.start..s.span.end];
     const name = if (lex.len > 0 and lex[0] == '@') lex[1..] else lex;
@@ -649,6 +652,7 @@ fn emitSymRef(
     } else {
         try errors.append(allocator, .{
             .code = .undefined_symbol,
+            .note = symbols.suggestSimilar(name),
             .parse_error = core.parseError(
                 "codegen",
                 s.span.start,
@@ -669,6 +673,7 @@ fn emitLabelRef(
     consts: expr.ConstantTable,
     width: u32,
     parent_label: ?[]const u8,
+    symbols: *const symtab.SymbolTable,
 ) !void {
     const lex = source[l.span.start..l.span.end];
     const resolved = resolveLabelKey(lex, parent_label, allocator) catch {
@@ -690,6 +695,7 @@ fn emitLabelRef(
     } else {
         try errors.append(allocator, .{
             .code = .undefined_symbol,
+            .note = symbols.suggestSimilar(resolved.key),
             .parse_error = core.parseError(
                 "codegen",
                 l.span.start,
@@ -708,6 +714,7 @@ fn emitCast(
     source: []const u8,
     c: ast.CastOperand,
     consts: expr.ConstantTable,
+    symbols: *const symtab.SymbolTable,
 ) !void {
     // `<Type> @sym.field` desugars to `@sym + Type.field`.
     const sym_lex = source[c.sym_ref.span.start..c.sym_ref.span.end];
@@ -718,6 +725,7 @@ fn emitCast(
     const sym_val: u16 = if (consts.get(sym_name)) |v| v else blk: {
         try errors.append(allocator, .{
             .code = .undefined_symbol,
+            .note = symbols.suggestSimilar(sym_name),
             .parse_error = core.parseError(
                 "codegen",
                 c.sym_ref.span.start,
@@ -734,6 +742,7 @@ fn emitCast(
     const offset: u16 = if (consts.get(qualified)) |v| v else blk: {
         try errors.append(allocator, .{
             .code = .undefined_symbol,
+            .note = symbols.suggestSimilar(qualified),
             .parse_error = core.parseError(
                 "codegen",
                 c.field_name.start,

--- a/src/asm/expr.zig
+++ b/src/asm/expr.zig
@@ -16,6 +16,7 @@ const knit = @import("knit");
 const core = knit.core;
 const lexer = @import("lexer.zig");
 const ast = @import("ast.zig");
+const include = @import("include.zig");
 
 // ---------- ConstantTable ----------
 
@@ -92,7 +93,7 @@ pub const ParseError = error{
 pub fn parseExpression(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     return parseBitOr(state, allocator, errors);
 }
@@ -110,7 +111,7 @@ pub fn parseExpression(
 fn parseBitOr(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     var lhs = try parseBitXor(state, allocator, errors);
     while (peekKind(state, .pipe)) {
@@ -127,7 +128,7 @@ fn parseBitOr(
 fn parseBitXor(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     var lhs = try parseBitAnd(state, allocator, errors);
     while (peekKind(state, .caret)) {
@@ -144,7 +145,7 @@ fn parseBitXor(
 fn parseBitAnd(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     var lhs = try parseShift(state, allocator, errors);
     while (peekKind(state, .ampersand)) {
@@ -161,7 +162,7 @@ fn parseBitAnd(
 fn parseShift(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     var lhs = try parseAdd(state, allocator, errors);
     while (true) {
@@ -183,7 +184,7 @@ fn parseShift(
 fn parseAdd(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     var lhs = try parseMul(state, allocator, errors);
     while (true) {
@@ -205,7 +206,7 @@ fn parseAdd(
 fn parseMul(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     var lhs = try parseUnary(state, allocator, errors);
     while (true) {
@@ -228,7 +229,7 @@ fn parseMul(
 fn parseUnary(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     skipBlanks(state);
     if (peekKind(state, .tilde)) {
@@ -249,7 +250,7 @@ fn parseUnary(
 fn parsePrimary(
     state: *core.ParseState,
     allocator: std.mem.Allocator,
-    errors: *std.ArrayList(@import("include.zig").Diagnostic),
+    errors: *std.ArrayList(include.Diagnostic),
 ) ParseError!*ast.Expr {
     skipBlanks(state);
     const start = state.index;
@@ -296,6 +297,15 @@ fn parsePrimary(
             } };
             return expr;
         }
+        // The leading byte was `$` — anything past that is a
+        // malformed hex literal, never "this isn't hex at all".
+        // Surface the lexer's specific message + map it to an
+        // E-code per asm spec §8.
+        try errors.append(state.allocator, .{
+            .code = include.ErrorCode.fromLexerMessage(r.err.message),
+            .parse_error = r.err,
+        });
+        return error.ParseFailed;
     } else if (next == '\'') {
         const r = lexer.charP.parseFn(state);
         if (r == .ok) {
@@ -307,6 +317,11 @@ fn parsePrimary(
             } };
             return expr;
         }
+        try errors.append(state.allocator, .{
+            .code = include.ErrorCode.fromLexerMessage(r.err.message),
+            .parse_error = r.err,
+        });
+        return error.ParseFailed;
     } else if (next == '&') {
         // `&FFFF` address literal as expression primary. The
         // wider `&[...]` form lives at the operand layer; it
@@ -321,6 +336,11 @@ fn parsePrimary(
             } };
             return expr;
         }
+        try errors.append(state.allocator, .{
+            .code = include.ErrorCode.fromLexerMessage(r.err.message),
+            .parse_error = r.err,
+        });
+        return error.ParseFailed;
     } else if (next == '@') {
         const r = lexer.symRefP.parseFn(state);
         if (r == .ok) {
@@ -390,7 +410,7 @@ fn isIdentStart(b: u8) bool {
 /// describing why folding failed (unknown ident, div-by-zero, etc.).
 pub const EvalResult = union(enum) {
     ok: u16,
-    err: @import("include.zig").Diagnostic,
+    err: include.Diagnostic,
 };
 
 /// Fold an expression tree to a `u16` using the visible

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -170,6 +170,22 @@ pub const ErrorCode = enum(u8) {
     /// E016: char literal must be exactly one byte.
     char_literal_size = 16,
 
+    /// Map a lexer-level `ParseError.message` to the asm spec §8
+    /// code, or `null` when the message isn't one of the four
+    /// lex-level categories that map to E-codes (E006 / E010 /
+    /// E011 / E016). Substring match — the lexer messages are
+    /// stable strings; keep this lookup close to the enum so
+    /// drift is easy to spot.
+    pub fn fromLexerMessage(message: []const u8) ?ErrorCode {
+        if (std.mem.indexOf(u8, message, "hex literal exceeds 4 digits") != null) return .hex_out_of_range;
+        if (std.mem.indexOf(u8, message, "unterminated string literal") != null) return .unterminated_string;
+        if (std.mem.indexOf(u8, message, "unknown escape sequence") != null) return .unknown_escape;
+        if (std.mem.indexOf(u8, message, "empty char literal") != null) return .char_literal_size;
+        if (std.mem.indexOf(u8, message, "char literal must be exactly one byte") != null) return .char_literal_size;
+        if (std.mem.indexOf(u8, message, "unterminated char literal") != null) return .char_literal_size;
+        return null;
+    }
+
     /// Render as `E001`..`E016`. Caller owns nothing — the
     /// returned slice has static storage.
     pub fn shortLabel(self: ErrorCode) []const u8 {

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -580,15 +580,35 @@ pub fn formatPretty(
     };
     const lc = computeLineCol(loc.file.content, loc.file_offset);
     try writeHeader(writer, loc.file.path, lc, err, style);
+    try writeCaretSnippet(writer, loc.file.content, loc.file_offset, lc, style);
+}
 
-    const line_slice = lineAt(loc.file.content, loc.file_offset);
-    // Right-align the gutter so the caret column math stays simple.
-    try writer.print("{s}{d: >4} |{s} {s}\n", .{ style.gutter, lc.line, style.reset, line_slice });
-    try writer.print("{s}     |{s} ", .{ style.gutter, style.reset });
-    // Pad to column-1 spaces, then a caret. col is 1-based.
-    var pad: u32 = 1;
-    while (pad < lc.col) : (pad += 1) try writer.writeByte(' ');
-    try writer.print("{s}^{s}\n", .{ style.caret, style.reset });
+/// Same as `formatPretty` but without the leading `<path>:` —
+/// emits `<line>:<col>: [Exxx] <msg>` plus the caret snippet.
+/// Use this when the caller prints a path section header itself
+/// and wants per-file grouping (e.g. multiple errors from one
+/// included file).
+pub fn formatPrettyBody(
+    writer: anytype,
+    source_map: SourceMap,
+    err: Diagnostic,
+    style: Style,
+) !void {
+    // safety: ParseError indexes fit in u32 — our sources are
+    // bounded by max_file_size (16 MiB).
+    const offset: u32 = @intCast(err.parse_error.index);
+    const loc = source_map.lookup(offset) orelse {
+        // No source-map info — fall back to the full path-bearing
+        // shape so the user still sees something useful.
+        return formatDiagnostic(writer, source_map, err, style);
+    };
+    const lc = computeLineCol(loc.file.content, loc.file_offset);
+    try writer.print("{s}{d}:{d}{s}: ", .{ style.location, lc.line, lc.col, style.reset });
+    if (err.code) |c| {
+        try writer.print("{s}[{s}]{s} ", .{ style.code, c.shortLabel(), style.reset });
+    }
+    try writer.print("{s}\n", .{err.parse_error.message});
+    try writeCaretSnippet(writer, loc.file.content, loc.file_offset, lc, style);
 }
 
 /// `<path>:<line>:<col>: [Exxx] <message>` header line, shared
@@ -605,6 +625,25 @@ fn writeHeader(
         try writer.print("{s}[{s}]{s} ", .{ style.code, c.shortLabel(), style.reset });
     }
     try writer.print("{s}\n", .{err.parse_error.message});
+}
+
+/// Two lines: the source line with line-number gutter + the
+/// caret line under the offending column. Shared between
+/// `formatPretty` and `formatPrettyBody`.
+fn writeCaretSnippet(
+    writer: anytype,
+    content: []const u8,
+    target_offset: u32,
+    lc: LineCol,
+    style: Style,
+) !void {
+    const line_slice = lineAt(content, target_offset);
+    // Right-align the gutter so the caret column math stays simple.
+    try writer.print("{s}{d: >4} |{s} {s}\n", .{ style.gutter, lc.line, style.reset, line_slice });
+    try writer.print("{s}     |{s} ", .{ style.gutter, style.reset });
+    var pad: u32 = 1;
+    while (pad < lc.col) : (pad += 1) try writer.writeByte(' ');
+    try writer.print("{s}^{s}\n", .{ style.caret, style.reset });
 }
 
 const LineCol = struct { line: u32, col: u32 };

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -499,6 +499,35 @@ fn matchIncludeLine(line: []const u8) ?[]const u8 {
     return line[path_start..path_end];
 }
 
+/// ANSI escape strings the formatter wraps around the colored
+/// pieces of a diagnostic. `Style.plain` emits no escapes; the
+/// CLI flips to `Style.ansi` when stderr is a TTY.
+pub const Style = struct {
+    /// Wraps the `path:line:col` prefix.
+    location: []const u8 = "",
+    /// Wraps the `[Exxx]` error code.
+    code: []const u8 = "",
+    /// Wraps the gutter (line-number column + `|` separator).
+    gutter: []const u8 = "",
+    /// Wraps the caret `^` under the offending column.
+    caret: []const u8 = "",
+    /// Reset escape, emitted after every wrapped piece.
+    reset: []const u8 = "",
+
+    /// No ANSI escapes — default for tests + non-TTY output.
+    pub const plain: Style = .{};
+
+    /// Standard ANSI palette: bold location, red `[Exxx]`, dim
+    /// gutter, red caret.
+    pub const ansi: Style = .{
+        .location = "\x1b[1m",
+        .code = "\x1b[1;31m",
+        .gutter = "\x1b[2m",
+        .caret = "\x1b[1;31m",
+        .reset = "\x1b[0m",
+    };
+};
+
 /// Format one `Diagnostic` as
 /// `<path>:<line>:<col>: [<code>] <message>`. The `[Exxx]` prefix
 /// is included only when the diagnostic carries an `ErrorCode`
@@ -508,21 +537,20 @@ pub fn formatDiagnostic(
     writer: anytype,
     source_map: SourceMap,
     err: Diagnostic,
+    style: Style,
 ) !void {
     // safety: ParseError indexes fit in u32 — our sources are
     // bounded by max_file_size (16 MiB).
     const offset: u32 = @intCast(err.parse_error.index);
     if (source_map.lookup(offset)) |loc| {
         const lc = computeLineCol(loc.file.content, loc.file_offset);
-        if (err.code) |c| {
-            try writer.print("{s}:{d}:{d}: [{s}] {s}\n", .{ loc.file.path, lc.line, lc.col, c.shortLabel(), err.parse_error.message });
-        } else {
-            try writer.print("{s}:{d}:{d}: {s}\n", .{ loc.file.path, lc.line, lc.col, err.parse_error.message });
-        }
-    } else if (err.code) |c| {
-        try writer.print("<unknown>:0:{d}: [{s}] {s}\n", .{ offset, c.shortLabel(), err.parse_error.message });
+        try writeHeader(writer, loc.file.path, lc, err, style);
     } else {
-        try writer.print("<unknown>:0:{d}: {s}\n", .{ offset, err.parse_error.message });
+        try writer.print("{s}<unknown>:0:{d}{s}: ", .{ style.location, offset, style.reset });
+        if (err.code) |c| {
+            try writer.print("{s}[{s}]{s} ", .{ style.code, c.shortLabel(), style.reset });
+        }
+        try writer.print("{s}\n", .{err.parse_error.message});
     }
 }
 
@@ -542,27 +570,41 @@ pub fn formatPretty(
     writer: anytype,
     source_map: SourceMap,
     err: Diagnostic,
+    style: Style,
 ) !void {
     // safety: ParseError indexes fit in u32 — our sources are
     // bounded by max_file_size (16 MiB).
     const offset: u32 = @intCast(err.parse_error.index);
     const loc = source_map.lookup(offset) orelse {
-        return formatDiagnostic(writer, source_map, err);
+        return formatDiagnostic(writer, source_map, err, style);
     };
     const lc = computeLineCol(loc.file.content, loc.file_offset);
-    if (err.code) |c| {
-        try writer.print("{s}:{d}:{d}: [{s}] {s}\n", .{ loc.file.path, lc.line, lc.col, c.shortLabel(), err.parse_error.message });
-    } else {
-        try writer.print("{s}:{d}:{d}: {s}\n", .{ loc.file.path, lc.line, lc.col, err.parse_error.message });
-    }
+    try writeHeader(writer, loc.file.path, lc, err, style);
+
     const line_slice = lineAt(loc.file.content, loc.file_offset);
     // Right-align the gutter so the caret column math stays simple.
-    try writer.print("{d: >4} | {s}\n", .{ lc.line, line_slice });
-    try writer.writeAll("     | ");
+    try writer.print("{s}{d: >4} |{s} {s}\n", .{ style.gutter, lc.line, style.reset, line_slice });
+    try writer.print("{s}     |{s} ", .{ style.gutter, style.reset });
     // Pad to column-1 spaces, then a caret. col is 1-based.
     var pad: u32 = 1;
     while (pad < lc.col) : (pad += 1) try writer.writeByte(' ');
-    try writer.writeAll("^\n");
+    try writer.print("{s}^{s}\n", .{ style.caret, style.reset });
+}
+
+/// `<path>:<line>:<col>: [Exxx] <message>` header line, shared
+/// between `formatDiagnostic` and `formatPretty`.
+fn writeHeader(
+    writer: anytype,
+    path: []const u8,
+    lc: LineCol,
+    err: Diagnostic,
+    style: Style,
+) !void {
+    try writer.print("{s}{s}:{d}:{d}{s}: ", .{ style.location, path, lc.line, lc.col, style.reset });
+    if (err.code) |c| {
+        try writer.print("{s}[{s}]{s} ", .{ style.code, c.shortLabel(), style.reset });
+    }
+    try writer.print("{s}\n", .{err.parse_error.message});
 }
 
 const LineCol = struct { line: u32, col: u32 };

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -129,9 +129,12 @@ pub const Located = struct {
 /// `parse_error.index`). Use `SourceMap.lookup` to resolve.
 /// `code` is set for semantic errors that map to asm spec §8's
 /// E001..E016 list; generic syntax errors leave it `null`.
+/// `note` is an optional borrowed hint (e.g. "did you mean `foo`?")
+/// that the formatter renders below the main diagnostic line.
 pub const Diagnostic = struct {
     parse_error: core.ParseError,
     code: ?ErrorCode = null,
+    note: ?[]const u8 = null,
 };
 
 /// Asm spec §8 error codes. Numerical IDs match the spec's
@@ -581,6 +584,7 @@ pub fn formatPretty(
     const lc = computeLineCol(loc.file.content, loc.file_offset);
     try writeHeader(writer, loc.file.path, lc, err, style);
     try writeCaretSnippet(writer, loc.file.content, loc.file_offset, lc, style);
+    try writeNote(writer, err.note, style);
 }
 
 /// Same as `formatPretty` but without the leading `<path>:` —
@@ -609,6 +613,7 @@ pub fn formatPrettyBody(
     }
     try writer.print("{s}\n", .{err.parse_error.message});
     try writeCaretSnippet(writer, loc.file.content, loc.file_offset, lc, style);
+    try writeNote(writer, err.note, style);
 }
 
 /// `<path>:<line>:<col>: [Exxx] <message>` header line, shared
@@ -625,6 +630,13 @@ fn writeHeader(
         try writer.print("{s}[{s}]{s} ", .{ style.code, c.shortLabel(), style.reset });
     }
     try writer.print("{s}\n", .{err.parse_error.message});
+}
+
+/// Render an optional `note:` suggestion line below the caret.
+fn writeNote(writer: anytype, note: ?[]const u8, style: Style) !void {
+    if (note) |n| {
+        try writer.print("{s}     ={s} note: did you mean `{s}{s}{s}`?\n", .{ style.gutter, style.reset, style.location, n, style.reset });
+    }
 }
 
 /// Two lines: the source line with line-number gutter + the

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -73,6 +73,7 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "mov8", .kinds = &.{ .addr, .reg }, .opcode = 0x22 },
     .{ .mnemonic = "mov8", .kinds = &.{ .reg, .reg_indirect }, .opcode = 0x23 },
     .{ .mnemonic = "mov8", .kinds = &.{ .reg_indirect, .reg }, .opcode = 0x24 },
+    .{ .mnemonic = "mov8", .kinds = &.{ .indexed, .reg }, .opcode = 0x29 },
     .{ .mnemonic = "movh", .kinds = &.{ .reg, .addr }, .opcode = 0x25 },
     .{ .mnemonic = "movl", .kinds = &.{ .reg, .addr }, .opcode = 0x26 },
 
@@ -205,13 +206,17 @@ fn classifyLabelRef(l: ast.LabelRef, symbols: ?*const symtab.SymbolTable) Kind {
 }
 
 /// Resolve a `label_ref` operand's `Kind` given its lexeme and
-/// the populated `SymbolTable`. A `const` resolves to `imm16`;
-/// a label or data symbol resolves to `addr`; an unknown name
-/// (forward reference or genuine miss) defaults to `addr`.
+/// the populated `SymbolTable`. A `const` resolves to `imm8` when
+/// its value fits in `u8`, otherwise `imm16`; a label or data
+/// symbol resolves to `addr`; an unknown name (forward reference
+/// or genuine miss) defaults to `addr`. The same narrowing rule
+/// that `codegen.narrowImm` applies to literal `.immediate`
+/// operands also applies here so symbolic ergonomics (`int PRINT`
+/// where `PRINT = $10`) work with imm8-only opcodes.
 pub fn labelRefKind(name: []const u8, symbols: symtab.SymbolTable) Kind {
     if (symbols.get(name)) |sym| {
         return switch (sym.kind) {
-            .const_value, .struct_field => .imm16,
+            .const_value, .struct_field => if (sym.value <= 0xFF) .imm8 else .imm16,
             .label, .data => .addr,
         };
     }

--- a/src/asm/parser.zig
+++ b/src/asm/parser.zig
@@ -152,6 +152,12 @@ fn tryParseLabel(
 ) !bool {
     const saved = state.index;
     skipBlanksInLine(state);
+    // Local label: `.foo:` — the leading `.` is part of the name
+    // span. Codegen mangles to `parent.foo` against the most
+    // recent global label.
+    const has_dot = state.index < state.input.len and state.input[state.index] == '.';
+    const name_start: u32 = u32At(state.index);
+    if (has_dot) state.advance(1);
     const ident_result = lexer.identP.parseFn(state);
     if (ident_result != .ok) {
         state.index = saved;
@@ -166,11 +172,17 @@ fn tryParseLabel(
     }
     const colon_token = colon_result.ok.value;
     _ = stmt_start;
+    const name_span: ast.Span = .{ .start = name_start, .end = ident_token.end };
     try statements.append(allocator, .{ .label = .{
-        .name = ast.Span.fromToken(ident_token),
-        .span = ast.Span.join(ast.Span.fromToken(ident_token), ast.Span.fromToken(colon_token)),
+        .name = name_span,
+        .span = ast.Span.join(name_span, ast.Span.fromToken(colon_token)),
     } });
     return true;
+}
+
+fn u32At(i: usize) u32 {
+    // @as: fused-source byte offsets fit in u32 (max_file_size = 16 MiB).
+    return @as(u32, @intCast(i));
 }
 
 // ---------- const directive ----------
@@ -386,9 +398,14 @@ fn parseDataValue(
                 .span = .{ .start = tok.start, .end = tok.end },
             } };
         }
-        // Fall through — the string parser refused (probably
-        // unterminated). Let the lexer's earlier error stand;
-        // we'll surface a generic "expected value" below.
+        // The leading byte was `"` — anything past that is a
+        // malformed string literal (unterminated, bad escape).
+        // Surface the lexer's specific error with its E-code.
+        try errors.append(state.allocator, .{
+            .code = include.ErrorCode.fromLexerMessage(r.err.message),
+            .parse_error = r.err,
+        });
+        return error.ParseFailed;
     }
 
     // `&FFFF` address literal — must come before the expression
@@ -854,6 +871,26 @@ fn parseOperand(
         return error.ParseFailed;
     }
 
+    // Local-label ref: `.foo` (codegen mangles via parent label).
+    if (b == '.') {
+        const dot_start: u32 = u32At(state.index);
+        state.advance(1);
+        const r = lexer.identP.parseFn(state);
+        if (r != .ok) {
+            try errors.append(state.allocator, .{
+                .parse_error = core.parseError(
+                    "operand",
+                    state.index,
+                    "expected identifier after `.` for a local-label reference",
+                    .{ .expected = "local label name", .kind = .syntactic },
+                ),
+            });
+            return error.ParseFailed;
+        }
+        const tok = r.ok.value;
+        return .{ .label_ref = .{ .span = .{ .start = dot_start, .end = tok.end } } };
+    }
+
     // Identifier — either a register name or a label/const reference.
     if ((b >= 'A' and b <= 'Z') or (b >= 'a' and b <= 'z') or b == '_') {
         const r = lexer.identP.parseFn(state);
@@ -1143,7 +1180,7 @@ fn recordUnknown(
         .parse_error = core.parseError(
             "statement",
             stmt_start,
-            "unrecognized statement shape (directives + instructions arrive in follow-up PRs)",
+            "unrecognized statement",
             .{ .kind = .syntactic },
         ),
     });

--- a/src/asm/symtab.zig
+++ b/src/asm/symtab.zig
@@ -89,6 +89,61 @@ pub const SymbolTable = struct {
         return self.entries.get(name);
     }
 
+    /// Scan every known name for one that's "close" to `query`
+    /// by Levenshtein distance. Returns the closest match within
+    /// threshold (1 for short names, 2 for longer) or `null`. The
+    /// returned slice borrows from the symbol table's keys —
+    /// callers must treat it as valid only for the table's
+    /// lifetime. Used to power "did you mean?" hints on E004.
+    pub fn suggestSimilar(self: SymbolTable, query: []const u8) ?[]const u8 {
+        if (query.len == 0) return null;
+        const threshold: usize = if (query.len <= 4) 1 else 2;
+        var best: ?[]const u8 = null;
+        var best_dist: usize = std.math.maxInt(usize);
+        var it = self.entries.keyIterator();
+        while (it.next()) |k_ptr| {
+            const k = k_ptr.*;
+            // Length filter: anything farther in length than the
+            // threshold can't possibly fit. Cheap pre-check before
+            // the O(n*m) edit-distance walk.
+            const dlen = if (k.len > query.len) k.len - query.len else query.len - k.len;
+            if (dlen > threshold) continue;
+            const d = levenshtein(query, k);
+            if (d <= threshold and d < best_dist) {
+                best_dist = d;
+                best = k;
+            }
+        }
+        return best;
+    }
+
+    /// Compact Levenshtein implementation backed by a small
+    /// stack buffer. Used only for "did you mean?" suggestions on
+    /// names of typical asm-symbol length, so the cap is fine.
+    fn levenshtein(a: []const u8, b: []const u8) usize {
+        const max_len: usize = 64;
+        if (a.len > max_len or b.len > max_len) {
+            // Beyond the buffer — return a value past every
+            // sensible threshold so the candidate is skipped.
+            return std.math.maxInt(usize);
+        }
+        var prev: [max_len + 1]usize = undefined;
+        var curr: [max_len + 1]usize = undefined;
+        for (0..b.len + 1) |j| prev[j] = j;
+        for (1..a.len + 1) |i| {
+            curr[0] = i;
+            for (1..b.len + 1) |j| {
+                const cost: usize = if (a[i - 1] == b[j - 1]) 0 else 1;
+                curr[j] = @min(
+                    @min(curr[j - 1] + 1, prev[j] + 1),
+                    prev[j - 1] + cost,
+                );
+            }
+            @memcpy(prev[0 .. b.len + 1], curr[0 .. b.len + 1]);
+        }
+        return prev[b.len];
+    }
+
     /// Project this table down to a `ConstantTable` so the
     /// expression evaluator can use it. Keys + values are
     /// borrowed — the returned table's lifetime is bounded by

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -93,6 +93,7 @@ pub const handler_table: [256]Handler = blk: {
     t[0x22] = mov.mov8AddrReg;
     t[0x23] = mov.mov8RegPtr;
     t[0x24] = mov.mov8PtrReg;
+    t[0x29] = mov.mov8Indexed;
     t[0x25] = mov.movhRegAddr;
     t[0x26] = mov.movlRegAddr;
     t[0x27] = mov.bcpyRegRegReg;

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -189,6 +189,21 @@ pub fn mov8PtrReg(vm: *VM) StepResult {
     return ok;
 }
 
+/// `0x29` — `mov8 [Addr + Reg], Reg` → byte-level indexed load:
+/// `dst.lo ← mem[addr + idx]; dst.hi ← 0`. Use for stepping
+/// through `data8` byte arrays (the word-sized `0x17` overlaps
+/// adjacent bytes on each iteration).
+pub fn mov8Indexed(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const base = vm.readWord(ip +% 1);
+    const idx_reg = vm.readByte(ip +% 3);
+    const dst = vm.readByte(ip +% 4);
+    const offset = vm.regs.readByIndex(idx_reg) orelse return fault(vm, .invalid_register);
+    const value = vm.readByte(base +% offset);
+    if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
 /// `0x25` — `movh Reg, Addr` → `mem[addr] ← reg.hi`.
 pub fn movhRegAddr(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -61,6 +61,7 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x22] = .{ .mnemonic = "mov8", .operands = &.{ .addr, .reg } };
     t[0x23] = .{ .mnemonic = "mov8", .operands = &.{ .reg, .reg } };
     t[0x24] = .{ .mnemonic = "mov8", .operands = &.{ .reg, .reg } };
+    t[0x29] = .{ .mnemonic = "mov8", .operands = &.{ .addr, .reg, .reg } };
     t[0x25] = .{ .mnemonic = "movh", .operands = &.{ .reg, .addr } };
     t[0x26] = .{ .mnemonic = "movl", .operands = &.{ .reg, .addr } };
 

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -117,6 +117,27 @@ test "codegen: same local-label name reuses across global scopes" {
     try std.testing.expect(!out.cg.hasErrors());
 }
 
+test "codegen: undefined label_ref suggests a close-by name via `note`" {
+    var out = try assemble(
+        \\nowhere:
+        \\  hlt
+        \\main:
+        \\  jmp nowher
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var found = false;
+    for (out.cg.errors) |e| {
+        if (e.code == .undefined_symbol) {
+            if (e.note) |n| if (std.mem.eql(u8, n, "nowhere")) {
+                found = true;
+            };
+        }
+    }
+    try std.testing.expect(found);
+}
+
 test "codegen: local label with no enclosing global is E004-shape" {
     var out = try assemble(
         \\.orphan:

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -74,6 +74,71 @@ test "codegen: int $10 narrows to 1-byte imm8 operand (0xFC 0x10)" {
     try std.testing.expectEqualSlices(u8, &.{ 0xFC, 0x10 }, out.imageBody());
 }
 
+test "codegen: int CONST narrows when const value ≤ u8" {
+    // `const PRINT = $10` resolves the bare ident to an imm8
+    // operand, matching the `int Imm8` shape. Same on-wire bytes
+    // as `int $10`.
+    var out = try assemble(
+        \\const PRINT = $10
+        \\int PRINT
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    try std.testing.expectEqualSlices(u8, &.{ 0xFC, 0x10 }, out.imageBody());
+}
+
+test "codegen: local labels resolve against the enclosing global" {
+    var out = try assemble(
+        \\main:
+        \\.loop:
+        \\  jmp .loop
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    // image: jmp(0x70) + addr LE(0x0000) — local label resolves to
+    // offset 0, the address of `main:` / `.loop:` (they share the
+    // same byte address since neither emits code before .loop).
+    try std.testing.expectEqualSlices(u8, &.{ 0x70, 0x00, 0x00 }, out.imageBody());
+}
+
+test "codegen: same local-label name reuses across global scopes" {
+    var out = try assemble(
+        \\first:
+        \\.done:
+        \\  hlt
+        \\second:
+        \\.done:
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+}
+
+test "codegen: local label with no enclosing global is E004-shape" {
+    var out = try assemble(
+        \\.orphan:
+        \\hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+}
+
+test "codegen: int CONST errors when const value > u8" {
+    // `const BIG = $1234` → label_ref reports .imm16, no imm16
+    // shape for `int`, no widening possible — E003.
+    var out = try assemble(
+        \\const BIG = $1234
+        \\int BIG
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+}
+
 test "codegen: shl r1, $03 uses imm8 shape (0x58 reg imm8)" {
     var out = try assemble("shl r1, $03\n", .{});
     defer out.deinit();
@@ -229,6 +294,37 @@ test "codegen: header magic + version + entry_point + image_size" {
     // bank_count = 0, sram_bank_count = 0.
     try std.testing.expectEqual(@as(u8, 0), out.cg.image[12]);
     try std.testing.expectEqual(@as(u8, 0), out.cg.image[13]);
+}
+
+test "codegen: entry_point auto-detects a `main:` label" {
+    // `nop` then `main:` then `hlt`. main is at offset 1.
+    var out = try assemble(
+        \\nop
+        \\main:
+        \\hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[8]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[9]);
+}
+
+test "codegen: entry_point defaults to 0 when no `main:` label exists" {
+    var out = try assemble("hlt\n", .{});
+    defer out.deinit();
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[8]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[9]);
+}
+
+test "codegen: explicit entry_point overrides `main:` auto-detect" {
+    var out = try assemble(
+        \\main:
+        \\hlt
+        \\
+    , .{ .entry_point = 0x2222 });
+    defer out.deinit();
+    try std.testing.expectEqual(@as(u8, 0x22), out.cg.image[8]);
+    try std.testing.expectEqual(@as(u8, 0x22), out.cg.image[9]);
 }
 
 // ---------- errors ----------

--- a/tests/asm/include.test.zig
+++ b/tests/asm/include.test.zig
@@ -332,7 +332,7 @@ test "include: formatDiagnostic produces path:line:col prefix" {
 
     var allocating = std.Io.Writer.Allocating.init(alloc);
     defer allocating.deinit();
-    try gero.asm_.formatDiagnostic(&allocating.writer, fused.source_map, fused.errors[0]);
+    try gero.asm_.formatDiagnostic(&allocating.writer, fused.source_map, fused.errors[0], .plain);
 
     const out = allocating.written();
     try std.testing.expect(std.mem.indexOf(u8, out, "main.gas") != null);
@@ -354,7 +354,7 @@ test "include: formatPretty emits a caret line under the column" {
 
     var allocating = std.Io.Writer.Allocating.init(alloc);
     defer allocating.deinit();
-    try gero.asm_.formatPretty(&allocating.writer, fused.source_map, fused.errors[0]);
+    try gero.asm_.formatPretty(&allocating.writer, fused.source_map, fused.errors[0], .plain);
 
     const out = allocating.written();
     // Header line has the [E015] prefix.
@@ -363,4 +363,27 @@ test "include: formatPretty emits a caret line under the column" {
     try std.testing.expect(std.mem.indexOf(u8, out, "include \"nope.gas\"") != null);
     // A caret line exists.
     try std.testing.expect(std.mem.indexOf(u8, out, "^") != null);
+    // No ANSI escapes with the default plain style.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[") == null);
+}
+
+test "include: formatPretty with ansi style emits ANSI escapes" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("main.gas", "include \"nope.gas\"\n");
+
+    const main_path = try fx.pathOf("main.gas");
+    defer alloc.free(main_path);
+
+    var fused = try gero.asm_.resolveIncludes(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    defer allocating.deinit();
+    try gero.asm_.formatPretty(&allocating.writer, fused.source_map, fused.errors[0], .ansi);
+
+    const out = allocating.written();
+    // At minimum: the bold-red [Exxx] wrap + a reset.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[1;31m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[0m") != null);
 }

--- a/tests/asm/opcode_resolver.test.zig
+++ b/tests/asm/opcode_resolver.test.zig
@@ -72,6 +72,17 @@ test "opres: indexed addressing emits 3-byte operand (addr + reg)" {
     try std.testing.expectEqualSlices(u8, &.{ 0x17, 0x20, 0x26, 0x02, 0x03 }, cg.image[16..]);
 }
 
+test "opres: mov8 indexed emits 5-byte operand (opcode + addr + 2 regs)" {
+    const src = "mov8 [&3000 + r1], r2\n";
+    var pt = try gero.asm_.parse(alloc, src);
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    defer cg.deinit();
+    try std.testing.expect(!cg.hasErrors());
+    // 0x29 + addr LE (00 30) + idx_reg (r1 = 0x02) + dst_reg (r2 = 0x03)
+    try std.testing.expectEqualSlices(u8, &.{ 0x29, 0x00, 0x30, 0x02, 0x03 }, cg.image[16..]);
+}
+
 test "opres: imm8 narrowing — mov8 picks Imm8 shape over widening" {
     // `mov8 $42, r1` — value fits u8, mov8 has an Imm8,Reg shape
     // exactly. Total 3 bytes: opcode + imm8 + reg.

--- a/tests/asm/parser.test.zig
+++ b/tests/asm/parser.test.zig
@@ -361,6 +361,50 @@ test "parser: data16 accepts the same forms minus strings" {
     }
 }
 
+test "parser: hex literal exceeding 4 digits surfaces [E006]" {
+    var pt = try parseSource("data16 X = $12345\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    var saw = false;
+    for (pt.errors) |e| if (e.code == .hex_out_of_range) {
+        saw = true;
+    };
+    try std.testing.expect(saw);
+}
+
+test "parser: unknown string escape surfaces [E010]" {
+    var pt = try parseSource("data8 X = \"a\\q\"\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    var saw = false;
+    for (pt.errors) |e| if (e.code == .unknown_escape) {
+        saw = true;
+    };
+    try std.testing.expect(saw);
+}
+
+test "parser: unterminated string surfaces [E011]" {
+    var pt = try parseSource("data8 X = \"oops\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    var saw = false;
+    for (pt.errors) |e| if (e.code == .unterminated_string) {
+        saw = true;
+    };
+    try std.testing.expect(saw);
+}
+
+test "parser: multi-byte char literal surfaces [E016]" {
+    var pt = try parseSource("data8 X = 'AB'\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    var saw = false;
+    for (pt.errors) |e| if (e.code == .char_literal_size) {
+        saw = true;
+    };
+    try std.testing.expect(saw);
+}
+
 test "parser: data16 with string literal surfaces a diagnostic" {
     var pt = try parseSource("data16 bad = \"hi\"\n");
     defer pt.deinit();

--- a/tests/asm/symtab.test.zig
+++ b/tests/asm/symtab.test.zig
@@ -55,6 +55,23 @@ test "symtab: putOwned owns the key memory" {
     // Cleanup via st.deinit() frees the owned key — no leak.
 }
 
+test "symtab: suggestSimilar finds a close match for a typo" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    try st.putBorrowed("nowhere", .{ .kind = .label, .value = 0x10 });
+    try st.putBorrowed("main", .{ .kind = .label, .value = 0x20 });
+    // `nowher` (1 deletion) → "nowhere"
+    try std.testing.expectEqualStrings("nowhere", st.suggestSimilar("nowher").?);
+}
+
+test "symtab: suggestSimilar returns null when nothing is close" {
+    var st = gero.asm_.SymbolTable.init(alloc);
+    defer st.deinit();
+    try st.putBorrowed("foo", .{ .kind = .label, .value = 0 });
+    try st.putBorrowed("bar", .{ .kind = .label, .value = 0 });
+    try std.testing.expect(st.suggestSimilar("xyzqwertyu") == null);
+}
+
 test "symtab: toConstantTable projects to expr.ConstantTable" {
     var st = gero.asm_.SymbolTable.init(alloc);
     defer st.deinit();

--- a/tests/vm/handlers/mov.test.zig
+++ b/tests/vm/handlers/mov.test.zig
@@ -106,6 +106,19 @@ test "mov 0x17 addr,reg,reg: indexed load (base + offset_reg)" {
     try std.testing.expectEqual(@as(u16, 0x1105), vm.regs.read(.ip));
 }
 
+test "mov8 0x29 addr,reg,reg: indexed BYTE load (base + offset_reg)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+
+    vm.regs.write(.r1, 0x10); // offset
+    vm.mmap.writeByte(0x2010, 0x42);
+    vm.mmap.writeByte(0x2011, 0xFF); // adjacent byte — must NOT bleed into r2 hi
+    loadProgram(&vm, &.{ 0x29, 0x00, 0x20, 0x02, 0x03 }); // r2 ← mem[0x2000 + r1]
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0042), vm.regs.read(.r2));
+    try std.testing.expectEqual(@as(u16, 0x1105), vm.regs.read(.ip));
+}
+
 test "mov 0x18 imm16,[reg]: imm to memory via pointer register" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -29,12 +29,12 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
-test "opcodes: table holds exactly 92 named entries" {
+test "opcodes: table holds exactly 93 named entries" {
     var count: usize = 0;
     for (table) |entry| if (entry != null) {
         count += 1;
     };
-    try std.testing.expectEqual(@as(usize, 92), count);
+    try std.testing.expectEqual(@as(usize, 93), count);
 }
 
 test "opcodes: every named entry has a non-empty mnemonic" {
@@ -96,15 +96,15 @@ test "opcodes: instruction sizes span the full 1-5 byte range" {
     try std.testing.expectEqual(@as(u8, 4), table[0x40].?.size()); // add imm16,reg
     try std.testing.expectEqual(@as(u8, 4), table[0x7E].?.size()); // djnz reg,addr
 
-    // 5 bytes — only the indexed mov.
+    // 5 bytes — indexed mov (word) + indexed mov8 (byte).
     try std.testing.expectEqual(@as(u8, 5), table[0x17].?.size()); // mov addr,reg,reg
+    try std.testing.expectEqual(@as(u8, 5), table[0x29].?.size()); // mov8 addr,reg,reg
 }
 
 test "opcodes: unused byte values are null" {
     // Spot-check several gaps in the spec's opcode space.
     try std.testing.expect(table[0x00] == null);
     try std.testing.expect(table[0x0F] == null);
-    try std.testing.expect(table[0x29] == null);
     try std.testing.expect(table[0x33] == null);
     try std.testing.expect(table[0x57] == null);
     try std.testing.expect(table[0x68] == null);


### PR DESCRIPTION
## Summary

Real-conditions end-to-end testing of the assembler surfaced six interlocking gaps. All fixed here in 4 logical commits.

### Asm side (5 fixes in one commit)
- **Stale parser scaffold message** removed — directives + instructions are fully implemented now.
- **`int CONST` narrowing**: `labelRefKind` reports `.imm8` when const_value fits `u8`, mirroring PR #91's literal-imm narrowing.
- **Entry-point auto-detect**: `Options.entry_point: ?u16 = null` triggers detection of a `main:` label; explicit overrides win.
- **Lexer E-codes propagated**: hex / string / char / escape errors raised by the lexer leaves now flow up with `[E006] / [E010] / [E011] / [E016]` instead of the generic "expected a hex literal..." fallback.
- **Local labels (`.foo:`)**: parser accepts a leading dot in both declarations and operand refs; codegen mangles to `parent.foo` against the most recent global label. Each new global resets the local scope.

### VM + ISA (1 commit)
- **`0x29 mov8 [Addr + Reg], Reg`** — byte-level indexed load. The existing `0x17 mov` form reads a `u16` word, which made byte-by-byte iteration over `data8` strings impossible. New opcode reads exactly one byte.

### CLI multi-error mode (1 commit)
- Show parse + codegen errors together (sorted by source position) instead of short-circuiting after parse failures.
- Dedupe `const_decl` re-evaluation diagnostics — codegen stays silent on eval failure since the parser already raised the same error.

## Real-conditions smoke

```bash
$ cat /tmp/gero-test/ok/kitchen-sink.gas
const NEWLINE = $0A
const PRINT   = $10
struct Header { magic: u16, flags: u8 }
org $0040
main:
  mov $00, r3
.loop:
  mov8 [@GREETING + r3], r1
  cmp r1, $00
  jeq .done
  int PRINT
  inc r3
  jmp .loop
.done:
  mov NEWLINE, r1
  int PRINT
  hlt
data8 GREETING = "Hi from gero!", $00

$ gero asm /tmp/gero-test/ok/kitchen-sink.gas
/tmp/gero-test/ok/kitchen-sink.gx (124 bytes, 0 banks, debug: no)

$ gero info /tmp/gero-test/ok/kitchen-sink.gx
entry:   0x0040           ← auto-detected from `main:`

$ gero run /tmp/gero-test/ok/kitchen-sink.gx
Hi from gero!
[exit=0]
```

## Multi-error output

```
$ gero asm broken.gas
broken.gas:2:13: [E009] division by zero...
broken.gas:4:1:  [E005] duplicate label
broken.gas:5:10: [E006] hex literal exceeds 4 digits
broken.gas:6:5:  [E004] undefined symbol
broken.gas:7:1:  [E001] unknown mnemonic
broken.gas:8:1:  [E003] operand type mismatch
broken.gas:9:15: [E010] unknown escape sequence
broken.gas:10:13: [E016] char literal must be exactly one byte
broken.gas:14:1: [E014] backward `org` would overlap...
[exit=3]
```

## Test plan
- [x] `zig build ci` green
- [x] 7 new codegen tests (int CONST, entry-point, local labels, mov8 indexed)
- [x] 4 new parser tests (lexer E-codes E006/E010/E011/E016)
- [x] 1 new VM handler test (mov8 indexed byte semantics)
- [x] Manual smoke: kitchen-sink prints `Hi from gero!\n`, exit 0
- [x] Manual multi-error smoke: 9 distinct errors in one file all surface in source order
- [x] E-code coverage in formatter: 12/16 (up from 8). E002/E007/E008/E013 untagged — orthogonal scope.

Closes #92.