### PR TITLE
docs(meta): add brew install option to Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ console and other Gero-ecosystem consumers.
 
 ## Quickstart
 
-Build the `gero` CLI from source:
+Install via Homebrew (macOS Apple Silicon + Linux):
+
+```bash
+brew install salty-max/tap/gero
+```
+
+Or build from source:
 
 ```bash
 git clone https://github.com/salty-max/gero
@@ -20,13 +26,14 @@ zig build                          # produces ./zig-out/bin/gero
 Assemble and run the smallest meaningful program:
 
 ```bash
-./zig-out/bin/gero asm examples/asm/hello.gas    # → examples/asm/hello.gx
-./zig-out/bin/gero run examples/asm/hello.gx     # → Hello, gero!
+gero asm examples/asm/hello.gas    # → examples/asm/hello.gx
+gero run examples/asm/hello.gx     # → Hello, gero!
 ```
 
-That's the entire asm path. To put `gero` on your `$PATH`, run
-`zig build install --prefix ~/.local` (drops the binary into
-`~/.local/bin`).
+That's the entire asm path. If you built from source, run the commands
+from the repo root and prefix them with `./zig-out/bin/` — or run
+`zig build install --prefix ~/.local` to drop the binary into
+`~/.local/bin`.
 
 ## What's here
 


### PR DESCRIPTION
## Summary

`brew install salty-max/tap/gero` now ships pre-built CLI binaries for **macOS Apple Silicon** and **x86_64 Linux** from the new tap at [salty-max/homebrew-tap](https://github.com/salty-max/homebrew-tap). The README's Quickstart now leads with brew; the `git clone + zig build` flow stays for hackers + unsupported platforms (Windows, wasm32-wasi, Intel macOS).

## Verified

- Tap repo public ✅
- `Formula/gero.rb` passes `brew style` ✅
- Pinned to **v0.1.1** (v0.1.0 release tarballs shipped without the CLI binary — fixed by PR #106 / [a13e3fc](https://github.com/salty-max/gero/commit/a13e3fc))

## Follow-up

- `gero --version` prints "gero 0.0.0" regardless of build — `apps/gero-cli/cli.zig:386` has a hardcoded `version_string` that `zig build version` doesn't bump. Will file a follow-up issue + fix the script to sed-replace the constant. Not blocking for brew.