### PR TITLE
feat(asm): printer — AST → canonical .gas text

### DIFF
--- a/.changeset/asm-printer.md
+++ b/.changeset/asm-printer.md
@@ -8,6 +8,8 @@ instruction indent, blank-line discipline around top-level decls,
 canonical operand separators). Expression and operand contents are
 sliced verbatim from `source` so literal forms (`$10`, `'A'`, `&FFFF`)
 round-trip exactly; only the layout between statements is normalized.
-Public API: `printProgram` + `PrintOptions`. Foundation for the
-upcoming `gero fmt` subcommand. Comments are currently dropped because
-the lexer doesn't preserve them in the AST — tracked separately.
+The parser now surfaces `; ...` comments as first-class `Statement.
+comment` nodes so the printer can preserve them — trailing comments
+on the same line as a statement demote to standalone lines, then stay
+stable across re-formats. Public API: `printProgram` + `PrintOptions`.
+Foundation for the upcoming `gero fmt` subcommand.

--- a/.changeset/asm-printer.md
+++ b/.changeset/asm-printer.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+`src/asm/printer.zig` lands — the asm AST → canonical `.gas` text
+re-emitter. Walks an `ast.Program` and emits a fixed layout (2-space
+instruction indent, blank-line discipline around top-level decls,
+canonical operand separators). Expression and operand contents are
+sliced verbatim from `source` so literal forms (`$10`, `'A'`, `&FFFF`)
+round-trip exactly; only the layout between statements is normalized.
+Public API: `printProgram` + `PrintOptions`. Foundation for the
+upcoming `gero fmt` subcommand. Comments are currently dropped because
+the lexer doesn't preserve them in the AST — tracked separately.

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -15,6 +15,7 @@ const expr_mod = @import("asm/expr.zig");
 const symtab_mod = @import("asm/symtab.zig");
 const codegen_mod = @import("asm/codegen.zig");
 const opres_mod = @import("asm/opcode_resolver.zig");
+const printer_mod = @import("asm/printer.zig");
 
 /// Re-export: lexer token.
 pub const Token = lexer.Token;
@@ -116,6 +117,13 @@ pub const Codegen = codegen_mod.Codegen;
 pub const CodegenOptions = codegen_mod.Options;
 /// Re-export: assemble a parsed program into a `.gx` byte image.
 pub const assemble = codegen_mod.assemble;
+/// Re-export: canonical-printer knobs (indent etc.).
+pub const PrintOptions = printer_mod.PrintOptions;
+/// Re-export: default canonical-printer options.
+pub const default_print_options = printer_mod.default_options;
+/// Re-export: emit an `ast.Program` as canonical `.gas` source.
+pub const printProgram = printer_mod.print;
+
 /// Re-export: name → u16 lookup for compile-time constants.
 pub const ConstantTable = expr_mod.ConstantTable;
 /// Re-export: fold an `Expr` tree to a `u16` using a `ConstantTable`.

--- a/src/asm/ast.zig
+++ b/src/asm/ast.zig
@@ -45,6 +45,14 @@ pub const Statement = union(enum) {
     /// body emitted.
     sram_banks_decl: SramBanksDecl,
     instruction: Instruction,
+    /// A `; ...` comment line. The parser surfaces these as
+    /// first-class statements so the pretty-printer (`gero fmt`)
+    /// can preserve them; codegen / symtab skip them as semantic
+    /// no-ops. Trailing comments on the same line as another
+    /// statement are emitted as separate `Comment` statements in
+    /// parse order — `gero fmt` therefore "demotes" them to their
+    /// own line.
+    comment: Comment,
     /// Catch-all for unrecognized lines — carries a span so the
     /// consumer can skip past it cleanly.
     unknown: Unknown,
@@ -61,9 +69,17 @@ pub const Statement = union(enum) {
             .bank_switch => |b| b.span,
             .sram_banks_decl => |s| s.span,
             .instruction => |i| i.span,
+            .comment => |c| c.span,
             .unknown => |u| u.span,
         };
     }
+};
+
+/// `; ...` — comment line. Span covers the leading `;` and the
+/// comment text up to (but not including) the line-terminating
+/// newline. Pure documentation: codegen + symtab skip these.
+pub const Comment = struct {
+    span: Span,
 };
 
 /// `name:` — binds the current emit address to `name`.

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -465,7 +465,7 @@ fn layoutPass(
                     cursor_ptr.* += 1;
                 }
             },
-            .unknown => {},
+            .comment, .unknown => {},
         }
     }
 }
@@ -542,7 +542,7 @@ fn emitPass(
                 const name = source[l.name.start..l.name.end];
                 if (name.len == 0 or name[0] != '.') parent_label = name;
             },
-            .const_decl, .struct_decl, .sram_banks_decl, .unknown => {},
+            .const_decl, .struct_decl, .sram_banks_decl, .comment, .unknown => {},
             .bank_switch => |b| {
                 if (b.index) |idx| current_bank = idx;
             },

--- a/src/asm/parser.zig
+++ b/src/asm/parser.zig
@@ -57,7 +57,7 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8) !ParseTree {
     var state = core.ParseState.init(source, allocator);
 
     while (state.index < source.len) {
-        skipSeparators(&state);
+        try skipSeparatorsCapturingComments(&state, &statements, allocator);
         if (state.index >= source.len) break;
         try parseStatement(&state, allocator, &statements, &errors, &consts);
     }
@@ -1301,9 +1301,12 @@ fn skipBlanksInLine(state: *core.ParseState) void {
         const b = state.input[state.index];
         if (b == ' ' or b == '\t') {
             state.advance(1);
-        } else if (b == ';') {
-            while (state.index < state.input.len and state.input[state.index] != '\n') state.advance(1);
         } else {
+            // Stop at `;` so the top-level `skipSeparatorsCapturing
+            // Comments` can capture trailing comments as first-class
+            // `Comment` statements. `atStatementEnd` recognizes `;`
+            // as a statement terminator, so the rest of intra-line
+            // parsing handles the same shape as today.
             break;
         }
     }
@@ -1316,6 +1319,33 @@ fn skipSeparators(state: *core.ParseState) void {
             state.advance(1);
         } else if (b == ';') {
             while (state.index < state.input.len and state.input[state.index] != '\n') state.advance(1);
+        } else {
+            break;
+        }
+    }
+}
+
+/// Same as `skipSeparators` but captures every `;` comment as a
+/// first-class `Statement.comment` and appends it to the program
+/// in parse order. Trailing comments on a statement line surface
+/// as standalone `Comment` statements following the statement
+/// they trailed — the pretty-printer uses span proximity in the
+/// source to recover the "trailing vs standalone" distinction.
+fn skipSeparatorsCapturingComments(
+    state: *core.ParseState,
+    statements: *std.ArrayList(ast.Statement),
+    allocator: std.mem.Allocator,
+) std.mem.Allocator.Error!void {
+    while (state.index < state.input.len) {
+        const b = state.input[state.index];
+        if (b == ' ' or b == '\t' or b == '\n') {
+            state.advance(1);
+        } else if (b == ';') {
+            const start = state.index;
+            while (state.index < state.input.len and state.input[state.index] != '\n') state.advance(1);
+            try statements.append(allocator, .{
+                .comment = .{ .span = spanFrom(start, state.index) },
+            });
         } else {
             break;
         }

--- a/src/asm/printer.zig
+++ b/src/asm/printer.zig
@@ -12,9 +12,12 @@
 /// parse + print of canonical text picks up the same spans and
 /// re-emits identical bytes).
 ///
-/// Known limitation: comments are stripped, because the lexer
-/// currently doesn't preserve them in the AST. Tracked as a
-/// follow-up; the printer itself stays comment-agnostic.
+/// Comments are preserved: the parser surfaces every `; ...` line
+/// as a `Statement.comment` node and the printer emits it span-
+/// sliced from source. Trailing comments (`hlt ; halt`) demote to
+/// standalone (`hlt\n; halt`) on the first format pass and then
+/// stay stable — the blank-line rule counts newlines in the
+/// source gap so the layout is idempotent.
 const std = @import("std");
 const ast = @import("ast.zig");
 

--- a/src/asm/printer.zig
+++ b/src/asm/printer.zig
@@ -42,7 +42,7 @@ pub fn print(
     var prev: ?ast.Statement = null;
     for (program.statements) |stmt| {
         if (prev) |p| {
-            if (needsBlankLineBefore(stmt, p)) try writer.writeByte('\n');
+            if (needsBlankLineBefore(stmt, p, source)) try writer.writeByte('\n');
         }
         try writeStatement(writer, stmt, source, opts);
         try writer.writeByte('\n');
@@ -51,17 +51,49 @@ pub fn print(
 }
 
 /// True when the canonical layout puts a blank line between `prev`
-/// and `curr`. Instructions stay attached to their preceding label
-/// or directive; consecutive same-kind decls (consts together,
-/// data blocks together) cluster without separators.
-fn needsBlankLineBefore(curr: ast.Statement, prev: ast.Statement) bool {
-    // Instructions cling to the preceding label / directive.
+/// and `curr`. Rules:
+///
+/// - Instructions cling to the preceding label / directive.
+/// - After a label header, anything follows tightly.
+/// - Same-kind consecutive decls cluster (consts together, data
+///   blocks together, comments together).
+/// - Comments preserve the user's source blank-line intent: a
+///   comment that had a blank line before it in source gets one
+///   in the output too; a comment tight against its preceding
+///   statement stays tight. This makes trailing-comment demotion
+///   (`hlt ; halt` → `hlt\n; halt`) idempotent across re-formats.
+/// - A standalone comment leads into the following statement
+///   tightly (no blank between).
+fn needsBlankLineBefore(
+    curr: ast.Statement,
+    prev: ast.Statement,
+    source: []const u8,
+) bool {
     if (curr == .instruction) return false;
-    // After a label header, anything follows tightly.
     if (prev == .label) return false;
-    // Cluster same-kind decls (const-const, data8-data8, etc.).
     if (std.meta.activeTag(curr) == std.meta.activeTag(prev)) return false;
+    if (curr == .comment) {
+        // Preserve "≥1 blank line in source" by counting newlines
+        // in the inter-statement gap.
+        return sourceNewlineCount(source, prev.span().end, curr.span().start) >= 2;
+    }
+    if (prev == .comment) return false;
     return true;
+}
+
+/// Number of `\n` bytes in `source[end_a..start_b)`. Caps inputs
+/// at the source length for safety. Used by the blank-line rule
+/// to inspect the original gap between two AST nodes.
+fn sourceNewlineCount(source: []const u8, end_a: u32, start_b: u32) usize {
+    if (start_b <= end_a) return 0;
+    const lo: usize = end_a;
+    // @as: widen u32 → usize so `@min` matches `source.len`'s type.
+    const hi: usize = @min(@as(usize, start_b), source.len);
+    var n: usize = 0;
+    for (source[lo..hi]) |b| {
+        if (b == '\n') n += 1;
+    }
+    return n;
 }
 
 /// Render one statement to `writer` (no trailing newline — `print`
@@ -100,6 +132,7 @@ fn writeStatement(
             try writer.print("sram_banks ${X:0>2}", .{count});
         },
         .instruction => |i| try writeInstruction(writer, i, source, opts),
+        .comment => |c| try writer.writeAll(slice(source, c.span)),
         .unknown => |u| try writer.writeAll(slice(source, u.span)),
     }
 }

--- a/src/asm/printer.zig
+++ b/src/asm/printer.zig
@@ -1,0 +1,189 @@
+/// Asm pretty-printer — `ast.Program` + source → canonical `.gas`
+/// text. Foundation for the `gero fmt` subcommand.
+///
+/// Approach: walk the AST and re-emit each statement in a fixed
+/// shape (2-space indent for instructions, blank-line discipline
+/// around top-level decls, canonical operand separators).
+/// Expression and operand *contents* are sliced verbatim from
+/// `source` — the printer normalizes the **layout** between
+/// statements, not the bytes within them. This keeps round-trip
+/// trivially semantic-preserving (the assembler sees the same
+/// expression bytes either way) and idempotent (a second
+/// parse + print of canonical text picks up the same spans and
+/// re-emits identical bytes).
+///
+/// Known limitation: comments are stripped, because the lexer
+/// currently doesn't preserve them in the AST. Tracked as a
+/// follow-up; the printer itself stays comment-agnostic.
+const std = @import("std");
+const ast = @import("ast.zig");
+
+/// Knobs for the canonical printer. Defaults match the asm style
+/// used across `examples/asm/`.
+pub const PrintOptions = struct {
+    /// Spaces to indent instruction lines under their enclosing
+    /// label.
+    indent: usize = 2,
+};
+
+/// Default options — used by `gero fmt` and the round-trip tests.
+pub const default_options: PrintOptions = .{};
+
+/// Emit a canonical-form representation of `program` to `writer`.
+/// `source` is the same buffer that produced `program` — the
+/// printer slices it for expression / operand contents whose
+/// source form must be preserved verbatim.
+pub fn print(
+    writer: *std.Io.Writer,
+    program: *const ast.Program,
+    source: []const u8,
+    opts: PrintOptions,
+) std.Io.Writer.Error!void {
+    var prev: ?ast.Statement = null;
+    for (program.statements) |stmt| {
+        if (prev) |p| {
+            if (needsBlankLineBefore(stmt, p)) try writer.writeByte('\n');
+        }
+        try writeStatement(writer, stmt, source, opts);
+        try writer.writeByte('\n');
+        prev = stmt;
+    }
+}
+
+/// True when the canonical layout puts a blank line between `prev`
+/// and `curr`. Instructions stay attached to their preceding label
+/// or directive; consecutive same-kind decls (consts together,
+/// data blocks together) cluster without separators.
+fn needsBlankLineBefore(curr: ast.Statement, prev: ast.Statement) bool {
+    // Instructions cling to the preceding label / directive.
+    if (curr == .instruction) return false;
+    // After a label header, anything follows tightly.
+    if (prev == .label) return false;
+    // Cluster same-kind decls (const-const, data8-data8, etc.).
+    if (std.meta.activeTag(curr) == std.meta.activeTag(prev)) return false;
+    return true;
+}
+
+/// Render one statement to `writer` (no trailing newline — `print`
+/// adds it). Branches per `Statement` variant.
+fn writeStatement(
+    writer: *std.Io.Writer,
+    stmt: ast.Statement,
+    source: []const u8,
+    opts: PrintOptions,
+) std.Io.Writer.Error!void {
+    switch (stmt) {
+        .label => |l| try writer.print("{s}:", .{slice(source, l.name)}),
+        .const_decl => |c| try writer.print(
+            "const {s} = {s}",
+            .{ slice(source, c.name), slice(source, c.expr.span()) },
+        ),
+        .data8 => |d| try writeData(writer, "data8", d, source),
+        .data16 => |d| try writeData(writer, "data16", d, source),
+        .struct_decl => |s| try writeStruct(writer, s, source),
+        .org => |o| try writer.print(
+            "org {s}",
+            .{slice(source, o.addr_expr.span())},
+        ),
+        .bank_switch => |b| {
+            // Folded `u8` re-emitted as a 2-digit hex literal
+            // (`bank $00`) to match the asm-spec syntax — bare
+            // decimals aren't accepted by the lexer. `null` only
+            // happens when the parser flagged the RHS unresolvable;
+            // emit `bank $00` so the canonical text still re-parses
+            // cleanly (codegen has already raised the diagnostic).
+            const idx = b.index orelse 0;
+            try writer.print("bank ${X:0>2}", .{idx});
+        },
+        .sram_banks_decl => |s| {
+            const count = s.count orelse 0;
+            try writer.print("sram_banks ${X:0>2}", .{count});
+        },
+        .instruction => |i| try writeInstruction(writer, i, source, opts),
+        .unknown => |u| try writer.writeAll(slice(source, u.span)),
+    }
+}
+
+/// `data8` / `data16 NAME = v1, v2, ...` — keyword + name + comma-
+/// separated value list. Values are span-sliced from source so
+/// every literal form (`$10`, `'A'`, `&FFFF`, `@sym`, `"string"`,
+/// `reserve N`) round-trips verbatim.
+fn writeData(
+    writer: *std.Io.Writer,
+    keyword: []const u8,
+    d: ast.DataDecl,
+    source: []const u8,
+) std.Io.Writer.Error!void {
+    try writer.print("{s} {s} = ", .{ keyword, slice(source, d.name) });
+    for (d.values, 0..) |v, i| {
+        if (i > 0) try writer.writeAll(", ");
+        try writer.writeAll(slice(source, v.span()));
+    }
+}
+
+/// Multi-line struct emission:
+///
+/// ```asm
+/// struct NAME {
+///   field1: u8,
+///   field2: u16,
+/// }
+/// ```
+fn writeStruct(
+    writer: *std.Io.Writer,
+    s: ast.StructDecl,
+    source: []const u8,
+) std.Io.Writer.Error!void {
+    try writer.print("struct {s} {{\n", .{slice(source, s.name)});
+    for (s.fields) |f| {
+        try writer.print(
+            "  {s}: {s},\n",
+            .{ slice(source, f.name), @tagName(f.ty) },
+        );
+    }
+    try writer.writeByte('}');
+}
+
+/// Instruction emission: indent + mnemonic + comma-separated
+/// operands. Zero-operand mnemonics (`hlt`, `nop`, `ret`) emit
+/// without trailing whitespace.
+fn writeInstruction(
+    writer: *std.Io.Writer,
+    inst: ast.Instruction,
+    source: []const u8,
+    opts: PrintOptions,
+) std.Io.Writer.Error!void {
+    var pad: usize = opts.indent;
+    while (pad > 0) : (pad -= 1) try writer.writeByte(' ');
+    try writer.writeAll(slice(source, inst.mnemonic));
+    for (inst.operands, 0..) |op, i| {
+        try writer.writeAll(if (i == 0) " " else ", ");
+        try writeOperand(writer, op, source);
+    }
+}
+
+/// One operand. Registers and indirect-via-register use the enum
+/// `@tagName` (deterministic — no source variability); everything
+/// else slices its span from `source` to preserve literal form
+/// (`$10` stays `$10`, not `$0010`).
+fn writeOperand(
+    writer: *std.Io.Writer,
+    op: ast.Operand,
+    source: []const u8,
+) std.Io.Writer.Error!void {
+    switch (op) {
+        .register => |r| try writer.writeAll(@tagName(r.id)),
+        .indirect => |i| try writer.print("[{s}]", .{@tagName(i.reg.id)}),
+        .immediate => |e| try writer.writeAll(slice(source, e.span())),
+        .addr_lit => |a| try writer.writeAll(slice(source, a.span)),
+        .sym_ref => |s| try writer.writeAll(slice(source, s.span)),
+        .label_ref => |l| try writer.writeAll(slice(source, l.span)),
+        .addr_expr => |a| try writer.writeAll(slice(source, a.span)),
+        .indexed => |i| try writer.writeAll(slice(source, i.span)),
+        .cast => |c| try writer.writeAll(slice(source, c.span)),
+    }
+}
+
+inline fn slice(source: []const u8, span: ast.Span) []const u8 {
+    return source[span.start..span.end];
+}

--- a/tests/asm/parser.test.zig
+++ b/tests/asm/parser.test.zig
@@ -16,7 +16,7 @@ test "parser: empty source produces empty program, no errors" {
     try std.testing.expect(!pt.hasErrors());
 }
 
-test "parser: blank lines + comments produce no statements" {
+test "parser: blank lines around a comment produce one Comment statement" {
     var pt = try parseSource(
         \\
         \\; just a comment
@@ -24,7 +24,8 @@ test "parser: blank lines + comments produce no statements" {
         \\
     );
     defer pt.deinit();
-    try std.testing.expectEqual(@as(usize, 0), pt.program.statements.len);
+    try std.testing.expectEqual(@as(usize, 1), pt.program.statements.len);
+    try std.testing.expect(pt.program.statements[0] == .comment);
     try std.testing.expect(!pt.hasErrors());
 }
 

--- a/tests/asm/printer.test.zig
+++ b/tests/asm/printer.test.zig
@@ -1,0 +1,202 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+/// Run `parse → print` once. Caller owns the returned buffer +
+/// must `deinit` the parse tree. The buffer is large enough for
+/// every example in `examples/asm/`.
+const Printed = struct {
+    pt: gero.asm_.ParseTree,
+    text: []u8,
+
+    fn deinit(self: *Printed) void {
+        self.pt.deinit();
+        alloc.free(self.text);
+    }
+};
+
+fn parseAndPrint(source: []const u8) !Printed {
+    var pt = try gero.asm_.parse(alloc, source);
+    errdefer pt.deinit();
+
+    var allocating = std.Io.Writer.Allocating.init(alloc);
+    errdefer allocating.deinit();
+    try gero.asm_.printProgram(&allocating.writer, &pt.program, source, gero.asm_.default_print_options);
+
+    const text = try allocating.toOwnedSlice();
+    return .{ .pt = pt, .text = text };
+}
+
+test "printProgram: empty program → empty output" {
+    var p = try parseAndPrint("");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("", p.text);
+}
+
+test "printProgram: single label" {
+    var p = try parseAndPrint("main:\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("main:\n", p.text);
+}
+
+test "printProgram: const decl with hex literal" {
+    var p = try parseAndPrint("const PRINT = $10\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("const PRINT = $10\n", p.text);
+}
+
+test "printProgram: consecutive consts stay clustered (no blank line)" {
+    var p = try parseAndPrint("const A = $01\nconst B = $02\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("const A = $01\nconst B = $02\n", p.text);
+}
+
+test "printProgram: blank line between kind transitions" {
+    var p = try parseAndPrint("const A = $01\nmain:\n  hlt\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("const A = $01\n\nmain:\n  hlt\n", p.text);
+}
+
+test "printProgram: instructions indent under label" {
+    var p = try parseAndPrint("main:\n  mov $00, r1\n  hlt\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("main:\n  mov $00, r1\n  hlt\n", p.text);
+}
+
+test "printProgram: zero-operand instruction has no trailing space" {
+    var p = try parseAndPrint("main:\nhlt\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("main:\n  hlt\n", p.text);
+}
+
+test "printProgram: data8 with mixed value forms" {
+    var p = try parseAndPrint("data8 GREETING = \"Hi\", $00\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("data8 GREETING = \"Hi\", $00\n", p.text);
+}
+
+test "printProgram: data16 with single value" {
+    var p = try parseAndPrint("data16 IVT = $FFFF\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("data16 IVT = $FFFF\n", p.text);
+}
+
+test "printProgram: org directive" {
+    var p = try parseAndPrint("org $1000\nmain:\n  hlt\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("org $1000\n\nmain:\n  hlt\n", p.text);
+}
+
+test "printProgram: bank directive" {
+    var p = try parseAndPrint("bank $01\nmain:\n  hlt\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("bank $01\n\nmain:\n  hlt\n", p.text);
+}
+
+test "printProgram: sram_banks directive" {
+    var p = try parseAndPrint("sram_banks $02\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("sram_banks $02\n", p.text);
+}
+
+test "printProgram: struct multi-line" {
+    var p = try parseAndPrint("struct Player { hp: u8, x: u16 }\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings(
+        \\struct Player {
+        \\  hp: u8,
+        \\  x: u16,
+        \\}
+        \\
+    , p.text);
+}
+
+test "printProgram: indirect operand uses [reg] form" {
+    var p = try parseAndPrint("main:\n  mov [r1], r2\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("main:\n  mov [r1], r2\n", p.text);
+}
+
+test "printProgram: address-literal operand" {
+    var p = try parseAndPrint("main:\n  call &C000\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("main:\n  call &C000\n", p.text);
+}
+
+test "printProgram: label-ref operand (forward reference)" {
+    var p = try parseAndPrint("main:\n  jmp loop\nloop:\n  hlt\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("main:\n  jmp loop\n\nloop:\n  hlt\n", p.text);
+}
+
+test "printProgram: sym-ref operand" {
+    var p = try parseAndPrint("data8 GREETING = \"Hi\"\nmain:\n  mov @GREETING, r1\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings(
+        \\data8 GREETING = "Hi"
+        \\
+        \\main:
+        \\  mov @GREETING, r1
+        \\
+    , p.text);
+}
+
+test "printProgram: idempotence — second pass matches first" {
+    const src = "const PRINT = $10\n\nmain:\n  mov $00, r1\n  int PRINT\n  hlt\n";
+    var p1 = try parseAndPrint(src);
+    defer p1.deinit();
+    var p2 = try parseAndPrint(p1.text);
+    defer p2.deinit();
+    try std.testing.expectEqualStrings(p1.text, p2.text);
+}
+
+test "printProgram: idempotence on every examples/asm/* program" {
+    const examples = [_][]const u8{
+        @import("examples").hello_gas,
+        @import("examples").fib_gas,
+        @import("examples").counter_gas,
+    };
+    for (examples) |src| {
+        var p1 = try parseAndPrint(src);
+        defer p1.deinit();
+        try std.testing.expect(!p1.pt.hasErrors());
+
+        var p2 = try parseAndPrint(p1.text);
+        defer p2.deinit();
+        try std.testing.expect(!p2.pt.hasErrors());
+
+        try std.testing.expectEqualStrings(p1.text, p2.text);
+    }
+}
+
+test "printProgram: semantic preservation — asm(print(parse(src))) == asm(src)" {
+    const examples = [_][]const u8{
+        @import("examples").hello_gas,
+        @import("examples").fib_gas,
+        @import("examples").counter_gas,
+    };
+    for (examples) |src| {
+        var p = try parseAndPrint(src);
+        defer p.deinit();
+
+        const opts: gero.asm_.CodegenOptions = .{ .debug_symbols = false };
+        var cg1 = try gero.asm_.assemble(alloc, src, p.pt, opts);
+        defer cg1.deinit();
+
+        var pt2 = try gero.asm_.parse(alloc, p.text);
+        defer pt2.deinit();
+        var cg2 = try gero.asm_.assemble(alloc, p.text, pt2, opts);
+        defer cg2.deinit();
+
+        try std.testing.expectEqualSlices(u8, cg1.image, cg2.image);
+    }
+}
+
+test "printProgram: handles include resolution markers cleanly" {
+    // The parser eats `\f` form-feed markers used by the include
+    // resolver — the printer just doesn't emit them.
+    var p = try parseAndPrint("main:\n  hlt\n");
+    defer p.deinit();
+    try std.testing.expect(std.mem.indexOfScalar(u8, p.text, '\x0c') == null);
+}

--- a/tests/asm/printer.test.zig
+++ b/tests/asm/printer.test.zig
@@ -142,6 +142,48 @@ test "printProgram: sym-ref operand" {
     , p.text);
 }
 
+test "printProgram: standalone comment line preserved verbatim" {
+    var p = try parseAndPrint("; hello world\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("; hello world\n", p.text);
+}
+
+test "printProgram: comment block before a label stays tight (no blank inserted)" {
+    var p = try parseAndPrint("; section header\n; line two\nmain:\n  hlt\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings(
+        \\; section header
+        \\; line two
+        \\main:
+        \\  hlt
+        \\
+    , p.text);
+}
+
+test "printProgram: blank line preserved before a standalone comment block" {
+    var p = try parseAndPrint("main:\n  hlt\n\n; trailing block\nfib:\n  ret\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings(
+        \\main:
+        \\  hlt
+        \\
+        \\; trailing block
+        \\fib:
+        \\  ret
+        \\
+    , p.text);
+}
+
+test "printProgram: trailing comment demotes to standalone (same line attachment preserved)" {
+    // Trailing comment was inline with `hlt`; printer recognizes
+    // the source-same-line proximity and skips the blank line,
+    // so the comment stays tight to the instruction on the next
+    // line.
+    var p = try parseAndPrint("main:\n  hlt ; halt\n");
+    defer p.deinit();
+    try std.testing.expectEqualStrings("main:\n  hlt\n; halt\n", p.text);
+}
+
 test "printProgram: idempotence — second pass matches first" {
     const src = "const PRINT = $10\n\nmain:\n  mov $00, r1\n  int PRINT\n  hlt\n";
     var p1 = try parseAndPrint(src);


### PR DESCRIPTION
## Summary

New `src/asm/printer.zig` module — walks an `ast.Program` and re-emits canonical `.gas` source. Foundation for `gero fmt` (#117), shipped separately from the CLI wiring.

End-to-end **including comment preservation** — the parser surfaces `; ...` comments as first-class `Statement.comment` nodes, the printer round-trips them, trailing-comment demotion is idempotent across re-formats.

## Design choices

- **Layout-only normalization** — 2-space indent under labels, blank-line discipline at decl-kind transitions, consecutive same-kind decls cluster.
- **Source-sliced expressions** — `$10` / `'A'` / `&FFFF` round-trip exactly; the printer doesn't reformat literal forms.
- **Comment preservation** — parser captures `;` lines as `Comment` statements; printer emits them in place. Trailing comments (`hlt ; halt`) demote to standalone (`hlt\n; halt`) but then stay stable. Blank-line discipline around comment blocks follows the user's source intent (count `\n` bytes in the gap).
- **Multi-line struct emission**; **two-digit hex** for `bank` / `sram_banks` (decimal isn't a valid form per the asm lexer).
- **Public API**: `printProgram(writer, program, source, opts) !void` + `PrintOptions { indent }` + `default_print_options`.

## Properties (test-verified)

- **Idempotence** on every `examples/asm/*.gas` (hello/fib/counter): `print(parse(print(parse(src))))` is byte-equal to `print(parse(src))`.
- **Semantic preservation** on the same set: `assemble(print(parse(src))).image == assemble(src).image`.
- **Comment-shape tests**: standalone block, leading-into-label tightness, blank-separated comment block, trailing-demotion.

## Self-review

- Step 1 — issue #115 AC: all 6 boxes ticked + comment preservation now included in scope
- Step 2 — `zig build ci` local: EXIT=0 (lint + test-modes + test-all + test-examples)
- Step 3 — diff walk: AST + parser + printer + codegen catch-all updates, ~140 extra lines for comments; one `@as` cast has its `// @as:` justification; no `*anyopaque`, no `anyerror`
- Step 4 — hygiene: changeset (patch) added, conventional commits + scope, no AI attribution

Closes #115.