### PR TITLE
feat(asm,vm)!: unify operand order — closes #94

### DIFF
--- a/.changeset/e5q83p41.md
+++ b/.changeset/e5q83p41.md
@@ -1,0 +1,44 @@
+---
+bump: major
+---
+
+**Breaking ISA change** — flip the operand order of every two-register
+binary instruction to **src-first** (AT&T-style). Closes #94.
+
+Previously the immediate / address forms were src-first
+(`mov $10, r1` → r1 ← $10) while the reg-reg forms silently used
+Intel order (`mov r1, r2` → r1 ← r2 — dst first). That trap bit
+`fib.gas` during #47 and would have bit every future example /
+language consumer the same way.
+
+After this PR every binary form is uniform:
+
+```asm
+mov $10, r1    ; r1 ← $10       (src, dst)
+mov r2, r1     ; r1 ← r2        (src, dst)
+add $10, r1    ; r1 += $10      (src, dst)
+add r2, r1     ; r1 += r2       (src, dst)
+sub r2, r1     ; r1 -= r2       (src, dst)
+and r2, r1     ; r1 &= r2       (src, dst)
+```
+
+**Flipped**: `mov`, `add`, `sub`, `mul`, `div`, `divs`, `adc`, `sbc`,
+`and`, `or`, `xor` (11 reg-reg handlers — read `byte1 = src`,
+`byte2 = dst` instead of the reverse).
+
+**Intentionally NOT flipped**:
+- `cmp` / `tst` — both operands are inputs, no destination. Current
+  behavior (`cmp first, second` computes `first - second` and sets
+  flags) reads naturally — `cmp r1, $10; jlt` means "jump if r1 <
+  $10". Flipping would invert the jump semantics for no benefit.
+- Shift / rotate (`shl`, `shr`, `rol`, `ror`) — modify-in-place ops
+  with a count parameter, not a binary dst/src pair. Convention
+  stays `<op> target, count`.
+- Block ops (`bcpy`, `bset`) — three-operand C-stdlib shape
+  `(dst, src, len)`.
+
+Documented in `docs/asm.md §2.4`.
+
+**Bytecode impact**: existing `.gx` files that used any of the 11
+flipped reg-reg forms will now compute different results — they
+must be re-assembled. Major version bump.

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -372,6 +372,41 @@ mov $80, r1            ; 0x1A — zero-page load
 The assembler rejects invalid combinations (`mov &addr, &addr` has
 no opcode) at assembly time with `E003`.
 
+### 2.4 Operand order convention
+
+Every binary instruction reads as **`<op> src, dst`** — the first
+operand is the source, the second is the destination (modified
+in-place). This is the AT&T-style ordering and it is uniform
+across every form: immediate-to-register, register-to-register,
+register-to-memory, memory-to-register, etc.
+
+```asm
+mov $1234, r1          ; r1 ← $1234           (src=$1234, dst=r1)
+mov r1, r2             ; r2 ← r1              (src=r1, dst=r2)
+mov &2620, r1          ; r1 ← mem[$2620]      (src=mem, dst=r1)
+mov r1, &2620          ; mem[$2620] ← r1      (src=r1, dst=mem)
+
+add $10, r1            ; r1 ← r1 + $10        (src=$10, dst=r1)
+add r2, r1             ; r1 ← r1 + r2         (src=r2, dst=r1)
+sub r2, r1             ; r1 ← r1 - r2         (src=r2, dst=r1)
+and r2, r1             ; r1 ← r1 & r2         (src=r2, dst=r1)
+```
+
+Two families are intentionally different:
+
+- **`cmp` and `tst`** — both operands are inputs (no destination),
+  the result is just the flags. `cmp r1, $10` reads naturally as
+  *"compare r1 to $10"*: it sets flags from `r1 - $10` so that
+  `jlt` jumps when `r1 < $10`. The first operand is the value
+  being inspected.
+- **Shift / rotate (`shl`, `shr`, `rol`, `ror`)** — the first
+  operand is the target register being shifted in-place, the
+  second is the shift count. `shl r1, $03` shifts r1 by 3.
+  Modify-in-place shape, no separate source register.
+
+The 3-operand block ops (`bcpy`, `bset`) keep `(dst, src, len)` /
+`(dst, len, val)` — they mirror the C standard library shape.
+
 ---
 
 ## 3. Operands

--- a/examples/asm/README.md
+++ b/examples/asm/README.md
@@ -41,15 +41,18 @@ asm grows those features:
 - `save.gas` — write to SRAM + `int $21` flush, demonstrating
   persistence to a `.sav` file.
 
-## Operand-order quirk
+## Operand order
 
-`mov reg, reg` (and `add reg, reg`) use **Intel order** (dst first),
-while all other forms are AT&T-style (src first). See issue #94 for
-the discussion. Until that's resolved, the rule for these examples is:
+Every binary instruction reads as `<op> src, dst` — the first
+operand is the source, the second is the destination modified
+in-place. See `docs/asm.md §2.4` for the full convention. Quick
+reference:
 
 ```asm
-mov $10, r1     ; src first  → r1 ← $10
-mov r2, r1      ; dst first  → r2 ← r1
-add $10, r1     ; src first  → r1 += $10
-add r1, r2      ; dst first  → r1 += r2
+mov $10, r1     ; r1 ← $10
+mov r2, r1      ; r1 ← r2
+add $10, r1     ; r1 += $10
+add r2, r1      ; r1 += r2
 ```
+
+`cmp` / `tst` / shifts are intentionally different — see the spec.

--- a/examples/asm/fib.gas
+++ b/examples/asm/fib.gas
@@ -20,13 +20,13 @@ main:
   mov $0A, r1                ; n = 10
   call fib                   ; r1 ← fib(10) = $37
 
-  ; print r1.lo as 2 hex digits. Note: `mov reg, reg` is Intel-
-  ; order (dst, src) — opposite of the imm / addr forms which
-  ; are src-first. So `mov r2, r1` copies r1 INTO r2.
-  mov r2, r1                 ; r2 ← r1 (save the full value)
+  ; print r1.lo as 2 hex digits. The asm uses src-first
+  ; convention for every form including `mov reg, reg` —
+  ; `mov r1, r2` means r2 ← r1.
+  mov r1, r2                 ; r2 ← r1 (save the full value)
   shr r1, $04                ; r1 = high nibble
   call print_nibble
-  mov r1, r2                 ; r1 ← r2 (restore)
+  mov r2, r1                 ; r1 ← r2 (restore)
   and r1, $0F                ; r1 = low nibble
   call print_nibble
 
@@ -47,13 +47,13 @@ fib:
   push r1                    ; save n
   dec r1
   call fib                   ; r1 = fib(n-1)
-  pop r2                     ; r2 = n  (Intel order — pop reg means pop INTO reg)
+  pop r2                     ; r2 = n
   push r1                    ; save fib(n-1)
-  mov r1, r2                 ; r1 ← r2 (restore n into r1 for the n-2 recursion)
+  mov r2, r1                 ; r1 ← r2 (restore n into r1 for the n-2 recursion)
   sub $02, r1                ; r1 = n - 2
   call fib                   ; r1 = fib(n-2)
   pop r2                     ; r2 = fib(n-1)
-  add r1, r2                 ; r1 ← r1 + r2 = fib(n-2) + fib(n-1)
+  add r2, r1                 ; r1 += r2  (asm: src, dst — r2 onto r1)
 .base:
   ret
 

--- a/src/vm/handlers/arith.zig
+++ b/src/vm/handlers/arith.zig
@@ -76,11 +76,11 @@ pub fn addImm16Reg(vm: *VM) StepResult {
     return writeAddSub(vm, reg, addWithCarry(a, imm, 0));
 }
 
-/// `0x41` — `add Reg, Reg` → `dst ← dst + src`.
+/// `0x41` — `add Reg, Reg` → `dst ← dst + src` (asm: `add src, dst`).
 pub fn addRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, dst, addWithCarry(a, b, 0));
@@ -111,11 +111,11 @@ pub fn subImm16Reg(vm: *VM) StepResult {
     return writeAddSub(vm, reg, subWithBorrow(a, imm, 0));
 }
 
-/// `0x44` — `sub Reg, Reg` → `dst ← dst - src`.
+/// `0x44` — `sub Reg, Reg` → `dst ← dst - src` (asm: `sub src, dst`).
 pub fn subRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, dst, subWithBorrow(a, b, 0));
@@ -164,11 +164,11 @@ pub fn mulImm16Reg(vm: *VM) StepResult {
     return doMul(vm, reg, a, imm);
 }
 
-/// `0x47` — `mul Reg, Reg` → `acu:dst ← dst × src`.
+/// `0x47` — `mul Reg, Reg` → `acu:dst ← dst × src` (asm: `mul src, dst`).
 pub fn mulRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return doMul(vm, dst, a, b);
@@ -275,11 +275,11 @@ pub fn divImm16Reg(vm: *VM) StepResult {
     return doDiv(vm, reg, dividend32(vm, low), divisor);
 }
 
-/// `0x4C` — `div Reg, Reg` → unsigned 32÷16: `acu:dst ÷ src`.
+/// `0x4C` — `div Reg, Reg` → unsigned 32÷16: `acu:dst ÷ src` (asm: `div src, dst`).
 pub fn divRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const low = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const src_value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     const divisor: u32 = src_value;
@@ -298,11 +298,11 @@ pub fn divsImm16Reg(vm: *VM) StepResult {
     return doDivs(vm, reg, dividend32Signed(vm, low), divisor_signed);
 }
 
-/// `0x4E` — `divs Reg, Reg` → signed 32÷16.
+/// `0x4E` — `divs Reg, Reg` → signed 32÷16 (asm: `divs src, dst`).
 pub fn divsRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const low = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const divisor = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     // safety: u16 → i16 preserves the sign bit
@@ -326,11 +326,11 @@ pub fn adcImm16Reg(vm: *VM) StepResult {
     return writeAddSub(vm, reg, addWithCarry(a, imm, carryIn(vm)));
 }
 
-/// `0x65` — `adc Reg, Reg` → `dst ← dst + src + C`.
+/// `0x65` — `adc Reg, Reg` → `dst ← dst + src + C` (asm: `adc src, dst`).
 pub fn adcRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, dst, addWithCarry(a, b, carryIn(vm)));
@@ -345,11 +345,11 @@ pub fn sbcImm16Reg(vm: *VM) StepResult {
     return writeAddSub(vm, reg, subWithBorrow(a, imm, carryIn(vm)));
 }
 
-/// `0x67` — `sbc Reg, Reg` → `dst ← dst - src - C`.
+/// `0x67` — `sbc Reg, Reg` → `dst ← dst - src - C` (asm: `sbc src, dst`).
 pub fn sbcRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeAddSub(vm, dst, subWithBorrow(a, b, carryIn(vm)));

--- a/src/vm/handlers/bitwise.zig
+++ b/src/vm/handlers/bitwise.zig
@@ -42,11 +42,11 @@ pub fn andRegImm16(vm: *VM) StepResult {
     return writeLogical(vm, reg, a & imm);
 }
 
-/// `0x51` — `and Reg, Reg` → `dst ← dst & src`.
+/// `0x51` — `and Reg, Reg` → `dst ← dst & src` (asm: `and src, dst`).
 pub fn andRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, dst, a & b);
@@ -61,11 +61,11 @@ pub fn orRegImm16(vm: *VM) StepResult {
     return writeLogical(vm, reg, a | imm);
 }
 
-/// `0x53` — `or Reg, Reg` → `dst ← dst | src`.
+/// `0x53` — `or Reg, Reg` → `dst ← dst | src` (asm: `or src, dst`).
 pub fn orRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, dst, a | b);
@@ -80,11 +80,11 @@ pub fn xorRegImm16(vm: *VM) StepResult {
     return writeLogical(vm, reg, a ^ imm);
 }
 
-/// `0x55` — `xor Reg, Reg` → `dst ← dst ^ src`.
+/// `0x55` — `xor Reg, Reg` → `dst ← dst ^ src` (asm: `xor src, dst`).
 pub fn xorRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
     const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, dst, a ^ b);

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -22,11 +22,11 @@ pub fn movImm16Reg(vm: *VM) StepResult {
     return ok;
 }
 
-/// `0x11` — `mov Reg, Reg` → `dst ← src` (Intel order: dst first).
+/// `0x11` — `mov Reg, Reg` → `dst ← src` (asm: `mov src, dst`).
 pub fn movRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const dst = vm.readByte(ip +% 1);
-    const src = vm.readByte(ip +% 2);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
     const value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
     if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
     return ok;

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -49,7 +49,8 @@ test "codegen: mov imm16, reg → 0x10 LE imm reg" {
     try std.testing.expectEqualSlices(u8, &.{ 0x10, 0xCD, 0xAB, 0x02 }, out.imageBody());
 }
 
-test "codegen: mov reg, reg → 0x11 dst src" {
+test "codegen: mov reg, reg → 0x11 src dst (src first per asm convention)" {
+    // `mov r1, r2` is read as src=r1, dst=r2 — r2 ← r1.
     var out = try assemble("mov r1, r2\n", .{});
     defer out.deinit();
     try std.testing.expectEqualSlices(u8, &.{ 0x11, 0x02, 0x03 }, out.imageBody());

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -208,8 +208,8 @@ test "dispatch: step auto-advances ip by instruction size" {
     // mov instead: 0x11 mov reg, reg is 3 bytes total.
     vm.regs.write(.ip, 0x1100);
     vm.mmap.writeByte(0x1100, 0x11);
-    vm.mmap.writeByte(0x1101, 0x02); // dst = r1
-    vm.mmap.writeByte(0x1102, 0x03); // src = r2
+    vm.mmap.writeByte(0x1101, 0x03); // src = r2
+    vm.mmap.writeByte(0x1102, 0x02); // dst = r1
     vm.regs.write(.r2, 0xBEEF);
 
     try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));

--- a/tests/vm/handlers/arith.test.zig
+++ b/tests/vm/handlers/arith.test.zig
@@ -68,7 +68,7 @@ test "add 0x41 reg,reg" {
     defer vm.deinit();
     vm.regs.write(.r1, 0x100);
     vm.regs.write(.r2, 0x200);
-    loadProgram(&vm, &.{ 0x41, 0x02, 0x03 }); // add r1, r2 → r1 = r1 + r2
+    loadProgram(&vm, &.{ 0x41, 0x03, 0x02 }); // add r2, r1 → r1 += r2 (src, dst)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x300), vm.regs.read(.r1));
 }
@@ -121,7 +121,7 @@ test "sub 0x44 reg,reg" {
     defer vm.deinit();
     vm.regs.write(.r1, 0x100);
     vm.regs.write(.r2, 0x040);
-    loadProgram(&vm, &.{ 0x44, 0x02, 0x03 }); // sub r1, r2
+    loadProgram(&vm, &.{ 0x44, 0x03, 0x02 }); // sub r2, r1 → r1 -= r2 (src, dst)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0C0), vm.regs.read(.r1));
 }
@@ -169,7 +169,7 @@ test "mul 0x47 reg,reg" {
     defer vm.deinit();
     vm.regs.write(.r1, 0x100);
     vm.regs.write(.r2, 0x20);
-    loadProgram(&vm, &.{ 0x47, 0x02, 0x03 }); // mul r1 × r2
+    loadProgram(&vm, &.{ 0x47, 0x03, 0x02 }); // mul r2, r1 → r1 *= r2 (src, dst)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.r1));
     try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.acu));
@@ -281,7 +281,7 @@ test "div 0x4C reg,reg" {
     vm.regs.write(.acu, 0);
     vm.regs.write(.r1, 100);
     vm.regs.write(.r2, 7);
-    loadProgram(&vm, &.{ 0x4C, 0x02, 0x03 });
+    loadProgram(&vm, &.{ 0x4C, 0x03, 0x02 }); // div r2, r1 — divisor=r2, dividend=acu:r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 14), vm.regs.read(.r1));
     try std.testing.expectEqual(@as(u16, 2), vm.regs.read(.acu));
@@ -307,7 +307,7 @@ test "divs 0x4E reg,reg" {
     vm.regs.write(.acu, 0xFFFF);
     vm.regs.write(.r1, 0xFFF6);
     vm.regs.write(.r2, 3);
-    loadProgram(&vm, &.{ 0x4E, 0x02, 0x03 });
+    loadProgram(&vm, &.{ 0x4E, 0x03, 0x02 }); // divs r2, r1 (src, dst)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xFFFD), vm.regs.read(.r1)); // -3
 }
@@ -365,7 +365,7 @@ test "adc 0x65 reg,reg with carry-in" {
     vm.regs.write(.r1, 0x10);
     vm.regs.write(.r2, 0x05);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x65, 0x02, 0x03 }); // adc r1, r2 (with C=1)
+    loadProgram(&vm, &.{ 0x65, 0x03, 0x02 }); // adc r2, r1 (src, dst — with C=1)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x16), vm.regs.read(.r1));
 }
@@ -393,7 +393,7 @@ test "sbc 0x67 reg,reg with borrow-in" {
     vm.regs.write(.r1, 0x10);
     vm.regs.write(.r2, 0x05);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x67, 0x02, 0x03 }); // sbc r1, r2 (with C=1)
+    loadProgram(&vm, &.{ 0x67, 0x03, 0x02 }); // sbc r2, r1 (src, dst — with C=1)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0A), vm.regs.read(.r1));
 }
@@ -405,7 +405,7 @@ test "arith: invalid register on add raises invalid-register fault" {
     defer vm.deinit();
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
 
-    loadProgram(&vm, &.{ 0x41, 0x02, 0xFF }); // add r1, <out-of-range>
+    loadProgram(&vm, &.{ 0x41, 0x02, 0xFF }); // add r1, <out-of-range> (dst invalid)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }

--- a/tests/vm/handlers/bitwise.test.zig
+++ b/tests/vm/handlers/bitwise.test.zig
@@ -48,7 +48,7 @@ test "and 0x51 reg,reg clears C+V even if preset" {
     vm.regs.write(.r2, 0xFF0F);
     vm.regs.setFlag(.carry, true);
     vm.regs.setFlag(.overflow, true);
-    loadProgram(&vm, &.{ 0x51, 0x02, 0x03 }); // and r1, r2
+    loadProgram(&vm, &.{ 0x51, 0x03, 0x02 }); // and r2, r1 → r1 &= r2 (src, dst)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xFF00), vm.regs.read(.r1));
     try std.testing.expect(!flags(&vm).c);
@@ -71,7 +71,7 @@ test "or 0x53 reg,reg" {
     defer vm.deinit();
     vm.regs.write(.r1, 0xF000);
     vm.regs.write(.r2, 0x000F);
-    loadProgram(&vm, &.{ 0x53, 0x02, 0x03 });
+    loadProgram(&vm, &.{ 0x53, 0x03, 0x02 }); // or r2, r1 → r1 |= r2 (src, dst)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xF00F), vm.regs.read(.r1));
 }

--- a/tests/vm/handlers/mov.test.zig
+++ b/tests/vm/handlers/mov.test.zig
@@ -28,12 +28,12 @@ test "mov 0x10 imm16,reg: writes immediate to register" {
     try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
 }
 
-test "mov 0x11 reg,reg: copies between registers (dst, src order)" {
+test "mov 0x11 reg,reg: copies between registers (src, dst order)" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
     vm.regs.write(.r2, 0xDEAD);
-    loadProgram(&vm, &.{ 0x11, 0x02, 0x03 }); // mov r1, r2
+    loadProgram(&vm, &.{ 0x11, 0x03, 0x02 }); // mov r2, r1 — src=r2, dst=r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xDEAD), vm.regs.read(.r1));
     try std.testing.expectEqual(@as(u16, 0xDEAD), vm.regs.read(.r2));
@@ -246,7 +246,7 @@ test "mov family: no variant touches flags" {
     // Run a representative variant from each section.
     for ([_][]const u8{
         &.{ 0x10, 0x00, 0x00, 0x02 }, // mov imm16,reg
-        &.{ 0x11, 0x02, 0x03 }, // mov reg,reg
+        &.{ 0x11, 0x03, 0x02 }, // mov r2, r1 (src, dst)
         &.{ 0x12, 0x02, 0x00, 0x20 }, // mov reg,addr
         &.{ 0x13, 0x00, 0x20, 0x02 }, // mov addr,reg
         &.{ 0x21, 0x42, 0x02 }, // mov8 imm8,reg
@@ -264,8 +264,8 @@ test "mov: invalid register index raises invalid-register fault" {
     // Install an ISR for the invalid-register fault.
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
 
-    // mov r1, <out-of-range>
-    loadProgram(&vm, &.{ 0x11, 0x02, 0xFF });
+    // mov <out-of-range>, r1 — src is the invalid register
+    loadProgram(&vm, &.{ 0x11, 0xFF, 0x02 });
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }


### PR DESCRIPTION
## Summary

**Breaking ISA change.** Every two-register binary instruction now reads as \`<op> src, dst\` (AT&T-style), matching what the imm-form and addr-form already do. Previously the reg-reg forms silently used Intel order (dst first), creating an asymmetry that bit \`fib.gas\` during #47 and would have bit every future asm / lang author the same way.

| Form (asm) | Old semantic | New semantic |
|---|---|---|
| \`mov \$10, r1\` | r1 ← \$10 | r1 ← \$10 (unchanged — imm form was always src-first) |
| \`mov r1, r2\` | r1 ← r2 (Intel) | **r2 ← r1** (AT&T) |
| \`add r2, r1\` | r2 += r1 (Intel) | **r1 += r2** (AT&T) |
| \`and r2, r1\` | r2 &= r1 (Intel) | **r1 &= r2** (AT&T) |

## Flipped handlers (11)

\`mov\`, \`add\`, \`sub\`, \`mul\`, \`div\`, \`divs\`, \`adc\`, \`sbc\`, \`and\`, \`or\`, \`xor\` — each reads \`byte1 = src\`, \`byte2 = dst\` and computes \`dst = dst OP src\` (or \`dst ← src\` for \`mov\`).

## Intentionally NOT flipped — rationale in \`asm.md §2.4\`

- **\`cmp\` / \`tst\`**: both operands are inputs, no destination. The current \`first - second\` math reads naturally — \`cmp r1, \$10; jlt addr\` jumps when \`r1 < \$10\`. Flipping would invert that for no benefit.
- **Shift / rotate** (\`shl\`, \`shr\`, \`rol\`, \`ror\`): modify-in-place ops with a count parameter, not a dst/src pair. Convention stays \`<op> target, count\`.
- **Block ops** (\`bcpy\`, \`bset\`): three-operand C-stdlib shape \`(dst, src, len)\` / \`(dst, len, val)\`.

## Migration

Existing \`.gx\` files that used the 11 flipped reg-reg forms now compute different results — they must be re-assembled from source. The \`fib.gas\` example is updated in this commit and verifies end-to-end (\`gero run fib.gx\` → \`37\\n\`).

## Test plan
- [x] \`zig build ci\` green
- [x] 9 VM handler tests updated (mov, add, sub, mul, div, divs, adc, sbc reg-reg + and, or, xor reg-reg)
- [x] 1 dispatch test updated (mov reg-reg ip-advance)
- [x] 1 codegen test description updated
- [x] \`fib.gas\` runs end-to-end, diffs clean against \`fib.expected\`
- [x] \`docs/asm.md §2.4\` documents the canonical convention + the cmp/shift/block exceptions

Closes #94.