### PR TITLE
ci: drop redundant actions/cache — setup-zig already caches .zig-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,6 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
-      - name: Cache .zig-cache
-        uses: actions/cache@v4
-        with:
-          path: .zig-cache
-          key: zig-${{ runner.os }}-test-${{ matrix.mode }}-${{ hashFiles('build.zig', 'build.zig.zon', 'src/**', 'tests/**', 'apps/**') }}
-          restore-keys: |
-            zig-${{ runner.os }}-test-${{ matrix.mode }}-
       - name: Build
         run: zig build -Doptimize=${{ matrix.mode }} -freference-trace
       - name: Test
@@ -75,13 +68,6 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
-      - name: Cache .zig-cache
-        uses: actions/cache@v4
-        with:
-          path: .zig-cache
-          key: zig-${{ runner.os }}-cross-${{ hashFiles('build.zig', 'build.zig.zon', 'src/**', 'tests/**', 'apps/**') }}
-          restore-keys: |
-            zig-${{ runner.os }}-cross-
       - name: test-all (compile-only on extra targets)
         run: zig build test-all -freference-trace
 
@@ -93,12 +79,5 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
-      - name: Cache .zig-cache
-        uses: actions/cache@v4
-        with:
-          path: .zig-cache
-          key: zig-${{ runner.os }}-examples-${{ hashFiles('build.zig', 'build.zig.zon', 'src/**', 'tests/**', 'apps/**', 'examples/**') }}
-          restore-keys: |
-            zig-${{ runner.os }}-examples-
       - name: test-examples (assemble + run + diff + round-trip each example)
         run: zig build test-examples -freference-trace


### PR DESCRIPTION
## Summary

- Drop the \`actions/cache@v4\` step added in commit affeb5a (PR #102) for \`test\` / \`cross-targets\` / \`examples\` jobs.
- \`mlugg/setup-zig@v2\` already provides built-in \`.zig-cache\` caching, observed in the PR #103 run logs:
  \`\`\`
  Cache hit (setup-zig-cache-v2-test-...): populating .zig-cache
  Cache hit for restore-key: zig-Linux-test-Debug-...
  \`\`\`
- The explicit step was at best redundant, at worst overwriting setup-zig's restore with a stale cache from a different run.

## Why now

Discovered while verifying the cache-speedup claim made on PR #103 — the timing improvement (ReleaseSafe 6m48s → 1m30s) was attributable to setup-zig's own cache, not my added step. Keeping one source of truth.

## Test plan

- [x] \`zig build ci\` still green locally.
- [ ] CI run on this PR confirms \`.zig-cache\` is still being restored via setup-zig (and timings are comparable to PR #103).