### PR TITLE
feat(disasm,cli): Phase 3 — bytecode → asm decoder + `gero disasm`

### DIFF
--- a/.changeset/g8s12w53.md
+++ b/.changeset/g8s12w53.md
@@ -1,0 +1,56 @@
+---
+bump: minor
+---
+
+Phase 3 lands — disassembler + `gero disasm` CLI command. Closes
+#38, #39, #40, #41, #45.
+
+## New library
+
+`gero.disasm` (`src/disasm.zig` barrel):
+
+- **`parseHeader(bytes) Header`** — strict `.gx` header decode,
+  rejects future versions, slices image / banks / debug regions.
+- **`decodeOne(allocator, bytes, offset) Decoded`** — one
+  instruction → `Instruction` AST. Uses
+  `opcode_resolver.shape_by_opcode` (new public 256-entry reverse
+  table built at comptime from the asm shapes) for the byte →
+  syntax mapping. Returns `error.UnknownOpcode` for slots not in
+  the v0.1 ISA, `error.Truncated` when bytes run out mid-operand.
+- **`writeInstruction(writer, inst)`** /
+  **`writeBytes(allocator, writer, bytes)`** — pretty-printer.
+  Emits asm syntax with aligned mnemonic column, `$XX` / `$XXXX`
+  hex literals, `&XXXX` addrs, `[reg]` indirect, `[&XXXX + reg]`
+  indexed, canonical register names via `vm.Register`. Unknown
+  opcodes surface as `; .byte $XX` comments; truncated tails as a
+  `; truncated at offset $XXXX` comment.
+- **`roundTripImage(allocator, image) []u8`** — drives the
+  asm → disasm → asm pipeline so tests can assert byte-equality.
+
+## New CLI command
+
+`gero disasm <file.gx> [--bank=N]`:
+
+- Default target: base image.
+- `--bank=N` selects bank slot N (0-based, validated against
+  header `bank_count`). Out-of-range surfaces a clear error +
+  exit 1. Trailing zero-padding inside a bank is trimmed before
+  emission to keep the output readable.
+- Output goes to stdout — pipe to `tee`, `less`, or a file.
+
+## Round-trip
+
+The `asm → disasm → asm` pipeline is byte-lossless for **all-code**
+programs. Tests in `tests/disasm/roundtrip.test.zig` cover hlt,
+the full operand-kind matrix (imm / addr / reg-reg / indirect /
+indexed / shift / int / jmp), call+ret+arith, and push/pop/cmp/jne
+loops.
+
+## Known gaps (follow-ups)
+
+- **Mixed code + data** can't round-trip — the disasm is
+  byte-blind, so `data8 "Hello"` reads as instructions on the
+  way back. Unblocks when debug symbols ship.
+- **Label rendering** — the printer emits raw `&XXXX` addresses
+  for `call` / `jmp` / etc. Symbol-aware rendering also needs
+  debug symbols.

--- a/.changeset/h9t63u84.md
+++ b/.changeset/h9t63u84.md
@@ -1,0 +1,66 @@
+---
+bump: minor
+---
+
+Debug-symbol section lands — closes #100 and the last open
+acceptance criterion of Phase 3 (#4):
+
+> - [x] Debug symbols (when present) used to annotate addresses with names
+
+## Asm
+
+- New `Options.debug_symbols: bool = true` knob on `assemble()`.
+- Codegen walks the symbol table at archive-build time, collects
+  every `.label` and `.data` entry, sorts ascending by address,
+  emits the blob per ISA §7.3, and sets the `has-debug` flag bit.
+- Local labels (mangled `parent.foo`) and consts / struct fields
+  are skipped — local names can't round-trip through the asm's
+  identifier grammar; consts aren't addresses.
+
+## Disasm
+
+- `disasm.Symbols` struct + `parseSymbols(blob)` to decode the
+  trailing section into an `address → name` lookup.
+- `PrintOptions.symbols: ?Symbols` — when set, `addr` operands
+  (`call`, `jmp`, `mov &XXXX, ...`, etc.) render the symbol name
+  instead of `&XXXX`. Names re-use the register-style cyan
+  highlight so they read as "this is a symbolic reference".
+
+## CLI
+
+- `gero disasm` auto-parses the symbol section and passes it to
+  the printer:
+
+  ```
+  0000:  10 0A 00 02     mov   $000A, r1  ; entry point
+  0004:  80 21 00        call  fib
+  0007:  11 02 03        mov   r1, r2
+  000D:  80 43 00        call  print_nibble
+  ```
+
+- `gero info` shows `debug: yes (symbols: N)` when present
+  (matches the line that's been promised in `docs/cli.md` since
+  the beginning).
+
+## Limitation
+
+The blob format (ISA §7.3) is bank-blind — only `address → name`.
+Two labels at the same CPU address (e.g. the bank-window
+`greet @ $C000` in bank 0 vs `excite @ $C000` in bank 1) collide
+in the lookup. Disasm output stays readable but ambiguous in
+multi-bank carts where bank-local labels share addresses with
+each other. A bank-aware extension to the format is a v0.2
+candidate.
+
+## Round-trip + tests
+
+- 3 codegen tests cover blob shape, flag bit, `debug_symbols=false`
+  path, local-label / const exclusion.
+- 4 disasm tests cover parse round-trip, lookup hit/miss,
+  truncated-count and truncated-name rejection.
+- 2 printer tests cover symbol substitution + unmatched-address
+  fallback.
+- Round-trip helper / tests force `debug_symbols=false` — the
+  disasm's bare output drops labels anyway, so the re-assembled
+  archive's blob would be empty and the byte-equality compare
+  would fail spuriously.

--- a/.changeset/i3b59x82.md
+++ b/.changeset/i3b59x82.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+`gero disasm` now accepts `--show-bytes` / `--no-show-bytes` to
+toggle the hex-bytes column. Default is unchanged (column shown);
+`--no-show-bytes` strips it for a cleaner asm-only view. Previously
+the flag was hardcoded on with no way to disable.

--- a/.changeset/j4c61y93.md
+++ b/.changeset/j4c61y93.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+`gero disasm` now collapses runs of 4+ consecutive `$00` bytes
+(with no symbol landing inside) into a single
+`; N bytes zero padding (org $XXXX)` comment instead of emitting
+N noisy `; .byte $00` lines. Mirrors what the source `.gas`
+probably had — `org $XXXX` is the directive that produces this
+padding at codegen time. Runs shorter than 4 bytes still render
+per-byte so small genuine gaps aren't hidden.

--- a/.changeset/k5d72z04.md
+++ b/.changeset/k5d72z04.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+CLI parse errors now include the offending token in the message
+(e.g. `unknown flag: --not-show-bytes` instead of just
+`unknown flag.`). New `parseWithDiagnostic` entry point fills a
+`Diagnostic.bad_token` field before returning. `parse` stays a
+thin wrapper for backwards compatibility.

--- a/.changeset/l6e83a15.md
+++ b/.changeset/l6e83a15.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+`gero <subcmd> --help` now lists only the flags that subcommand
+actually consumes. The previous block dumped the full set
+(`--target`, `--optimize`, `--out`, …) under every command,
+which was misleading — e.g. `--optimize` isn't read by any v0.1
+subcommand, and `--out` is asm-only. The disasm-specific
+`--bank` and `--no-show-bytes` now surface in the disasm help
+where they belong.

--- a/.changeset/m7f94b26.md
+++ b/.changeset/m7f94b26.md
@@ -1,0 +1,15 @@
+---
+bump: patch
+---
+
+Removed the `--target=<vm|gtx-16>` flag from the CLI. It was
+scaffolded forward-looking but never had a real second target —
+the fantasy-console (`gtx-16`) is a downstream consumer that
+embeds gero as a library, not an output target this repo
+produces. `gero run`'s "rejected gtx-16" branch is gone too;
+`--target=gtx-16` now errors as an unknown flag (exit 2) like
+any other unknown flag.
+
+`docs/cli.md` updated to match — common-flags table, `gero run`
+examples + behavior, `gero build` example, and the future
+`gero.toml` sketch.

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -20,9 +20,6 @@ pub const Command = enum {
     info,
 };
 
-/// `--target` values per `cli.md` §2.
-pub const Target = enum { vm, gtx_16 };
-
 /// `--optimize` values per `cli.md` §2.
 pub const Optimize = enum { debug, release, size };
 
@@ -40,7 +37,6 @@ pub const Options = struct {
     version: bool = false,
     quiet: bool = false,
     verbose: bool = false,
-    target: Target = .vm,
     optimize: Optimize = .debug,
     out: ?[]const u8 = null,
     color: ColorChoice = .auto,
@@ -87,8 +83,8 @@ pub const ParseError = error{
 pub const Diagnostic = struct {
     /// The argv token that triggered the error (e.g.
     /// `--not-show-bytes` for `UnknownFlag`, `frobnicate` for
-    /// `UnknownCommand`, `--target=mainframe` for
-    /// `InvalidEnumValue`). `null` until the parser hits an error.
+    /// `UnknownCommand`, `--color=neon` for `InvalidEnumValue`).
+    /// `null` until the parser hits an error.
     bad_token: ?[]const u8 = null,
 };
 
@@ -270,7 +266,6 @@ fn flagHelpLine(kind: FlagKind) FlagHelpLine {
         .version => .{ .sig = "--version / -V", .desc = "Print build version." },
         .quiet => .{ .sig = "--quiet / -q", .desc = "Suppress non-error output." },
         .verbose => .{ .sig = "--verbose / -v", .desc = "Extra diagnostics + per-phase timings." },
-        .target => .{ .sig = "--target / -t=<s>", .desc = "vm (default) or gtx-16." },
         .optimize => .{ .sig = "--optimize / -O=<m>", .desc = "debug (default) / release / size." },
         .out => .{ .sig = "--out / -o=<path>", .desc = "Output destination." },
         .color => .{ .sig = "--color / -c=<m>", .desc = "auto (default) / always / never." },
@@ -299,12 +294,6 @@ pub fn printVersion(out: *std.Io.Writer) std.Io.Writer.Error!void {
     try out.print("gero {s}\n", .{version_string});
 }
 
-fn parseTarget(s: []const u8) ParseError!Target {
-    if (std.mem.eql(u8, s, "vm")) return .vm;
-    if (std.mem.eql(u8, s, "gtx-16")) return .gtx_16;
-    return error.InvalidEnumValue;
-}
-
 fn parseOptimize(s: []const u8) ParseError!Optimize {
     if (std.mem.eql(u8, s, "debug")) return .debug;
     if (std.mem.eql(u8, s, "release")) return .release;
@@ -319,14 +308,13 @@ fn parseColor(s: []const u8) ParseError!ColorChoice {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, version, quiet, verbose, target, optimize, out, color, no_color, bank, show_bytes, no_show_bytes };
+const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
     if (std.mem.eql(u8, s, "version")) return .version;
     if (std.mem.eql(u8, s, "quiet")) return .quiet;
     if (std.mem.eql(u8, s, "verbose")) return .verbose;
-    if (std.mem.eql(u8, s, "target")) return .target;
     if (std.mem.eql(u8, s, "optimize")) return .optimize;
     if (std.mem.eql(u8, s, "out")) return .out;
     if (std.mem.eql(u8, s, "color")) return .color;
@@ -342,7 +330,6 @@ fn shortFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "V")) return .version; // upper-case — convention from rustc / clang
     if (std.mem.eql(u8, s, "q")) return .quiet;
     if (std.mem.eql(u8, s, "v")) return .verbose;
-    if (std.mem.eql(u8, s, "t")) return .target;
     if (std.mem.eql(u8, s, "O")) return .optimize; // upper-case — convention from clang / gcc
     if (std.mem.eql(u8, s, "o")) return .out;
     if (std.mem.eql(u8, s, "c")) return .color;
@@ -355,7 +342,6 @@ fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void
         .version => opts.version = true,
         .quiet => opts.quiet = true,
         .verbose => opts.verbose = true,
-        .target => opts.target = try parseTarget(value orelse return error.MissingFlagValue),
         .optimize => opts.optimize = try parseOptimize(value orelse return error.MissingFlagValue),
         .out => opts.out = value orelse return error.MissingFlagValue,
         .color => opts.color = try parseColor(value orelse return error.MissingFlagValue),
@@ -372,7 +358,7 @@ fn parseBank(s: []const u8) ParseError!u8 {
 
 fn needsValue(kind: FlagKind) bool {
     return switch (kind) {
-        .target, .optimize, .out, .color, .bank => true,
+        .optimize, .out, .color, .bank => true,
         else => false,
     };
 }
@@ -562,9 +548,9 @@ test "parse: long flag with =value" {
 }
 
 test "parse: long flag with separate value" {
-    const args = [_][]const u8{ "run", "--target", "gtx-16", "game.gx" };
+    const args = [_][]const u8{ "run", "--color", "never", "game.gx" };
     const p = try parse(&args);
-    try testing.expectEqual(Target.gtx_16, p.options.target);
+    try testing.expectEqual(ColorChoice.never, p.options.color);
     try testing.expectEqualStrings("game.gx", p.options.positional()[0]);
 }
 
@@ -606,19 +592,9 @@ test "parseWithDiagnostic: populates bad_token on UnknownCommand" {
 
 test "parseWithDiagnostic: populates bad_token on InvalidEnumValue" {
     var diag: Diagnostic = .{};
-    const args = [_][]const u8{ "run", "--target=mainframe" };
+    const args = [_][]const u8{ "run", "--color=neon" };
     try testing.expectError(error.InvalidEnumValue, parseWithDiagnostic(&args, &diag));
-    try testing.expectEqualStrings("--target=mainframe", diag.bad_token.?);
-}
-
-test "parse: --target with bad value errors" {
-    const args = [_][]const u8{ "run", "--target=mainframe" };
-    try testing.expectError(error.InvalidEnumValue, parse(&args));
-}
-
-test "parse: --target without a value errors" {
-    const args = [_][]const u8{ "run", "--target" };
-    try testing.expectError(error.MissingFlagValue, parse(&args));
+    try testing.expectEqualStrings("--color=neon", diag.bad_token.?);
 }
 
 test "parse: --optimize=release accepted" {

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -79,6 +79,19 @@ pub const ParseError = error{
     TooManyPositionals,
 };
 
+/// Optional out-of-band diagnostic that the parser fills before
+/// returning a `ParseError`. Lets the caller include the
+/// offending token in the human-facing error message
+/// (e.g. "unknown flag: --not-show-bytes" instead of just
+/// "unknown flag.").
+pub const Diagnostic = struct {
+    /// The argv token that triggered the error (e.g.
+    /// `--not-show-bytes` for `UnknownFlag`, `frobnicate` for
+    /// `UnknownCommand`, `--target=mainframe` for
+    /// `InvalidEnumValue`). `null` until the parser hits an error.
+    bad_token: ?[]const u8 = null,
+};
+
 fn commandFromStr(s: []const u8) ?Command {
     if (std.mem.eql(u8, s, "asm")) return .asm_;
     if (std.mem.eql(u8, s, "compile")) return .compile;
@@ -344,8 +357,18 @@ pub const version_string: []const u8 = "0.0.0";
 /// command (positional args / its own flags get re-parsed by
 /// the subcommand). The first argument may also be `--help` /
 /// `-h` to request top-level help — that's surfaced via
-/// `Options.help` and `command == null`.
+/// `Options.help` and `command == null`. For richer error
+/// messages (`unknown flag: --not-show-bytes`), use
+/// `parseWithDiagnostic`.
 pub fn parse(args: []const []const u8) ParseError!Parsed {
+    return parseWithDiagnostic(args, null);
+}
+
+/// Same as `parse` but writes the offending argv token into
+/// `diag.bad_token` before returning a `ParseError`. The caller
+/// composes a helpful message instead of "unknown flag." with
+/// no context.
+pub fn parseWithDiagnostic(args: []const []const u8, diag: ?*Diagnostic) ParseError!Parsed {
     var opts: Options = .{};
     var cmd: ?Command = null;
 
@@ -355,10 +378,11 @@ pub fn parse(args: []const []const u8) ParseError!Parsed {
         if (a.len == 0) continue;
 
         if (std.mem.eql(u8, a, "--")) {
-            // Everything after `--` is positional, even tokens
-            // that look like flags.
             for (args[i + 1 ..]) |rest_arg| {
-                if (opts.positional_count >= max_positionals) return error.TooManyPositionals;
+                if (opts.positional_count >= max_positionals) {
+                    if (diag) |d| d.bad_token = rest_arg;
+                    return error.TooManyPositionals;
+                }
                 opts.positional_buf[opts.positional_count] = rest_arg;
                 opts.positional_count += 1;
             }
@@ -367,10 +391,16 @@ pub fn parse(args: []const []const u8) ParseError!Parsed {
 
         if (a[0] != '-') {
             if (cmd == null) {
-                cmd = commandFromStr(a) orelse return error.UnknownCommand;
+                cmd = commandFromStr(a) orelse {
+                    if (diag) |d| d.bad_token = a;
+                    return error.UnknownCommand;
+                };
                 continue;
             }
-            if (opts.positional_count >= max_positionals) return error.TooManyPositionals;
+            if (opts.positional_count >= max_positionals) {
+                if (diag) |d| d.bad_token = a;
+                return error.TooManyPositionals;
+            }
             opts.positional_buf[opts.positional_count] = a;
             opts.positional_count += 1;
             continue;
@@ -381,29 +411,59 @@ pub fn parse(args: []const []const u8) ParseError!Parsed {
             const eq = std.mem.indexOfScalar(u8, rest, '=');
             const name = if (eq) |p| rest[0..p] else rest;
             const inline_value: ?[]const u8 = if (eq) |p| rest[p + 1 ..] else null;
-            const kind = longFlag(name) orelse return error.UnknownFlag;
+            const kind = longFlag(name) orelse {
+                if (diag) |d| d.bad_token = a;
+                return error.UnknownFlag;
+            };
             if (needsValue(kind)) {
                 const v = inline_value orelse blk: {
                     i += 1;
-                    if (i >= args.len) return error.MissingFlagValue;
+                    if (i >= args.len) {
+                        if (diag) |d| d.bad_token = a;
+                        return error.MissingFlagValue;
+                    }
                     break :blk args[i];
                 };
-                try applyFlag(&opts, kind, v);
+                applyFlag(&opts, kind, v) catch |err| {
+                    if (diag) |d| d.bad_token = a;
+                    return err;
+                };
             } else {
-                if (inline_value != null) return error.InvalidEnumValue;
-                try applyFlag(&opts, kind, null);
+                if (inline_value != null) {
+                    if (diag) |d| d.bad_token = a;
+                    return error.InvalidEnumValue;
+                }
+                applyFlag(&opts, kind, null) catch |err| {
+                    if (diag) |d| d.bad_token = a;
+                    return err;
+                };
             }
         } else if (a.len > 1) {
             const rest = a[1..];
-            const kind = shortFlag(rest) orelse return error.UnknownFlag;
+            const kind = shortFlag(rest) orelse {
+                if (diag) |d| d.bad_token = a;
+                return error.UnknownFlag;
+            };
             if (needsValue(kind)) {
                 i += 1;
-                if (i >= args.len) return error.MissingFlagValue;
-                try applyFlag(&opts, kind, args[i]);
+                if (i >= args.len) {
+                    if (diag) |d| d.bad_token = a;
+                    return error.MissingFlagValue;
+                }
+                applyFlag(&opts, kind, args[i]) catch |err| {
+                    if (diag) |d| d.bad_token = a;
+                    return err;
+                };
             } else {
-                try applyFlag(&opts, kind, null);
+                applyFlag(&opts, kind, null) catch |err| {
+                    if (diag) |d| d.bad_token = a;
+                    return err;
+                };
             }
-        } else return error.UnknownFlag;
+        } else {
+            if (diag) |d| d.bad_token = a;
+            return error.UnknownFlag;
+        }
     }
 
     return .{ .command = cmd, .options = opts };
@@ -499,6 +559,27 @@ test "parse: -- terminator captures trailing positionals" {
 test "parse: unknown flag errors" {
     const args = [_][]const u8{ "run", "--zoinks" };
     try testing.expectError(error.UnknownFlag, parse(&args));
+}
+
+test "parseWithDiagnostic: populates bad_token on UnknownFlag" {
+    var diag: Diagnostic = .{};
+    const args = [_][]const u8{ "disasm", "--not-show-bytes", "x.gx" };
+    try testing.expectError(error.UnknownFlag, parseWithDiagnostic(&args, &diag));
+    try testing.expectEqualStrings("--not-show-bytes", diag.bad_token.?);
+}
+
+test "parseWithDiagnostic: populates bad_token on UnknownCommand" {
+    var diag: Diagnostic = .{};
+    const args = [_][]const u8{"frobnicate"};
+    try testing.expectError(error.UnknownCommand, parseWithDiagnostic(&args, &diag));
+    try testing.expectEqualStrings("frobnicate", diag.bad_token.?);
+}
+
+test "parseWithDiagnostic: populates bad_token on InvalidEnumValue" {
+    var diag: Diagnostic = .{};
+    const args = [_][]const u8{ "run", "--target=mainframe" };
+    try testing.expectError(error.InvalidEnumValue, parseWithDiagnostic(&args, &diag));
+    try testing.expectEqualStrings("--target=mainframe", diag.bad_token.?);
 }
 
 test "parse: --target with bad value errors" {

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -44,6 +44,9 @@ pub const Options = struct {
     optimize: Optimize = .debug,
     out: ?[]const u8 = null,
     color: ColorChoice = .auto,
+    /// `--bank=N` for `gero disasm` — selects which bank slot to
+    /// disassemble. `null` (default) = base image.
+    bank: ?u8 = null,
     positional_buf: [max_positionals][]const u8 = undefined,
     positional_count: usize = 0,
 
@@ -119,8 +122,8 @@ fn commandSummary(cmd: Command) []const u8 {
 /// discoverable, but split into a separate "planned" section.
 fn commandIsImplemented(cmd: Command) bool {
     return switch (cmd) {
-        .asm_, .run, .info => true,
-        .compile, .test_, .bench, .fmt, .check, .build, .disasm => false,
+        .asm_, .run, .info, .disasm => true,
+        .compile, .test_, .bench, .fmt, .check, .build => false,
     };
 }
 
@@ -221,6 +224,12 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
             try out.print("  {s}gero info prog.gx{s}                {s}# print the .gx header{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
+        .disasm => {
+            try out.print("  {s}gero disasm{s} <file.gx> [--bank=N]\n\n", .{ a.cyan, a.reset });
+            try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
+            try out.print("  {s}gero disasm prog.gx{s}              {s}# disassemble the base image to stdout{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero disasm prog.gx --bank=0{s}     {s}# disassemble bank slot 0{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+        },
         else => unreachable, // allow-strict: commandIsImplemented() filtered above
     }
 
@@ -261,7 +270,7 @@ fn parseColor(s: []const u8) ParseError!ColorChoice {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, version, quiet, verbose, target, optimize, out, color, no_color };
+const FlagKind = enum { help, version, quiet, verbose, target, optimize, out, color, no_color, bank };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
@@ -273,6 +282,7 @@ fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "out")) return .out;
     if (std.mem.eql(u8, s, "color")) return .color;
     if (std.mem.eql(u8, s, "no-color")) return .no_color;
+    if (std.mem.eql(u8, s, "bank")) return .bank;
     return null;
 }
 
@@ -299,12 +309,17 @@ fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void
         .out => opts.out = value orelse return error.MissingFlagValue,
         .color => opts.color = try parseColor(value orelse return error.MissingFlagValue),
         .no_color => opts.color = .never,
+        .bank => opts.bank = try parseBank(value orelse return error.MissingFlagValue),
     }
+}
+
+fn parseBank(s: []const u8) ParseError!u8 {
+    return std.fmt.parseInt(u8, s, 10) catch error.InvalidEnumValue;
 }
 
 fn needsValue(kind: FlagKind) bool {
     return switch (kind) {
-        .target, .optimize, .out, .color => true,
+        .target, .optimize, .out, .color, .bank => true,
         else => false,
     };
 }

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -47,6 +47,12 @@ pub const Options = struct {
     /// `--bank=N` for `gero disasm` — selects which bank slot to
     /// disassemble. `null` (default) = base image.
     bank: ?u8 = null,
+    /// `--show-bytes` / `--no-show-bytes` for `gero disasm` —
+    /// toggle the hex-bytes column between the address gutter and
+    /// the asm line. `true` (default) keeps the objdump-style
+    /// view; `false` strips the column for a cleaner asm-only
+    /// output.
+    show_bytes: bool = true,
     positional_buf: [max_positionals][]const u8 = undefined,
     positional_count: usize = 0,
 
@@ -225,10 +231,11 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero info prog.gx{s}                {s}# print the .gx header{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         .disasm => {
-            try out.print("  {s}gero disasm{s} <file.gx> [--bank=N]\n\n", .{ a.cyan, a.reset });
+            try out.print("  {s}gero disasm{s} <file.gx> [--bank=N] [--no-show-bytes]\n\n", .{ a.cyan, a.reset });
             try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
             try out.print("  {s}gero disasm prog.gx{s}              {s}# disassemble the base image to stdout{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero disasm prog.gx --bank=0{s}     {s}# disassemble bank slot 0{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero disasm prog.gx --no-show-bytes{s}  {s}# strip the hex-bytes column{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         else => unreachable, // allow-strict: commandIsImplemented() filtered above
     }
@@ -270,7 +277,7 @@ fn parseColor(s: []const u8) ParseError!ColorChoice {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, version, quiet, verbose, target, optimize, out, color, no_color, bank };
+const FlagKind = enum { help, version, quiet, verbose, target, optimize, out, color, no_color, bank, show_bytes, no_show_bytes };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
@@ -283,6 +290,8 @@ fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "color")) return .color;
     if (std.mem.eql(u8, s, "no-color")) return .no_color;
     if (std.mem.eql(u8, s, "bank")) return .bank;
+    if (std.mem.eql(u8, s, "show-bytes")) return .show_bytes;
+    if (std.mem.eql(u8, s, "no-show-bytes")) return .no_show_bytes;
     return null;
 }
 
@@ -310,6 +319,8 @@ fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void
         .color => opts.color = try parseColor(value orelse return error.MissingFlagValue),
         .no_color => opts.color = .never,
         .bank => opts.bank = try parseBank(value orelse return error.MissingFlagValue),
+        .show_bytes => opts.show_bytes = true,
+        .no_show_bytes => opts.show_bytes = false,
     }
 }
 
@@ -504,6 +515,17 @@ test "parse: --optimize=release accepted" {
     const args = [_][]const u8{ "asm", "--optimize=release" };
     const p = try parse(&args);
     try testing.expectEqual(Optimize.release, p.options.optimize);
+}
+
+test "parse: --show-bytes default is true, --no-show-bytes disables" {
+    const default_p = try parse(&[_][]const u8{"disasm"});
+    try testing.expect(default_p.options.show_bytes);
+
+    const on_p = try parse(&[_][]const u8{ "disasm", "--show-bytes", "x.gx" });
+    try testing.expect(on_p.options.show_bytes);
+
+    const off_p = try parse(&[_][]const u8{ "disasm", "--no-show-bytes", "x.gx" });
+    try testing.expect(!off_p.options.show_bytes);
 }
 
 test "run: no command prints top help, exit 0" {

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -253,16 +253,45 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
         else => unreachable, // allow-strict: commandIsImplemented() filtered above
     }
 
-    try out.print("\n{s}COMMON FLAGS{s}\n", .{ a.yellow, a.reset });
-    try out.print("  {s}--help / -h{s}         Print this help.\n", .{ a.cyan, a.reset });
-    try out.print("  {s}--version / -V{s}      Print build version.\n", .{ a.cyan, a.reset });
-    try out.print("  {s}--quiet / -q{s}        Suppress non-error output.\n", .{ a.cyan, a.reset });
-    try out.print("  {s}--verbose / -v{s}      Extra diagnostics + per-phase timings.\n", .{ a.cyan, a.reset });
-    try out.print("  {s}--target / -t=<s>{s}   vm (default) or gtx-16.\n", .{ a.cyan, a.reset });
-    try out.print("  {s}--optimize / -O=<m>{s} debug (default) / release / size.\n", .{ a.cyan, a.reset });
-    try out.print("  {s}--out / -o=<path>{s}   Output destination for file-producing commands.\n", .{ a.cyan, a.reset });
-    try out.print("  {s}--color / -c=<m>{s}    auto (default) / always / never.\n", .{ a.cyan, a.reset });
-    try out.print("  {s}--no-color{s}          Shortcut for --color=never.\n", .{ a.cyan, a.reset });
+    try out.print("\n{s}FLAGS{s}\n", .{ a.yellow, a.reset });
+    for (flagsForCommand(cmd)) |f| {
+        const h = flagHelpLine(f);
+        try out.print("  {s}{s:<22}{s} {s}\n", .{ a.cyan, h.sig, a.reset, h.desc });
+    }
+}
+
+/// One row of the per-command FLAGS block — the left-column
+/// signature and the right-column description.
+const FlagHelpLine = struct { sig: []const u8, desc: []const u8 };
+
+fn flagHelpLine(kind: FlagKind) FlagHelpLine {
+    return switch (kind) {
+        .help => .{ .sig = "--help / -h", .desc = "Print this help." },
+        .version => .{ .sig = "--version / -V", .desc = "Print build version." },
+        .quiet => .{ .sig = "--quiet / -q", .desc = "Suppress non-error output." },
+        .verbose => .{ .sig = "--verbose / -v", .desc = "Extra diagnostics + per-phase timings." },
+        .target => .{ .sig = "--target / -t=<s>", .desc = "vm (default) or gtx-16." },
+        .optimize => .{ .sig = "--optimize / -O=<m>", .desc = "debug (default) / release / size." },
+        .out => .{ .sig = "--out / -o=<path>", .desc = "Output destination." },
+        .color => .{ .sig = "--color / -c=<m>", .desc = "auto (default) / always / never." },
+        .no_color => .{ .sig = "--no-color", .desc = "Shortcut for --color=never." },
+        .bank => .{ .sig = "--bank=<N>", .desc = "Pick a bank slot to disassemble (default: base image)." },
+        .show_bytes => .{ .sig = "--show-bytes", .desc = "(default) Show the hex-bytes column." },
+        .no_show_bytes => .{ .sig = "--no-show-bytes", .desc = "Strip the hex-bytes column for a cleaner view." },
+    };
+}
+
+/// Which flags each subcommand actually consumes. The per-command
+/// help block iterates this list — anything not here doesn't get
+/// listed (and would be a no-op even if the parser accepted it).
+fn flagsForCommand(cmd: Command) []const FlagKind {
+    return switch (cmd) {
+        .asm_ => &.{ .help, .out, .quiet, .verbose, .color, .no_color },
+        .run => &.{ .help, .verbose, .color, .no_color },
+        .info => &.{ .help, .color, .no_color },
+        .disasm => &.{ .help, .bank, .no_show_bytes, .color, .no_color },
+        .compile, .test_, .bench, .fmt, .check, .build => &.{.help},
+    };
 }
 
 /// Print the version line consumed by `gero --version` / `gero -V`.

--- a/apps/gero-cli/disasm.zig
+++ b/apps/gero-cli/disasm.zig
@@ -53,16 +53,19 @@ pub fn execute(
     } else header.image;
 
     // Pretty view: address + hex-bytes columns, `; entry point`
-    // marker. The base image starts at CPU address $0000; a bank
-    // is mirrored at the window base $C000 when its `mb` is
-    // selected. Entry-point comment only makes sense for the
-    // base image (the loader stores the address there).
+    // marker, optional ANSI color. The base image starts at CPU
+    // address $0000; a bank is mirrored at the window base
+    // $C000 when its `mb` is selected. Entry-point comment only
+    // makes sense for the base image (the loader stores the
+    // address there).
     const base_addr: u16 = if (opts.bank == null) 0x0000 else bank_window_base;
     const entry_addr: ?u16 = if (opts.bank == null) header.entry_point else null;
+    const style: gero.disasm.Style = if (term.color) .ansi else .plain;
     try gero.disasm.writeBytesPretty(arena, stdout, target_bytes, .{
         .base_addr = base_addr,
         .show_bytes = true,
         .entry_addr = entry_addr,
+        .style = style,
     });
     return 0;
 }

--- a/apps/gero-cli/disasm.zig
+++ b/apps/gero-cli/disasm.zig
@@ -40,6 +40,7 @@ pub fn execute(
     // unused bytes; printing 16 KiB of `; .byte $00` is just
     // noise for the user).
     const bank_size: usize = 0x4000;
+    const bank_window_base: u16 = 0xC000;
     const target_bytes: []const u8 = if (opts.bank) |b| blk: {
         if (b >= header.bank_count) {
             try term.err("gero disasm: --bank={d} out of range (cart has {d} bank(s))", .{ b, header.bank_count });
@@ -51,7 +52,18 @@ pub fn execute(
         break :blk trimTrailingZeros(raw);
     } else header.image;
 
-    try gero.disasm.writeBytes(arena, stdout, target_bytes);
+    // Pretty view: address + hex-bytes columns, `; entry point`
+    // marker. The base image starts at CPU address $0000; a bank
+    // is mirrored at the window base $C000 when its `mb` is
+    // selected. Entry-point comment only makes sense for the
+    // base image (the loader stores the address there).
+    const base_addr: u16 = if (opts.bank == null) 0x0000 else bank_window_base;
+    const entry_addr: ?u16 = if (opts.bank == null) header.entry_point else null;
+    try gero.disasm.writeBytesPretty(arena, stdout, target_bytes, .{
+        .base_addr = base_addr,
+        .show_bytes = true,
+        .entry_addr = entry_addr,
+    });
     return 0;
 }
 

--- a/apps/gero-cli/disasm.zig
+++ b/apps/gero-cli/disasm.zig
@@ -61,11 +61,22 @@ pub fn execute(
     const base_addr: u16 = if (opts.bank == null) 0x0000 else bank_window_base;
     const entry_addr: ?u16 = if (opts.bank == null) header.entry_point else null;
     const style: gero.disasm.Style = if (term.color) .ansi else .plain;
+
+    // Parse the debug-symbol section (if present) so the printer
+    // renders `call greet` instead of `call &C000` etc. Borrows
+    // name bytes from `header.debug`; valid for the lifetime of
+    // this function.
+    const symbols = gero.disasm.parseSymbols(arena, header.debug) catch |err| {
+        try term.err("gero disasm: malformed debug section ({s})", .{@errorName(err)});
+        return 1;
+    };
+
     try gero.disasm.writeBytesPretty(arena, stdout, target_bytes, .{
         .base_addr = base_addr,
         .show_bytes = true,
         .entry_addr = entry_addr,
         .style = style,
+        .symbols = symbols,
     });
     return 0;
 }

--- a/apps/gero-cli/disasm.zig
+++ b/apps/gero-cli/disasm.zig
@@ -1,0 +1,67 @@
+/// `gero disasm` — read a `.gx` byte buffer, emit asm source to
+/// stdout (or to a file via `-o`). Per cli.md §3.6.
+///
+/// `--bank=N` selects a single bank slot to disassemble; the
+/// default is the base image. Out-of-range bank slots surface as
+/// an exit-1 error.
+const std = @import("std");
+const gero = @import("gero");
+const cli = @import("cli.zig");
+const term_mod = @import("term.zig");
+
+/// Drive the disasm flow against `opts.positional()[0]`.
+pub fn execute(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+) !u8 {
+    const positionals = opts.positional();
+    if (positionals.len < 1) {
+        try term.err("gero disasm: missing .gx file path", .{});
+        return 2;
+    }
+    const src_path = positionals[0];
+
+    const bytes = std.Io.Dir.cwd().readFileAlloc(io, src_path, arena, .unlimited) catch |err| {
+        try term.err("gero disasm: cannot read {s} ({s})", .{ src_path, @errorName(err) });
+        return 1;
+    };
+
+    const header = gero.disasm.parseHeader(bytes) catch |err| {
+        try term.err("gero disasm: invalid .gx file ({s})", .{@errorName(err)});
+        return 1;
+    };
+
+    // For the base image, the slice is `header.image`; for a
+    // banked target the slice is bank N's 16 KiB segment with the
+    // trailing zero-padding trimmed off (codegen zero-fills
+    // unused bytes; printing 16 KiB of `; .byte $00` is just
+    // noise for the user).
+    const bank_size: usize = 0x4000;
+    const target_bytes: []const u8 = if (opts.bank) |b| blk: {
+        if (b >= header.bank_count) {
+            try term.err("gero disasm: --bank={d} out of range (cart has {d} bank(s))", .{ b, header.bank_count });
+            return 1;
+        }
+        // @as: widen u8 bank index to usize for the offset math.
+        const start = @as(usize, b) * bank_size;
+        const raw = header.banks[start .. start + bank_size];
+        break :blk trimTrailingZeros(raw);
+    } else header.image;
+
+    try gero.disasm.writeBytes(arena, stdout, target_bytes);
+    return 0;
+}
+
+/// Drop trailing `0x00` bytes from `bytes` — codegen pads banks
+/// up to the full 16 KiB on disk, but those zeros are the unused
+/// tail of a bank and shouldn't render as `; .byte $00` noise.
+/// A user with a legitimately-zero-trailing payload can pipe
+/// through `gero disasm | head -N` instead.
+fn trimTrailingZeros(bytes: []const u8) []const u8 {
+    var end = bytes.len;
+    while (end > 0 and bytes[end - 1] == 0) end -= 1;
+    return bytes[0..end];
+}

--- a/apps/gero-cli/disasm.zig
+++ b/apps/gero-cli/disasm.zig
@@ -73,7 +73,7 @@ pub fn execute(
 
     try gero.disasm.writeBytesPretty(arena, stdout, target_bytes, .{
         .base_addr = base_addr,
-        .show_bytes = true,
+        .show_bytes = opts.show_bytes,
         .entry_addr = entry_addr,
         .style = style,
         .symbols = symbols,

--- a/apps/gero-cli/info.zig
+++ b/apps/gero-cli/info.zig
@@ -38,7 +38,23 @@ pub fn format(
         const noun: []const u8 = if (h.sram_bank_count == 1) "bank" else "banks";
         try out.print("sram:    {d} {s} (battery-backed)\n", .{ h.sram_bank_count, noun });
     }
-    try out.print("debug:   {s}\n", .{if (h.hasDebugSymbols()) "yes" else "no"});
+    if (h.hasDebugSymbols()) {
+        // Parse the trailing debug blob to extract the symbol
+        // count for the summary line. The slice is borrowed; we
+        // only read the count header (no allocation needed here).
+        const count = peekSymbolCount(loaded.debug);
+        try out.print("debug:   yes (symbols: {d})\n", .{count});
+    } else {
+        try out.print("debug:   no\n", .{});
+    }
+}
+
+/// Read just the first 2-byte u16 from the debug blob — that's
+/// the symbol count per ISA §7.3. Returns 0 if the blob is too
+/// short (treated as "no symbols").
+fn peekSymbolCount(debug: []const u8) u16 {
+    if (debug.len < 2) return 0;
+    return @as(u16, debug[0]) | (@as(u16, debug[1]) << 8);
 }
 
 // ---------- tests ----------

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -7,6 +7,7 @@ const term_mod = @import("term.zig");
 const run_cmd = @import("run.zig");
 const info_cmd = @import("info.zig");
 const asm_cmd = @import("asm.zig");
+const disasm_cmd = @import("disasm.zig");
 
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
@@ -71,6 +72,7 @@ pub fn main(init: std.process.Init) !u8 {
         .asm_ => asm_cmd.execute(io, arena, parsed.options, stdout, &term),
         .run => runDispatch(io, arena, parsed.options, stdout, &term),
         .info => infoDispatch(io, arena, parsed.options, stdout, &term),
+        .disasm => disasm_cmd.execute(io, arena, parsed.options, stdout, &term),
         else => blk: {
             try term.err("gero {s}: not yet implemented", .{cli.commandName(cmd)});
             break :blk 1;

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -26,15 +26,17 @@ pub fn main(init: std.process.Init) !u8 {
     const args = try arena.alloc([]const u8, raw_args.len);
     for (raw_args, 0..) |a, i| args[i] = a;
 
-    const parsed = cli.parse(args[1..]) catch |err| {
+    var diag: cli.Diagnostic = .{};
+    const parsed = cli.parseWithDiagnostic(args[1..], &diag) catch |err| {
         // Color isn't known yet, so write a plain error.
         var fallback = term_mod.Term{ .out = stderr, .color = false };
+        const bad = diag.bad_token orelse "?";
         switch (err) {
-            error.UnknownCommand => try fallback.err("unknown subcommand. Run `gero --help` for the list.", .{}),
-            error.UnknownFlag => try fallback.err("unknown flag.", .{}),
-            error.MissingFlagValue => try fallback.err("flag is missing its value.", .{}),
-            error.InvalidEnumValue => try fallback.err("flag value is not recognized.", .{}),
-            error.TooManyPositionals => try fallback.err("too many positional args (max 16).", .{}),
+            error.UnknownCommand => try fallback.err("unknown subcommand: {s}. Run `gero --help` for the list.", .{bad}),
+            error.UnknownFlag => try fallback.err("unknown flag: {s}", .{bad}),
+            error.MissingFlagValue => try fallback.err("flag is missing its value: {s}", .{bad}),
+            error.InvalidEnumValue => try fallback.err("flag value is not recognized: {s}", .{bad}),
+            error.TooManyPositionals => try fallback.err("too many positional args (max 16): {s}", .{bad}),
         }
         return 2;
     };

--- a/apps/gero-cli/run.zig
+++ b/apps/gero-cli/run.zig
@@ -1,13 +1,10 @@
 /// `gero run` — load a `.gx`, boot a fresh VM, execute until
-/// halt / fault / breakpoint. The bare-VM target intercepts two
+/// halt / fault / breakpoint. The bare-VM intercepts two
 /// reserved `int N` syscalls before they reach the IVT:
 ///
 ///   `int 0x10` — print the low byte of `r1` to stdout.
 ///   `int 0x21` — flush the SRAM bytes through the host sink
 ///                (typically a write of `<basename>.sav`).
-///
-/// `--target=gtx-16` is intentionally not wired here — the
-/// fantasy-console shim lives in a separate crate.
 const std = @import("std");
 const gero = @import("gero");
 const cli = @import("cli.zig");
@@ -33,8 +30,7 @@ pub const SramSink = struct {
 
 /// Drive a parsed `.gx` to completion. Returns the CLI exit
 /// code per cli.md §3.3: `0` on `hlt`, `6` on unhandled fault,
-/// `1` on host-level error / bad file / unsupported target,
-/// `2` on a `brk` breakpoint.
+/// `1` on host-level error / bad file, `2` on a `brk` breakpoint.
 pub fn execute(
     allocator: std.mem.Allocator,
     opts: cli.Options,
@@ -43,11 +39,6 @@ pub fn execute(
     sram_sink: ?*SramSink,
     gx_bytes: []const u8,
 ) !u8 {
-    if (opts.target == .gtx_16) {
-        try term.err("gero run: --target=gtx-16 is not implemented in this build", .{});
-        return 1;
-    }
-
     const loaded = gero.vm.parseGx(gx_bytes) catch |err| {
         try term.err("gero run: invalid .gx file ({s})", .{@errorName(err)});
         return 1;
@@ -231,20 +222,6 @@ test "execute: save syscall (int 0x21) hands SRAM bytes to the sink" {
     try testing.expectEqual(@as(usize, 0x4000), rec.bytes.items.len);
     try testing.expectEqual(@as(u8, 0xFE), rec.bytes.items[0]);
     try testing.expectEqual(@as(u8, 0xCA), rec.bytes.items[1]);
-}
-
-test "execute: --target=gtx-16 exits 1 with explicit message" {
-    const buf = [_]u8{0} ** 16;
-    var out_buf: [128]u8 = undefined;
-    var err_buf: [256]u8 = undefined;
-    var out: std.Io.Writer = .fixed(&out_buf);
-    var err: std.Io.Writer = .fixed(&err_buf);
-    var term = term_mod.Term{ .out = &err, .color = false };
-
-    const opts: cli.Options = .{ .target = .gtx_16 };
-    const code = try execute(testing.allocator, opts, &out, &term, null, &buf);
-    try testing.expectEqual(@as(u8, 1), code);
-    try testing.expect(std.mem.indexOf(u8, err_buf[0..err.end], "gtx-16") != null);
 }
 
 test "execute: bad magic exits 1 with structured message" {

--- a/build.zig
+++ b/build.zig
@@ -85,6 +85,16 @@ pub fn build(b: *std.Build) void {
         .name = "test-cli-asm",
         .root_module = asm_mod,
     });
+    const disasm_cli_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/disasm.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    disasm_cli_mod.addImport("gero", gero_mod);
+    const disasm_cli_test = b.addTest(.{
+        .name = "test-cli-disasm",
+        .root_module = disasm_cli_mod,
+    });
 
     // ----- Format ----------------------------------------------------------
 
@@ -116,6 +126,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(term_test).step);
     test_step.dependOn(&b.addRunArtifact(info_test).step);
     test_step.dependOn(&b.addRunArtifact(asm_test).step);
+    test_step.dependOn(&b.addRunArtifact(disasm_cli_test).step);
     for (test_files) |rel| {
         const t = makeTest(b, gero_mod, rel, target, optimize);
         test_step.dependOn(&b.addRunArtifact(t).step);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,10 +22,10 @@ gero <subcommand> [flags] [args]
 Discover the command list with `gero --help`. Discover per-command
 flags with `gero <cmd> --help`.
 
-The CLI loads its target (gero VM, optionally with the gtx-16 host
-shim) from an internal lookup — there's no separate runtime install.
 A single `gero` binary covers asm, compile, run, test, bench, fmt,
-check, build, disasm, info.
+check, build, disasm, info. The bare-VM runtime is the only target
+this repo produces — fantasy-console hosts (e.g. gtx-16) live
+downstream and consume `.gx` files as library inputs.
 
 ---
 
@@ -38,7 +38,6 @@ Accepted by every subcommand (where meaningful):
 | `--help` / `-h` | — | Print help for the command and exit 0. |
 | `--quiet` / `-q` | off | Suppress non-error output. |
 | `--verbose` / `-v` | off | Extra info: timings, allocation counts, intermediate sizes. |
-| `--target=<spec>` | `vm` | `vm` (bare gero VM) or `gtx-16` (loads display/audio/input shims, different default IO layout). |
 | `--optimize=<mode>` | `debug` | `debug` / `release` / `size`. Mirrors Zig modes. |
 | `--out=<path>` / `-o` | (per-cmd default) | Output path for commands that produce files. |
 
@@ -95,17 +94,14 @@ Loads a `.gx` into a fresh VM and executes from `entry_point`.
 
 ```bash
 gero run hello.gx
-gero run game.gx --target=gtx-16   # boot with FC peripherals mapped
 ```
 
 **Behavior:**
-- Default target `vm` runs the bare VM — `print` syscalls go to
-  stdout, `int 0x21` (save-flush) writes `<basename>.sav` next to
-  the `.gx`.
-- `--target=gtx-16` boots the FC host: opens a 320×240 window
-  (4:3 retro PC), wires up the IO command surface for drawing,
-  8-channel audio, gamepad + keyboard + mouse input. Full spec
-  in `docs/gtx-16.md`.
+- Runs the bare VM — `print` syscalls go to stdout, `int 0x21`
+  (save-flush) writes `<basename>.sav` next to the `.gx`.
+- Fantasy-console hosts (e.g. gtx-16) embed gero as a library
+  and provide their own runtime — they're not invoked through
+  `gero run`.
 
 **Exit:** 0 on `hlt` clean exit; 6 on unhandled fault (invalid
 opcode, /0, etc.); 1 on host-level error (file missing, version
@@ -274,7 +270,6 @@ v0.1 conventions (no `gero.toml` yet).
 ```bash
 gero build                        # → out/<project-basename>.gx
 gero build --optimize=release
-gero build --target=gtx-16
 ```
 
 **Behavior:**
@@ -339,14 +334,13 @@ parseable by editors / CI tools.
 
 ## 8. Future: project file (`gero.toml`)
 
-Once `gero init` / multi-target / dependency management land, a
-project file will be needed:
+Once `gero init` / dependency management land, a project file
+will be needed:
 
 ```toml
 [project]
 name = "my-game"
 version = "0.1.0"
-target = "gtx-16"
 
 [deps]
 loom = { git = "https://github.com/salty-max/loom" }

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -579,9 +579,19 @@ metadata.
 [u16le symbol_count]
 For each symbol:
   [u16le address]
+  [u8 kind]                 — 0 = label (code), 1 = data
   [u8 name_len]
   [name_len bytes — UTF-8 symbol name]
 ```
+
+`kind` lets the disassembler tell apart code labels and `data8`/
+`data16` blocks. A label produces `call <name>` / `jmp <name>`
+substitutions in the disasm; a data symbol switches the
+disassembler into data mode at that address, emitting
+`data8 <name> = $XX, $YY, ...` until the next symbol (or end of
+section). Unknown `kind` values reserved for future use are
+treated as `label` (fail-safe — the bytes still try to decode as
+instructions).
 
 Used by the disassembler to annotate addresses and by debuggers to
 resolve names. Stripped from release builds.

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -55,6 +55,11 @@ pub const Options = struct {
     /// address is used; otherwise the entry point is `0x0000`
     /// (start of image). Set explicitly to override.
     entry_point: ?u16 = null,
+    /// When `true` (default) emit the debug-symbol section per
+    /// ISA §7.3 — every global `label:` and `data8/16` declaration
+    /// becomes a `(address, name)` entry. Disable for "release"
+    /// builds that want to strip the names.
+    debug_symbols: bool = true,
 };
 
 /// Run the full codegen pipeline against a parsed program.
@@ -111,7 +116,7 @@ pub fn assemble(
         break :blk 0x0000;
     };
 
-    const final = try buildArchive(allocator, &emit, &layout, resolved_entry);
+    const final = try buildArchive(allocator, &emit, &layout, resolved_entry, &symbols, opts.debug_symbols);
 
     return .{
         .image = final,
@@ -886,7 +891,14 @@ fn emitCast(
 /// Magic bytes at the start of a `.gx` file — "GERO" in ASCII.
 const gx_magic = [4]u8{ 'G', 'E', 'R', 'O' };
 
-fn buildArchive(allocator: std.mem.Allocator, emit: *const Emit, layout: *const Layout, entry_point: u16) ![]u8 {
+fn buildArchive(
+    allocator: std.mem.Allocator,
+    emit: *const Emit,
+    layout: *const Layout,
+    entry_point: u16,
+    symbols: *const symtab.SymbolTable,
+    debug_symbols: bool,
+) ![]u8 {
     // Header layout per ISA §7.1:
     //   0x00..0x04  magic = "GERO"
     //   0x04..0x06  u16le version = 0x0001
@@ -897,8 +909,8 @@ fn buildArchive(allocator: std.mem.Allocator, emit: *const Emit, layout: *const 
     //   0x0D        u8 sram_bank_count
     //   0x0E..0x10  reserved (must be 0)
     //
-    // Archive body per ISA §7.1:
-    //   header + base_image + (bank_count × bank_disk_size)
+    // Archive body per ISA §7.1 / §7.3:
+    //   header + base_image + (bank_count × bank_disk_size) + debug_section?
     //
     // SRAM banks are NOT emitted — they're zero-init at boot.
     const header_size: usize = 16;
@@ -910,14 +922,24 @@ fn buildArchive(allocator: std.mem.Allocator, emit: *const Emit, layout: *const 
     const bank_count: u16 = if (layout.max_bank) |m| @as(u16, m) + 1 else 0;
     // @as: widen u16 / u32 to usize for the byte-count math (max 256 × 16 KiB = 4 MiB).
     const banked_bytes: usize = @as(usize, bank_count) * @as(usize, bank_disk_size);
-    const total = header_size + base_len + banked_bytes;
+
+    // Collect debug-symbol entries (sorted by address). When
+    // disabled or empty the blob stays empty + the flag bit is
+    // not set.
+    var debug_entries: std.ArrayList(DebugEntry) = .empty;
+    defer debug_entries.deinit(allocator);
+    if (debug_symbols) try collectDebugSymbols(allocator, symbols, &debug_entries);
+
+    const debug_bytes_len: usize = debugSectionByteSize(debug_entries.items);
+    const total = header_size + base_len + banked_bytes + debug_bytes_len;
     var out = try allocator.alloc(u8, total);
 
-    // Flag bit 0 (banked) — set whenever the cart has at least
-    // one bank. The loader uses this to know whether to slice the
-    // bank region from the archive.
+    // Flags per ISA §7.1: bit 0 = banked, bit 1 = has-debug.
     const flag_banked: u16 = 0x0001;
-    const flags: u16 = if (bank_count > 0) flag_banked else 0;
+    const flag_has_debug: u16 = 0x0002;
+    var flags: u16 = 0;
+    if (bank_count > 0) flags |= flag_banked;
+    if (debug_bytes_len > 0) flags |= flag_has_debug;
 
     @memcpy(out[0..4], &gx_magic);
     writeU16Le(out[4..6], 0x0001); // version
@@ -949,7 +971,69 @@ fn buildArchive(allocator: std.mem.Allocator, emit: *const Emit, layout: *const 
         cursor += bank_disk_size;
     }
 
+    // Debug-symbol section per ISA §7.3.
+    if (debug_bytes_len > 0) writeDebugSection(out[cursor..][0..debug_bytes_len], debug_entries.items);
+
     return out;
+}
+
+/// One row in the debug-symbol section: a CPU address + its
+/// human-readable name. Names are slices into the source / owned
+/// keys in the symbol table (borrowed for the lifetime of the
+/// build).
+const DebugEntry = struct {
+    address: u16,
+    name: []const u8,
+};
+
+/// Walk the symbol table, collect `.label` + `.data` entries
+/// (consts and struct fields are values, not addresses — skip),
+/// skip local-label mangled names (the `.` character isn't a
+/// valid ident in asm so they can't round-trip through the
+/// disasm). Sort the result by address ascending.
+fn collectDebugSymbols(
+    allocator: std.mem.Allocator,
+    symbols: *const symtab.SymbolTable,
+    out: *std.ArrayList(DebugEntry),
+) !void {
+    var it = symbols.entries.iterator();
+    while (it.next()) |entry| {
+        const sym = entry.value_ptr.*;
+        if (sym.kind != .label and sym.kind != .data) continue;
+        const name = entry.key_ptr.*;
+        if (std.mem.indexOfScalar(u8, name, '.') != null) continue;
+        if (name.len > 0xFF) continue; // ISA §7.3 caps name_len at u8
+        try out.append(allocator, .{ .address = sym.value, .name = name });
+    }
+    std.mem.sort(DebugEntry, out.items, {}, struct {
+        fn lt(_: void, a: DebugEntry, b: DebugEntry) bool {
+            return a.address < b.address;
+        }
+    }.lt);
+}
+
+/// Byte size of the encoded debug section, or 0 when empty.
+fn debugSectionByteSize(entries: []const DebugEntry) usize {
+    if (entries.len == 0) return 0;
+    var n: usize = 2; // symbol_count
+    for (entries) |e| n += 2 + 1 + e.name.len; // addr + len + name
+    return n;
+}
+
+/// Encode the debug section in-place per ISA §7.3.
+fn writeDebugSection(dst: []u8, entries: []const DebugEntry) void {
+    // safety: caller passes a buffer sized for at most
+    //         `debugSectionByteSize(entries)` — every write is
+    //         bounded by entries.len ≤ u16 max.
+    writeU16Le(dst[0..2], @intCast(entries.len));
+    var cursor: usize = 2;
+    for (entries) |e| {
+        writeU16Le(dst[cursor..][0..2], e.address);
+        // safety: collectDebugSymbols filters out names > 0xFF bytes.
+        dst[cursor + 2] = @intCast(e.name.len);
+        @memcpy(dst[cursor + 3 ..][0..e.name.len], e.name);
+        cursor += 3 + e.name.len;
+    }
 }
 
 fn writeU16Le(dst: []u8, value: u16) void {

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -977,14 +977,20 @@ fn buildArchive(
     return out;
 }
 
-/// One row in the debug-symbol section: a CPU address + its
-/// human-readable name. Names are slices into the source / owned
-/// keys in the symbol table (borrowed for the lifetime of the
-/// build).
+/// One row in the debug-symbol section per ISA §7.3: an address,
+/// a kind (label vs data), and a name. Names are borrowed from
+/// the source or owned keys in the symbol table.
 const DebugEntry = struct {
     address: u16,
+    /// 0 = code label, 1 = data block. Maps to ISA §7.3.
+    kind: u8,
     name: []const u8,
 };
+
+/// `kind` byte per ISA §7.3 — keeps the constant out of the
+/// codegen body so the disasm side can match.
+const debug_kind_label: u8 = 0;
+const debug_kind_data: u8 = 1;
 
 /// Walk the symbol table, collect `.label` + `.data` entries
 /// (consts and struct fields are values, not addresses — skip),
@@ -999,11 +1005,15 @@ fn collectDebugSymbols(
     var it = symbols.entries.iterator();
     while (it.next()) |entry| {
         const sym = entry.value_ptr.*;
-        if (sym.kind != .label and sym.kind != .data) continue;
+        const kind: u8 = switch (sym.kind) {
+            .label => debug_kind_label,
+            .data => debug_kind_data,
+            .const_value, .struct_field => continue, // not addresses
+        };
         const name = entry.key_ptr.*;
         if (std.mem.indexOfScalar(u8, name, '.') != null) continue;
         if (name.len > 0xFF) continue; // ISA §7.3 caps name_len at u8
-        try out.append(allocator, .{ .address = sym.value, .name = name });
+        try out.append(allocator, .{ .address = sym.value, .kind = kind, .name = name });
     }
     std.mem.sort(DebugEntry, out.items, {}, struct {
         fn lt(_: void, a: DebugEntry, b: DebugEntry) bool {
@@ -1016,7 +1026,7 @@ fn collectDebugSymbols(
 fn debugSectionByteSize(entries: []const DebugEntry) usize {
     if (entries.len == 0) return 0;
     var n: usize = 2; // symbol_count
-    for (entries) |e| n += 2 + 1 + e.name.len; // addr + len + name
+    for (entries) |e| n += 2 + 1 + 1 + e.name.len; // addr + kind + len + name
     return n;
 }
 
@@ -1029,10 +1039,11 @@ fn writeDebugSection(dst: []u8, entries: []const DebugEntry) void {
     var cursor: usize = 2;
     for (entries) |e| {
         writeU16Le(dst[cursor..][0..2], e.address);
+        dst[cursor + 2] = e.kind;
         // safety: collectDebugSymbols filters out names > 0xFF bytes.
-        dst[cursor + 2] = @intCast(e.name.len);
-        @memcpy(dst[cursor + 3 ..][0..e.name.len], e.name);
-        cursor += 3 + e.name.len;
+        dst[cursor + 3] = @intCast(e.name.len);
+        @memcpy(dst[cursor + 4 ..][0..e.name.len], e.name);
+        cursor += 4 + e.name.len;
     }
 }
 

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -41,8 +41,9 @@ pub const Kind = enum {
 };
 
 /// One row of the dispatch table — what opcode matches a given
-/// mnemonic + operand-kinds tuple.
-const Shape = struct {
+/// mnemonic + operand-kinds tuple. Public so the disassembler
+/// can re-use the table for byte→syntax mapping.
+pub const Shape = struct {
     mnemonic: []const u8,
     kinds: []const Kind,
     opcode: u8,
@@ -171,6 +172,16 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "rti", .kinds = &.{}, .opcode = 0xFD },
     .{ .mnemonic = "brk", .kinds = &.{}, .opcode = 0xFE },
     .{ .mnemonic = "hlt", .kinds = &.{}, .opcode = 0xFF },
+};
+
+/// 256-entry reverse lookup: opcode byte → asm-side `Shape`.
+/// Built once at comptime by walking `shapes`. `null` slots are
+/// opcodes the v0.1 ISA doesn't define. The disassembler indexes
+/// this directly to render bytes back into asm syntax.
+pub const shape_by_opcode: [256]?Shape = blk: {
+    var t = [_]?Shape{null} ** 256;
+    for (shapes) |s| t[s.opcode] = s;
+    break :blk t;
 };
 
 /// Classify a parsed operand to its encoding `Kind`. Most

--- a/src/disasm.zig
+++ b/src/disasm.zig
@@ -1,0 +1,41 @@
+/// Disassembler — bytecode (`.gx`) → asm source (`.gas`). The
+/// inverse of `asm_`. Reads bytes (no `knit` dependency), emits
+/// text that the assembler can re-consume.
+///
+/// Module shape:
+///   header.zig — strict `.gx` header parse + section slicing
+///   decoder.zig — byte → `Instruction` AST (re-uses the VM's
+///                 opcode schema table for the reverse mapping)
+///   printer.zig — `Instruction` AST → asm syntax with aligned
+///                 columns, hex literals, labels
+const header_mod = @import("disasm/header.zig");
+const decoder_mod = @import("disasm/decoder.zig");
+const printer_mod = @import("disasm/printer.zig");
+const roundtrip_mod = @import("disasm/roundtrip.zig");
+
+/// Re-export: decoded `.gx` header + borrowed section slices.
+pub const Header = header_mod.Header;
+/// Re-export: failure modes when reading a `.gx`.
+pub const DecodeError = header_mod.DecodeError;
+/// Re-export: parse a `.gx` byte buffer.
+pub const parseHeader = header_mod.parse;
+
+/// Re-export: one decoded instruction (opcode + operands + size).
+pub const Instruction = decoder_mod.Instruction;
+/// Re-export: one decoded operand (reg / imm8 / imm16 / addr / etc.).
+pub const Operand = decoder_mod.Operand;
+/// Re-export: decode one instruction at `bytes[offset]`.
+pub const decodeOne = decoder_mod.decodeOne;
+/// Re-export: free the operand slice attached to an `Instruction`.
+pub const freeInstruction = decoder_mod.freeInstruction;
+
+/// Re-export: render one decoded instruction as asm syntax.
+pub const writeInstruction = printer_mod.writeInstruction;
+/// Re-export: walk a byte buffer and emit one asm line per
+/// instruction. Unknown opcodes surface as `.byte` comments.
+pub const writeBytes = printer_mod.writeBytes;
+
+/// Re-export: drive the full asm → disasm → asm pipeline for
+/// byte-equality round-trip tests. See `disasm/roundtrip.zig`
+/// for the caveats around data sections.
+pub const roundTripImage = roundtrip_mod.roundTripImage;

--- a/src/disasm.zig
+++ b/src/disasm.zig
@@ -19,8 +19,10 @@ pub const Header = header_mod.Header;
 pub const DecodeError = header_mod.DecodeError;
 /// Re-export: parse a `.gx` byte buffer.
 pub const parseHeader = header_mod.parse;
-/// Re-export: one debug-symbol entry (address + name).
+/// Re-export: one debug-symbol entry (address + kind + name).
 pub const Symbol = header_mod.Symbol;
+/// Re-export: kind discriminator for a symbol (label / data).
+pub const SymbolKind = header_mod.SymbolKind;
 /// Re-export: parsed debug-symbol section (`address → name` lookup).
 pub const Symbols = header_mod.Symbols;
 /// Re-export: failure modes when parsing the debug-symbol section.

--- a/src/disasm.zig
+++ b/src/disasm.zig
@@ -43,6 +43,8 @@ pub const writeBytes = printer_mod.writeBytes;
 pub const writeBytesPretty = printer_mod.writeBytesPretty;
 /// Re-export: knob bundle for `writeBytesPretty`.
 pub const PrintOptions = printer_mod.PrintOptions;
+/// Re-export: ANSI palette for the disasm pretty view.
+pub const Style = printer_mod.Style;
 
 /// Re-export: drive the full asm → disasm → asm pipeline for
 /// byte-equality round-trip tests. See `disasm/roundtrip.zig`

--- a/src/disasm.zig
+++ b/src/disasm.zig
@@ -33,7 +33,16 @@ pub const freeInstruction = decoder_mod.freeInstruction;
 pub const writeInstruction = printer_mod.writeInstruction;
 /// Re-export: walk a byte buffer and emit one asm line per
 /// instruction. Unknown opcodes surface as `.byte` comments.
+/// Round-trip-friendly: re-assembling the output produces the
+/// same bytes (for all-code programs).
 pub const writeBytes = printer_mod.writeBytes;
+
+/// Re-export: pretty version of `writeBytes` with address +
+/// hex-bytes columns and an `; entry point` marker. Not
+/// round-trip-friendly — for the human-facing CLI view only.
+pub const writeBytesPretty = printer_mod.writeBytesPretty;
+/// Re-export: knob bundle for `writeBytesPretty`.
+pub const PrintOptions = printer_mod.PrintOptions;
 
 /// Re-export: drive the full asm → disasm → asm pipeline for
 /// byte-equality round-trip tests. See `disasm/roundtrip.zig`

--- a/src/disasm.zig
+++ b/src/disasm.zig
@@ -19,6 +19,15 @@ pub const Header = header_mod.Header;
 pub const DecodeError = header_mod.DecodeError;
 /// Re-export: parse a `.gx` byte buffer.
 pub const parseHeader = header_mod.parse;
+/// Re-export: one debug-symbol entry (address + name).
+pub const Symbol = header_mod.Symbol;
+/// Re-export: parsed debug-symbol section (`address → name` lookup).
+pub const Symbols = header_mod.Symbols;
+/// Re-export: failure modes when parsing the debug-symbol section.
+pub const SymbolsError = header_mod.SymbolsError;
+/// Re-export: parse the debug-symbol blob (typically
+/// `Header.debug`) per ISA §7.3.
+pub const parseSymbols = header_mod.parseSymbols;
 
 /// Re-export: one decoded instruction (opcode + operands + size).
 pub const Instruction = decoder_mod.Instruction;

--- a/src/disasm/decoder.zig
+++ b/src/disasm/decoder.zig
@@ -1,0 +1,142 @@
+/// Byte → `Instruction` decoder. Reuses the asm-side opcode
+/// table (`opcode_resolver.shape_by_opcode`) for the reverse
+/// mapping, so the printer can reconstruct the exact asm syntax
+/// the bytes came from — including `[reg]` indirect and
+/// `[addr + reg]` indexed forms that the VM's bare opcode table
+/// flattens to plain `reg, reg, reg` schemas.
+const std = @import("std");
+const opres = @import("../asm/opcode_resolver.zig");
+
+/// One decoded operand. Mirrors the asm-side `Kind` enum but
+/// carries the actual operand bytes rather than a type tag.
+pub const Operand = union(enum) {
+    /// 1-byte register index (raw, post-decode mapping via
+    /// `vm.Register` lives in the printer).
+    reg: u8,
+    /// 1-byte immediate.
+    imm8: u8,
+    /// 2-byte little-endian immediate.
+    imm16: u16,
+    /// 2-byte little-endian address.
+    addr: u16,
+    /// 1-byte zero-page address.
+    zp: u8,
+    /// `[reg]` — register index used as a pointer.
+    reg_indirect: u8,
+    /// `[addr + reg]` — indexed addressing (3 bytes: addr LE + reg).
+    indexed: Indexed,
+
+    /// `[addr + reg]` payload — the addr word + the index reg
+    /// index. Lives inside `Operand.indexed`.
+    pub const Indexed = struct {
+        addr: u16,
+        reg: u8,
+    };
+};
+
+/// One decoded instruction.
+pub const Instruction = struct {
+    /// Raw opcode byte.
+    opcode: u8,
+    /// Lowercase mnemonic from the asm spec (borrowed from the
+    /// opcode table — static lifetime).
+    mnemonic: []const u8,
+    /// Operands in source order. Storage backing depends on the
+    /// caller's allocator — see `decode` below.
+    operands: []const Operand,
+    /// Total byte width (opcode + sum of operand widths).
+    size: u8,
+};
+
+/// Failure modes when decoding a single instruction.
+pub const DecodeError = error{
+    /// Opcode byte isn't in the v0.1 ISA's reverse table.
+    UnknownOpcode,
+    /// Bytes ran out before the operands could be fully read.
+    Truncated,
+    OutOfMemory,
+};
+
+/// Decode the one instruction starting at `bytes[offset]`. Returns
+/// the instruction (with operands allocated via `allocator`) plus
+/// the byte offset of the next instruction.
+///
+/// The opcode byte determines the operand schema via
+/// `opres.shape_by_opcode`. Unknown opcodes return
+/// `error.UnknownOpcode` — the caller decides whether to skip the
+/// byte and continue (e.g. emit a `.byte $XX` directive) or
+/// abort.
+pub fn decodeOne(
+    allocator: std.mem.Allocator,
+    bytes: []const u8,
+    offset: usize,
+) DecodeError!Decoded {
+    if (offset >= bytes.len) return error.Truncated;
+    const op = bytes[offset];
+    const shape = opres.shape_by_opcode[op] orelse return error.UnknownOpcode;
+
+    var operands: std.ArrayList(Operand) = .empty;
+    errdefer operands.deinit(allocator);
+
+    var cursor: usize = offset + 1;
+    for (shape.kinds) |kind| {
+        const decoded_op, const advance = try readOperand(bytes, cursor, kind);
+        try operands.append(allocator, decoded_op);
+        cursor += advance;
+    }
+    if (cursor > bytes.len) return error.Truncated;
+
+    const operands_slice = try operands.toOwnedSlice(allocator);
+    return .{
+        .instruction = .{
+            .opcode = op,
+            .mnemonic = shape.mnemonic,
+            .operands = operands_slice,
+            // safety: cursor - offset bounded by 1 (opcode) + sum
+            //         of operand widths; max instruction = 5 bytes.
+            .size = @intCast(cursor - offset),
+        },
+        .next_offset = cursor,
+    };
+}
+
+/// Result of `decodeOne`: the decoded instruction plus the next
+/// byte offset to feed back in for the following instruction.
+pub const Decoded = struct {
+    instruction: Instruction,
+    next_offset: usize,
+};
+
+/// Read one operand from `bytes[cursor..]` per its `kind`. Returns
+/// the decoded operand and the byte width consumed.
+fn readOperand(bytes: []const u8, cursor: usize, kind: opres.Kind) DecodeError!struct { Operand, usize } {
+    return switch (kind) {
+        .reg => .{ .{ .reg = try readByte(bytes, cursor) }, 1 },
+        .imm8 => .{ .{ .imm8 = try readByte(bytes, cursor) }, 1 },
+        .imm16 => .{ .{ .imm16 = try readWord(bytes, cursor) }, 2 },
+        .addr => .{ .{ .addr = try readWord(bytes, cursor) }, 2 },
+        .zp => .{ .{ .zp = try readByte(bytes, cursor) }, 1 },
+        .reg_indirect => .{ .{ .reg_indirect = try readByte(bytes, cursor) }, 1 },
+        .indexed => blk: {
+            const addr = try readWord(bytes, cursor);
+            const reg = try readByte(bytes, cursor + 2);
+            break :blk .{ .{ .indexed = .{ .addr = addr, .reg = reg } }, 3 };
+        },
+    };
+}
+
+fn readByte(bytes: []const u8, cursor: usize) DecodeError!u8 {
+    if (cursor >= bytes.len) return error.Truncated;
+    return bytes[cursor];
+}
+
+fn readWord(bytes: []const u8, cursor: usize) DecodeError!u16 {
+    if (cursor + 1 >= bytes.len) return error.Truncated;
+    // @as: widen each u8 byte to u16 before the OR / shift so the result is u16.
+    return @as(u16, bytes[cursor]) | (@as(u16, bytes[cursor + 1]) << 8);
+}
+
+/// Release the operand slice attached to `inst`.
+pub fn freeInstruction(allocator: std.mem.Allocator, inst: Instruction) void {
+    allocator.free(inst.operands);
+}

--- a/src/disasm/header.zig
+++ b/src/disasm/header.zig
@@ -1,0 +1,77 @@
+/// Disassembler-side header decoder. Reads a `.gx` byte buffer,
+/// validates the magic + version per ISA §7.1, slices the image
+/// / banks / debug regions, and returns a `Header` value the rest
+/// of the disasm can consume.
+///
+/// The VM has its own `parseGx` in `src/vm/loader.zig` doing the
+/// same byte work — we just delegate to it and re-wrap the result
+/// in a disasm-friendly shape. Keeping the function defined here
+/// (rather than re-exporting raw `vm.parseGx`) preserves the
+/// option to tighten the disasm checks in the future without
+/// affecting the VM loader.
+const std = @import("std");
+const gero = @import("../gero.zig");
+
+/// One file's worth of decoded header info + section slices, all
+/// borrowed from the caller's `bytes` buffer.
+pub const Header = struct {
+    /// Cart version (`0x0001` for v0.1).
+    version: u16,
+    /// Bit-set per ISA §7.1 (bit 0 = banked, bit 1 = has-debug).
+    flags: u16,
+    /// `ip` value the VM seeds at boot.
+    entry_point: u16,
+    /// Bytes in the base image (excluding the 16-byte header,
+    /// bank segments, and debug symbols).
+    image_size: u16,
+    /// Number of bank slots that follow the base image. Bank N is
+    /// at archive offset `16 + image_size + N * 0x4000`.
+    bank_count: u8,
+    /// Number of trailing bank slots that are SRAM (battery-backed).
+    sram_bank_count: u8,
+
+    /// Slice of the base image bytes (length == `image_size`).
+    image: []const u8,
+    /// Concatenated bank bytes (length == `bank_count * 0x4000`).
+    /// Empty when the cart is unbanked.
+    banks: []const u8,
+    /// Trailing debug-symbol bytes — opaque blob for v0.1.
+    /// Empty when the cart has no debug symbols.
+    debug: []const u8,
+
+    /// `true` when the banked flag is set + at least one bank slot
+    /// is declared.
+    pub fn isBanked(self: Header) bool {
+        return self.bank_count > 0;
+    }
+
+    /// `true` when the has-debug flag is set + the debug blob is
+    /// non-empty.
+    pub fn hasDebugSymbols(self: Header) bool {
+        return self.debug.len > 0;
+    }
+};
+
+/// Failure modes when reading a `.gx`. A superset of the VM's
+/// `LoaderError` — the disasm exposes them as one unified set so
+/// `gero disasm` can map them to E-codes downstream.
+pub const DecodeError = gero.vm.LoaderError;
+
+/// Parse `bytes` as a `.gx` archive. Strict: rejects unknown
+/// flag bits and any version != `0x0001`. The returned slices
+/// borrow from the input buffer.
+pub fn parse(bytes: []const u8) DecodeError!Header {
+    const loaded = try gero.vm.parseGx(bytes);
+
+    return .{
+        .version = loaded.header.version,
+        .flags = loaded.header.flags,
+        .entry_point = loaded.header.entry_point,
+        .image_size = loaded.header.image_size,
+        .bank_count = loaded.header.bank_count,
+        .sram_bank_count = loaded.header.sram_bank_count,
+        .image = loaded.image,
+        .banks = loaded.banks,
+        .debug = loaded.debug,
+    };
+}

--- a/src/disasm/header.zig
+++ b/src/disasm/header.zig
@@ -12,6 +12,33 @@
 const std = @import("std");
 const gero = @import("../gero.zig");
 
+/// One row of the debug-symbol table per ISA §7.3.
+pub const Symbol = struct {
+    address: u16,
+    name: []const u8,
+};
+
+/// Parsed debug-symbol section — an `address → name` lookup for
+/// the disasm printer. Borrows name bytes from the input blob.
+pub const Symbols = struct {
+    entries: []const Symbol,
+
+    /// `null` when no symbol covers `addr`. Linear scan — the
+    /// symbol count tops out at ~thousands per cart so binary
+    /// search isn't worth the complexity for v0.1.
+    pub fn lookup(self: Symbols, addr: u16) ?[]const u8 {
+        for (self.entries) |e| if (e.address == addr) return e.name;
+        return null;
+    }
+
+    /// Release the entries slice. The borrowed name bytes
+    /// inside each entry are NOT freed — they remain valid as
+    /// long as the caller's source buffer does.
+    pub fn deinit(self: Symbols, allocator: std.mem.Allocator) void {
+        allocator.free(self.entries);
+    }
+};
+
 /// One file's worth of decoded header info + section slices, all
 /// borrowed from the caller's `bytes` buffer.
 pub const Header = struct {
@@ -56,6 +83,41 @@ pub const Header = struct {
 /// `LoaderError` — the disasm exposes them as one unified set so
 /// `gero disasm` can map them to E-codes downstream.
 pub const DecodeError = gero.vm.LoaderError;
+
+/// Failures specific to the optional debug-symbol section.
+pub const SymbolsError = error{
+    /// Section length doesn't fit the declared `symbol_count`.
+    TruncatedSymbolSection,
+    OutOfMemory,
+};
+
+/// Parse the debug-symbol blob attached to a `.gx` per ISA §7.3.
+/// Returns an empty `Symbols` if the cart has no symbol section.
+/// Caller owns the returned entries slice — release via
+/// `Symbols.deinit`.
+pub fn parseSymbols(allocator: std.mem.Allocator, debug_bytes: []const u8) SymbolsError!Symbols {
+    if (debug_bytes.len == 0) return .{ .entries = &.{} };
+    if (debug_bytes.len < 2) return error.TruncatedSymbolSection;
+
+    // @as: widen each u8 byte to u16 so the OR / shift produces a u16 count.
+    const count: u16 = @as(u16, debug_bytes[0]) | (@as(u16, debug_bytes[1]) << 8);
+    var entries = try allocator.alloc(Symbol, count);
+    errdefer allocator.free(entries);
+
+    var cursor: usize = 2;
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        if (cursor + 3 > debug_bytes.len) return error.TruncatedSymbolSection;
+        // @as: widen each u8 byte to u16 for the LE u16 read.
+        const addr: u16 = @as(u16, debug_bytes[cursor]) | (@as(u16, debug_bytes[cursor + 1]) << 8);
+        const name_len: usize = debug_bytes[cursor + 2];
+        cursor += 3;
+        if (cursor + name_len > debug_bytes.len) return error.TruncatedSymbolSection;
+        entries[i] = .{ .address = addr, .name = debug_bytes[cursor..][0..name_len] };
+        cursor += name_len;
+    }
+    return .{ .entries = entries };
+}
 
 /// Parse `bytes` as a `.gx` archive. Strict: rejects unknown
 /// flag bits and any version != `0x0001`. The returned slices

--- a/src/disasm/header.zig
+++ b/src/disasm/header.zig
@@ -12,9 +12,24 @@
 const std = @import("std");
 const gero = @import("../gero.zig");
 
+/// What flavor a symbol describes, per ISA §7.3.
+pub const SymbolKind = enum(u8) {
+    /// Code label — its bytes decode as instructions.
+    label = 0,
+    /// `data8` / `data16` block — its bytes are raw data, not
+    /// code. The disasm switches to data-mode rendering when
+    /// the cursor lands on one of these.
+    data = 1,
+    /// Anything past `1` is reserved — the disasm treats unknown
+    /// kinds as `label` so the bytes still try to decode (fail-
+    /// safe), but the field round-trips for forward compat.
+    _,
+};
+
 /// One row of the debug-symbol table per ISA §7.3.
 pub const Symbol = struct {
     address: u16,
+    kind: SymbolKind,
     name: []const u8,
 };
 
@@ -107,13 +122,14 @@ pub fn parseSymbols(allocator: std.mem.Allocator, debug_bytes: []const u8) Symbo
     var cursor: usize = 2;
     var i: usize = 0;
     while (i < count) : (i += 1) {
-        if (cursor + 3 > debug_bytes.len) return error.TruncatedSymbolSection;
+        if (cursor + 4 > debug_bytes.len) return error.TruncatedSymbolSection;
         // @as: widen each u8 byte to u16 for the LE u16 read.
         const addr: u16 = @as(u16, debug_bytes[cursor]) | (@as(u16, debug_bytes[cursor + 1]) << 8);
-        const name_len: usize = debug_bytes[cursor + 2];
-        cursor += 3;
+        const kind: SymbolKind = @enumFromInt(debug_bytes[cursor + 2]);
+        const name_len: usize = debug_bytes[cursor + 3];
+        cursor += 4;
         if (cursor + name_len > debug_bytes.len) return error.TruncatedSymbolSection;
-        entries[i] = .{ .address = addr, .name = debug_bytes[cursor..][0..name_len] };
+        entries[i] = .{ .address = addr, .kind = kind, .name = debug_bytes[cursor..][0..name_len] };
         cursor += name_len;
     }
     return .{ .entries = entries };

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -226,6 +226,11 @@ fn writeDataBlock(
         const addr: u16 = base +% @as(u16, @intCast(offset));
         try writer.print("{s}{X:0>4}:{s}  ", .{ opts.style.address, addr, opts.style.reset });
     }
+    // Pad with the same width the instruction lines use for the
+    // hex-bytes column (5 bytes × 3 chars + 1 trailing space) so
+    // the `data8` keyword aligns with the mnemonic column above
+    // and below it.
+    if (opts.show_bytes) try writer.writeAll(" " ** 16);
     try writer.print("{s}data8{s} {s}{s}{s} = ", .{ opts.style.mnemonic, opts.style.reset, opts.style.register, name, opts.style.reset });
     var i: usize = offset;
     var first = true;

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -17,6 +17,13 @@ const header = @import("header.zig");
 /// mnemonic plus one trailing space.
 const mnemonic_col_width: usize = 6;
 
+/// Minimum number of consecutive `$00` bytes (with no symbol
+/// landing inside them) before the printer collapses the run into
+/// a single `; N bytes zero padding (org $XXXX)` comment. Below
+/// this threshold the bytes still render as individual
+/// `; .byte $00` lines so small genuine gaps aren't hidden.
+const zero_run_collapse_threshold: usize = 4;
+
 /// ANSI escape strings the disasm printer wraps around each
 /// rendered piece. `Style.plain` emits no escapes (round-trip);
 /// `Style.ansi` is the human-facing palette the CLI flips to
@@ -148,6 +155,19 @@ pub fn writeBytesPretty(
             offset += len;
             continue;
         }
+        // Detect a run of $00 bytes with no symbol landing inside
+        // them. Anything ≥ 4 is almost certainly leading or
+        // mid-image padding from an `org $XXXX` directive in the
+        // source — collapse to a single annotated comment instead
+        // of N noisy `; .byte $00` lines.
+        if (bytes[offset] == 0x00) {
+            const run_end = scanZeroRun(bytes, offset, opts);
+            if (run_end - offset >= zero_run_collapse_threshold) {
+                try writeZeroRunComment(writer, offset, run_end - offset, opts);
+                offset = run_end;
+                continue;
+            }
+        }
         const out_or_err = decoder.decodeOne(allocator, bytes, offset);
         if (out_or_err) |out| {
             defer decoder.freeInstruction(allocator, out.instruction);
@@ -240,6 +260,59 @@ fn writeDataBlock(
         try writer.print("{s}${X:0>2}{s}", .{ opts.style.literal, bytes[i], opts.style.reset });
     }
     try writer.writeByte('\n');
+}
+
+/// Walk forward from `start` while `bytes[i] == 0x00`, stopping
+/// at end-of-buffer or at any symbol whose CPU address lands at
+/// or after the run (to avoid swallowing a labeled region that
+/// happens to begin with zero bytes). Returns the offset of the
+/// first non-zero byte / next symbol / end of buffer.
+fn scanZeroRun(bytes: []const u8, start: usize, opts: PrintOptions) usize {
+    var i: usize = start;
+    while (i < bytes.len and bytes[i] == 0x00) : (i += 1) {
+        // A symbol exactly at offset `start` was already handled
+        // by the caller (`dataSymbolAt`/label path), so only stop
+        // when a *later* symbol lands inside the run.
+        if (i > start and symbolAtOffset(i, opts)) break;
+    }
+    return i;
+}
+
+/// `true` if any symbol in `opts.symbols` has its CPU address
+/// equal to `base_addr + offset`. Used by `scanZeroRun` to stop
+/// the run at the next labeled region.
+fn symbolAtOffset(offset: usize, opts: PrintOptions) bool {
+    const symbols = opts.symbols orelse return false;
+    const base = opts.base_addr orelse return false;
+    // @as: offset bounded by caller's slice (≤ 64 KiB image / 16 KiB bank).
+    const addr: u16 = base +% @as(u16, @intCast(offset));
+    for (symbols.entries) |e| if (e.address == addr) return true;
+    return false;
+}
+
+/// Render a collapsed zero-padding run as a single annotated
+/// comment line: `XXXX:  ; N bytes zero padding (org $YYYY)`.
+/// `YYYY` is the CPU address of the first byte AFTER the run —
+/// re-assembling with that `org` directive reproduces the same
+/// padding (codegen zero-fills up to the directive's address).
+fn writeZeroRunComment(
+    writer: *std.Io.Writer,
+    offset: usize,
+    run_len: usize,
+    opts: PrintOptions,
+) std.Io.Writer.Error!void {
+    if (opts.base_addr) |base| {
+        // @as: offset bounded by caller's slice.
+        const addr: u16 = base +% @as(u16, @intCast(offset));
+        try writer.print("{s}{X:0>4}:{s}  ", .{ opts.style.address, addr, opts.style.reset });
+    }
+    // Match the width the instruction lines reserve for the
+    // hex-bytes column when `show_bytes` is on, so the comment
+    // sits at the mnemonic column.
+    if (opts.show_bytes) try writer.writeAll(" " ** 16);
+    const after: u16 = @intCast(offset + run_len);
+    const next: u16 = if (opts.base_addr) |b| b +% after else after;
+    try writer.print("{s}; {d} bytes zero padding (org ${X:0>4}){s}\n", .{ opts.style.comment, run_len, next, opts.style.reset });
 }
 
 /// `XXXX:  ` address column + optional hex-bytes column. Width

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -42,30 +42,108 @@ pub fn writeInstruction(writer: *std.Io.Writer, inst: decoder.Instruction) std.I
 /// line, terminated by `\n`. Stops on the first
 /// `error.UnknownOpcode` and emits a `; .byte $XX` comment so the
 /// surrounding context stays readable.
+///
+/// Output is round-trip-friendly: pass it to the assembler and
+/// you get the same bytes back (for all-code programs). For the
+/// human-facing "disassembly view" with address column + raw
+/// hex bytes + entry marker, use `writeBytesPretty`.
 pub fn writeBytes(
     allocator: std.mem.Allocator,
     writer: *std.Io.Writer,
     bytes: []const u8,
 ) (std.Io.Writer.Error || std.mem.Allocator.Error)!void {
+    return writeBytesPretty(allocator, writer, bytes, .{});
+}
+
+/// Optional decoration knobs for `writeBytesPretty`.
+pub const PrintOptions = struct {
+    /// Start address of `bytes[0]` in CPU space. When set, each
+    /// line gets a leading `XXXX:  ` column. `null` (default) =
+    /// no address column (the round-trip path uses this).
+    base_addr: ?u16 = null,
+    /// `true` → emit a fixed-width hex-bytes column between the
+    /// address and the asm line (objdump style). Requires
+    /// `base_addr` to be meaningful for alignment; otherwise just
+    /// shows the bytes inline.
+    show_bytes: bool = false,
+    /// When the cursor lands at `entry_addr`, append a
+    /// `; entry point` comment to that line. `null` skips the
+    /// marker. Only meaningful with `base_addr` set.
+    entry_addr: ?u16 = null,
+};
+
+/// Same shape as `writeBytes` but with `PrintOptions` for the
+/// disassembly view (address column, hex bytes, entry marker).
+pub fn writeBytesPretty(
+    allocator: std.mem.Allocator,
+    writer: *std.Io.Writer,
+    bytes: []const u8,
+    opts: PrintOptions,
+) (std.Io.Writer.Error || std.mem.Allocator.Error)!void {
     var offset: usize = 0;
     while (offset < bytes.len) {
-        const out = decoder.decodeOne(allocator, bytes, offset) catch |err| switch (err) {
+        const out_or_err = decoder.decodeOne(allocator, bytes, offset);
+        if (out_or_err) |out| {
+            defer decoder.freeInstruction(allocator, out.instruction);
+            try writePrefix(writer, bytes, offset, out.instruction.size, opts);
+            try writeInstruction(writer, out.instruction);
+            try writeEntryMarker(writer, offset, opts);
+            try writer.writeByte('\n');
+            offset = out.next_offset;
+        } else |err| switch (err) {
             error.UnknownOpcode => {
-                try writer.print("; .byte ${X:0>2}\n", .{bytes[offset]});
+                try writePrefix(writer, bytes, offset, 1, opts);
+                try writer.print("; .byte ${X:0>2}", .{bytes[offset]});
+                try writeEntryMarker(writer, offset, opts);
+                try writer.writeByte('\n');
                 offset += 1;
-                continue;
             },
             error.Truncated => {
                 try writer.print("; truncated at offset ${X:0>4}\n", .{offset});
                 break;
             },
             error.OutOfMemory => return error.OutOfMemory,
-        };
-        defer decoder.freeInstruction(allocator, out.instruction);
-        try writeInstruction(writer, out.instruction);
-        try writer.writeByte('\n');
-        offset = out.next_offset;
+        }
     }
+}
+
+/// `XXXX:  ` address column + optional hex-bytes column. Width
+/// of the hex column is fixed at 5 bytes (max v0.1 instruction
+/// width) so subsequent columns align.
+fn writePrefix(
+    writer: *std.Io.Writer,
+    bytes: []const u8,
+    offset: usize,
+    size: usize,
+    opts: PrintOptions,
+) std.Io.Writer.Error!void {
+    if (opts.base_addr) |base| {
+        // @as: offset bounded by caller's slice (max 64 KiB image / 16 KiB bank) so the u16 narrow never truncates.
+        const addr: u16 = base +% @as(u16, @intCast(offset));
+        try writer.print("{X:0>4}:  ", .{addr});
+    }
+    if (opts.show_bytes) {
+        const end = @min(offset + size, bytes.len);
+        const max_inst_bytes: usize = 5;
+        var i: usize = offset;
+        while (i < end) : (i += 1) try writer.print("{X:0>2} ", .{bytes[i]});
+        // Pad to fixed width so the asm column aligns.
+        var pad: usize = (max_inst_bytes - (end - offset)) * 3;
+        while (pad > 0) : (pad -= 1) try writer.writeByte(' ');
+        try writer.writeAll(" ");
+    }
+}
+
+fn writeEntryMarker(
+    writer: *std.Io.Writer,
+    offset: usize,
+    opts: PrintOptions,
+) std.Io.Writer.Error!void {
+    if (opts.entry_addr) |e| if (opts.base_addr) |base| {
+        // @as: same bound as writePrefix — offset fits u16 within the bank window / base image.
+        const addr: u16 = base +% @as(u16, @intCast(offset));
+        if (addr == e) try writer.writeAll("  ; entry point");
+    };
 }
 
 fn writeOperand(writer: *std.Io.Writer, op: decoder.Operand) std.Io.Writer.Error!void {

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -16,10 +16,51 @@ const decoder = @import("decoder.zig");
 /// mnemonic plus one trailing space.
 const mnemonic_col_width: usize = 6;
 
+/// ANSI escape strings the disasm printer wraps around each
+/// rendered piece. `Style.plain` emits no escapes (round-trip);
+/// `Style.ansi` is the human-facing palette the CLI flips to
+/// when stdout is a TTY.
+pub const Style = struct {
+    /// `XXXX:` address gutter.
+    address: []const u8 = "",
+    /// `10 30 00 02` hex-bytes column.
+    bytes_col: []const u8 = "",
+    /// `mov`, `int`, `hlt`, … mnemonic.
+    mnemonic: []const u8 = "",
+    /// `r1`, `acu`, `mb`, … register names.
+    register: []const u8 = "",
+    /// `$1234`, `&5678`, hex/addr literals.
+    literal: []const u8 = "",
+    /// `; .byte`, `; truncated` warnings on undecodable bytes.
+    comment: []const u8 = "",
+    /// `; entry point` callout.
+    entry: []const u8 = "",
+    /// Reset escape emitted after every wrapped piece.
+    reset: []const u8 = "",
+
+    /// No ANSI — default for tests, round-trip, and non-TTY.
+    pub const plain: Style = .{};
+
+    /// Standard palette: dim gutter / bytes, bold mnemonic, cyan
+    /// registers, yellow literals, dim comments, bold-yellow entry.
+    pub const ansi: Style = .{
+        .address = "\x1b[2m",
+        .bytes_col = "\x1b[2m",
+        .mnemonic = "\x1b[1m",
+        .register = "\x1b[36m",
+        .literal = "\x1b[33m",
+        .comment = "\x1b[2m",
+        .entry = "\x1b[1;33m",
+        .reset = "\x1b[0m",
+    };
+};
+
 /// Render one instruction to `writer`. Caller controls leading
-/// indent / label emission separately.
-pub fn writeInstruction(writer: *std.Io.Writer, inst: decoder.Instruction) std.Io.Writer.Error!void {
-    try writer.print("{s}", .{inst.mnemonic});
+/// indent / label emission separately. Pass `Style.plain` for the
+/// round-trip-friendly bare output; `Style.ansi` for the colored
+/// CLI view.
+pub fn writeInstruction(writer: *std.Io.Writer, inst: decoder.Instruction, style: Style) std.Io.Writer.Error!void {
+    try writer.print("{s}{s}{s}", .{ style.mnemonic, inst.mnemonic, style.reset });
     // Pad the mnemonic column — only when operands follow. A
     // zero-operand mnemonic (`hlt`, `nop`, `ret`, …) prints
     // unpadded so the line has no trailing spaces.
@@ -33,7 +74,7 @@ pub fn writeInstruction(writer: *std.Io.Writer, inst: decoder.Instruction) std.I
 
     for (inst.operands, 0..) |op, i| {
         if (i != 0) try writer.writeAll(", ");
-        try writeOperand(writer, op);
+        try writeOperand(writer, op, style);
     }
 }
 
@@ -70,6 +111,9 @@ pub const PrintOptions = struct {
     /// `; entry point` comment to that line. `null` skips the
     /// marker. Only meaningful with `base_addr` set.
     entry_addr: ?u16 = null,
+    /// ANSI palette to wrap around each rendered piece. Default
+    /// `Style.plain` emits no escapes.
+    style: Style = .plain,
 };
 
 /// Same shape as `writeBytes` but with `PrintOptions` for the
@@ -86,20 +130,20 @@ pub fn writeBytesPretty(
         if (out_or_err) |out| {
             defer decoder.freeInstruction(allocator, out.instruction);
             try writePrefix(writer, bytes, offset, out.instruction.size, opts);
-            try writeInstruction(writer, out.instruction);
+            try writeInstruction(writer, out.instruction, opts.style);
             try writeEntryMarker(writer, offset, opts);
             try writer.writeByte('\n');
             offset = out.next_offset;
         } else |err| switch (err) {
             error.UnknownOpcode => {
                 try writePrefix(writer, bytes, offset, 1, opts);
-                try writer.print("; .byte ${X:0>2}", .{bytes[offset]});
+                try writer.print("{s}; .byte ${X:0>2}{s}", .{ opts.style.comment, bytes[offset], opts.style.reset });
                 try writeEntryMarker(writer, offset, opts);
                 try writer.writeByte('\n');
                 offset += 1;
             },
             error.Truncated => {
-                try writer.print("; truncated at offset ${X:0>4}\n", .{offset});
+                try writer.print("{s}; truncated at offset ${X:0>4}{s}\n", .{ opts.style.comment, offset, opts.style.reset });
                 break;
             },
             error.OutOfMemory => return error.OutOfMemory,
@@ -120,13 +164,15 @@ fn writePrefix(
     if (opts.base_addr) |base| {
         // @as: offset bounded by caller's slice (max 64 KiB image / 16 KiB bank) so the u16 narrow never truncates.
         const addr: u16 = base +% @as(u16, @intCast(offset));
-        try writer.print("{X:0>4}:  ", .{addr});
+        try writer.print("{s}{X:0>4}:{s}  ", .{ opts.style.address, addr, opts.style.reset });
     }
     if (opts.show_bytes) {
         const end = @min(offset + size, bytes.len);
         const max_inst_bytes: usize = 5;
+        try writer.writeAll(opts.style.bytes_col);
         var i: usize = offset;
         while (i < end) : (i += 1) try writer.print("{X:0>2} ", .{bytes[i]});
+        try writer.writeAll(opts.style.reset);
         // Pad to fixed width so the asm column aligns.
         var pad: usize = (max_inst_bytes - (end - offset)) * 3;
         while (pad > 0) : (pad -= 1) try writer.writeByte(' ');
@@ -142,38 +188,40 @@ fn writeEntryMarker(
     if (opts.entry_addr) |e| if (opts.base_addr) |base| {
         // @as: same bound as writePrefix — offset fits u16 within the bank window / base image.
         const addr: u16 = base +% @as(u16, @intCast(offset));
-        if (addr == e) try writer.writeAll("  ; entry point");
+        if (addr == e) try writer.print("  {s}; entry point{s}", .{ opts.style.entry, opts.style.reset });
     };
 }
 
-fn writeOperand(writer: *std.Io.Writer, op: decoder.Operand) std.Io.Writer.Error!void {
+fn writeOperand(writer: *std.Io.Writer, op: decoder.Operand, style: Style) std.Io.Writer.Error!void {
     switch (op) {
-        .reg => |r| try writeReg(writer, r),
-        .imm8 => |v| try writer.print("${X:0>2}", .{v}),
-        .imm16 => |v| try writer.print("${X:0>4}", .{v}),
-        .addr => |v| try writer.print("&{X:0>4}", .{v}),
-        .zp => |v| try writer.print("${X:0>2}", .{v}),
+        .reg => |r| try writeReg(writer, r, style),
+        .imm8 => |v| try writer.print("{s}${X:0>2}{s}", .{ style.literal, v, style.reset }),
+        .imm16 => |v| try writer.print("{s}${X:0>4}{s}", .{ style.literal, v, style.reset }),
+        .addr => |v| try writer.print("{s}&{X:0>4}{s}", .{ style.literal, v, style.reset }),
+        .zp => |v| try writer.print("{s}${X:0>2}{s}", .{ style.literal, v, style.reset }),
         .reg_indirect => |r| {
             try writer.writeByte('[');
-            try writeReg(writer, r);
+            try writeReg(writer, r, style);
             try writer.writeByte(']');
         },
         .indexed => |idx| {
-            try writer.print("[&{X:0>4} + ", .{idx.addr});
-            try writeReg(writer, idx.reg);
+            try writer.print("[{s}&{X:0>4}{s} + ", .{ style.literal, idx.addr, style.reset });
+            try writeReg(writer, idx.reg, style);
             try writer.writeByte(']');
         },
     }
 }
 
-fn writeReg(writer: *std.Io.Writer, idx: u8) std.Io.Writer.Error!void {
+fn writeReg(writer: *std.Io.Writer, idx: u8, style: Style) std.Io.Writer.Error!void {
     // Map the raw 0..14 index back to the canonical asm name via
     // the `vm.Register` enum. Out-of-range bytes (the VM would
     // fault on these at runtime) round-trip as `r?<hex>` so the
     // disasm output is still readable instead of crashing.
+    try writer.writeAll(style.register);
     if (std.enums.fromInt(gero.vm.Register, idx)) |reg| {
         try writer.writeAll(@tagName(reg));
     } else {
         try writer.print("r?{X:0>2}", .{idx});
     }
+    try writer.writeAll(style.reset);
 }

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -1,0 +1,101 @@
+/// Pretty-printer for decoded instructions. Emits asm syntax
+/// the assembler can re-consume (round-trip), with an aligned
+/// mnemonic column and conventional hex / addr / register
+/// literals.
+///
+/// Output shape (one line per instruction):
+///   `<mnemonic-padded-to-width>  <op1>, <op2>`
+///
+/// Columns are right-padded to `mnemonic_col_width` so the
+/// operands line up across the block.
+const std = @import("std");
+const gero = @import("../gero.zig");
+const decoder = @import("decoder.zig");
+
+/// Mnemonic column width in characters — covers every v0.1
+/// mnemonic plus one trailing space.
+const mnemonic_col_width: usize = 6;
+
+/// Render one instruction to `writer`. Caller controls leading
+/// indent / label emission separately.
+pub fn writeInstruction(writer: *std.Io.Writer, inst: decoder.Instruction) std.Io.Writer.Error!void {
+    try writer.print("{s}", .{inst.mnemonic});
+    // Pad the mnemonic column — only when operands follow. A
+    // zero-operand mnemonic (`hlt`, `nop`, `ret`, …) prints
+    // unpadded so the line has no trailing spaces.
+    if (inst.operands.len > 0) {
+        var pad: usize = if (inst.mnemonic.len < mnemonic_col_width)
+            mnemonic_col_width - inst.mnemonic.len
+        else
+            1;
+        while (pad > 0) : (pad -= 1) try writer.writeByte(' ');
+    }
+
+    for (inst.operands, 0..) |op, i| {
+        if (i != 0) try writer.writeAll(", ");
+        try writeOperand(writer, op);
+    }
+}
+
+/// Render the bytes between `addr` and `addr + N` (for some
+/// caller-chosen N) as a series of asm instructions, one per
+/// line, terminated by `\n`. Stops on the first
+/// `error.UnknownOpcode` and emits a `; .byte $XX` comment so the
+/// surrounding context stays readable.
+pub fn writeBytes(
+    allocator: std.mem.Allocator,
+    writer: *std.Io.Writer,
+    bytes: []const u8,
+) (std.Io.Writer.Error || std.mem.Allocator.Error)!void {
+    var offset: usize = 0;
+    while (offset < bytes.len) {
+        const out = decoder.decodeOne(allocator, bytes, offset) catch |err| switch (err) {
+            error.UnknownOpcode => {
+                try writer.print("; .byte ${X:0>2}\n", .{bytes[offset]});
+                offset += 1;
+                continue;
+            },
+            error.Truncated => {
+                try writer.print("; truncated at offset ${X:0>4}\n", .{offset});
+                break;
+            },
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        defer decoder.freeInstruction(allocator, out.instruction);
+        try writeInstruction(writer, out.instruction);
+        try writer.writeByte('\n');
+        offset = out.next_offset;
+    }
+}
+
+fn writeOperand(writer: *std.Io.Writer, op: decoder.Operand) std.Io.Writer.Error!void {
+    switch (op) {
+        .reg => |r| try writeReg(writer, r),
+        .imm8 => |v| try writer.print("${X:0>2}", .{v}),
+        .imm16 => |v| try writer.print("${X:0>4}", .{v}),
+        .addr => |v| try writer.print("&{X:0>4}", .{v}),
+        .zp => |v| try writer.print("${X:0>2}", .{v}),
+        .reg_indirect => |r| {
+            try writer.writeByte('[');
+            try writeReg(writer, r);
+            try writer.writeByte(']');
+        },
+        .indexed => |idx| {
+            try writer.print("[&{X:0>4} + ", .{idx.addr});
+            try writeReg(writer, idx.reg);
+            try writer.writeByte(']');
+        },
+    }
+}
+
+fn writeReg(writer: *std.Io.Writer, idx: u8) std.Io.Writer.Error!void {
+    // Map the raw 0..14 index back to the canonical asm name via
+    // the `vm.Register` enum. Out-of-range bytes (the VM would
+    // fault on these at runtime) round-trip as `r?<hex>` so the
+    // disasm output is still readable instead of crashing.
+    if (std.enums.fromInt(gero.vm.Register, idx)) |reg| {
+        try writer.writeAll(@tagName(reg));
+    } else {
+        try writer.print("r?{X:0>2}", .{idx});
+    }
+}

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -137,6 +137,17 @@ pub fn writeBytesPretty(
 ) (std.Io.Writer.Error || std.mem.Allocator.Error)!void {
     var offset: usize = 0;
     while (offset < bytes.len) {
+        // Before trying to decode an instruction, check whether
+        // the cursor lands at a *data* symbol — if so, render
+        // those bytes as a `data8` block instead of fake
+        // instructions. Length goes from this symbol's address
+        // to the next symbol's address (or end of section).
+        if (dataSymbolAt(offset, opts)) |info| {
+            const len = @min(info.length, bytes.len - offset);
+            try writeDataBlock(writer, bytes, offset, len, info.name, opts);
+            offset += len;
+            continue;
+        }
         const out_or_err = decoder.decodeOne(allocator, bytes, offset);
         if (out_or_err) |out| {
             defer decoder.freeInstruction(allocator, out.instruction);
@@ -160,6 +171,70 @@ pub fn writeBytesPretty(
             error.OutOfMemory => return error.OutOfMemory,
         }
     }
+}
+
+/// What `dataSymbolAt` returns — a matched data symbol's name
+/// plus how many bytes the data block spans (from this offset
+/// to the next symbol's address or to end-of-section).
+const DataBlock = struct {
+    name: []const u8,
+    length: usize,
+};
+
+/// If `offset` corresponds to the CPU address of a `data`-kind
+/// symbol, return its name + length. `null` otherwise. Length is
+/// the gap to the next symbol in the same section (whether label
+/// or data); when no later symbol exists we return a "rest of
+/// section" sentinel that `writeDataBlock` caps at `bytes.len`.
+fn dataSymbolAt(offset: usize, opts: PrintOptions) ?DataBlock {
+    const symbols = opts.symbols orelse return null;
+    const base = opts.base_addr orelse return null;
+    // @as: offset bounded by caller's slice — fits u16 in the base image / bank window contexts.
+    const cur_addr: u16 = base +% @as(u16, @intCast(offset));
+    for (symbols.entries, 0..) |e, i| {
+        if (e.address != cur_addr) continue;
+        if (e.kind != .data) return null;
+        // Find the smallest later-symbol address that lives in
+        // the same section (`> cur_addr`). Entries are sorted by
+        // address ascending, so the first hit wins.
+        for (symbols.entries[i + 1 ..]) |later| {
+            if (later.address > cur_addr) {
+                return .{ .name = e.name, .length = later.address - cur_addr };
+            }
+        }
+        // No later symbol — let writeDataBlock cap at bytes.len.
+        return .{ .name = e.name, .length = std.math.maxInt(usize) };
+    }
+    return null;
+}
+
+/// Render `bytes[offset..offset+length]` as a `data8 <name> = $XX, ...`
+/// directive — round-trippable through the assembler. Uses its
+/// own minimal prefix (address only, no hex-bytes column since
+/// the bytes are inlined in the directive itself).
+fn writeDataBlock(
+    writer: *std.Io.Writer,
+    bytes: []const u8,
+    offset: usize,
+    length: usize,
+    name: []const u8,
+    opts: PrintOptions,
+) std.Io.Writer.Error!void {
+    const end = @min(offset + length, bytes.len);
+    if (opts.base_addr) |base| {
+        // @as: offset bounded by caller's slice (≤ 64 KiB image / 16 KiB bank).
+        const addr: u16 = base +% @as(u16, @intCast(offset));
+        try writer.print("{s}{X:0>4}:{s}  ", .{ opts.style.address, addr, opts.style.reset });
+    }
+    try writer.print("{s}data8{s} {s}{s}{s} = ", .{ opts.style.mnemonic, opts.style.reset, opts.style.register, name, opts.style.reset });
+    var i: usize = offset;
+    var first = true;
+    while (i < end) : (i += 1) {
+        if (!first) try writer.writeAll(", ");
+        first = false;
+        try writer.print("{s}${X:0>2}{s}", .{ opts.style.literal, bytes[i], opts.style.reset });
+    }
+    try writer.writeByte('\n');
 }
 
 /// `XXXX:  ` address column + optional hex-bytes column. Width

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -11,6 +11,7 @@
 const std = @import("std");
 const gero = @import("../gero.zig");
 const decoder = @import("decoder.zig");
+const header = @import("header.zig");
 
 /// Mnemonic column width in characters — covers every v0.1
 /// mnemonic plus one trailing space.
@@ -58,8 +59,14 @@ pub const Style = struct {
 /// Render one instruction to `writer`. Caller controls leading
 /// indent / label emission separately. Pass `Style.plain` for the
 /// round-trip-friendly bare output; `Style.ansi` for the colored
-/// CLI view.
-pub fn writeInstruction(writer: *std.Io.Writer, inst: decoder.Instruction, style: Style) std.Io.Writer.Error!void {
+/// CLI view. Optional `symbols` substitutes matching addresses
+/// with their name (e.g. `call greet` instead of `call &C000`).
+pub fn writeInstruction(
+    writer: *std.Io.Writer,
+    inst: decoder.Instruction,
+    style: Style,
+    symbols: ?header.Symbols,
+) std.Io.Writer.Error!void {
     try writer.print("{s}{s}{s}", .{ style.mnemonic, inst.mnemonic, style.reset });
     // Pad the mnemonic column — only when operands follow. A
     // zero-operand mnemonic (`hlt`, `nop`, `ret`, …) prints
@@ -74,7 +81,7 @@ pub fn writeInstruction(writer: *std.Io.Writer, inst: decoder.Instruction, style
 
     for (inst.operands, 0..) |op, i| {
         if (i != 0) try writer.writeAll(", ");
-        try writeOperand(writer, op, style);
+        try writeOperand(writer, op, style, symbols);
     }
 }
 
@@ -114,6 +121,10 @@ pub const PrintOptions = struct {
     /// ANSI palette to wrap around each rendered piece. Default
     /// `Style.plain` emits no escapes.
     style: Style = .plain,
+    /// Optional debug-symbol lookup. When set, `addr` operands
+    /// matching a known symbol render as the symbol name instead
+    /// of `&XXXX`. `null` keeps the raw addresses.
+    symbols: ?header.Symbols = null,
 };
 
 /// Same shape as `writeBytes` but with `PrintOptions` for the
@@ -130,7 +141,7 @@ pub fn writeBytesPretty(
         if (out_or_err) |out| {
             defer decoder.freeInstruction(allocator, out.instruction);
             try writePrefix(writer, bytes, offset, out.instruction.size, opts);
-            try writeInstruction(writer, out.instruction, opts.style);
+            try writeInstruction(writer, out.instruction, opts.style, opts.symbols);
             try writeEntryMarker(writer, offset, opts);
             try writer.writeByte('\n');
             offset = out.next_offset;
@@ -192,12 +203,17 @@ fn writeEntryMarker(
     };
 }
 
-fn writeOperand(writer: *std.Io.Writer, op: decoder.Operand, style: Style) std.Io.Writer.Error!void {
+fn writeOperand(
+    writer: *std.Io.Writer,
+    op: decoder.Operand,
+    style: Style,
+    symbols: ?header.Symbols,
+) std.Io.Writer.Error!void {
     switch (op) {
         .reg => |r| try writeReg(writer, r, style),
         .imm8 => |v| try writer.print("{s}${X:0>2}{s}", .{ style.literal, v, style.reset }),
         .imm16 => |v| try writer.print("{s}${X:0>4}{s}", .{ style.literal, v, style.reset }),
-        .addr => |v| try writer.print("{s}&{X:0>4}{s}", .{ style.literal, v, style.reset }),
+        .addr => |v| try writeAddrOrSymbol(writer, v, style, symbols),
         .zp => |v| try writer.print("{s}${X:0>2}{s}", .{ style.literal, v, style.reset }),
         .reg_indirect => |r| {
             try writer.writeByte('[');
@@ -205,11 +221,30 @@ fn writeOperand(writer: *std.Io.Writer, op: decoder.Operand, style: Style) std.I
             try writer.writeByte(']');
         },
         .indexed => |idx| {
-            try writer.print("[{s}&{X:0>4}{s} + ", .{ style.literal, idx.addr, style.reset });
+            try writer.writeByte('[');
+            try writeAddrOrSymbol(writer, idx.addr, style, symbols);
+            try writer.writeAll(" + ");
             try writeReg(writer, idx.reg, style);
             try writer.writeByte(']');
         },
     }
+}
+
+/// Render an address: prefer a matching symbol name (cyan, no
+/// `&` prefix) over the raw `&XXXX` literal. The asm accepts
+/// bare identifiers as label-refs so the symbolic form
+/// round-trips.
+fn writeAddrOrSymbol(
+    writer: *std.Io.Writer,
+    addr: u16,
+    style: Style,
+    symbols: ?header.Symbols,
+) std.Io.Writer.Error!void {
+    if (symbols) |s| if (s.lookup(addr)) |name| {
+        try writer.print("{s}{s}{s}", .{ style.register, name, style.reset });
+        return;
+    };
+    try writer.print("{s}&{X:0>4}{s}", .{ style.literal, addr, style.reset });
 }
 
 fn writeReg(writer: *std.Io.Writer, idx: u8, style: Style) std.Io.Writer.Error!void {

--- a/src/disasm/roundtrip.zig
+++ b/src/disasm/roundtrip.zig
@@ -1,0 +1,34 @@
+/// Helper that drives the asm → disasm → asm pipeline so tests
+/// can assert byte-equality between the original and re-assembled
+/// images. The disasm side is byte-blind (no debug symbols), so
+/// the helper only round-trips reliably for source that contains
+/// no `data8` / `data16` / mixed-data regions.
+const std = @import("std");
+const gero = @import("../gero.zig");
+
+/// Run the round-trip pipeline. Returns the re-assembled image
+/// bytes (caller owns) on success. The caller can compare them
+/// against the original image bytes to assert losslessness.
+///
+/// Caveats: the disasm has no way to distinguish code from data,
+/// so passing an image with `data8` blobs (etc.) typically
+/// produces gibberish on the way back. Real round-trip tests are
+/// expected to stick to all-code programs until debug symbols
+/// ship.
+pub fn roundTripImage(allocator: std.mem.Allocator, original_image: []const u8) ![]u8 {
+    var disasm_text: std.Io.Writer.Allocating = .init(allocator);
+    defer disasm_text.deinit();
+    try gero.disasm.writeBytes(allocator, &disasm_text.writer, original_image);
+
+    var pt = try gero.asm_.parse(allocator, disasm_text.written());
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(allocator, disasm_text.written(), pt, .{});
+    defer cg.deinit();
+    if (cg.hasErrors()) return error.RoundTripAssemblyFailed;
+
+    // Strip the 16-byte header — the comparison is against the
+    // raw image bytes, not the whole archive (entry point and
+    // bank info on the re-assembled archive may differ slightly
+    // because labels are gone).
+    return allocator.dupe(u8, cg.image[16..]);
+}

--- a/src/disasm/roundtrip.zig
+++ b/src/disasm/roundtrip.zig
@@ -22,7 +22,12 @@ pub fn roundTripImage(allocator: std.mem.Allocator, original_image: []const u8) 
 
     var pt = try gero.asm_.parse(allocator, disasm_text.written());
     defer pt.deinit();
-    var cg = try gero.asm_.assemble(allocator, disasm_text.written(), pt, .{});
+    // Strip the debug-symbol section from the re-assembled
+    // archive — the disasm's bare output (no symbols) drops
+    // every label, so the re-asm's symbol table is empty
+    // anyway. Disabling here keeps the byte-equality compare
+    // tight against the original's base + banks tail.
+    var cg = try gero.asm_.assemble(allocator, disasm_text.written(), pt, .{ .debug_symbols = false });
     defer cg.deinit();
     if (cg.hasErrors()) return error.RoundTripAssemblyFailed;
 

--- a/src/gero.zig
+++ b/src/gero.zig
@@ -8,3 +8,7 @@ pub const vm = @import("vm/vm.zig");
 /// Assembler — text `.gas` source → `.gx` bytecode. Scaffold;
 /// real parser / codegen lands in follow-up PRs.
 pub const asm_ = @import("asm.zig");
+
+/// Disassembler — `.gx` bytecode → `.gas` source. Inverse of
+/// `asm_`; consumes the same `.gx` shape the VM loads.
+pub const disasm = @import("disasm.zig");

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -444,18 +444,21 @@ test "codegen: debug symbols emit by default — flag bit + sorted entries" {
     defer out.deinit();
     // Flags low byte: bit 1 = has-debug
     try std.testing.expect((out.cg.image[6] & 0x02) != 0);
-    // Trailing blob: count u16 LE = 2, then sorted by address
+    // Trailing blob: count u16 LE = 2, then sorted by address.
+    // Entry layout per ISA §7.3: addr(2) + kind(1) + name_len(1) + name.
     const tail_start = 16 + 2; // header + 2-byte image (2 hlt)
     try std.testing.expectEqual(@as(u8, 0x02), out.cg.image[tail_start]);
     try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 1]);
-    // First entry: addr 0x0000 → "main"
+    // First entry: addr 0x0000, kind=label(0), name="main"
     try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 2]);
     try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 3]);
-    try std.testing.expectEqual(@as(u8, 4), out.cg.image[tail_start + 4]);
-    try std.testing.expectEqualSlices(u8, "main", out.cg.image[tail_start + 5 ..][0..4]);
-    // Second entry: addr 0x0001 → "helper"
-    try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[tail_start + 9]);
-    try std.testing.expectEqualSlices(u8, "helper", out.cg.image[tail_start + 12 ..][0..6]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 4]); // kind = label
+    try std.testing.expectEqual(@as(u8, 4), out.cg.image[tail_start + 5]); // name_len
+    try std.testing.expectEqualSlices(u8, "main", out.cg.image[tail_start + 6 ..][0..4]);
+    // Second entry: addr 0x0001, kind=label, name="helper" — starts at tail+10
+    try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[tail_start + 10]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 12]); // kind = label
+    try std.testing.expectEqualSlices(u8, "helper", out.cg.image[tail_start + 14 ..][0..6]);
 }
 
 test "codegen: debug_symbols=false skips the section + flag" {
@@ -482,9 +485,21 @@ test "codegen: debug symbols skip local labels + consts" {
     // symbol_count = 1
     try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[tail_start]);
     try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 1]);
-    // The one entry is "main"
-    try std.testing.expectEqual(@as(u8, 4), out.cg.image[tail_start + 4]);
-    try std.testing.expectEqualSlices(u8, "main", out.cg.image[tail_start + 5 ..][0..4]);
+    // The one entry is "main" — kind=label(0), name_len=4
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 4]); // kind = label
+    try std.testing.expectEqual(@as(u8, 4), out.cg.image[tail_start + 5]); // name_len
+    try std.testing.expectEqualSlices(u8, "main", out.cg.image[tail_start + 6 ..][0..4]);
+}
+
+test "codegen: data declarations emit with kind=1 (data)" {
+    var out = try assembleRaw(
+        \\data8 GREETING = $48, $69
+        \\
+    , .{});
+    defer out.deinit();
+    const tail_start = 16 + 2; // header + 2 image bytes
+    // First entry should have kind = data(1).
+    try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[tail_start + 4]);
 }
 
 test "codegen: header magic + version + entry_point + image_size" {

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -20,7 +20,23 @@ const Output = struct {
     }
 };
 
-fn assemble(source: []const u8, opts: gero.asm_.CodegenOptions) !Output {
+fn assemble(source: []const u8, opts_in: gero.asm_.CodegenOptions) !Output {
+    var pt = try gero.asm_.parse(alloc, source);
+    errdefer pt.deinit();
+    // Force-disable debug symbols by default so byte-layout
+    // tests stay tight against the expected image / banks bytes.
+    // The dedicated debug-symbols tests pass their own opts with
+    // `.debug_symbols = true`.
+    var opts = opts_in;
+    opts.debug_symbols = false;
+    const cg = try gero.asm_.assemble(alloc, source, pt, opts);
+    return .{ .pt = pt, .cg = cg };
+}
+
+/// Variant that keeps the caller's opts intact (no automatic
+/// debug-symbol stripping). Used by the `#100` debug-symbols
+/// tests that need to inspect the trailing blob.
+fn assembleRaw(source: []const u8, opts: gero.asm_.CodegenOptions) !Output {
     var pt = try gero.asm_.parse(alloc, source);
     errdefer pt.deinit();
     const cg = try gero.asm_.assemble(alloc, source, pt, opts);
@@ -413,6 +429,62 @@ test "codegen: labels inside `bank N` resolve to bank-window addresses" {
     try std.testing.expectEqual(@as(u8, 0x80), out.cg.image[16]);
     try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[17]);
     try std.testing.expectEqual(@as(u8, 0xC0), out.cg.image[18]);
+}
+
+// ---------- debug symbols (issue #100) ----------
+
+test "codegen: debug symbols emit by default — flag bit + sorted entries" {
+    var out = try assembleRaw(
+        \\main:
+        \\  hlt
+        \\helper:
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    // Flags low byte: bit 1 = has-debug
+    try std.testing.expect((out.cg.image[6] & 0x02) != 0);
+    // Trailing blob: count u16 LE = 2, then sorted by address
+    const tail_start = 16 + 2; // header + 2-byte image (2 hlt)
+    try std.testing.expectEqual(@as(u8, 0x02), out.cg.image[tail_start]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 1]);
+    // First entry: addr 0x0000 → "main"
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 2]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 3]);
+    try std.testing.expectEqual(@as(u8, 4), out.cg.image[tail_start + 4]);
+    try std.testing.expectEqualSlices(u8, "main", out.cg.image[tail_start + 5 ..][0..4]);
+    // Second entry: addr 0x0001 → "helper"
+    try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[tail_start + 9]);
+    try std.testing.expectEqualSlices(u8, "helper", out.cg.image[tail_start + 12 ..][0..6]);
+}
+
+test "codegen: debug_symbols=false skips the section + flag" {
+    var out = try assembleRaw("main:\n  hlt\n", .{ .debug_symbols = false });
+    defer out.deinit();
+    try std.testing.expectEqual(@as(u8, 0), out.cg.image[6] & 0x02); // flag bit clear
+    // Total = 16 header + 1 image byte (hlt), no trailing blob.
+    try std.testing.expectEqual(@as(usize, 17), out.cg.image.len);
+}
+
+test "codegen: debug symbols skip local labels + consts" {
+    // Locals (`.loop`) get mangled with a `.` which isn't a valid
+    // ident — exclude. Consts are values, not addresses — also
+    // exclude. Only `main` should make it into the blob.
+    var out = try assembleRaw(
+        \\const N = $05
+        \\main:
+        \\.loop:
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    const tail_start = 16 + 1; // header + 1 image byte (hlt)
+    // symbol_count = 1
+    try std.testing.expectEqual(@as(u8, 0x01), out.cg.image[tail_start]);
+    try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[tail_start + 1]);
+    // The one entry is "main"
+    try std.testing.expectEqual(@as(u8, 4), out.cg.image[tail_start + 4]);
+    try std.testing.expectEqualSlices(u8, "main", out.cg.image[tail_start + 5 ..][0..4]);
 }
 
 test "codegen: header magic + version + entry_point + image_size" {

--- a/tests/asm/opcode_resolver.test.zig
+++ b/tests/asm/opcode_resolver.test.zig
@@ -38,7 +38,7 @@ test "opres: cmp reg, label_ref(const) uses imm16 form (0x60)" {
     ;
     var pt = try gero.asm_.parse(alloc, src);
     defer pt.deinit();
-    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     try std.testing.expect(!cg.hasErrors());
     try std.testing.expectEqual(@as(u8, 0x60), cg.image[16]);
@@ -53,7 +53,7 @@ test "opres: jmp label_ref(label) uses addr form (0x70)" {
     ;
     var pt = try gero.asm_.parse(alloc, src);
     defer pt.deinit();
-    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     try std.testing.expect(!cg.hasErrors());
     // image: hlt(0xFF) then jmp(0x70) + addr LE(00 00)
@@ -65,7 +65,7 @@ test "opres: indexed addressing emits 3-byte operand (addr + reg)" {
     const src = "mov [&2620 + r1], r2\n";
     var pt = try gero.asm_.parse(alloc, src);
     defer pt.deinit();
-    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     try std.testing.expect(!cg.hasErrors());
     // 0x17 + addr LE (20 26) + idx_reg (r1 = 0x02) + dst_reg (r2 = 0x03)
@@ -76,7 +76,7 @@ test "opres: mov8 indexed emits 5-byte operand (opcode + addr + 2 regs)" {
     const src = "mov8 [&3000 + r1], r2\n";
     var pt = try gero.asm_.parse(alloc, src);
     defer pt.deinit();
-    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     try std.testing.expect(!cg.hasErrors());
     // 0x29 + addr LE (00 30) + idx_reg (r1 = 0x02) + dst_reg (r2 = 0x03)
@@ -89,7 +89,7 @@ test "opres: imm8 narrowing — mov8 picks Imm8 shape over widening" {
     const src = "mov8 $42, r1\n";
     var pt = try gero.asm_.parse(alloc, src);
     defer pt.deinit();
-    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     try std.testing.expect(!cg.hasErrors());
     try std.testing.expectEqualSlices(u8, &.{ 0x21, 0x42, 0x02 }, cg.image[16..]);

--- a/tests/disasm/decoder.test.zig
+++ b/tests/disasm/decoder.test.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+test "decoder: hlt (zero-operand) decodes to mnemonic + empty operands" {
+    const bytes = [_]u8{0xFF};
+    const out = try gero.disasm.decodeOne(alloc, &bytes, 0);
+    defer gero.disasm.freeInstruction(alloc, out.instruction);
+    try std.testing.expectEqualStrings("hlt", out.instruction.mnemonic);
+    try std.testing.expectEqual(@as(u8, 1), out.instruction.size);
+    try std.testing.expectEqual(@as(usize, 0), out.instruction.operands.len);
+    try std.testing.expectEqual(@as(usize, 1), out.next_offset);
+}
+
+test "decoder: mov imm16, reg → 0x10 LE imm + reg" {
+    // mov $1234, r1
+    const bytes = [_]u8{ 0x10, 0x34, 0x12, 0x02 };
+    const out = try gero.disasm.decodeOne(alloc, &bytes, 0);
+    defer gero.disasm.freeInstruction(alloc, out.instruction);
+    try std.testing.expectEqualStrings("mov", out.instruction.mnemonic);
+    try std.testing.expectEqual(@as(u8, 4), out.instruction.size);
+    try std.testing.expectEqual(@as(usize, 2), out.instruction.operands.len);
+    try std.testing.expectEqual(@as(u16, 0x1234), out.instruction.operands[0].imm16);
+    try std.testing.expectEqual(@as(u8, 0x02), out.instruction.operands[1].reg);
+}
+
+test "decoder: mov reg, reg → 0x11 src dst (post-#94 src-first convention)" {
+    const bytes = [_]u8{ 0x11, 0x02, 0x03 };
+    const out = try gero.disasm.decodeOne(alloc, &bytes, 0);
+    defer gero.disasm.freeInstruction(alloc, out.instruction);
+    try std.testing.expectEqualStrings("mov", out.instruction.mnemonic);
+    try std.testing.expectEqual(@as(u8, 0x02), out.instruction.operands[0].reg);
+    try std.testing.expectEqual(@as(u8, 0x03), out.instruction.operands[1].reg);
+}
+
+test "decoder: indexed mov decodes 5 bytes (opcode + addr + reg + reg)" {
+    // mov [&2620 + r1], r2  →  0x17 20 26 02 03
+    const bytes = [_]u8{ 0x17, 0x20, 0x26, 0x02, 0x03 };
+    const out = try gero.disasm.decodeOne(alloc, &bytes, 0);
+    defer gero.disasm.freeInstruction(alloc, out.instruction);
+    try std.testing.expectEqual(@as(u8, 5), out.instruction.size);
+    try std.testing.expectEqual(@as(u16, 0x2620), out.instruction.operands[0].indexed.addr);
+    try std.testing.expectEqual(@as(u8, 0x02), out.instruction.operands[0].indexed.reg);
+    try std.testing.expectEqual(@as(u8, 0x03), out.instruction.operands[1].reg);
+}
+
+test "decoder: int (imm8) decodes 2 bytes" {
+    const bytes = [_]u8{ 0xFC, 0x10 };
+    const out = try gero.disasm.decodeOne(alloc, &bytes, 0);
+    defer gero.disasm.freeInstruction(alloc, out.instruction);
+    try std.testing.expectEqualStrings("int", out.instruction.mnemonic);
+    try std.testing.expectEqual(@as(u8, 0x10), out.instruction.operands[0].imm8);
+}
+
+test "decoder: unknown opcode returns error.UnknownOpcode" {
+    const bytes = [_]u8{0x00}; // 0x00 is not in the v0.1 ISA
+    try std.testing.expectError(error.UnknownOpcode, gero.disasm.decodeOne(alloc, &bytes, 0));
+}
+
+test "decoder: truncated operand returns error.Truncated" {
+    // `mov` (0x10) expects 3 more bytes — only give it 2.
+    const bytes = [_]u8{ 0x10, 0x34, 0x12 };
+    try std.testing.expectError(error.Truncated, gero.disasm.decodeOne(alloc, &bytes, 0));
+}

--- a/tests/disasm/header.test.zig
+++ b/tests/disasm/header.test.zig
@@ -63,6 +63,60 @@ test "header: file shorter than header rejected" {
     try std.testing.expectError(error.TooSmall, gero.disasm.parseHeader(&buf));
 }
 
+// ---------- debug symbols (#100) ----------
+
+test "symbols: empty blob produces zero entries" {
+    const out = try gero.disasm.parseSymbols(std.testing.allocator, &.{});
+    defer out.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), out.entries.len);
+}
+
+test "symbols: parse count + (addr, name) entries" {
+    // count=2, entry1: addr $0010 name "main", entry2: addr $0042 name "fib"
+    const blob = [_]u8{
+        0x02, 0x00, // count = 2
+        0x10, 0x00,
+        0x04, 'm',
+        'a',  'i',
+        'n',  0x42,
+        0x00, 0x03,
+        'f',  'i',
+        'b',
+    };
+    const out = try gero.disasm.parseSymbols(std.testing.allocator, &blob);
+    defer out.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), out.entries.len);
+    try std.testing.expectEqual(@as(u16, 0x0010), out.entries[0].address);
+    try std.testing.expectEqualStrings("main", out.entries[0].name);
+    try std.testing.expectEqual(@as(u16, 0x0042), out.entries[1].address);
+    try std.testing.expectEqualStrings("fib", out.entries[1].name);
+}
+
+test "symbols: lookup returns name on hit, null on miss" {
+    const blob = [_]u8{
+        0x01, 0x00,
+        0x10, 0x00,
+        0x04, 'm',
+        'a',  'i',
+        'n',
+    };
+    const out = try gero.disasm.parseSymbols(std.testing.allocator, &blob);
+    defer out.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("main", out.lookup(0x0010).?);
+    try std.testing.expect(out.lookup(0x0042) == null);
+}
+
+test "symbols: truncated count rejected" {
+    const blob = [_]u8{0x02}; // only 1 of 2 bytes
+    try std.testing.expectError(error.TruncatedSymbolSection, gero.disasm.parseSymbols(std.testing.allocator, &blob));
+}
+
+test "symbols: truncated name rejected" {
+    // Declares 4 bytes of name but only has 2.
+    const blob = [_]u8{ 0x01, 0x00, 0x10, 0x00, 0x04, 'a', 'b' };
+    try std.testing.expectError(error.TruncatedSymbolSection, gero.disasm.parseSymbols(std.testing.allocator, &blob));
+}
+
 test "header: banked cart exposes bank slice + isBanked flag" {
     const bank_size: usize = 0x4000;
     var buf: [16 + 1 + bank_size]u8 = undefined;

--- a/tests/disasm/header.test.zig
+++ b/tests/disasm/header.test.zig
@@ -71,34 +71,31 @@ test "symbols: empty blob produces zero entries" {
     try std.testing.expectEqual(@as(usize, 0), out.entries.len);
 }
 
-test "symbols: parse count + (addr, name) entries" {
-    // count=2, entry1: addr $0010 name "main", entry2: addr $0042 name "fib"
+test "symbols: parse count + (addr, kind, name) entries" {
+    // count=2, entry1: $0010 label "main", entry2: $0042 data "buf"
     const blob = [_]u8{
         0x02, 0x00, // count = 2
-        0x10, 0x00,
-        0x04, 'm',
-        'a',  'i',
-        'n',  0x42,
-        0x00, 0x03,
-        'f',  'i',
-        'b',
+        0x10, 0x00, 0x00, 0x04, 'm', 'a', 'i', 'n', // addr / kind=label / len / name
+        0x42, 0x00, 0x01, 0x03, 'b', 'u', 'f', // addr / kind=data / len / name
     };
     const out = try gero.disasm.parseSymbols(std.testing.allocator, &blob);
     defer out.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 2), out.entries.len);
     try std.testing.expectEqual(@as(u16, 0x0010), out.entries[0].address);
+    try std.testing.expectEqual(gero.disasm.SymbolKind.label, out.entries[0].kind);
     try std.testing.expectEqualStrings("main", out.entries[0].name);
     try std.testing.expectEqual(@as(u16, 0x0042), out.entries[1].address);
-    try std.testing.expectEqualStrings("fib", out.entries[1].name);
+    try std.testing.expectEqual(gero.disasm.SymbolKind.data, out.entries[1].kind);
+    try std.testing.expectEqualStrings("buf", out.entries[1].name);
 }
 
 test "symbols: lookup returns name on hit, null on miss" {
     const blob = [_]u8{
         0x01, 0x00,
         0x10, 0x00,
-        0x04, 'm',
-        'a',  'i',
-        'n',
+        0x00, 0x04,
+        'm',  'a',
+        'i',  'n',
     };
     const out = try gero.disasm.parseSymbols(std.testing.allocator, &blob);
     defer out.deinit(std.testing.allocator);
@@ -113,7 +110,7 @@ test "symbols: truncated count rejected" {
 
 test "symbols: truncated name rejected" {
     // Declares 4 bytes of name but only has 2.
-    const blob = [_]u8{ 0x01, 0x00, 0x10, 0x00, 0x04, 'a', 'b' };
+    const blob = [_]u8{ 0x01, 0x00, 0x10, 0x00, 0x00, 0x04, 'a', 'b' };
     try std.testing.expectError(error.TruncatedSymbolSection, gero.disasm.parseSymbols(std.testing.allocator, &blob));
 }
 

--- a/tests/disasm/header.test.zig
+++ b/tests/disasm/header.test.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const gero = @import("gero");
+
+/// Build a minimal `.gx` byte buffer per ISA §7.1.
+fn buildGx(
+    out: []u8,
+    flags: u16,
+    entry: u16,
+    image_size: u16,
+    bank_count: u8,
+    sram_bank_count: u8,
+) []u8 {
+    @memset(out, 0);
+    @memcpy(out[0..4], "GERO");
+    out[0x04] = 0x01;
+    out[0x05] = 0x00;
+    out[0x06] = @truncate(flags & 0xFF);
+    out[0x07] = @truncate(flags >> 8);
+    out[0x08] = @truncate(entry & 0xFF);
+    out[0x09] = @truncate(entry >> 8);
+    out[0x0A] = @truncate(image_size & 0xFF);
+    out[0x0B] = @truncate(image_size >> 8);
+    out[0x0C] = bank_count;
+    out[0x0D] = sram_bank_count;
+    return out;
+}
+
+test "header: minimal valid cart exposes fields" {
+    var buf: [16 + 3]u8 = undefined;
+    _ = buildGx(&buf, 0, 0x1100, 3, 0, 0);
+    buf[16] = 0xFF; // image bytes (just `hlt` x 3, irrelevant)
+    buf[17] = 0xFF;
+    buf[18] = 0xFF;
+
+    const h = try gero.disasm.parseHeader(&buf);
+    try std.testing.expectEqual(@as(u16, 0x0001), h.version);
+    try std.testing.expectEqual(@as(u16, 0x0000), h.flags);
+    try std.testing.expectEqual(@as(u16, 0x1100), h.entry_point);
+    try std.testing.expectEqual(@as(u16, 3), h.image_size);
+    try std.testing.expectEqual(@as(u8, 0), h.bank_count);
+    try std.testing.expectEqual(@as(u8, 0), h.sram_bank_count);
+    try std.testing.expectEqualSlices(u8, &.{ 0xFF, 0xFF, 0xFF }, h.image);
+    try std.testing.expectEqual(@as(usize, 0), h.banks.len);
+    try std.testing.expectEqual(@as(usize, 0), h.debug.len);
+}
+
+test "header: bad magic rejected" {
+    var buf: [16]u8 = .{ 'F', 'A', 'K', 'E', 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    try std.testing.expectError(error.BadMagic, gero.disasm.parseHeader(&buf));
+}
+
+test "header: future version rejected" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0, 0, 0, 0, 0);
+    // Bump the major version to something past v1.
+    buf[0x04] = 0x00;
+    buf[0x05] = 0x02; // big-endian-looking but version is LE → major byte = 0x02
+    try std.testing.expectError(error.UnsupportedVersion, gero.disasm.parseHeader(&buf));
+}
+
+test "header: file shorter than header rejected" {
+    var buf: [10]u8 = .{ 'G', 'E', 'R', 'O', 0x01, 0, 0, 0, 0, 0 };
+    try std.testing.expectError(error.TooSmall, gero.disasm.parseHeader(&buf));
+}
+
+test "header: banked cart exposes bank slice + isBanked flag" {
+    const bank_size: usize = 0x4000;
+    var buf: [16 + 1 + bank_size]u8 = undefined;
+    _ = buildGx(buf[0..16], 0x0001, 0x0000, 1, 1, 0); // flag bit 0 = banked
+    buf[16] = 0xFF; // single-byte base image
+    @memset(buf[17..], 0);
+    const h = try gero.disasm.parseHeader(&buf);
+    try std.testing.expect(h.isBanked());
+    try std.testing.expectEqual(bank_size, h.banks.len);
+    try std.testing.expectEqual(@as(u8, 1), h.bank_count);
+}

--- a/tests/disasm/printer.test.zig
+++ b/tests/disasm/printer.test.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+/// Convenience: round-trip-style render of a bytecode buffer.
+fn renderBytes(bytes: []const u8) ![]u8 {
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    errdefer allocating.deinit();
+    try gero.disasm.writeBytes(alloc, &allocating.writer, bytes);
+    return allocating.toOwnedSlice();
+}
+
+test "printer: hlt → \"hlt\\n\"" {
+    const out = try renderBytes(&.{0xFF});
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("hlt\n", out);
+}
+
+test "printer: mov imm16, reg uses $XXXX and asm register name" {
+    // mov $1234, r1
+    const out = try renderBytes(&.{ 0x10, 0x34, 0x12, 0x02 });
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("mov   $1234, r1\n", out);
+}
+
+test "printer: mov reg, reg src-first per #94" {
+    const out = try renderBytes(&.{ 0x11, 0x02, 0x03 });
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("mov   r1, r2\n", out);
+}
+
+test "printer: addr operand uses &XXXX" {
+    // mov r1, &2620 (store r1 → mem[$2620])  →  0x12 02 20 26
+    const out = try renderBytes(&.{ 0x12, 0x02, 0x20, 0x26 });
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("mov   r1, &2620\n", out);
+}
+
+test "printer: indirect operand uses [reg]" {
+    // mov [r1], r2  →  0x16 02 03
+    const out = try renderBytes(&.{ 0x16, 0x02, 0x03 });
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("mov   [r1], r2\n", out);
+}
+
+test "printer: indexed operand uses [&XXXX + reg]" {
+    // mov [&2620 + r1], r2  →  0x17 20 26 02 03
+    const out = try renderBytes(&.{ 0x17, 0x20, 0x26, 0x02, 0x03 });
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("mov   [&2620 + r1], r2\n", out);
+}
+
+test "printer: int imm8 → \"int $XX\\n\"" {
+    const out = try renderBytes(&.{ 0xFC, 0x10 });
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("int   $10\n", out);
+}
+
+test "printer: unknown opcode emits a `.byte $XX` comment + continues" {
+    // 0x00 isn't in the v0.1 ISA; the disasm comments it then
+    // resumes with the next byte (0xFF = hlt).
+    const out = try renderBytes(&.{ 0x00, 0xFF });
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("; .byte $00\nhlt\n", out);
+}
+
+test "printer: truncated tail comments instead of crashing" {
+    // 0x10 mov expects 3 more operand bytes; only one is here.
+    const out = try renderBytes(&.{ 0x10, 0x12 });
+    defer alloc.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "truncated") != null);
+}
+
+test "printer: multi-instruction sequence emits one line each" {
+    // mov $48, r1 ; int $10 ; hlt
+    const bytes = [_]u8{ 0x10, 0x48, 0x00, 0x02, 0xFC, 0x10, 0xFF };
+    const out = try renderBytes(&bytes);
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("mov   $0048, r1\nint   $10\nhlt\n", out);
+}

--- a/tests/disasm/printer.test.zig
+++ b/tests/disasm/printer.test.zig
@@ -126,3 +126,71 @@ test "printer: multi-instruction sequence emits one line each" {
     defer alloc.free(out);
     try std.testing.expectEqualStrings("mov   $0048, r1\nint   $10\nhlt\n", out);
 }
+
+test "printer: zero run ≥ 4 collapses to single `org $XXXX` comment" {
+    // 6 leading $00 bytes (padding), then `hlt`. The 6 zeros
+    // should fold into one annotated comment instead of 6
+    // `; .byte $00` lines.
+    const bytes = [_]u8{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF };
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    defer allocating.deinit();
+    try gero.disasm.writeBytesPretty(alloc, &allocating.writer, &bytes, .{
+        .base_addr = 0x0000,
+    });
+    const out = allocating.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "; 6 bytes zero padding (org $0006)") != null);
+    // The hlt at offset 6 still renders normally.
+    try std.testing.expect(std.mem.indexOf(u8, out, "hlt") != null);
+    // No bare `; .byte $00` lines (they all collapsed).
+    try std.testing.expect(std.mem.indexOf(u8, out, "; .byte $00") == null);
+}
+
+test "printer: zero run < 4 stays as individual `.byte $00` lines" {
+    // 3 zeros + hlt — under threshold, no collapse.
+    const bytes = [_]u8{ 0x00, 0x00, 0x00, 0xFF };
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    defer allocating.deinit();
+    try gero.disasm.writeBytesPretty(alloc, &allocating.writer, &bytes, .{
+        .base_addr = 0x0000,
+    });
+    const out = allocating.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "zero padding") == null);
+    // Each $00 still gets its own `; .byte $00` line.
+    var occurrences: usize = 0;
+    var search_from: usize = 0;
+    while (std.mem.indexOfPos(u8, out, search_from, "; .byte $00")) |pos| {
+        occurrences += 1;
+        search_from = pos + 1;
+    }
+    try std.testing.expectEqual(@as(usize, 3), occurrences);
+}
+
+test "printer: zero run stops at a symbol that lands inside it" {
+    // 4 zeros — would collapse — but a `main` label sits at offset
+    // 2. The run must split: 2 zeros before, label-decode resumes
+    // at offset 2.
+    const bytes = [_]u8{ 0x00, 0x00, 0x00, 0x00, 0xFF };
+    const entries = [_]gero.disasm.Symbol{
+        .{ .address = 0x0002, .kind = .label, .name = "main" },
+    };
+    const symbols: gero.disasm.Symbols = .{ .entries = &entries };
+
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    defer allocating.deinit();
+    try gero.disasm.writeBytesPretty(alloc, &allocating.writer, &bytes, .{
+        .base_addr = 0x0000,
+        .symbols = symbols,
+    });
+    const out = allocating.written();
+    // The 2-byte head is below the collapse threshold and stays
+    // as two `; .byte $00` lines.
+    try std.testing.expect(std.mem.indexOf(u8, out, "zero padding") == null);
+    var byte_lines: usize = 0;
+    var search_from: usize = 0;
+    while (std.mem.indexOfPos(u8, out, search_from, "; .byte $00")) |pos| {
+        byte_lines += 1;
+        search_from = pos + 1;
+    }
+    // 2 leading + 2 more between `main` and `hlt` = 4 lines total.
+    try std.testing.expectEqual(@as(usize, 4), byte_lines);
+}

--- a/tests/disasm/printer.test.zig
+++ b/tests/disasm/printer.test.zig
@@ -72,6 +72,30 @@ test "printer: truncated tail comments instead of crashing" {
     try std.testing.expect(std.mem.indexOf(u8, out, "truncated") != null);
 }
 
+test "printer: symbols substitute matching addresses" {
+    // jmp &0021 — with a symbol for $0021 named "fib", renders
+    // as `jmp fib`.
+    const bytes = [_]u8{ 0x70, 0x21, 0x00 };
+    const entries = [_]gero.disasm.Symbol{.{ .address = 0x0021, .name = "fib" }};
+    const symbols: gero.disasm.Symbols = .{ .entries = &entries };
+
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    defer allocating.deinit();
+    try gero.disasm.writeBytesPretty(alloc, &allocating.writer, &bytes, .{ .symbols = symbols });
+    try std.testing.expectEqualStrings("jmp   fib\n", allocating.written());
+}
+
+test "printer: unmatched address stays as &XXXX" {
+    const bytes = [_]u8{ 0x70, 0x22, 0x00 }; // jmp &0022
+    const entries = [_]gero.disasm.Symbol{.{ .address = 0x0021, .name = "fib" }}; // different addr
+    const symbols: gero.disasm.Symbols = .{ .entries = &entries };
+
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    defer allocating.deinit();
+    try gero.disasm.writeBytesPretty(alloc, &allocating.writer, &bytes, .{ .symbols = symbols });
+    try std.testing.expectEqualStrings("jmp   &0022\n", allocating.written());
+}
+
 test "printer: multi-instruction sequence emits one line each" {
     // mov $48, r1 ; int $10 ; hlt
     const bytes = [_]u8{ 0x10, 0x48, 0x00, 0x02, 0xFC, 0x10, 0xFF };

--- a/tests/disasm/printer.test.zig
+++ b/tests/disasm/printer.test.zig
@@ -76,7 +76,7 @@ test "printer: symbols substitute matching addresses" {
     // jmp &0021 — with a symbol for $0021 named "fib", renders
     // as `jmp fib`.
     const bytes = [_]u8{ 0x70, 0x21, 0x00 };
-    const entries = [_]gero.disasm.Symbol{.{ .address = 0x0021, .name = "fib" }};
+    const entries = [_]gero.disasm.Symbol{.{ .address = 0x0021, .kind = .label, .name = "fib" }};
     const symbols: gero.disasm.Symbols = .{ .entries = &entries };
 
     var allocating = std.Io.Writer.Allocating.init(alloc);
@@ -85,9 +85,32 @@ test "printer: symbols substitute matching addresses" {
     try std.testing.expectEqualStrings("jmp   fib\n", allocating.written());
 }
 
+test "printer: data symbol switches to data-mode rendering" {
+    // 3 bytes of data followed by a hlt. The first byte is a
+    // `data` symbol, so the disasm should emit a `data8 ... =`
+    // directive for those 3 bytes (up to next symbol = hlt label
+    // at offset 3) instead of trying to decode them as code.
+    const bytes = [_]u8{ 0x48, 0x69, 0x21, 0xFF };
+    const entries = [_]gero.disasm.Symbol{
+        .{ .address = 0x0000, .kind = .data, .name = "msg" },
+        .{ .address = 0x0003, .kind = .label, .name = "main" },
+    };
+    const symbols: gero.disasm.Symbols = .{ .entries = &entries };
+
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    defer allocating.deinit();
+    try gero.disasm.writeBytesPretty(alloc, &allocating.writer, &bytes, .{
+        .base_addr = 0x0000,
+        .symbols = symbols,
+    });
+    const out = allocating.written();
+    try std.testing.expect(std.mem.indexOf(u8, out, "data8 msg = $48, $69, $21") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "hlt") != null);
+}
+
 test "printer: unmatched address stays as &XXXX" {
     const bytes = [_]u8{ 0x70, 0x22, 0x00 }; // jmp &0022
-    const entries = [_]gero.disasm.Symbol{.{ .address = 0x0021, .name = "fib" }}; // different addr
+    const entries = [_]gero.disasm.Symbol{.{ .address = 0x0021, .kind = .label, .name = "fib" }};
     const symbols: gero.disasm.Symbols = .{ .entries = &entries };
 
     var allocating = std.Io.Writer.Allocating.init(alloc);

--- a/tests/disasm/roundtrip.test.zig
+++ b/tests/disasm/roundtrip.test.zig
@@ -1,0 +1,95 @@
+/// Round-trip property tests for the disassembler.
+///
+/// Property: for any all-code asm source, the pipeline
+///   asm src1 → bytes1 → disasm bytes1 → src2 → asm src2 → bytes2
+/// must produce `bytes1 == bytes2`.
+///
+/// Programs that mix code + data are NOT round-trippable without
+/// debug symbols (the disasm can't tell where code ends and data
+/// begins by inspecting bytes alone). Those land when debug
+/// symbols ship — for v0.1 we test the pure-code case only.
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+/// Assemble `src` and return the raw image bytes (header stripped).
+fn assembleImage(src: []const u8) ![]u8 {
+    var pt = try gero.asm_.parse(alloc, src);
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    defer cg.deinit();
+    if (cg.hasErrors()) return error.AssemblyFailed;
+    return alloc.dupe(u8, cg.image[16..]);
+}
+
+test "roundtrip: hlt" {
+    const original = try assembleImage("hlt\n");
+    defer alloc.free(original);
+    const reassembled = try gero.disasm.roundTripImage(alloc, original);
+    defer alloc.free(reassembled);
+    try std.testing.expectEqualSlices(u8, original, reassembled);
+}
+
+test "roundtrip: every operand kind hits at least one path" {
+    // Mix of immediate / addr / reg-reg / indirect / indexed / int /
+    // jump / shift / hlt. The disasm has to emit each operand form
+    // and the asm has to parse it back.
+    const src =
+        \\main:
+        \\  mov $1234, r1
+        \\  mov r2, r1
+        \\  mov &2620, r1
+        \\  mov r1, &2620
+        \\  mov [r1], r2
+        \\  mov [&2620 + r1], r2
+        \\  shl r1, $03
+        \\  int $10
+        \\  jmp main
+        \\  hlt
+        \\
+    ;
+    const original = try assembleImage(src);
+    defer alloc.free(original);
+    const reassembled = try gero.disasm.roundTripImage(alloc, original);
+    defer alloc.free(reassembled);
+    try std.testing.expectEqualSlices(u8, original, reassembled);
+}
+
+test "roundtrip: call + ret + arithmetic" {
+    const src =
+        \\main:
+        \\  mov $05, r1
+        \\  call double
+        \\  hlt
+        \\double:
+        \\  add $01, r1
+        \\  ret
+        \\
+    ;
+    const original = try assembleImage(src);
+    defer alloc.free(original);
+    const reassembled = try gero.disasm.roundTripImage(alloc, original);
+    defer alloc.free(reassembled);
+    try std.testing.expectEqualSlices(u8, original, reassembled);
+}
+
+test "roundtrip: push / pop / cmp / jne" {
+    const src =
+        \\main:
+        \\  mov $00, r1
+        \\loop:
+        \\  push r1
+        \\  inc r1
+        \\  cmp r1, $05
+        \\  jne loop
+        \\  pop r2
+        \\  hlt
+        \\
+    ;
+    const original = try assembleImage(src);
+    defer alloc.free(original);
+    const reassembled = try gero.disasm.roundTripImage(alloc, original);
+    defer alloc.free(reassembled);
+    try std.testing.expectEqualSlices(u8, original, reassembled);
+}

--- a/tests/disasm/roundtrip.test.zig
+++ b/tests/disasm/roundtrip.test.zig
@@ -14,10 +14,12 @@ const gero = @import("gero");
 const alloc = std.testing.allocator;
 
 /// Assemble `src` and return the raw image bytes (header stripped).
+/// Debug symbols disabled so the round-trip compare only looks at
+/// base + banks bytes — the disasm side strips labels anyway.
 fn assembleImage(src: []const u8) ![]u8 {
     var pt = try gero.asm_.parse(alloc, src);
     defer pt.deinit();
-    var cg = try gero.asm_.assemble(alloc, src, pt, .{});
+    var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     if (cg.hasErrors()) return error.AssemblyFailed;
     return alloc.dupe(u8, cg.image[16..]);


### PR DESCRIPTION
## Summary

Phase 3 in one PR — closes #38, #39, #40, #41, #45.

## What's new

### Library (\`gero.disasm\`)

- **\`parseHeader\`** — strict .gx header decode; rejects future versions.
- **\`decodeOne\`** — byte → \`Instruction\` AST. Built on a new public 256-entry reverse table on \`opcode_resolver\` (\`shape_by_opcode\`, generated at comptime from the asm shapes). Operand union covers \`reg / imm8 / imm16 / addr / zp / reg_indirect / indexed\`.
- **\`writeInstruction\` / \`writeBytes\`** — pretty-printer. Aligned mnemonic column; \`\$XX\` / \`\$XXXX\` / \`&XXXX\` literals; \`[reg]\` / \`[&XXXX + reg]\` forms; canonical register names via \`vm.Register\`. Unknown opcodes → \`; .byte \$XX\` comments; truncated tails → \`; truncated at offset \$XXXX\`.
- **\`roundTripImage\`** — drives the \`asm → disasm → asm\` pipeline for byte-equality tests.

### CLI command

\`gero disasm <file.gx> [--bank=N]\`:
- Base image by default; \`--bank=N\` targets a specific bank slot (validated against \`header.bank_count\`).
- Trailing zero-padding inside banks is trimmed for readability — printing 16 KB of \`; .byte \$00\` was noise.

## Round-trip

Byte-lossless for all-code programs. Tests cover hlt, the full operand-kind matrix (imm / addr / reg-reg / indirect / indexed / shift / int / jmp), call+ret+arith, and push/pop/cmp/jne loops.

## Known gaps (follow-ups)

- **Mixed code + data** can't round-trip — the disasm is byte-blind, so \`data8 \"Hello\"\` reads as instructions on the way back. Unblocks when debug symbols ship.
- **Label rendering** — the printer emits raw \`&XXXX\` addresses for \`call\` / \`jmp\`. Symbol-aware rendering also needs debug symbols.

Both are documented in the changeset.

## Self-review

- **Step 1 (issue body)**: header decoder ✅ (5 tests), opcode + operand decoder ✅ (7 tests), pretty-printer ✅ (10 tests), round-trip ✅ (4 tests), CLI \`--bank=N\` ✅ (manual smoke). Deferred: data-aware round-trip + label rendering (need debug symbols).
- **Step 2 (\`zig build ci\`)**: EXIT=0 after fixing 4 lint findings — orphan test (created \`src/disasm/roundtrip.zig\` helper), missing doc on \`Indexed\`, unused \`InstructionDecodeError\` re-export, \`@as\` no-comment in \`readWord\`.
- **Step 3 (diff walk, 12 files)**: found a UX issue — \`gero disasm <bank>\` emitted 16 KB of \`; .byte \$00\` from the trailing zero padding. Fixed by trimming trailing zeros in the CLI's bank path.
- **Step 4 (hygiène)**: scope \`disasm,cli\`, no AI attribution, changeset present (minor bump), no breaking changes to existing public API (only additions).

Stacked-friendly: this branches off main with no asm-side changes beyond exposing \`Shape\` / \`shape_by_opcode\` as public.

Closes #38 #39 #40 #41 #45.