### PR TITLE
build(tooling): zig build test-examples integration step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,14 @@ jobs:
           version: 0.16.0
       - name: test-all (compile-only on extra targets)
         run: zig build test-all -freference-trace
+
+  examples:
+    name: Example integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+      - name: test-examples (assemble + run + diff each example)
+        run: zig build test-examples -freference-trace

--- a/build.zig
+++ b/build.zig
@@ -214,12 +214,28 @@ pub fn build(b: *std.Build) void {
     lint_step.dependOn(&check_docs.step);
     lint_step.dependOn(&check_naming.step);
 
+    // ----- Example integration tests ---------------------------------------
+    //
+    // Drive every examples/asm/*.gas through the installed `gero`
+    // CLI (assemble + run) and diff stdout against its golden
+    // `.expected` file. Depends on the install step so the binary
+    // is on disk before the script runs.
+
+    const test_examples_cmd = b.addSystemCommand(&.{ "bash", "scripts/test-examples.sh" });
+    test_examples_cmd.step.dependOn(b.getInstallStep());
+    const test_examples_step = b.step(
+        "test-examples",
+        "Assemble + run every examples/asm/*.gas and diff against its .expected",
+    );
+    test_examples_step.dependOn(&test_examples_cmd.step);
+
     // ----- All-in-one CI ---------------------------------------------------
 
-    const ci_step = b.step("ci", "Local equivalent of CI: lint + test-modes + test-all");
+    const ci_step = b.step("ci", "Local equivalent of CI: lint + test-modes + test-all + test-examples");
     ci_step.dependOn(lint_step);
     ci_step.dependOn(test_modes_step);
     ci_step.dependOn(test_all);
+    ci_step.dependOn(&test_examples_cmd.step);
 
     // ----- Changesets ------------------------------------------------------
 

--- a/examples/asm/README.md
+++ b/examples/asm/README.md
@@ -29,8 +29,14 @@ zig build              # builds zig-out/bin/gero
 ./zig-out/bin/gero run examples/asm/hello.gx | diff - examples/asm/hello.expected
 ```
 
-A clean run produces no diff and exits 0. (`zig build test-examples`
-will land in #48 to bundle this into CI.)
+A clean run produces no diff and exits 0. To drive every example
+at once:
+
+```bash
+zig build test-examples
+```
+
+That step is wired into `zig build ci` and runs on every PR.
 
 ## Operand order
 

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Drive every example asm program under examples/asm/ through the
+# `gero` CLI and diff its stdout against the golden `.expected`
+# file alongside it. Wired into `zig build test-examples` and
+# `zig build ci`.
+#
+# Env knobs:
+#   GERO_BIN       — path to the `gero` binary (default ./zig-out/bin/gero)
+#   EXAMPLES_DIR   — root to walk for *.gas (default examples/asm)
+#   NO_COLOR       — disable ANSI colors (auto-off when stdout is not a TTY)
+#
+# Exit codes:
+#   0 — every example passed
+#   1 — at least one example failed, or a precondition is missing
+
+set -euo pipefail
+
+GERO_BIN="${GERO_BIN:-./zig-out/bin/gero}"
+EXAMPLES_DIR="${EXAMPLES_DIR:-examples/asm}"
+
+if [[ ! -x "$GERO_BIN" ]]; then
+    printf 'test-examples: %s not found — run `zig build install` first\n' "$GERO_BIN" >&2
+    exit 1
+fi
+
+if [[ ! -d "$EXAMPLES_DIR" ]]; then
+    printf 'test-examples: %s missing\n' "$EXAMPLES_DIR" >&2
+    exit 1
+fi
+
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    GREEN=$'\033[32m'; RED=$'\033[31m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+    GREEN=''; RED=''; BOLD=''; RESET=''
+fi
+
+tmp_root="$(mktemp -d -t gero-test-examples.XXXXXX)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+mapfile -t -d '' gas_files < <(find "$EXAMPLES_DIR" -type f -name '*.gas' -print0 | sort -z)
+
+if [[ ${#gas_files[@]} -eq 0 ]]; then
+    printf 'test-examples: no .gas files under %s\n' "$EXAMPLES_DIR" >&2
+    exit 1
+fi
+
+pass=0; fail=0; skip=0
+for gas in "${gas_files[@]}"; do
+    expected="${gas%.gas}.expected"
+    if [[ ! -f "$expected" ]]; then
+        # Sibling .gas with no golden file — include-only fragment
+        # (e.g. examples/asm/banks/bank0_greet.gas). Drive these
+        # through the entry program, not on their own.
+        skip=$((skip+1))
+        continue
+    fi
+
+    rel="${gas#$EXAMPLES_DIR/}"
+    name="${rel//\//-}"; name="${name%.gas}"
+    work="$tmp_root/$name"
+    mkdir -p "$work"
+    gx="$work/out.gx"
+    actual="$work/stdout"
+
+    printf '  %-24s ... ' "$rel"
+
+    rc=0
+    "$GERO_BIN" asm --quiet "$gas" -o "$gx" >"$work/asm.err" 2>&1 || rc=$?
+    if (( rc != 0 )); then
+        printf '%sFAIL%s (asm, exit=%d)\n' "$RED" "$RESET" "$rc"
+        sed 's/^/      /' "$work/asm.err"
+        fail=$((fail+1))
+        continue
+    fi
+
+    rc=0
+    "$GERO_BIN" run "$gx" >"$actual" 2>"$work/run.err" || rc=$?
+    if (( rc != 0 )); then
+        printf '%sFAIL%s (run, exit=%d)\n' "$RED" "$RESET" "$rc"
+        sed 's/^/      /' "$work/run.err"
+        fail=$((fail+1))
+        continue
+    fi
+
+    if ! diff -u "$expected" "$actual" >"$work/diff" 2>&1; then
+        printf '%sFAIL%s (stdout)\n' "$RED" "$RESET"
+        sed 's/^/      /' "$work/diff"
+        fail=$((fail+1))
+        continue
+    fi
+
+    printf '%sok%s\n' "$GREEN" "$RESET"
+    pass=$((pass+1))
+done
+
+printf '\n%sexamples:%s %d passed, %d failed' "$BOLD" "$RESET" "$pass" "$fail"
+if (( skip > 0 )); then
+    plural=""
+    (( skip == 1 )) || plural="s"
+    printf ', %d include-only file%s skipped' "$skip" "$plural"
+fi
+printf '\n'
+
+(( fail == 0 )) || exit 1


### PR DESCRIPTION
## Summary

- New `zig build test-examples` step driving every `examples/asm/*.gas` through the installed `gero` CLI (assemble + run) and diffing stdout against its golden `.expected` file.
- Hooked into `zig build ci` plus a dedicated `examples` job in `.github/workflows/ci.yml`, so PR breakage on the example pipeline blocks merges.
- README under `examples/asm/` updated — the future-tense reference to #48 now points at the live step.

## Acceptance (per #48)

- [x] `zig build test-examples` runs all examples + verifies output — 5/5 pass on `main`
- [x] Failure on any example fails the build (`exit 1` on any non-zero leg)
- [x] Hooked into `ci` step (`zig build ci` + new GH Actions job)
- [x] Mirror per-example expected files — already in tree

## Out of scope

Round-trip property check (`asm → disasm → reasm → identical bytes`) — that's the remaining AC on #41 and will land in a follow-up PR. The CLI helper exists (`src/disasm/roundtrip.zig`) but the cross-bank wiring for the example set needs its own pass.

## Test plan

- [x] `zig build test-examples` (local, EXIT=0, 5 passed)
- [x] `zig build ci` (local, EXIT=0)
- [ ] CI green on GitHub Actions

Closes #48.