### PR TITLE
feat(apps/gero-cli): gero check — validate .gas without writing .gx

### DIFF
--- a/.changeset/cli-check.md
+++ b/.changeset/cli-check.md
@@ -4,11 +4,14 @@ bump: patch
 
 `gero check <file.gas>` now ships — runs the full assembler
 pipeline (resolve includes → parse → codegen-validate) without
-writing a `.gx`. Reports caret-style diagnostics on failure, a
-one-line `✓ <path>` summary on success (suppressed by `--quiet`).
-Exit codes per cli.md §3.9 + §5: `0` clean, `4` on any diagnostic,
-`1` on host IO, `2` on usage. `.gr` sources route to a "not yet
-implemented" stub until v0.3 wires the gero-lang front-end.
+writing a `.gx`. Reports caret-style diagnostics on failure;
+on success, a `gero asm`-style summary line `✓ <path> (N bytes,
+M banks)` plus a Cargo-style `Finished in X ms` footer.
+`--quiet` suppresses the success line, `--verbose` adds per-phase
+timings (include / parse / codegen). Exit codes per cli.md §3.9
++ §5: `0` clean, `4` on any diagnostic, `1` on host IO, `2` on
+usage. `.gr` sources route to a "not yet implemented" stub until
+v0.3 wires the gero-lang front-end.
 
 A `zig build check-examples` step drives every `examples/asm/*.gas`
 (recursive — banks/ included) through `gero check` and is wired

--- a/.changeset/cli-check.md
+++ b/.changeset/cli-check.md
@@ -1,0 +1,15 @@
+---
+bump: patch
+---
+
+`gero check <file.gas>` now ships — runs the full assembler
+pipeline (resolve includes → parse → codegen-validate) without
+writing a `.gx`. Reports caret-style diagnostics on failure, a
+one-line `✓ <path>` summary on success (suppressed by `--quiet`).
+Exit codes per cli.md §3.9 + §5: `0` clean, `4` on any diagnostic,
+`1` on host IO, `2` on usage. `.gr` sources route to a "not yet
+implemented" stub until v0.3 wires the gero-lang front-end.
+
+A `zig build check-examples` step drives every `examples/asm/*.gas`
+(recursive — banks/ included) through `gero check` and is wired
+into `zig build ci` alongside the existing `test-examples`.

--- a/.changeset/cli-check.md
+++ b/.changeset/cli-check.md
@@ -2,16 +2,19 @@
 bump: patch
 ---
 
-`gero check <file.gas>` now ships — runs the full assembler
-pipeline (resolve includes → parse → codegen-validate) without
-writing a `.gx`. Reports caret-style diagnostics on failure;
-on success, a `gero asm`-style summary line `✓ <path> (N bytes,
-M banks)` plus a Cargo-style `Finished in X ms` footer.
-`--quiet` suppresses the success line, `--verbose` adds per-phase
-timings (include / parse / codegen). Exit codes per cli.md §3.9
-+ §5: `0` clean, `4` on any diagnostic, `1` on host IO, `2` on
-usage. `.gr` sources route to a "not yet implemented" stub until
-v0.3 wires the gero-lang front-end.
+`gero check` now ships — runs the full assembler pipeline
+(resolve includes → parse → codegen-validate) without writing a
+`.gx`. Positional args can be individual files **or directories
+(walked recursively for `*.gas`)** and any mix of the two. Single-
+file invocations get a `gero asm`-style rich summary
+(`✓ <path>  (N bytes, M banks)` + `Finished in X ms` footer +
+optional `--verbose` per-phase timings); multi-file walks print
+one `✓` / `✗` line per file plus a `check: N files passed, M
+failures` summary. Caret-style diagnostics appear on every failure.
+`--quiet` suppresses the per-file ok lines + summary. Exit codes
+per cli.md §3.9 + §5: `0` clean, `4` on any diagnostic, `1` on
+host IO, `2` on usage. `.gr` sources route to a "not yet
+implemented" stub until v0.3 wires the gero-lang front-end.
 
 A `zig build check-examples` step drives every `examples/asm/*.gas`
 (recursive — banks/ included) through `gero check` and is wired

--- a/.changeset/cli-check.md
+++ b/.changeset/cli-check.md
@@ -17,5 +17,9 @@ host IO, `2` on usage. `.gr` sources route to a "not yet
 implemented" stub until v0.3 wires the gero-lang front-end.
 
 A `zig build check-examples` step drives every `examples/asm/*.gas`
-(recursive — banks/ included) through `gero check` and is wired
-into `zig build ci` alongside the existing `test-examples`.
+(recursive — banks/ included) through `gero check` and asserts
+clean exit; a sibling `zig build check-broken` step walks
+`tests/asm/check-broken/*.gas` (intentionally-bad fixtures
+covering parse / E001 / E004 / E005 categories) and asserts each
+one **fails**. Both wired into `zig build ci` alongside
+`test-examples`.

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const gero = @import("gero");
 const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
+const diagnostics = @import("diagnostics.zig");
 
 /// Run the full `gero asm` flow against `opts.positional()[0]`.
 /// Caller owns `arena`; everything we allocate is short-lived.
@@ -41,7 +42,7 @@ pub fn execute(
     // before parse.
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
     if (fused.errors.len > 0) {
-        try printDiagnostics(stdout, fused.source_map, fused.errors, style);
+        try diagnostics.printSingle(stdout, fused.source_map, fused.errors, style);
         try writeFooter(stdout, io, style, t_start, .failed);
         return 3;
     }
@@ -61,7 +62,7 @@ pub fn execute(
 
     const had_errors = pt.hasErrors() or cg.hasErrors();
     if (had_errors) {
-        try printAllDiagnostics(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
+        try diagnostics.printMerged(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
         try writeFooter(stdout, io, style, t_start, .failed);
         return 3;
     }
@@ -159,87 +160,6 @@ fn writeDuration(stdout: *std.Io.Writer, ns: i96) !void {
     } else {
         try stdout.writeAll("< 1 ms");
     }
-}
-
-/// Pretty-print every diagnostic against the fused-source map.
-fn printDiagnostics(
-    stdout: *std.Io.Writer,
-    source_map: gero.asm_.SourceMap,
-    errors: []const gero.asm_.Diagnostic,
-    style: gero.asm_.Style,
-) !void {
-    for (errors) |d| try gero.asm_.formatPretty(stdout, source_map, d, style);
-}
-
-/// Augment each diagnostic with its resolved file path so we can
-/// group + sort by (path, fused_index) — diagnostics from the same
-/// file land in one section, sorted by source position.
-const KeyedDiag = struct {
-    diag: gero.asm_.Diagnostic,
-    path: []const u8,
-};
-
-/// Merge parse + codegen diagnostics, group by file, sort each
-/// group by fused-source offset, print a summary header + one
-/// section per file. `<unknown>` (rare — source-map miss) groups
-/// last under a single bucket.
-fn printAllDiagnostics(
-    arena: std.mem.Allocator,
-    stdout: *std.Io.Writer,
-    source_map: gero.asm_.SourceMap,
-    parse_errors: []const gero.asm_.Diagnostic,
-    codegen_errors: []const gero.asm_.Diagnostic,
-    style: gero.asm_.Style,
-) !void {
-    const total = parse_errors.len + codegen_errors.len;
-    const keyed = try arena.alloc(KeyedDiag, total);
-    for (parse_errors, 0..) |d, i| keyed[i] = .{ .diag = d, .path = pathOf(source_map, d) };
-    for (codegen_errors, 0..) |d, j| keyed[parse_errors.len + j] = .{ .diag = d, .path = pathOf(source_map, d) };
-    std.mem.sort(KeyedDiag, keyed, {}, byPathThenIndex);
-
-    // Count distinct files for the summary header.
-    var file_count: usize = 0;
-    var prev_path: []const u8 = "";
-    for (keyed) |k| {
-        if (!std.mem.eql(u8, k.path, prev_path)) {
-            file_count += 1;
-            prev_path = k.path;
-        }
-    }
-    try writeSummaryHeader(stdout, style, total, file_count);
-
-    // Emit per-file sections: blank line + `<path>:` header for
-    // each new file, then each diagnostic body (no path prefix).
-    prev_path = "";
-    for (keyed) |k| {
-        if (!std.mem.eql(u8, k.path, prev_path)) {
-            try stdout.writeByte('\n');
-            try stdout.print("{s}{s}{s}\n", .{ style.location, k.path, style.reset });
-            prev_path = k.path;
-        }
-        try gero.asm_.formatPrettyBody(stdout, source_map, k.diag, style);
-    }
-}
-
-fn writeSummaryHeader(stdout: *std.Io.Writer, style: gero.asm_.Style, errors: usize, files: usize) !void {
-    const error_noun: []const u8 = if (errors == 1) "error" else "errors";
-    const file_noun: []const u8 = if (files == 1) "file" else "files";
-    // Reuse Style.code for the count label so it pops in red like
-    // the per-line [Exxx] markers.
-    try stdout.print("{s}{d} {s}{s} in {d} {s}\n", .{ style.code, errors, error_noun, style.reset, files, file_noun });
-}
-
-fn pathOf(source_map: gero.asm_.SourceMap, d: gero.asm_.Diagnostic) []const u8 {
-    // @as: ParseError indexes fit in u32 — bounded by max_file_size (16 MiB).
-    const offset: u32 = @as(u32, @intCast(d.parse_error.index));
-    if (source_map.lookup(offset)) |loc| return loc.file.path;
-    return "<unknown>";
-}
-
-fn byPathThenIndex(_: void, a: KeyedDiag, b: KeyedDiag) bool {
-    const path_cmp = std.mem.order(u8, a.path, b.path);
-    if (path_cmp != .eq) return path_cmp == .lt;
-    return a.diag.parse_error.index < b.diag.parse_error.index;
 }
 
 /// Resolve the `.gx` output path from `--out` plus the source.

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -63,7 +63,13 @@ pub fn execute(
 
     const had_errors = pt.hasErrors() or cg.hasErrors();
     if (had_errors) {
-        try diagnostics.printMerged(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
+        try diagnostics.printAllFailures(arena, stdout, style, &.{
+            .{
+                .source_map = fused.source_map,
+                .parse_errors = pt.errors,
+                .codegen_errors = cg.errors,
+            },
+        });
         try footer.writeFooter(stdout, io, style, t_start, .failed);
         return 3;
     }

--- a/apps/gero-cli/asm.zig
+++ b/apps/gero-cli/asm.zig
@@ -10,6 +10,7 @@ const gero = @import("gero");
 const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const diagnostics = @import("diagnostics.zig");
+const footer = @import("footer.zig");
 
 /// Run the full `gero asm` flow against `opts.positional()[0]`.
 /// Caller owns `arena`; everything we allocate is short-lived.
@@ -43,7 +44,7 @@ pub fn execute(
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
     if (fused.errors.len > 0) {
         try diagnostics.printSingle(stdout, fused.source_map, fused.errors, style);
-        try writeFooter(stdout, io, style, t_start, .failed);
+        try footer.writeFooter(stdout, io, style, t_start, .failed);
         return 3;
     }
 
@@ -63,7 +64,7 @@ pub fn execute(
     const had_errors = pt.hasErrors() or cg.hasErrors();
     if (had_errors) {
         try diagnostics.printMerged(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
-        try writeFooter(stdout, io, style, t_start, .failed);
+        try footer.writeFooter(stdout, io, style, t_start, .failed);
         return 3;
     }
 
@@ -90,7 +91,7 @@ pub fn execute(
                 .write = t_after_codegen.durationTo(t_after_write).nanoseconds,
             });
         }
-        try writeFooter(stdout, io, style, t_start, .ok);
+        try footer.writeFooter(stdout, io, style, t_start, .ok);
     }
 
     return 0;
@@ -112,53 +113,8 @@ fn writePhaseTimings(stdout: *std.Io.Writer, style: gero.asm_.Style, t: PhaseTim
     };
     for (phases) |p| {
         try stdout.print("{s}{s}{s} ", .{ style.gutter, p.label, style.reset });
-        try writeDuration(stdout, p.ns);
+        try footer.writeDuration(stdout, p.ns);
         try stdout.writeByte('\n');
-    }
-}
-
-/// Whether `gero asm` produced a `.gx` or bailed on errors.
-const Outcome = enum { ok, failed };
-
-/// Cargo-style footer with elapsed wall time.
-///
-/// ```text
-///     Finished in 12.3 ms
-///     Failed in 4.1 ms
-/// ```
-fn writeFooter(stdout: *std.Io.Writer, io: std.Io, style: gero.asm_.Style, t_start: std.Io.Timestamp, outcome: Outcome) !void {
-    const t_end = std.Io.Timestamp.now(io, .awake);
-    const elapsed_ns: i96 = t_start.durationTo(t_end).nanoseconds;
-    const label = switch (outcome) {
-        .ok => "    Finished in ",
-        .failed => "    Failed in ",
-    };
-    const label_style = switch (outcome) {
-        .ok => style.location, // bold — same as path headers
-        .failed => style.code, // red — same as [Exxx]
-    };
-    try stdout.print("{s}{s}{s}", .{ label_style, label, style.reset });
-    try writeDuration(stdout, elapsed_ns);
-    try stdout.writeByte('\n');
-}
-
-fn writeDuration(stdout: *std.Io.Writer, ns: i96) !void {
-    const ns_per_ms: i96 = std.time.ns_per_ms;
-    const ns_per_s: i96 = std.time.ns_per_s;
-    if (ns >= ns_per_s) {
-        // safety: caller passes a non-negative duration; the cast
-        //         to u64 just lets {d} format unsigned without the
-        //         leading-sign business that confuses the spec.
-        const whole: u64 = @intCast(@divFloor(ns, ns_per_s));
-        const tenths: u64 = @intCast(@divFloor(@mod(ns, ns_per_s), ns_per_ms * 100));
-        try stdout.print("{d}.{d} s", .{ whole, tenths });
-    } else if (ns >= ns_per_ms) {
-        // @as: see above — non-negative ns by construction.
-        const whole: u64 = @intCast(@divFloor(ns, ns_per_ms));
-        const tenths: u64 = @intCast(@divFloor(@mod(ns, ns_per_ms), 100_000));
-        try stdout.print("{d}.{d} ms", .{ whole, tenths });
-    } else {
-        try stdout.writeAll("< 1 ms");
     }
 }
 

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -1,0 +1,73 @@
+/// `gero check` — validate a `.gas` source through the full
+/// assembler pipeline (resolveIncludes → parse → codegen) without
+/// writing a `.gx` output. Editor-LSP-style use case + CI gate
+/// covering more failure modes than `gero asm` would because the
+/// caller gets the merged diagnostics for free.
+///
+/// Exit codes per cli.md §3.9 + §5:
+///   - `0` clean (one-line `✓ <path>` summary, suppressed by `--quiet`)
+///   - `1` host IO problem (file missing, unreadable, etc.)
+///   - `2` usage error (missing positional)
+///   - `4` lint / parse / codegen error (≥ 1 diagnostic)
+///
+/// `.gr` source dispatches to a "not yet implemented" stub until
+/// the gero-lang front-end lands in v0.3 (#7).
+const std = @import("std");
+const gero = @import("gero");
+const cli = @import("cli.zig");
+const term_mod = @import("term.zig");
+const diagnostics = @import("diagnostics.zig");
+
+/// Drive `gero check` end-to-end against `opts.positional()[0]`.
+/// Caller owns `arena`; every allocation is short-lived.
+pub fn execute(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+) !u8 {
+    const positionals = opts.positional();
+    if (positionals.len < 1) {
+        try term.err("gero check: missing source file path", .{});
+        return 2;
+    }
+    const src_path = positionals[0];
+
+    if (std.mem.endsWith(u8, src_path, ".gr")) {
+        try term.err("gero check: .gr support lands in v0.3 (gero-lang front-end)", .{});
+        return 1;
+    }
+
+    var fused = gero.asm_.resolveIncludes(io, arena, src_path) catch |err| {
+        try term.err("gero check: cannot read {s} ({s})", .{ src_path, @errorName(err) });
+        return 1;
+    };
+    defer fused.deinit();
+
+    const style: gero.asm_.Style = if (term.color) .ansi else .plain;
+    if (fused.errors.len > 0) {
+        try diagnostics.printSingle(stdout, fused.source_map, fused.errors, style);
+        return 4;
+    }
+
+    // Statement-level recovery means parse always returns a tree;
+    // run codegen unconditionally so codegen-only errors (E001
+    // duplicate label, E003 undefined symbol, etc.) surface in the
+    // same pass as parse errors.
+    var pt = try gero.asm_.parse(arena, fused.source);
+    defer pt.deinit();
+
+    var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
+    defer cg.deinit();
+
+    if (pt.hasErrors() or cg.hasErrors()) {
+        try diagnostics.printMerged(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
+        return 4;
+    }
+
+    if (!opts.quiet) {
+        try stdout.print("{s}✓{s} {s}\n", .{ style.location, style.reset, src_path });
+    }
+    return 0;
+}

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -17,6 +17,7 @@ const gero = @import("gero");
 const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const diagnostics = @import("diagnostics.zig");
+const footer = @import("footer.zig");
 
 /// Drive `gero check` end-to-end against `opts.positional()[0]`.
 /// Caller owns `arena`; every allocation is short-lived.
@@ -27,6 +28,7 @@ pub fn execute(
     stdout: *std.Io.Writer,
     term: *term_mod.Term,
 ) !u8 {
+    const t_start = std.Io.Timestamp.now(io, .awake);
     const positionals = opts.positional();
     if (positionals.len < 1) {
         try term.err("gero check: missing source file path", .{});
@@ -39,15 +41,19 @@ pub fn execute(
         return 1;
     }
 
+    const style: gero.asm_.Style = if (term.color) .ansi else .plain;
+
+    const t_phase_start_include = std.Io.Timestamp.now(io, .awake);
     var fused = gero.asm_.resolveIncludes(io, arena, src_path) catch |err| {
         try term.err("gero check: cannot read {s} ({s})", .{ src_path, @errorName(err) });
         return 1;
     };
     defer fused.deinit();
+    const t_after_include = std.Io.Timestamp.now(io, .awake);
 
-    const style: gero.asm_.Style = if (term.color) .ansi else .plain;
     if (fused.errors.len > 0) {
         try diagnostics.printSingle(stdout, fused.source_map, fused.errors, style);
+        try footer.writeFooter(stdout, io, style, t_start, .failed);
         return 4;
     }
 
@@ -57,17 +63,61 @@ pub fn execute(
     // same pass as parse errors.
     var pt = try gero.asm_.parse(arena, fused.source);
     defer pt.deinit();
+    const t_after_parse = std.Io.Timestamp.now(io, .awake);
 
     var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
     defer cg.deinit();
+    const t_after_codegen = std.Io.Timestamp.now(io, .awake);
 
     if (pt.hasErrors() or cg.hasErrors()) {
         try diagnostics.printMerged(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
+        try footer.writeFooter(stdout, io, style, t_start, .failed);
         return 4;
     }
 
     if (!opts.quiet) {
-        try stdout.print("{s}✓{s} {s}\n", .{ style.location, style.reset, src_path });
+        // Mirror `gero asm`'s shape: path + parens stats + footer.
+        // No bytes are written to disk but we report what *would*
+        // have been emitted so the user has a sense of program size.
+        const loaded = gero.vm.parseGx(cg.image) catch unreachable; // allow-strict: codegen just produced these bytes — well-formed by construction
+        try stdout.print("{s}✓ {s}{s}  ({d} bytes, {d} banks)\n", .{
+            style.location,
+            src_path,
+            style.reset,
+            cg.image.len,
+            loaded.header.bank_count,
+        });
+        if (opts.verbose) {
+            try writePhaseTimings(stdout, style, .{
+                .include = t_phase_start_include.durationTo(t_after_include).nanoseconds,
+                .parse = t_after_include.durationTo(t_after_parse).nanoseconds,
+                .codegen = t_after_parse.durationTo(t_after_codegen).nanoseconds,
+            });
+        }
+        try footer.writeFooter(stdout, io, style, t_start, .ok);
     }
     return 0;
+}
+
+const PhaseTimings = struct {
+    include: i96,
+    parse: i96,
+    codegen: i96,
+};
+
+fn writePhaseTimings(
+    stdout: *std.Io.Writer,
+    style: gero.asm_.Style,
+    t: PhaseTimings,
+) std.Io.Writer.Error!void {
+    const phases = [_]struct { label: []const u8, ns: i96 }{
+        .{ .label = "    include", .ns = t.include },
+        .{ .label = "    parse  ", .ns = t.parse },
+        .{ .label = "    codegen", .ns = t.codegen },
+    };
+    for (phases) |p| {
+        try stdout.print("{s}{s}{s} ", .{ style.gutter, p.label, style.reset });
+        try footer.writeDuration(stdout, p.ns);
+        try stdout.writeByte('\n');
+    }
 }

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -38,9 +38,6 @@ pub fn execute(
 
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
 
-    // Resolve every positional into a flat list of `.gas` files.
-    // `.gr` positionals short-circuit with the v0.3 stub before
-    // any walking happens.
     var files: std.ArrayList([]const u8) = .empty;
     for (positionals) |path| {
         if (std.mem.endsWith(u8, path, ".gr")) {
@@ -57,15 +54,85 @@ pub fn execute(
 
     const single = files.items.len == 1;
 
+    // Pass 1: validate each file. Print per-file ✓ for successes
+    // as we go; accumulate failures with their diagnostic context
+    // so Pass 2 can render one merged report at the end.
+    //
+    // Resources allocated through `arena` (FusedSource buffers,
+    // ParseTree slices, Codegen image) stay live until the arena
+    // resets, so the failures collected here keep their source-map
+    // + diagnostic references valid across the loop.
     var pass: usize = 0;
-    var fail: usize = 0;
+    var failures: std.ArrayList(FileEntry) = .empty;
     for (files.items) |path| {
-        const ok = try checkOne(io, arena, opts, stdout, term, style, path, single);
-        if (ok) pass += 1 else fail += 1;
+        const t_phase_start_include = std.Io.Timestamp.now(io, .awake);
+        const fused = gero.asm_.resolveIncludes(io, arena, path) catch |err| {
+            try term.err("gero check: cannot read {s} ({s})", .{ path, @errorName(err) });
+            // Synthesize a single-diagnostic failure so the merged
+            // report has something to render. Skipping the failure
+            // would mis-count totals.
+            try failures.append(arena, .{ .path = path, .info = .read_error });
+            continue;
+        };
+        const t_after_include = std.Io.Timestamp.now(io, .awake);
+
+        if (fused.errors.len > 0) {
+            try failures.append(arena, .{
+                .path = path,
+                .info = .{ .from_pipeline = .{
+                    .source_map = fused.source_map,
+                    .parse_errors = fused.errors,
+                    .codegen_errors = &.{},
+                } },
+            });
+            continue;
+        }
+
+        var pt = try gero.asm_.parse(arena, fused.source);
+        const t_after_parse = std.Io.Timestamp.now(io, .awake);
+        var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
+        const t_after_codegen = std.Io.Timestamp.now(io, .awake);
+
+        if (pt.hasErrors() or cg.hasErrors()) {
+            try failures.append(arena, .{
+                .path = path,
+                .info = .{ .from_pipeline = .{
+                    .source_map = fused.source_map,
+                    .parse_errors = pt.errors,
+                    .codegen_errors = cg.errors,
+                } },
+            });
+            continue;
+        }
+
+        pass += 1;
+        if (!opts.quiet) {
+            try printPass(stdout, style, path, cg, single, opts.verbose, .{
+                .include = t_phase_start_include.durationTo(t_after_include).nanoseconds,
+                .parse = t_after_include.durationTo(t_after_parse).nanoseconds,
+                .codegen = t_after_parse.durationTo(t_after_codegen).nanoseconds,
+            });
+        }
     }
 
-    // Multi-file summary line — single-file mode already shows the
-    // rich `✓ <path> (N bytes, M banks)` line per file, no need.
+    // Pass 2: render the merged diagnostic report (if any failure).
+    if (failures.items.len > 0) {
+        // Read errors render as plain term.err lines (no source-
+        // map context to caret-format), so split them off first.
+        var pipeline_failures: std.ArrayList(diagnostics.FileFailure) = .empty;
+        for (failures.items) |f| switch (f.info) {
+            .read_error => {}, // already reported via term.err
+            .from_pipeline => |pf| try pipeline_failures.append(arena, pf),
+        };
+        if (pipeline_failures.items.len > 0) {
+            // Separator between the per-file ✓ section (if any
+            // success printed above) and the diagnostic block.
+            if (!single and !opts.quiet and pass > 0) try stdout.writeByte('\n');
+            try diagnostics.printAllFailures(arena, stdout, style, pipeline_failures.items);
+        }
+    }
+
+    const fail = failures.items.len;
     if (!single and !opts.quiet) {
         const pass_noun: []const u8 = if (pass == 1) "file" else "files";
         const fail_noun: []const u8 = if (fail == 1) "failure" else "failures";
@@ -78,6 +145,53 @@ pub fn execute(
         try footer.writeFooter(stdout, io, style, t_start, if (fail > 0) .failed else .ok);
     }
     return if (fail > 0) 4 else 0;
+}
+
+/// A per-file failure entry: either a host-IO problem (already
+/// surfaced via `term.err`) or a pipeline-level diagnostic set
+/// with its source-map context.
+const FileEntry = struct {
+    path: []const u8,
+    info: union(enum) {
+        read_error,
+        from_pipeline: diagnostics.FileFailure,
+    },
+};
+
+const PhaseTimings = struct {
+    include: i96,
+    parse: i96,
+    codegen: i96,
+};
+
+/// `✓ <path>` line on success. Single-file mode adds the `gero asm`-
+/// style stats (`(N bytes, M banks)`) and optional verbose phase
+/// timings; multi-file mode keeps it brief so the per-file output
+/// stays scannable.
+fn printPass(
+    stdout: *std.Io.Writer,
+    style: gero.asm_.Style,
+    src_path: []const u8,
+    cg: gero.asm_.Codegen,
+    single_mode: bool,
+    verbose: bool,
+    t: PhaseTimings,
+) std.Io.Writer.Error!void {
+    if (single_mode) {
+        const loaded = gero.vm.parseGx(cg.image) catch unreachable; // allow-strict: codegen just produced these bytes
+        try stdout.print("{s}✓ {s}{s}  ({d} bytes, {d} banks)\n", .{
+            style.location,
+            src_path,
+            style.reset,
+            cg.image.len,
+            loaded.header.bank_count,
+        });
+        if (verbose) {
+            try writePhaseTimings(stdout, style, t);
+        }
+    } else {
+        try stdout.print("{s}✓{s} {s}\n", .{ style.location, style.reset, src_path });
+    }
 }
 
 /// Resolve `path` into 0+ `.gas` entries appended to `out`. A
@@ -93,7 +207,7 @@ fn collectGasFiles(
 ) !void {
     const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch |err| {
         try term.err("gero check: cannot stat {s} ({s})", .{ path, @errorName(err) });
-        return error.OutOfMemory; // funnel to the only allocator error caller handles
+        return error.OutOfMemory;
     };
     if (stat.kind == .directory) {
         var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
@@ -116,79 +230,6 @@ fn collectGasFiles(
         return error.OutOfMemory;
     }
 }
-
-/// Validate one `.gas` file. Returns `true` on clean check,
-/// `false` if any diagnostic was emitted. `single_mode` controls
-/// the per-file output verbosity: rich `(N bytes, M banks)` +
-/// optional per-phase timings when `true`, brief `✓ <path>` /
-/// diagnostic when `false`.
-fn checkOne(
-    io: std.Io,
-    arena: std.mem.Allocator,
-    opts: cli.Options,
-    stdout: *std.Io.Writer,
-    term: *term_mod.Term,
-    style: gero.asm_.Style,
-    src_path: []const u8,
-    single_mode: bool,
-) !bool {
-    const t_phase_start_include = std.Io.Timestamp.now(io, .awake);
-    var fused = gero.asm_.resolveIncludes(io, arena, src_path) catch |err| {
-        try term.err("gero check: cannot read {s} ({s})", .{ src_path, @errorName(err) });
-        return false;
-    };
-    defer fused.deinit();
-    const t_after_include = std.Io.Timestamp.now(io, .awake);
-
-    if (fused.errors.len > 0) {
-        try stdout.print("{s}✗{s} {s}\n", .{ style.code, style.reset, src_path });
-        try diagnostics.printSingle(stdout, fused.source_map, fused.errors, style);
-        return false;
-    }
-
-    var pt = try gero.asm_.parse(arena, fused.source);
-    defer pt.deinit();
-    const t_after_parse = std.Io.Timestamp.now(io, .awake);
-
-    var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
-    defer cg.deinit();
-    const t_after_codegen = std.Io.Timestamp.now(io, .awake);
-
-    if (pt.hasErrors() or cg.hasErrors()) {
-        try stdout.print("{s}✗{s} {s}\n", .{ style.code, style.reset, src_path });
-        try diagnostics.printMerged(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
-        return false;
-    }
-
-    if (!opts.quiet) {
-        if (single_mode) {
-            const loaded = gero.vm.parseGx(cg.image) catch unreachable; // allow-strict: codegen just produced these bytes
-            try stdout.print("{s}✓ {s}{s}  ({d} bytes, {d} banks)\n", .{
-                style.location,
-                src_path,
-                style.reset,
-                cg.image.len,
-                loaded.header.bank_count,
-            });
-            if (opts.verbose) {
-                try writePhaseTimings(stdout, style, .{
-                    .include = t_phase_start_include.durationTo(t_after_include).nanoseconds,
-                    .parse = t_after_include.durationTo(t_after_parse).nanoseconds,
-                    .codegen = t_after_parse.durationTo(t_after_codegen).nanoseconds,
-                });
-            }
-        } else {
-            try stdout.print("{s}✓{s} {s}\n", .{ style.location, style.reset, src_path });
-        }
-    }
-    return true;
-}
-
-const PhaseTimings = struct {
-    include: i96,
-    parse: i96,
-    codegen: i96,
-};
 
 fn writePhaseTimings(
     stdout: *std.Io.Writer,

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -1,17 +1,18 @@
-/// `gero check` — validate a `.gas` source through the full
-/// assembler pipeline (resolveIncludes → parse → codegen) without
-/// writing a `.gx` output. Editor-LSP-style use case + CI gate
-/// covering more failure modes than `gero asm` would because the
-/// caller gets the merged diagnostics for free.
+/// `gero check` — validate one or more `.gas` sources through the
+/// full assembler pipeline (resolveIncludes → parse → codegen)
+/// without writing any `.gx`. Positional args can be individual
+/// files or directories (walked recursively for `*.gas`). Editor-
+/// LSP-style use case + CI gate.
 ///
 /// Exit codes per cli.md §3.9 + §5:
-///   - `0` clean (one-line `✓ <path>` summary, suppressed by `--quiet`)
+///   - `0` clean (every file passed)
 ///   - `1` host IO problem (file missing, unreadable, etc.)
 ///   - `2` usage error (missing positional)
-///   - `4` lint / parse / codegen error (≥ 1 diagnostic)
+///   - `4` ≥ 1 diagnostic from any file
 ///
-/// `.gr` source dispatches to a "not yet implemented" stub until
-/// the gero-lang front-end lands in v0.3 (#7).
+/// `.gr` positional paths dispatch to a "not yet implemented" stub
+/// until the gero-lang front-end lands in v0.3 (#7). Directory
+/// walks ignore `.gr` extensions entirely until then.
 const std = @import("std");
 const gero = @import("gero");
 const cli = @import("cli.zig");
@@ -19,7 +20,7 @@ const term_mod = @import("term.zig");
 const diagnostics = @import("diagnostics.zig");
 const footer = @import("footer.zig");
 
-/// Drive `gero check` end-to-end against `opts.positional()[0]`.
+/// Drive `gero check` end-to-end against `opts.positional()`.
 /// Caller owns `arena`; every allocation is short-lived.
 pub fn execute(
     io: std.Io,
@@ -31,36 +32,120 @@ pub fn execute(
     const t_start = std.Io.Timestamp.now(io, .awake);
     const positionals = opts.positional();
     if (positionals.len < 1) {
-        try term.err("gero check: missing source file path", .{});
+        try term.err("gero check: missing source file or directory path", .{});
         return 2;
-    }
-    const src_path = positionals[0];
-
-    if (std.mem.endsWith(u8, src_path, ".gr")) {
-        try term.err("gero check: .gr support lands in v0.3 (gero-lang front-end)", .{});
-        return 1;
     }
 
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
 
+    // Resolve every positional into a flat list of `.gas` files.
+    // `.gr` positionals short-circuit with the v0.3 stub before
+    // any walking happens.
+    var files: std.ArrayList([]const u8) = .empty;
+    for (positionals) |path| {
+        if (std.mem.endsWith(u8, path, ".gr")) {
+            try term.err("gero check: .gr support lands in v0.3 (gero-lang front-end)", .{});
+            return 1;
+        }
+        try collectGasFiles(io, arena, term, path, &files);
+    }
+
+    if (files.items.len == 0) {
+        try term.err("gero check: no .gas files found in the given paths", .{});
+        return 1;
+    }
+
+    const single = files.items.len == 1;
+
+    var pass: usize = 0;
+    var fail: usize = 0;
+    for (files.items) |path| {
+        const ok = try checkOne(io, arena, opts, stdout, term, style, path, single);
+        if (ok) pass += 1 else fail += 1;
+    }
+
+    // Multi-file summary line — single-file mode already shows the
+    // rich `✓ <path> (N bytes, M banks)` line per file, no need.
+    if (!single and !opts.quiet) {
+        const pass_noun: []const u8 = if (pass == 1) "file" else "files";
+        const fail_noun: []const u8 = if (fail == 1) "failure" else "failures";
+        try stdout.print(
+            "\n{s}check:{s} {d} {s} passed, {d} {s}\n",
+            .{ style.location, style.reset, pass, pass_noun, fail, fail_noun },
+        );
+    }
+    if (!opts.quiet) {
+        try footer.writeFooter(stdout, io, style, t_start, if (fail > 0) .failed else .ok);
+    }
+    return if (fail > 0) 4 else 0;
+}
+
+/// Resolve `path` into 0+ `.gas` entries appended to `out`. A
+/// directory is walked recursively; a regular file is appended as-
+/// is. Anything else (broken link, special file) emits a host IO
+/// error and propagates up.
+fn collectGasFiles(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    term: *term_mod.Term,
+    path: []const u8,
+    out: *std.ArrayList([]const u8),
+) !void {
+    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch |err| {
+        try term.err("gero check: cannot stat {s} ({s})", .{ path, @errorName(err) });
+        return error.OutOfMemory; // funnel to the only allocator error caller handles
+    };
+    if (stat.kind == .directory) {
+        var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
+            try term.err("gero check: cannot open dir {s} ({s})", .{ path, @errorName(err) });
+            return error.OutOfMemory;
+        };
+        defer dir.close(io);
+        var walker = try dir.walk(arena);
+        defer walker.deinit();
+        while (try walker.next(io)) |entry| {
+            if (entry.kind != .file) continue;
+            if (!std.mem.endsWith(u8, entry.path, ".gas")) continue;
+            const full = try std.fs.path.join(arena, &.{ path, entry.path });
+            try out.append(arena, full);
+        }
+    } else if (stat.kind == .file) {
+        try out.append(arena, try arena.dupe(u8, path));
+    } else {
+        try term.err("gero check: {s} is neither a file nor a directory", .{path});
+        return error.OutOfMemory;
+    }
+}
+
+/// Validate one `.gas` file. Returns `true` on clean check,
+/// `false` if any diagnostic was emitted. `single_mode` controls
+/// the per-file output verbosity: rich `(N bytes, M banks)` +
+/// optional per-phase timings when `true`, brief `✓ <path>` /
+/// diagnostic when `false`.
+fn checkOne(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+    style: gero.asm_.Style,
+    src_path: []const u8,
+    single_mode: bool,
+) !bool {
     const t_phase_start_include = std.Io.Timestamp.now(io, .awake);
     var fused = gero.asm_.resolveIncludes(io, arena, src_path) catch |err| {
         try term.err("gero check: cannot read {s} ({s})", .{ src_path, @errorName(err) });
-        return 1;
+        return false;
     };
     defer fused.deinit();
     const t_after_include = std.Io.Timestamp.now(io, .awake);
 
     if (fused.errors.len > 0) {
+        try stdout.print("{s}✗{s} {s}\n", .{ style.code, style.reset, src_path });
         try diagnostics.printSingle(stdout, fused.source_map, fused.errors, style);
-        try footer.writeFooter(stdout, io, style, t_start, .failed);
-        return 4;
+        return false;
     }
 
-    // Statement-level recovery means parse always returns a tree;
-    // run codegen unconditionally so codegen-only errors (E001
-    // duplicate label, E003 undefined symbol, etc.) surface in the
-    // same pass as parse errors.
     var pt = try gero.asm_.parse(arena, fused.source);
     defer pt.deinit();
     const t_after_parse = std.Io.Timestamp.now(io, .awake);
@@ -70,33 +155,33 @@ pub fn execute(
     const t_after_codegen = std.Io.Timestamp.now(io, .awake);
 
     if (pt.hasErrors() or cg.hasErrors()) {
+        try stdout.print("{s}✗{s} {s}\n", .{ style.code, style.reset, src_path });
         try diagnostics.printMerged(arena, stdout, fused.source_map, pt.errors, cg.errors, style);
-        try footer.writeFooter(stdout, io, style, t_start, .failed);
-        return 4;
+        return false;
     }
 
     if (!opts.quiet) {
-        // Mirror `gero asm`'s shape: path + parens stats + footer.
-        // No bytes are written to disk but we report what *would*
-        // have been emitted so the user has a sense of program size.
-        const loaded = gero.vm.parseGx(cg.image) catch unreachable; // allow-strict: codegen just produced these bytes — well-formed by construction
-        try stdout.print("{s}✓ {s}{s}  ({d} bytes, {d} banks)\n", .{
-            style.location,
-            src_path,
-            style.reset,
-            cg.image.len,
-            loaded.header.bank_count,
-        });
-        if (opts.verbose) {
-            try writePhaseTimings(stdout, style, .{
-                .include = t_phase_start_include.durationTo(t_after_include).nanoseconds,
-                .parse = t_after_include.durationTo(t_after_parse).nanoseconds,
-                .codegen = t_after_parse.durationTo(t_after_codegen).nanoseconds,
+        if (single_mode) {
+            const loaded = gero.vm.parseGx(cg.image) catch unreachable; // allow-strict: codegen just produced these bytes
+            try stdout.print("{s}✓ {s}{s}  ({d} bytes, {d} banks)\n", .{
+                style.location,
+                src_path,
+                style.reset,
+                cg.image.len,
+                loaded.header.bank_count,
             });
+            if (opts.verbose) {
+                try writePhaseTimings(stdout, style, .{
+                    .include = t_phase_start_include.durationTo(t_after_include).nanoseconds,
+                    .parse = t_after_include.durationTo(t_after_parse).nanoseconds,
+                    .codegen = t_after_parse.durationTo(t_after_codegen).nanoseconds,
+                });
+            }
+        } else {
+            try stdout.print("{s}✓{s} {s}\n", .{ style.location, style.reset, src_path });
         }
-        try footer.writeFooter(stdout, io, style, t_start, .ok);
     }
-    return 0;
+    return true;
 }
 
 const PhaseTimings = struct {

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -262,10 +262,11 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero test --verbose{s}          {s}# show per-test duration{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         .check => {
-            try out.print("  {s}gero check{s} <file.gas> [--quiet]\n\n", .{ a.cyan, a.reset });
+            try out.print("  {s}gero check{s} <file.gas> [--quiet] [-v]\n\n", .{ a.cyan, a.reset });
             try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
             try out.print("  {s}gero check prog.gas{s}             {s}# parse + codegen-validate, no .gx written{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero check prog.gas --quiet{s}     {s}# suppress the ok summary (exit code only){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero check prog.gas -v{s}          {s}# per-phase timings (include / parse / codegen){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         else => unreachable, // allow-strict: commandIsImplemented() filtered above
     }
@@ -308,7 +309,7 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .info => &.{ .help, .color, .no_color },
         .disasm => &.{ .help, .bank, .no_show_bytes, .check_roundtrip, .quiet, .color, .no_color },
         .test_ => &.{ .help, .verbose, .color, .no_color },
-        .check => &.{ .help, .quiet, .color, .no_color },
+        .check => &.{ .help, .quiet, .verbose, .color, .no_color },
         .compile, .bench, .fmt, .build => &.{.help},
     };
 }

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -262,9 +262,11 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero test --verbose{s}          {s}# show per-test duration{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         .check => {
-            try out.print("  {s}gero check{s} <file.gas> [--quiet] [-v]\n\n", .{ a.cyan, a.reset });
+            try out.print("  {s}gero check{s} <path...> [--quiet] [-v]\n\n", .{ a.cyan, a.reset });
             try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
             try out.print("  {s}gero check prog.gas{s}             {s}# parse + codegen-validate, no .gx written{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero check src/{s}                 {s}# walk a directory recursively for *.gas{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero check a.gas b.gas src/{s}     {s}# any mix of files and directories{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero check prog.gas --quiet{s}     {s}# suppress the ok summary (exit code only){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero check prog.gas -v{s}          {s}# per-phase timings (include / parse / codegen){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -144,8 +144,8 @@ fn commandSummary(cmd: Command) []const u8 {
 /// discoverable, but split into a separate "planned" section.
 fn commandIsImplemented(cmd: Command) bool {
     return switch (cmd) {
-        .asm_, .run, .info, .disasm, .test_ => true,
-        .compile, .bench, .fmt, .check, .build => false,
+        .asm_, .run, .info, .disasm, .test_, .check => true,
+        .compile, .bench, .fmt, .build => false,
     };
 }
 
@@ -261,6 +261,12 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero test loop{s}               {s}# only tests whose name contains 'loop'{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero test --verbose{s}          {s}# show per-test duration{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
+        .check => {
+            try out.print("  {s}gero check{s} <file.gas> [--quiet]\n\n", .{ a.cyan, a.reset });
+            try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
+            try out.print("  {s}gero check prog.gas{s}             {s}# parse + codegen-validate, no .gx written{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero check prog.gas --quiet{s}     {s}# suppress the ok summary (exit code only){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+        },
         else => unreachable, // allow-strict: commandIsImplemented() filtered above
     }
 
@@ -302,7 +308,8 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .info => &.{ .help, .color, .no_color },
         .disasm => &.{ .help, .bank, .no_show_bytes, .check_roundtrip, .quiet, .color, .no_color },
         .test_ => &.{ .help, .verbose, .color, .no_color },
-        .compile, .bench, .fmt, .check, .build => &.{.help},
+        .check => &.{ .help, .quiet, .color, .no_color },
+        .compile, .bench, .fmt, .build => &.{.help},
     };
 }
 

--- a/apps/gero-cli/diagnostics.zig
+++ b/apps/gero-cli/diagnostics.zig
@@ -25,51 +25,59 @@ pub const Keyed = struct {
     path: []const u8,
 };
 
-/// Merge parse + codegen diagnostic lists, group by file, sort
-/// each group by fused-source offset, and emit a per-file
-/// section with a Cargo-style summary header on top:
-///
-/// ```text
-/// 2 errors in 1 file
-///
-/// /path/to/file
-///   <caret-style body for each diagnostic>
-/// ```
-///
-/// `arena` owns the keyed scratch buffer. `<unknown>` (rare —
-/// source-map miss) groups last.
-pub fn printMerged(
-    arena: std.mem.Allocator,
-    stdout: *std.Io.Writer,
+/// One failed file's worth of diagnostic context — a path + the
+/// `SourceMap` the parser produced + the parse/codegen error
+/// slices. Owned by the caller's arena.
+pub const FileFailure = struct {
     source_map: gero.asm_.SourceMap,
     parse_errors: []const gero.asm_.Diagnostic,
     codegen_errors: []const gero.asm_.Diagnostic,
+};
+
+/// Render every diagnostic across one or more failed files under
+/// **a single** Cargo-style summary header. Each file's parse +
+/// codegen errors are merged, grouped by the path the source-map
+/// resolves them to (handles included-file diagnostics), and
+/// sorted within each group by fused-source offset.
+///
+/// ```text
+/// 3 errors in 2 files
+///
+/// foo.gas
+///   <caret-style body for each diagnostic>
+///
+/// bar.gas
+///   <caret-style body for each diagnostic>
+/// ```
+///
+/// Use a one-element `failures` slice for the single-file case —
+/// the header still emits cleanly.
+pub fn printAllFailures(
+    arena: std.mem.Allocator,
+    stdout: *std.Io.Writer,
     style: gero.asm_.Style,
+    failures: []const FileFailure,
 ) !void {
-    const total = parse_errors.len + codegen_errors.len;
-    const keyed = try arena.alloc(Keyed, total);
-    for (parse_errors, 0..) |d, i| keyed[i] = .{ .diag = d, .path = pathOf(source_map, d) };
-    for (codegen_errors, 0..) |d, j| keyed[parse_errors.len + j] = .{ .diag = d, .path = pathOf(source_map, d) };
-    std.mem.sort(Keyed, keyed, {}, byPathThenIndex);
+    var total: usize = 0;
+    for (failures) |f| total += f.parse_errors.len + f.codegen_errors.len;
+    try writeSummaryHeader(stdout, style, total, failures.len);
 
-    var file_count: usize = 0;
-    var prev_path: []const u8 = "";
-    for (keyed) |k| {
-        if (!std.mem.eql(u8, k.path, prev_path)) {
-            file_count += 1;
-            prev_path = k.path;
-        }
-    }
-    try writeSummaryHeader(stdout, style, total, file_count);
+    for (failures) |f| {
+        const local = f.parse_errors.len + f.codegen_errors.len;
+        const keyed = try arena.alloc(Keyed, local);
+        for (f.parse_errors, 0..) |d, i| keyed[i] = .{ .diag = d, .path = pathOf(f.source_map, d) };
+        for (f.codegen_errors, 0..) |d, j| keyed[f.parse_errors.len + j] = .{ .diag = d, .path = pathOf(f.source_map, d) };
+        std.mem.sort(Keyed, keyed, {}, byPathThenIndex);
 
-    prev_path = "";
-    for (keyed) |k| {
-        if (!std.mem.eql(u8, k.path, prev_path)) {
-            try stdout.writeByte('\n');
-            try stdout.print("{s}{s}{s}\n", .{ style.location, k.path, style.reset });
-            prev_path = k.path;
+        var prev_path: []const u8 = "";
+        for (keyed) |k| {
+            if (!std.mem.eql(u8, k.path, prev_path)) {
+                try stdout.writeByte('\n');
+                try stdout.print("{s}{s}{s}\n", .{ style.location, k.path, style.reset });
+                prev_path = k.path;
+            }
+            try gero.asm_.formatPrettyBody(stdout, f.source_map, k.diag, style);
         }
-        try gero.asm_.formatPrettyBody(stdout, source_map, k.diag, style);
     }
 }
 

--- a/apps/gero-cli/diagnostics.zig
+++ b/apps/gero-cli/diagnostics.zig
@@ -1,0 +1,137 @@
+/// Shared diagnostic-printing helpers for the CLI subcommands.
+/// Both `gero asm` and `gero check` produce the same per-file
+/// grouped output with caret snippets — this module owns that
+/// rendering so the surface stays in one place.
+const std = @import("std");
+const gero = @import("gero");
+
+/// Pretty-print a single list of diagnostics (e.g., include-phase
+/// errors) against a fused-source map. No header, no grouping —
+/// each diagnostic renders with its own caret snippet via
+/// `gero.asm_.formatPretty`.
+pub fn printSingle(
+    stdout: *std.Io.Writer,
+    source_map: gero.asm_.SourceMap,
+    errors: []const gero.asm_.Diagnostic,
+    style: gero.asm_.Style,
+) std.Io.Writer.Error!void {
+    for (errors) |d| try gero.asm_.formatPretty(stdout, source_map, d, style);
+}
+
+/// Augment each diagnostic with its resolved file path so the
+/// merged printer can group + sort by `(path, fused_index)`.
+pub const Keyed = struct {
+    diag: gero.asm_.Diagnostic,
+    path: []const u8,
+};
+
+/// Merge parse + codegen diagnostic lists, group by file, sort
+/// each group by fused-source offset, and emit a per-file
+/// section with a Cargo-style summary header on top:
+///
+/// ```text
+/// 2 errors in 1 file
+///
+/// /path/to/file
+///   <caret-style body for each diagnostic>
+/// ```
+///
+/// `arena` owns the keyed scratch buffer. `<unknown>` (rare —
+/// source-map miss) groups last.
+pub fn printMerged(
+    arena: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    source_map: gero.asm_.SourceMap,
+    parse_errors: []const gero.asm_.Diagnostic,
+    codegen_errors: []const gero.asm_.Diagnostic,
+    style: gero.asm_.Style,
+) !void {
+    const total = parse_errors.len + codegen_errors.len;
+    const keyed = try arena.alloc(Keyed, total);
+    for (parse_errors, 0..) |d, i| keyed[i] = .{ .diag = d, .path = pathOf(source_map, d) };
+    for (codegen_errors, 0..) |d, j| keyed[parse_errors.len + j] = .{ .diag = d, .path = pathOf(source_map, d) };
+    std.mem.sort(Keyed, keyed, {}, byPathThenIndex);
+
+    var file_count: usize = 0;
+    var prev_path: []const u8 = "";
+    for (keyed) |k| {
+        if (!std.mem.eql(u8, k.path, prev_path)) {
+            file_count += 1;
+            prev_path = k.path;
+        }
+    }
+    try writeSummaryHeader(stdout, style, total, file_count);
+
+    prev_path = "";
+    for (keyed) |k| {
+        if (!std.mem.eql(u8, k.path, prev_path)) {
+            try stdout.writeByte('\n');
+            try stdout.print("{s}{s}{s}\n", .{ style.location, k.path, style.reset });
+            prev_path = k.path;
+        }
+        try gero.asm_.formatPrettyBody(stdout, source_map, k.diag, style);
+    }
+}
+
+/// `<N> error(s) in <M> file(s)` summary printed above the per-
+/// file sections.
+pub fn writeSummaryHeader(
+    stdout: *std.Io.Writer,
+    style: gero.asm_.Style,
+    errors: usize,
+    files: usize,
+) std.Io.Writer.Error!void {
+    const error_noun: []const u8 = if (errors == 1) "error" else "errors";
+    const file_noun: []const u8 = if (files == 1) "file" else "files";
+    try stdout.print("{s}{d} {s}{s} in {d} {s}\n", .{ style.code, errors, error_noun, style.reset, files, file_noun });
+}
+
+/// Look up the file path the diagnostic points into. Falls back
+/// to `<unknown>` when the source-map miss (shouldn't normally
+/// happen in practice).
+pub fn pathOf(source_map: gero.asm_.SourceMap, d: gero.asm_.Diagnostic) []const u8 {
+    // @as: ParseError indexes fit in u32 — bounded by max_file_size (16 MiB) per include.zig.
+    const offset: u32 = @as(u32, @intCast(d.parse_error.index));
+    if (source_map.lookup(offset)) |loc| return loc.file.path;
+    return "<unknown>";
+}
+
+/// Sort comparator: by path lex order, then by fused-source
+/// offset within the same path. Used by `printMerged`.
+pub fn byPathThenIndex(_: void, a: Keyed, b: Keyed) bool {
+    const path_cmp = std.mem.order(u8, a.path, b.path);
+    if (path_cmp != .eq) return path_cmp == .lt;
+    return a.diag.parse_error.index < b.diag.parse_error.index;
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "diagnostics: byPathThenIndex sorts by path lex order" {
+    const a: Keyed = .{ .diag = mkDiag(0), .path = "a.gas" };
+    const b: Keyed = .{ .diag = mkDiag(0), .path = "b.gas" };
+    try testing.expect(byPathThenIndex({}, a, b));
+    try testing.expect(!byPathThenIndex({}, b, a));
+}
+
+test "diagnostics: byPathThenIndex breaks ties on parse_error.index" {
+    const a: Keyed = .{ .diag = mkDiag(5), .path = "same.gas" };
+    const b: Keyed = .{ .diag = mkDiag(10), .path = "same.gas" };
+    try testing.expect(byPathThenIndex({}, a, b));
+    try testing.expect(!byPathThenIndex({}, b, a));
+}
+
+fn mkDiag(index: u32) gero.asm_.Diagnostic {
+    return .{
+        .code = .duplicate_label,
+        .parse_error = .{
+            .parser = "test",
+            .index = index,
+            .message = "synthetic",
+            .expected = "",
+            .actual = "",
+            .kind = .semantic,
+        },
+    };
+}

--- a/apps/gero-cli/footer.zig
+++ b/apps/gero-cli/footer.zig
@@ -1,0 +1,66 @@
+/// Cargo-style elapsed-time footer printed by the long-running
+/// CLI subcommands (`gero asm`, `gero check`, …) to give a quick
+/// "how long did that take" signal. Shared so the format stays
+/// consistent across every command.
+///
+/// Output shape:
+///
+/// ```text
+///     Finished in 1.2 ms
+///     Failed in   4.1 ms
+/// ```
+///
+/// The footer label is right-padded by the caller's choice of
+/// style (`style.location` bold for ok, `style.code` red for
+/// failures).
+const std = @import("std");
+const gero = @import("gero");
+
+/// Did the command produce its artifact or bail on errors?
+pub const Outcome = enum { ok, failed };
+
+/// Write a single `Finished in …` / `Failed in …` line to `stdout`.
+pub fn writeFooter(
+    stdout: *std.Io.Writer,
+    io: std.Io,
+    style: gero.asm_.Style,
+    t_start: std.Io.Timestamp,
+    outcome: Outcome,
+) std.Io.Writer.Error!void {
+    const t_end = std.Io.Timestamp.now(io, .awake);
+    const elapsed_ns: i96 = t_start.durationTo(t_end).nanoseconds;
+    const label = switch (outcome) {
+        .ok => "    Finished in ",
+        .failed => "    Failed in ",
+    };
+    const label_style = switch (outcome) {
+        .ok => style.location, // bold — same as path headers
+        .failed => style.code, // red — same as [Exxx]
+    };
+    try stdout.print("{s}{s}{s}", .{ label_style, label, style.reset });
+    try writeDuration(stdout, elapsed_ns);
+    try stdout.writeByte('\n');
+}
+
+/// Render a wall-clock duration as `<whole>.<tenths> <unit>` with
+/// `s` / `ms` / `< 1 ms` granularity. Public so commands that want
+/// per-phase breakdowns can reuse the same rendering.
+pub fn writeDuration(stdout: *std.Io.Writer, ns: i96) std.Io.Writer.Error!void {
+    const ns_per_ms: i96 = std.time.ns_per_ms;
+    const ns_per_s: i96 = std.time.ns_per_s;
+    if (ns >= ns_per_s) {
+        // @as: caller passes a non-negative duration; the cast to
+        //      u64 just lets `{d}` format unsigned without the
+        //      leading-sign business that confuses the spec.
+        const whole: u64 = @intCast(@divFloor(ns, ns_per_s));
+        const tenths: u64 = @intCast(@divFloor(@mod(ns, ns_per_s), ns_per_ms * 100));
+        try stdout.print("{d}.{d} s", .{ whole, tenths });
+    } else if (ns >= ns_per_ms) {
+        // @as: see above — non-negative ns by construction.
+        const whole: u64 = @intCast(@divFloor(ns, ns_per_ms));
+        const tenths: u64 = @intCast(@divFloor(@mod(ns, ns_per_ms), 100_000));
+        try stdout.print("{d}.{d} ms", .{ whole, tenths });
+    } else {
+        try stdout.writeAll("< 1 ms");
+    }
+}

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -9,6 +9,7 @@ const info_cmd = @import("info.zig");
 const asm_cmd = @import("asm.zig");
 const disasm_cmd = @import("disasm.zig");
 const test_cmd = @import("test.zig");
+const check_cmd = @import("check.zig");
 
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
@@ -77,6 +78,7 @@ pub fn main(init: std.process.Init) !u8 {
         .info => infoDispatch(io, arena, parsed.options, stdout, &term),
         .disasm => disasm_cmd.execute(io, arena, parsed.options, stdout, &term),
         .test_ => test_cmd.execute(io, arena, parsed.options, stdout, &term),
+        .check => check_cmd.execute(io, arena, parsed.options, stdout, &term),
         else => blk: {
             try term.err("gero {s}: not yet implemented", .{cli.commandName(cmd)});
             break :blk 1;

--- a/build.zig
+++ b/build.zig
@@ -119,6 +119,27 @@ pub fn build(b: *std.Build) void {
         .name = "test-cli-test",
         .root_module = test_cli_mod,
     });
+    const check_cli_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/check.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    check_cli_mod.addImport("gero", gero_mod);
+    check_cli_mod.addOptions("build_options", cli_options);
+    const check_cli_test = b.addTest(.{
+        .name = "test-cli-check",
+        .root_module = check_cli_mod,
+    });
+    const diagnostics_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/diagnostics.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    diagnostics_mod.addImport("gero", gero_mod);
+    const diagnostics_test = b.addTest(.{
+        .name = "test-cli-diagnostics",
+        .root_module = diagnostics_mod,
+    });
 
     // ----- Format ----------------------------------------------------------
 
@@ -158,6 +179,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(asm_test).step);
     test_step.dependOn(&b.addRunArtifact(disasm_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(test_cli_test).step);
+    test_step.dependOn(&b.addRunArtifact(check_cli_test).step);
+    test_step.dependOn(&b.addRunArtifact(diagnostics_test).step);
     for (test_files) |rel| {
         const t = makeTest(b, gero_mod, examples_opts, rel, target, optimize);
         test_step.dependOn(&b.addRunArtifact(t).step);
@@ -260,12 +283,21 @@ pub fn build(b: *std.Build) void {
     );
     test_examples_step.dependOn(&test_examples_cmd.step);
 
+    const check_examples_cmd = b.addSystemCommand(&.{ "bash", "scripts/check-examples.sh" });
+    check_examples_cmd.step.dependOn(b.getInstallStep());
+    const check_examples_step = b.step(
+        "check-examples",
+        "Drive every examples/asm/*.gas through `gero check` (fails on any non-zero)",
+    );
+    check_examples_step.dependOn(&check_examples_cmd.step);
+
     // ----- All-in-one CI ---------------------------------------------------
 
-    const ci_step = b.step("ci", "Local equivalent of CI: lint + test-modes + test-all + test-examples");
+    const ci_step = b.step("ci", "Local equivalent of CI: lint + test-modes + test-all + check-examples + test-examples");
     ci_step.dependOn(lint_step);
     ci_step.dependOn(test_modes_step);
     ci_step.dependOn(test_all);
+    ci_step.dependOn(&check_examples_cmd.step);
     ci_step.dependOn(&test_examples_cmd.step);
 
     // ----- Changesets ------------------------------------------------------

--- a/build.zig
+++ b/build.zig
@@ -140,6 +140,16 @@ pub fn build(b: *std.Build) void {
         .name = "test-cli-diagnostics",
         .root_module = diagnostics_mod,
     });
+    const footer_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/footer.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    footer_mod.addImport("gero", gero_mod);
+    const footer_test = b.addTest(.{
+        .name = "test-cli-footer",
+        .root_module = footer_mod,
+    });
 
     // ----- Format ----------------------------------------------------------
 
@@ -181,6 +191,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(test_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(check_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(diagnostics_test).step);
+    test_step.dependOn(&b.addRunArtifact(footer_test).step);
     for (test_files) |rel| {
         const t = makeTest(b, gero_mod, examples_opts, rel, target, optimize);
         test_step.dependOn(&b.addRunArtifact(t).step);

--- a/build.zig
+++ b/build.zig
@@ -302,13 +302,22 @@ pub fn build(b: *std.Build) void {
     );
     check_examples_step.dependOn(&check_examples_cmd.step);
 
+    const check_broken_cmd = b.addSystemCommand(&.{ "bash", "scripts/check-broken.sh" });
+    check_broken_cmd.step.dependOn(b.getInstallStep());
+    const check_broken_step = b.step(
+        "check-broken",
+        "Drive every tests/asm/check-broken/*.gas through `gero check` and assert each fails",
+    );
+    check_broken_step.dependOn(&check_broken_cmd.step);
+
     // ----- All-in-one CI ---------------------------------------------------
 
-    const ci_step = b.step("ci", "Local equivalent of CI: lint + test-modes + test-all + check-examples + test-examples");
+    const ci_step = b.step("ci", "Local equivalent of CI: lint + test-modes + test-all + check-examples + check-broken + test-examples");
     ci_step.dependOn(lint_step);
     ci_step.dependOn(test_modes_step);
     ci_step.dependOn(test_all);
     ci_step.dependOn(&check_examples_cmd.step);
+    ci_step.dependOn(&check_broken_cmd.step);
     ci_step.dependOn(&test_examples_cmd.step);
 
     // ----- Changesets ------------------------------------------------------

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -274,20 +274,24 @@ gate that catches asm spec drift faster than the full assemble-and-
 run round-trip.
 
 ```bash
-gero check main.gas               # one .gas file (v0.2 — current)
+gero check main.gas               # one .gas file
+gero check src/                   # walk recursively for *.gas
+gero check a.gas b.gas src/       # any mix of files + dirs
 gero check main.gr                # → "not yet implemented" until v0.3
-gero check main.gas --quiet       # suppress ok summary; exit code only
-gero check main.gas --verbose     # per-phase timings (include / parse / codegen)
+gero check main.gas --quiet       # suppress per-file lines + summary
+gero check main.gas --verbose     # per-phase timings (single-file only)
 ```
 
 **Output (default):**
 
-- On success: `✓ <path>  (N bytes, M banks)` summary line followed
-  by a Cargo-style `Finished in X ms` footer. `--quiet` suppresses
-  both, `--verbose` adds per-phase timings between them.
-- On failure: a `<N> errors in <M> files` header, then per-file
-  caret-style diagnostics matching what `gero asm` would emit, plus
-  a `Failed in X ms` footer.
+- **Single-file pass:** `✓ <path>  (N bytes, M banks)` summary
+  followed by a Cargo-style `Finished in X ms` footer.
+  `--verbose` inserts per-phase timings between them.
+- **Multi-file:** one line per file (`✓ <path>` on success,
+  `✗ <path>` + caret-style diagnostic on failure), then a
+  `check: N files passed, M failures` line, then the footer.
+- `--quiet` suppresses per-file ok lines + the summary but keeps
+  failure diagnostics + the footer.
 
 **Exit:** `0` if clean; `4` on any diagnostic; `1` on host IO
 problem; `2` on usage error.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -287,9 +287,12 @@ gero check main.gas --verbose     # per-phase timings (single-file only)
 - **Single-file pass:** `✓ <path>  (N bytes, M banks)` summary
   followed by a Cargo-style `Finished in X ms` footer.
   `--verbose` inserts per-phase timings between them.
-- **Multi-file:** one line per file (`✓ <path>` on success,
-  `✗ <path>` + caret-style diagnostic on failure), then a
-  `check: N files passed, M failures` line, then the footer.
+- **Multi-file:** one `✓ <path>` line per successful file, then a
+  single `N errors in M files` block grouping every diagnostic
+  under per-file caret sections, then a `check: N files passed, M
+  failures` summary line, then the footer. Failures from multiple
+  files share one summary header — no per-file "1 error in 1 file"
+  noise.
 - `--quiet` suppresses per-file ok lines + the summary but keeps
   failure diagnostics + the footer.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -265,26 +265,31 @@ gero fmt src/                     # recurse into directory
 **Exit:** 0 (clean / formatted); 8 (`--check` would-modify); 3 on
 parse error in source.
 
-### 3.9 `gero check <files...>` — type-check / lint
+### 3.9 `gero check <file>` — validate without producing output
 
-Fast frontend-only path: lex + parse + type-check + lint, no codegen.
-Editor LSP-style use case.
+Run a source file through the full assembler pipeline (resolve
+includes → parse → codegen-validate) and report diagnostics
+without writing a `.gx` artifact. Editor-LSP-style use case + CI
+gate that catches asm spec drift faster than the full assemble-and-
+run round-trip.
 
 ```bash
-gero check main.gr                # one file
-gero check                        # whole project (cwd)
-gero check --format=json          # machine-readable for editor integration
+gero check main.gas               # one .gas file (v0.2 — current)
+gero check main.gr                # → "not yet implemented" until v0.3
+gero check main.gas --quiet       # suppress ok summary; exit code only
 ```
 
-**Output (default):** `<file>:<line>:<col>: <severity>: <message>`
-with caret underline.
+**Output (default):**
 
-**Output (`--format=json`):** one JSON object per diagnostic on its
-own line (jsonl), fields: `file`, `line`, `col`, `severity`,
-`message`, `code`.
+- On success: one-line `✓ <path>` summary (`--quiet` suppresses it).
+- On failure: a `<N> errors in <M> files` header, then per-file
+  caret-style diagnostics matching what `gero asm` would emit.
 
-**Exit:** 0 if clean (no errors); 4 if any errors; 1 if warnings
-only (configurable via `--werror`).
+**Exit:** `0` if clean; `4` on any diagnostic; `1` on host IO
+problem; `2` on usage error.
+
+**Roadmap:** `--format=json` for editor integration + `.gr` source
+support land alongside the lang front-end in v0.3 (#7).
 
 ### 3.10 `gero build` — build project
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -277,13 +277,17 @@ run round-trip.
 gero check main.gas               # one .gas file (v0.2 — current)
 gero check main.gr                # → "not yet implemented" until v0.3
 gero check main.gas --quiet       # suppress ok summary; exit code only
+gero check main.gas --verbose     # per-phase timings (include / parse / codegen)
 ```
 
 **Output (default):**
 
-- On success: one-line `✓ <path>` summary (`--quiet` suppresses it).
+- On success: `✓ <path>  (N bytes, M banks)` summary line followed
+  by a Cargo-style `Finished in X ms` footer. `--quiet` suppresses
+  both, `--verbose` adds per-phase timings between them.
 - On failure: a `<N> errors in <M> files` header, then per-file
-  caret-style diagnostics matching what `gero asm` would emit.
+  caret-style diagnostics matching what `gero asm` would emit, plus
+  a `Failed in X ms` footer.
 
 **Exit:** `0` if clean; `4` on any diagnostic; `1` on host IO
 problem; `2` on usage error.

--- a/scripts/check-broken.sh
+++ b/scripts/check-broken.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Sad-path companion to `check-examples.sh`. Drives every
+# `tests/asm/check-broken/*.gas` through `gero check` and asserts
+# **each one exits non-zero** with a diagnostic — verifies that
+# the validator actually catches what it's supposed to catch.
+#
+# Each fixture targets a distinct diagnostic category (lexical
+# parse error, [E001] unknown mnemonic, [E004] undefined symbol,
+# [E005] duplicate label). If any fixture starts passing the
+# check, this script fails — that's a regression in `gero check`
+# (or a fixture that's drifted into validity and needs updating).
+#
+# Env knobs:
+#   GERO_BIN       — path to the `gero` binary (default ./zig-out/bin/gero)
+#   FIXTURES_DIR   — root to walk (default tests/asm/check-broken)
+#   NO_COLOR       — disable ANSI colors (auto-off when stdout is not a TTY)
+#
+# Exit codes:
+#   0 — every fixture failed as expected
+#   1 — at least one fixture unexpectedly passed, or a precondition missing
+
+set -euo pipefail
+
+GERO_BIN="${GERO_BIN:-./zig-out/bin/gero}"
+FIXTURES_DIR="${FIXTURES_DIR:-tests/asm/check-broken}"
+
+if [[ ! -x "$GERO_BIN" ]]; then
+    printf 'check-broken: %s not found — run `zig build install` first\n' "$GERO_BIN" >&2
+    exit 1
+fi
+
+if [[ ! -d "$FIXTURES_DIR" ]]; then
+    printf 'check-broken: %s missing\n' "$FIXTURES_DIR" >&2
+    exit 1
+fi
+
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    GREEN=$'\033[32m'; RED=$'\033[31m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+    GREEN=''; RED=''; BOLD=''; RESET=''
+fi
+
+mapfile -t -d '' fixtures < <(find "$FIXTURES_DIR" -type f -name '*.gas' -print0 | sort -z)
+
+if [[ ${#fixtures[@]} -eq 0 ]]; then
+    printf 'check-broken: no .gas fixtures under %s\n' "$FIXTURES_DIR" >&2
+    exit 1
+fi
+
+caught=0; missed=0
+for gas in "${fixtures[@]}"; do
+    rel="${gas#$FIXTURES_DIR/}"
+    printf '  %-32s ... ' "$rel"
+
+    rc=0
+    "$GERO_BIN" check --quiet "$gas" >/dev/null 2>&1 || rc=$?
+    if (( rc == 0 )); then
+        printf '%sMISSED%s (gero check passed, expected failure)\n' "$RED" "$RESET"
+        missed=$((missed+1))
+    else
+        printf '%scaught%s (exit=%d)\n' "$GREEN" "$RESET" "$rc"
+        caught=$((caught+1))
+    fi
+done
+
+printf '\n%scheck-broken:%s %d caught, %d missed\n' "$BOLD" "$RESET" "$caught" "$missed"
+if (( missed > 0 )); then
+    exit 1
+fi

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Drive every `examples/asm/*.gas` (recursive) through `gero check`
+# and fail on any non-zero exit. Lighter sibling of `test-examples`:
+# no assemble/run/diff, just parse + codegen-validate. Catches asm
+# spec drift faster than the round-trip pipeline.
+#
+# Env knobs:
+#   GERO_BIN       — path to the `gero` binary (default ./zig-out/bin/gero)
+#   EXAMPLES_DIR   — root to walk for *.gas (default examples/asm)
+#   NO_COLOR       — disable ANSI colors (auto-off when stdout is not a TTY)
+#
+# Exit codes:
+#   0 — every example checked clean
+#   1 — at least one example failed, or a precondition is missing
+
+set -euo pipefail
+
+GERO_BIN="${GERO_BIN:-./zig-out/bin/gero}"
+EXAMPLES_DIR="${EXAMPLES_DIR:-examples/asm}"
+
+if [[ ! -x "$GERO_BIN" ]]; then
+    printf 'check-examples: %s not found — run `zig build install` first\n' "$GERO_BIN" >&2
+    exit 1
+fi
+
+if [[ ! -d "$EXAMPLES_DIR" ]]; then
+    printf 'check-examples: %s missing\n' "$EXAMPLES_DIR" >&2
+    exit 1
+fi
+
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    GREEN=$'\033[32m'; RED=$'\033[31m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+    GREEN=''; RED=''; BOLD=''; RESET=''
+fi
+
+mapfile -t -d '' gas_files < <(find "$EXAMPLES_DIR" -type f -name '*.gas' -print0 | sort -z)
+
+if [[ ${#gas_files[@]} -eq 0 ]]; then
+    printf 'check-examples: no .gas files under %s\n' "$EXAMPLES_DIR" >&2
+    exit 1
+fi
+
+pass=0; fail=0
+for gas in "${gas_files[@]}"; do
+    rel="${gas#$EXAMPLES_DIR/}"
+    printf '  %-24s ... ' "$rel"
+
+    rc=0
+    out="$("$GERO_BIN" check --quiet "$gas" 2>&1)" || rc=$?
+    if (( rc != 0 )); then
+        printf '%sFAIL%s (exit=%d)\n' "$RED" "$RESET" "$rc"
+        if [[ -n "$out" ]]; then
+            printf '%s\n' "$out" | sed 's/^/      /'
+        fi
+        fail=$((fail+1))
+        continue
+    fi
+
+    printf '%sok%s\n' "$GREEN" "$RESET"
+    pass=$((pass+1))
+done
+
+printf '\n%scheck-examples:%s %d passed, %d failed\n' "$BOLD" "$RESET" "$pass" "$fail"
+if (( fail > 0 )); then
+    exit 1
+fi

--- a/tests/asm/check-broken/duplicate-label.gas
+++ b/tests/asm/check-broken/duplicate-label.gas
@@ -1,0 +1,9 @@
+; duplicate-label.gas — same global label declared twice.
+; Expected: `gero check` exits 4 with an [E005] "duplicate label"
+; diagnostic on the second definition.
+
+main:
+  hlt
+
+main:
+  hlt

--- a/tests/asm/check-broken/parse-error.gas
+++ b/tests/asm/check-broken/parse-error.gas
@@ -1,0 +1,5 @@
+; parse-error.gas — invalid hex literal triggers the parser's
+; lexical-error path. Expected: `gero check` exits 4 with an
+; "expected 1-4 hex digits" diagnostic pointing at column 12.
+
+const A = $XYZ

--- a/tests/asm/check-broken/undefined-symbol.gas
+++ b/tests/asm/check-broken/undefined-symbol.gas
@@ -1,0 +1,7 @@
+; undefined-symbol.gas — operand references a symbol with no
+; declaration. Expected: `gero check` exits 4 with an [E004]
+; "undefined symbol" diagnostic on `@nope`.
+
+main:
+  mov @nope, r1
+  hlt

--- a/tests/asm/check-broken/unknown-mnemonic.gas
+++ b/tests/asm/check-broken/unknown-mnemonic.gas
@@ -1,0 +1,7 @@
+; unknown-mnemonic.gas — opcode the resolver doesn't recognize.
+; Expected: `gero check` exits 4 with an [E001] "unknown mnemonic"
+; diagnostic pointing at `badop`.
+
+main:
+  badop r1
+  hlt


### PR DESCRIPTION
## Summary

`gero check <file.gas>` ships — runs the full assembler pipeline (resolve includes → parse → codegen-validate) without writing a `.gx`. Faster CI gate than `test-examples` for spec-drift detection, foundation for the editor-LSP path in #122.

## Behavior

- `gero check examples/asm/hello.gas` → exit 0, `✓ <path>` summary
- `--quiet` suppresses the ok line (exit code only)
- Broken `.gas` → exit 4 with caret-style merged parse + codegen diagnostics
- `.gr` source → exit 1 with "not yet implemented" stub (lights up with #7 in v0.3)

## What's new

- `apps/gero-cli/check.zig` — new subcommand impl
- `apps/gero-cli/diagnostics.zig` — extracted the shared diagnostic-printing helpers that `gero asm` had as file-private. Both subcommands now route through it. Includes unit tests for the `byPathThenIndex` sort comparator.
- `scripts/check-examples.sh` + `zig build check-examples` step — drives every `examples/asm/*.gas` (including banks/ fragments) through `gero check --quiet`. Wired into `zig build ci`.
- `docs/cli.md` §3.9 updated to reflect v0.2 shipped behavior + v0.3 roadmap (the spec was forward-looking; now matches reality).

## Self-review

- Step 1 — issue #116 AC: ✓ exit 0 with ok summary, ✓ exit 4 with knit diagnostics on broken source, ✓ multi-error in one pass, ✓ CLI help + docs/cli.md updated, ✓ strict-mode + doc-comments, ✓ changeset added, ✓ wired into \`zig build check-examples\`
- Step 2 — \`zig build ci\` local: EXIT=0 (lint + test-modes + test-all + check-examples + test-examples — 7/7 asm examples check clean)
- Step 3 — diff walk (9 files, ~360 lines): zero findings. New \`@as\` in diagnostics.zig has its \`// @as:\` justification; no anyerror; doc comments on every pub
- Step 4 — hygiene: conventional commit \`feat(apps/gero-cli)\`, no AI attribution, changeset (patch), README unchanged (CLI not user-facing in README until #114 docs polish)

Closes #116.