### PR TITLE
docs(meta): README quickstart for v0.1.0 (asm path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,55 +7,84 @@ A 16-bit virtual machine, assembler, disassembler, and Lua-style
 language compiler — all in pure Zig. Foundation for the gtx-16 fantasy
 console and other Gero-ecosystem consumers.
 
-> **Day 1.** The repo just landed with full tooling but no library
-> code yet. The VM kernel, assembler, disassembler, and language
-> compiler will land as separate PRs. See [CLAUDE.md](./CLAUDE.md) for
-> the conventions every change must follow.
+## Quickstart
+
+Build the `gero` CLI from source:
+
+```bash
+git clone https://github.com/salty-max/gero
+cd gero
+zig build                          # produces ./zig-out/bin/gero
+```
+
+Assemble and run the smallest meaningful program:
+
+```bash
+./zig-out/bin/gero asm examples/asm/hello.gas    # → examples/asm/hello.gx
+./zig-out/bin/gero run examples/asm/hello.gx     # → Hello, gero!
+```
+
+That's the entire asm path. To put `gero` on your `$PATH`, run
+`zig build install --prefix ~/.local` (drops the binary into
+`~/.local/bin`).
+
+## What's here
+
+| Command | Purpose |
+|---------|---------|
+| `gero asm` | `.gas` source → `.gx` bytecode image |
+| `gero run` | Execute a `.gx` |
+| `gero disasm` | `.gx` → asm (round-trip-safe; CI-gated) |
+| `gero info` | Pretty-print a `.gx` header |
+| `gero test` | Walk `tests/asm/programs/`, diff stdout vs `.expected` golden files |
+
+Run `gero <subcommand> --help` for per-command flags.
+
+## Learn more
+
+- [examples/asm/](./examples/asm/) — five worked programs covering
+  loops, recursion, banks, and SRAM
+- [docs/asm.md](./docs/asm.md) — assembler syntax + directives
+- [docs/isa.md](./docs/isa.md) — ISA reference (opcodes, memory map,
+  `.gx` format)
+- [docs/cli.md](./docs/cli.md) — full CLI reference
+- [docs/gero-lang.md](./docs/gero-lang.md) — high-level language spec
+  (v0.2.0, not yet implemented)
+
+## Use as a library
+
+```bash
+zig fetch --save git+https://github.com/salty-max/gero
+```
+
+Then in your `build.zig`:
+
+```zig
+const gero = b.dependency("gero", .{
+    .target = target,
+    .optimize = optimize,
+});
+exe.root_module.addImport("gero", gero.module("gero"));
+```
 
 ## Roadmap
 
-- **VM** — 16-bit register machine + bytecode interpreter
-- **ISA spec** — bytecode contract, lives in `docs/isa.md`
-- **Assembler** — text → bytecode, built on [knit](https://github.com/salty-max/knit)
-- **Disassembler** — bytecode → text
-- **Gero language** — Lua-style syntax, compiles to bytecode
+- ✅ VM kernel — 16-bit register machine, banked memory, IRQs
+- ✅ Assembler — built on [knit](https://github.com/salty-max/knit)
+- ✅ Disassembler — round-trip-safe
+- ✅ CLI — `asm` / `run` / `disasm` / `info` / `test`
+- ⏳ Gero language compiler — Lua-flavored, gradually typed (v0.2.0)
+- ⏳ Bytecode freeze + cross-target perf pass (v1.0.0)
 
-Out of scope for this repo: the gtx-16 fantasy console and the
-`gero-lab` web playground — they consume gero as a library.
+The gtx-16 fantasy console and the `gero-lab` web playground are out
+of scope for this repo — they consume gero as a library.
 
 ## Compatibility
 
-- **Zig minimum**: 0.16.0 (pinned in `build.zig.zon`)
+- **Zig**: 0.16.0 minimum (pinned in `build.zig.zon`)
 - **Zero runtime dependencies** — pure Zig, no C deps, no FFI
 - **Cross-targets** compiled on every PR: `x86_64-linux`,
   `aarch64-macos`, `x86_64-windows`, `aarch64-windows`, `wasm32-wasi`
-
-## Development
-
-Three external tools, all single-binary installs:
-
-```bash
-# macOS (Homebrew)
-brew install zig lefthook convco
-```
-
-After cloning:
-
-```bash
-lefthook install                  # wires git hooks
-zig build --help                  # list every dev command
-zig build ci                      # what CI runs end-to-end
-```
-
-| Step | Purpose |
-|------|---------|
-| `zig build` | Build the library |
-| `zig build test` | Run native tests (Debug) |
-| `zig build test-modes` | Run tests in all four release modes |
-| `zig build test-all` | Cross-target compile gate |
-| `zig build lint` | Format + every static check |
-| `zig build ci` | lint + test-modes + test-all |
-| `zig build changeset` | Scaffold a new changeset |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Replace the obsolete "Day 1" landing copy with a real quickstart that gets a beginner from `git clone` to "Hello, gero!" in three commands.
- Add a "What's here" command table, a "Learn more" pointer block to `examples/asm/` + the five spec docs, and a "Use as a library" snippet for `zig fetch --save` consumers.
- Drop the README → `CLAUDE.md` link (CLAUDE.md is internal AI-agent conventions, not a user-facing reference).

## Acceptance (issue #49)

- [x] Install instructions (`git clone` + `zig build`, optional `zig build install --prefix`)
- [x] 3-line "write hello.gas, gero asm, gero run" example — uses the checked-in `examples/asm/hello.gas`
- [x] Pointer to `docs/` for the technical spec
- [x] Pointer to `examples/asm/` for more programs
- [x] README quickstart works copy-paste fresh — verified end-to-end in a `/tmp` clone
- [x] Reads in 30 seconds, gets a beginner to "hello world output" in 3 commands
- [x] Links to canonical docs / examples

Closes #49.