### PR TITLE
feat(apps/gero-cli): gero fmt — canonical .gas formatter

### DIFF
--- a/.changeset/cli-fmt.md
+++ b/.changeset/cli-fmt.md
@@ -1,0 +1,22 @@
+---
+bump: patch
+---
+
+`gero fmt <file.gas | dir>` ships — canonical formatter for `.gas`
+source. Parses each file directly (no include resolution → `include
+"..."` lines round-trip verbatim), re-emits through the v0.2 asm
+printer, compares against the source, and either rewrites in-place
+or reports diffs.
+
+Modes:
+
+- Default — rewrite each file in place if not canonical. Per-file
+  `✓ <path>` (unchanged) / `↻ <path> (reformatted)` line.
+- `--check` — non-destructive. Exits 8 on any would-reformat (CI
+  gate use case).
+- Directory positionals recurse for `*.gas`. Multi-path mixing
+  files and dirs works (`gero fmt a.gas b.gas src/`).
+
+Exit codes per cli.md §3.8 + §5: `0` clean, `8` `--check`-and-
+would-modify, `3` genuine parse error, `1` host IO, `2` usage.
+`.gr` sources stub "not yet implemented" until v0.3.

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -56,6 +56,10 @@ pub const Options = struct {
     /// success aside from a one-line ok summary (suppressed by
     /// `--quiet`). Intended for CI use against shipped examples.
     check_roundtrip: bool = false,
+    /// `--check` for `gero fmt` — non-destructive mode. Reports
+    /// files that would be reformatted (exit 8) without writing.
+    /// Editor / CI use case.
+    check: bool = false,
     positional_buf: [max_positionals][]const u8 = undefined,
     positional_count: usize = 0,
 
@@ -144,8 +148,8 @@ fn commandSummary(cmd: Command) []const u8 {
 /// discoverable, but split into a separate "planned" section.
 fn commandIsImplemented(cmd: Command) bool {
     return switch (cmd) {
-        .asm_, .run, .info, .disasm, .test_, .check => true,
-        .compile, .bench, .fmt, .build => false,
+        .asm_, .run, .info, .disasm, .test_, .check, .fmt => true,
+        .compile, .bench, .build => false,
     };
 }
 
@@ -270,6 +274,13 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero check prog.gas --quiet{s}     {s}# suppress the ok summary (exit code only){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero check prog.gas -v{s}          {s}# per-phase timings (include / parse / codegen){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
+        .fmt => {
+            try out.print("  {s}gero fmt{s} <path...> [--check] [--quiet]\n\n", .{ a.cyan, a.reset });
+            try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
+            try out.print("  {s}gero fmt prog.gas{s}               {s}# rewrite in place if not canonical{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero fmt src/{s}                   {s}# recurse + format every .gas{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero fmt --check src/{s}           {s}# CI mode — exit 8 if any file would change{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+        },
         else => unreachable, // allow-strict: commandIsImplemented() filtered above
     }
 
@@ -298,6 +309,7 @@ fn flagHelpLine(kind: FlagKind) FlagHelpLine {
         .show_bytes => .{ .sig = "--show-bytes", .desc = "(default) Show the hex-bytes column." },
         .no_show_bytes => .{ .sig = "--no-show-bytes", .desc = "Strip the hex-bytes column for a cleaner view." },
         .check_roundtrip => .{ .sig = "--check-roundtrip", .desc = "Verify asm → disasm → asm yields identical bytes (CI gate)." },
+        .check => .{ .sig = "--check", .desc = "Non-destructive — exit 8 if any file would be reformatted." },
     };
 }
 
@@ -312,7 +324,8 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .disasm => &.{ .help, .bank, .no_show_bytes, .check_roundtrip, .quiet, .color, .no_color },
         .test_ => &.{ .help, .verbose, .color, .no_color },
         .check => &.{ .help, .quiet, .verbose, .color, .no_color },
-        .compile, .bench, .fmt, .build => &.{.help},
+        .fmt => &.{ .help, .check, .quiet, .color, .no_color },
+        .compile, .bench, .build => &.{.help},
     };
 }
 
@@ -335,7 +348,7 @@ fn parseColor(s: []const u8) ParseError!ColorChoice {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip };
+const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
@@ -350,6 +363,7 @@ fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "show-bytes")) return .show_bytes;
     if (std.mem.eql(u8, s, "no-show-bytes")) return .no_show_bytes;
     if (std.mem.eql(u8, s, "check-roundtrip")) return .check_roundtrip;
+    if (std.mem.eql(u8, s, "check")) return .check;
     return null;
 }
 
@@ -378,6 +392,7 @@ fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void
         .show_bytes => opts.show_bytes = true,
         .no_show_bytes => opts.show_bytes = false,
         .check_roundtrip => opts.check_roundtrip = true,
+        .check => opts.check = true,
     }
 }
 

--- a/apps/gero-cli/fmt.zig
+++ b/apps/gero-cli/fmt.zig
@@ -1,0 +1,316 @@
+/// `gero fmt` — canonical formatter for `.gas` (and eventually
+/// `.gr`) source. Parses the file directly (without resolving
+/// includes), re-emits through `gero.asm_.printProgram`, and
+/// either writes in-place or reports `--check` diffs.
+///
+/// Exit codes per cli.md §3.8 + §5:
+///   - `0` every file is canonical (or was just made canonical)
+///   - `1` host IO problem
+///   - `2` usage error
+///   - `3` parse error in source
+///   - `8` `--check` mode and at least one file would change
+///
+/// `.gr` sources route to a "not yet implemented" stub until v0.3
+/// wires the gero-lang front-end.
+///
+/// Notes
+/// -----
+/// The parser is invoked **without** `resolveIncludes`, so the file
+/// is formatted as-written — `include "..."` lines round-trip
+/// verbatim (the parser surfaces them as `unknown` statements, the
+/// printer source-slices them back). Cross-file validation is the
+/// job of `gero check`, not `gero fmt`.
+const std = @import("std");
+const gero = @import("gero");
+const cli = @import("cli.zig");
+const term_mod = @import("term.zig");
+const footer = @import("footer.zig");
+
+/// Per-file outcome.
+const Outcome = enum {
+    /// File was already canonical (`--check` or normal mode).
+    unchanged,
+    /// File needed reformatting; in normal mode it was rewritten
+    /// in place, in `--check` mode the diff was recorded.
+    would_change,
+    /// Parse error before we could format — diagnostic was emitted.
+    parse_error,
+};
+
+pub fn execute(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+) !u8 {
+    const t_start = std.Io.Timestamp.now(io, .awake);
+    const positionals = opts.positional();
+    if (positionals.len < 1) {
+        try term.err("gero fmt: missing source file or directory path", .{});
+        return 2;
+    }
+
+    const style: gero.asm_.Style = if (term.color) .ansi else .plain;
+
+    var files: std.ArrayList([]const u8) = .empty;
+    for (positionals) |path| {
+        if (std.mem.endsWith(u8, path, ".gr")) {
+            try term.err("gero fmt: .gr support lands in v0.3 (gero-lang front-end)", .{});
+            return 1;
+        }
+        try collectGasFiles(io, arena, term, path, &files);
+    }
+    if (files.items.len == 0) {
+        try term.err("gero fmt: no .gas files found in the given paths", .{});
+        return 1;
+    }
+
+    const single = files.items.len == 1;
+
+    var unchanged: usize = 0;
+    var changed: usize = 0;
+    var parse_failed: usize = 0;
+    for (files.items) |path| {
+        const outcome = formatOne(io, arena, stdout, term, style, path, opts.check, single, opts.quiet) catch |err| {
+            try term.err("gero fmt: cannot read/write {s} ({s})", .{ path, @errorName(err) });
+            return 1;
+        };
+        switch (outcome) {
+            .unchanged => unchanged += 1,
+            .would_change => changed += 1,
+            .parse_error => parse_failed += 1,
+        }
+    }
+
+    if (!single and !opts.quiet) {
+        try writeSummary(stdout, style, unchanged, changed, parse_failed, opts.check);
+    }
+    if (!opts.quiet) {
+        const final_outcome: footer.Outcome = if (parse_failed > 0 or (opts.check and changed > 0)) .failed else .ok;
+        try footer.writeFooter(stdout, io, style, t_start, final_outcome);
+    }
+
+    if (parse_failed > 0) return 3;
+    if (opts.check and changed > 0) return 8;
+    return 0;
+}
+
+fn formatOne(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+    style: gero.asm_.Style,
+    path: []const u8,
+    check_mode: bool,
+    single: bool,
+    quiet: bool,
+) !Outcome {
+    const src = try std.Io.Dir.cwd().readFileAlloc(io, path, arena, .unlimited);
+
+    var pt = try gero.asm_.parse(arena, src);
+
+    // The parser emits a spurious diagnostic for every `include
+    // "..."` line because string literals aren't a valid operand
+    // shape — but parser recovery still produces an `unknown`
+    // statement covering the whole line, which the printer source-
+    // slices back verbatim. Filter those false positives so fmt
+    // can round-trip include-using files cleanly. Genuine syntax
+    // errors stay surfaced.
+    var real_errors: std.ArrayList(gero.asm_.Diagnostic) = .empty;
+    for (pt.errors) |d| {
+        if (!errorIsFromIncludeLine(src, d)) try real_errors.append(arena, d);
+    }
+    if (real_errors.items.len > 0) {
+        try printParseErrors(stdout, style, path, src, real_errors.items);
+        return .parse_error;
+    }
+
+    // Re-emit through the canonical printer, then compare bytes
+    // against the source. Equal → already canonical.
+    var allocating = std.Io.Writer.Allocating.init(arena);
+    try gero.asm_.printProgram(&allocating.writer, &pt.program, src, gero.asm_.default_print_options);
+    const formatted = allocating.written();
+
+    if (std.mem.eql(u8, src, formatted)) {
+        if (!quiet) try stdout.print("{s}✓{s} {s}\n", .{ style.location, style.reset, path });
+        _ = single;
+        return .unchanged;
+    }
+
+    if (check_mode) {
+        try stdout.print("{s}✗{s} {s} (would reformat)\n", .{ style.code, style.reset, path });
+        return .would_change;
+    }
+
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = formatted }) catch |err| {
+        try term.err("gero fmt: cannot write {s} ({s})", .{ path, @errorName(err) });
+        return err;
+    };
+    if (!quiet) try stdout.print("{s}↻{s} {s} (reformatted)\n", .{ style.gutter, style.reset, path });
+    return .would_change;
+}
+
+/// Resolve `path` into 0+ `.gas` entries appended to `out`.
+/// Mirrors the same helper in `check.zig` (split into a shared
+/// module later if more commands grow it).
+fn collectGasFiles(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    term: *term_mod.Term,
+    path: []const u8,
+    out: *std.ArrayList([]const u8),
+) !void {
+    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch |err| {
+        try term.err("gero fmt: cannot stat {s} ({s})", .{ path, @errorName(err) });
+        return error.OutOfMemory;
+    };
+    if (stat.kind == .directory) {
+        var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
+            try term.err("gero fmt: cannot open dir {s} ({s})", .{ path, @errorName(err) });
+            return error.OutOfMemory;
+        };
+        defer dir.close(io);
+        var walker = try dir.walk(arena);
+        defer walker.deinit();
+        while (try walker.next(io)) |entry| {
+            if (entry.kind != .file) continue;
+            if (!std.mem.endsWith(u8, entry.path, ".gas")) continue;
+            const full = try std.fs.path.join(arena, &.{ path, entry.path });
+            try out.append(arena, full);
+        }
+    } else if (stat.kind == .file) {
+        try out.append(arena, try arena.dupe(u8, path));
+    } else {
+        try term.err("gero fmt: {s} is neither a file nor a directory", .{path});
+        return error.OutOfMemory;
+    }
+}
+
+/// Plain `<path>:<line>:<col>: <message>` parse-error report.
+/// No caret style — building a SourceMap for a non-include-resolved
+/// file isn't worth the complexity. `gero check` does the caret
+/// version against the full include graph.
+fn printParseErrors(
+    stdout: *std.Io.Writer,
+    style: gero.asm_.Style,
+    path: []const u8,
+    src: []const u8,
+    errors: []const gero.asm_.Diagnostic,
+) !void {
+    for (errors) |d| {
+        // @as: ParseError.index is `usize`; widening to u32 for the
+        //      lineCol scan is safe — file size capped at 16 MiB.
+        const lc = lineColAt(src, @as(u32, @intCast(d.parse_error.index)));
+        try stdout.print("{s}{s}:{d}:{d}{s}: {s}\n", .{
+            style.location,
+            path,
+            lc.line,
+            lc.col,
+            style.reset,
+            d.parse_error.message,
+        });
+    }
+}
+
+/// True when the diagnostic at `d.parse_error.index` points into
+/// a source line whose first non-whitespace tokens are `include`.
+/// The parser flags every `include "..."` as a spurious diagnostic
+/// because string-literal operands aren't part of the instruction
+/// grammar; for fmt we ignore those since the unknown-statement
+/// recovery preserves the line via source-slice.
+fn errorIsFromIncludeLine(src: []const u8, d: gero.asm_.Diagnostic) bool {
+    // @as: ParseError.index fits in u32 — file size capped at 16 MiB.
+    var i: usize = @as(u32, @intCast(d.parse_error.index));
+    while (i > 0 and src[i - 1] != '\n') i -= 1;
+    while (i < src.len and (src[i] == ' ' or src[i] == '\t')) i += 1;
+    const kw = "include";
+    return i + kw.len <= src.len and std.mem.eql(u8, src[i .. i + kw.len], kw);
+}
+
+const LineCol = struct { line: usize, col: usize };
+
+fn lineColAt(src: []const u8, index: u32) LineCol {
+    var line: usize = 1;
+    var col: usize = 1;
+    var i: usize = 0;
+    // @as: ParseError index fits in u32 — bounded by max_file_size.
+    const target: usize = @as(usize, index);
+    while (i < src.len and i < target) : (i += 1) {
+        if (src[i] == '\n') {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    return .{ .line = line, .col = col };
+}
+
+fn writeSummary(
+    stdout: *std.Io.Writer,
+    style: gero.asm_.Style,
+    unchanged: usize,
+    changed: usize,
+    parse_failed: usize,
+    check_mode: bool,
+) !void {
+    const change_verb: []const u8 = if (check_mode) "would reformat" else "reformatted";
+    try stdout.print(
+        "\n{s}fmt:{s} {d} unchanged, {d} {s}",
+        .{ style.location, style.reset, unchanged, changed, change_verb },
+    );
+    if (parse_failed > 0) {
+        try stdout.print(", {d} parse failed", .{parse_failed});
+    }
+    try stdout.writeByte('\n');
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "fmt: lineColAt counts lines + cols from byte offset" {
+    const src = "line1\nline2\nline3";
+    try testing.expectEqual(LineCol{ .line = 1, .col = 1 }, lineColAt(src, 0));
+    try testing.expectEqual(LineCol{ .line = 1, .col = 6 }, lineColAt(src, 5));
+    try testing.expectEqual(LineCol{ .line = 2, .col = 1 }, lineColAt(src, 6));
+    try testing.expectEqual(LineCol{ .line = 3, .col = 3 }, lineColAt(src, 14));
+}
+
+test "fmt: errorIsFromIncludeLine recognizes include directives" {
+    const src =
+        \\const X = $10
+        \\
+        \\include "foo.gas"
+        \\  include "bar.gas"
+        \\not_an_include "x"
+    ;
+
+    const at_include = mkDiag(15); // points into the `include` line
+    try testing.expect(errorIsFromIncludeLine(src, at_include));
+
+    const at_indented_include = mkDiag(33); // points into "  include"
+    try testing.expect(errorIsFromIncludeLine(src, at_indented_include));
+
+    const at_other = mkDiag(53); // points into "not_an_include"
+    try testing.expect(!errorIsFromIncludeLine(src, at_other));
+
+    const at_const = mkDiag(0); // points into "const X"
+    try testing.expect(!errorIsFromIncludeLine(src, at_const));
+}
+
+fn mkDiag(index: u32) gero.asm_.Diagnostic {
+    return .{
+        .code = .duplicate_label,
+        .parse_error = .{
+            .parser = "test",
+            .index = index,
+            .message = "synthetic",
+            .expected = "",
+            .actual = "",
+            .kind = .semantic,
+        },
+    };
+}

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -10,6 +10,7 @@ const asm_cmd = @import("asm.zig");
 const disasm_cmd = @import("disasm.zig");
 const test_cmd = @import("test.zig");
 const check_cmd = @import("check.zig");
+const fmt_cmd = @import("fmt.zig");
 
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
@@ -79,6 +80,7 @@ pub fn main(init: std.process.Init) !u8 {
         .disasm => disasm_cmd.execute(io, arena, parsed.options, stdout, &term),
         .test_ => test_cmd.execute(io, arena, parsed.options, stdout, &term),
         .check => check_cmd.execute(io, arena, parsed.options, stdout, &term),
+        .fmt => fmt_cmd.execute(io, arena, parsed.options, stdout, &term),
         else => blk: {
             try term.err("gero {s}: not yet implemented", .{cli.commandName(cmd)});
             break :blk 1;

--- a/build.zig
+++ b/build.zig
@@ -130,6 +130,17 @@ pub fn build(b: *std.Build) void {
         .name = "test-cli-check",
         .root_module = check_cli_mod,
     });
+    const fmt_cli_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/fmt.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    fmt_cli_mod.addImport("gero", gero_mod);
+    fmt_cli_mod.addOptions("build_options", cli_options);
+    const fmt_cli_test = b.addTest(.{
+        .name = "test-cli-fmt",
+        .root_module = fmt_cli_mod,
+    });
     const diagnostics_mod = b.createModule(.{
         .root_source_file = b.path("apps/gero-cli/diagnostics.zig"),
         .target = target,
@@ -190,6 +201,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(disasm_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(test_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(check_cli_test).step);
+    test_step.dependOn(&b.addRunArtifact(fmt_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(diagnostics_test).step);
     test_step.dependOn(&b.addRunArtifact(footer_test).step);
     for (test_files) |rel| {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -244,26 +244,33 @@ debug:       yes (symbols: 142)
 
 ### 3.8 `gero fmt <files...>` — format source
 
-Canonical formatter for `.gas` and `.gr`. Style is fixed (no config
-file — like `gofmt` / `zig fmt`).
+Canonical formatter for `.gas` (and eventually `.gr`). Style is
+fixed — no config file, no flags (like `gofmt` / `zig fmt`).
 
 ```bash
-gero fmt main.gr                  # format in place
-gero fmt --check main.gr          # check only (exit 8 if changes needed)
-gero fmt --stdin < input.gr       # read stdin, write stdout
+gero fmt main.gas                 # format in place
+gero fmt --check main.gas         # check only (exit 8 if changes needed)
 gero fmt src/                     # recurse into directory
+gero fmt a.gas b.gas src/         # any mix of files and directories
 ```
 
 **Behavior:**
-- In-place edit by default; preserves file mode + timestamps where
-  possible.
-- `--check` exits 0 if file is already formatted, 8 if it would
-  change. CI use case.
-- Recurses into directories, formats every `.gas` and `.gr` it
-  finds.
+- In-place edit by default. Files already in canonical form are
+  left untouched.
+- `--check` is non-destructive: exits 0 if every file is canonical,
+  8 if any file would be reformatted, 3 on a genuine parse error.
+  CI use case.
+- Recurses into directories, formats every `.gas` found. `.gr`
+  sources route to "not yet implemented" until v0.3 wires the
+  gero-lang front-end.
+- `include "..."` directives round-trip verbatim — fmt doesn't
+  expand includes (that's `gero asm`'s job).
 
 **Exit:** 0 (clean / formatted); 8 (`--check` would-modify); 3 on
-parse error in source.
+parse error; 1 on host IO; 2 on usage.
+
+**Roadmap:** `--stdin` (read stdin, write stdout — editor format-
+on-save) lands alongside the LSP server (#122 / v0.3).
 
 ### 3.9 `gero check <file>` — validate without producing output
 


### PR DESCRIPTION
## Summary

`gero fmt <file.gas | dir>` ships — drives each source through the v0.2 asm printer (#115) and either rewrites in place or reports `--check` diffs. Companion to `gero check` (#116).

## Demo

```
$ gero fmt --check examples/asm/
✗ examples/asm/fib.gas (would reformat)
✗ examples/asm/counter.gas (would reformat)
✗ examples/asm/hello.gas (would reformat)
✗ examples/asm/banks/main.gas (would reformat)
...

fmt: 0 unchanged, 7 would reformat
    Failed in < 1 ms
$ echo $?
8

$ gero fmt examples/asm/hello.gas
↻ examples/asm/hello.gas (reformatted)
    Finished in < 1 ms

$ gero fmt --check examples/asm/hello.gas
✓ examples/asm/hello.gas
    Finished in < 1 ms
$ echo $?
0
```

Idempotent: a second `--check` after the first reformat reports clean.

## Design choices

- **Parses without `resolveIncludes`** so include lines round-trip verbatim. The parser surfaces `include "..."` as `unknown` statements (string-literal operands aren't part of the instruction grammar); the printer source-slices them back. Spurious parse errors those lines emit are filtered via `errorIsFromIncludeLine`. Cross-file validation stays `gero check`'s job.
- **Plain line:col error format** for parse errors (no caret). Building a SourceMap for a non-include-resolved file isn't worth the complexity; `gero check` does the caret version against the full include graph.
- **New `--check` flag** in `cli.Options` + parsing wiring. Reusable later for other commands (e.g., `gero compile --check` once lang lands).

## Self-review

- Step 1 — issue #117 AC: ✓ in-place rewrite, ✓ `--check` exits 8 on diff, ✓ multi-file + directory recursion, ✓ idempotence verified, ✓ help text + cli.md §3.8 updated, ✓ changeset. **Deferred** (legit scope of other issues): CI/lefthook wiring → #118; `docs/asm.md` canonical-style section → #124-127 docs polish; `--stdin` mode → #122 alongside LSP.
- Step 2 — \`zig build ci\` local: EXIT=0
- Step 3 — diff walk: 2 \`@as\` casts both with justifications; doc comments on every pub; \`errorIsFromIncludeLine\` + \`lineColAt\` unit-tested; \`include\` round-trip verified on banks/main.gas
- Step 4 — hygiene: \`feat(apps/gero-cli)\`, no AI attribution, changeset (patch), README unchanged (CLI not in README until #114 docs polish)

## Known limitation

`examples/asm/*.gas` aren't canonically formatted (hand-written alignment) and would reformat under `gero fmt`. Not auto-canonicalizing in this PR — opt-in via `gero fmt examples/asm/` when desired.

Closes #117.