### PR TITLE
feat(asm): gero fmt ignore directives — preserve hand-formatted regions

### DIFF
--- a/.changeset/fmt-ignore-directives.md
+++ b/.changeset/fmt-ignore-directives.md
@@ -1,0 +1,30 @@
+---
+bump: patch
+---
+
+`gero fmt` now respects `; gero-fmt-ignore-*` directives — same
+opt-out pattern as `// prettier-ignore` / `#[rustfmt::skip]` —
+letting users preserve hand-formatted regions through the
+canonicalizer:
+
+- `; gero-fmt-ignore-file` in the leading comment block → fmt is
+  a no-op on the whole file
+- `; gero-fmt-ignore-start` … `; gero-fmt-ignore-end` → statements
+  between the markers are source-sliced verbatim
+- `; gero-fmt-ignore-next` → the immediately following non-comment
+  statement is preserved
+- trailing `; gero-fmt-ignore` on the same source line as a
+  statement → that line is preserved (alignment + trailing comment
+  both stay intact)
+
+The directives are idempotent across re-formats. Concretely, this
+means `examples/asm/*.gas` can keep their hand-tuned `const`-block
+alignment by adding `; gero-fmt-ignore-file` at the top — opt-in
+per file.
+
+Required a parallel fix to `src/asm/expr.zig::skipBlanks` so it
+stops at `;` instead of silently eating trailing comments mid-
+expression (previously, trailing comments after a `const` RHS or
+inside `data8`-list expressions were dropped before reaching the
+AST). The parser's outer loop now captures them as first-class
+`Comment` statements.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -272,6 +272,28 @@ parse error; 1 on host IO; 2 on usage.
 **Roadmap:** `--stdin` (read stdin, write stdout — editor format-
 on-save) lands alongside the LSP server (#122 / v0.3).
 
+#### Ignore directives
+
+Drop these `;` comments to opt regions out of canonicalization
+(same pattern as `// prettier-ignore` / `#[rustfmt::skip]`):
+
+```asm
+; gero-fmt-ignore-file
+; (rest of file passed through verbatim)
+
+; gero-fmt-ignore-next
+const PRINT   = $10              ; only this line preserved
+
+; gero-fmt-ignore-start
+const PRINT   = $10
+const NEWLINE = $0A
+; gero-fmt-ignore-end             ; everything between markers preserved
+
+const FOO = $20  ; gero-fmt-ignore   ; this single line preserved (trailing)
+```
+
+The directive comments themselves stay in the output.
+
 ### 3.9 `gero check <file>` — validate without producing output
 
 Run a source file through the full assembler pipeline (resolve

--- a/src/asm/expr.zig
+++ b/src/asm/expr.zig
@@ -541,15 +541,15 @@ fn spanFrom(start: usize, end: usize) ast.Span {
     return .{ .start = @intCast(start), .end = @intCast(end) };
 }
 
-/// Skip ASCII whitespace + `;`-comments. Doesn't cross newlines
-/// (those terminate the expression).
+/// Skip ASCII whitespace. Stops at `;` so the caller's outer
+/// loop can capture trailing comments as first-class `Comment`
+/// statements (the parser surfaces them for the pretty-printer
+/// to round-trip).
 fn skipBlanks(state: *core.ParseState) void {
     while (state.index < state.input.len) {
         const b = state.input[state.index];
         if (b == ' ' or b == '\t') {
             state.advance(1);
-        } else if (b == ';') {
-            while (state.index < state.input.len and state.input[state.index] != '\n') state.advance(1);
         } else {
             break;
         }

--- a/src/asm/printer.zig
+++ b/src/asm/printer.zig
@@ -81,21 +81,19 @@ pub fn print(
 
         const directive = directiveOf(stmt, source);
 
-        // Detect a trailing-ignore directive on the *next* statement.
-        // When present, the host statement's protection extends to
-        // cover the trailing comment too — we source-slice through
-        // its end and skip the comment on the next loop iteration,
-        // so the line stays glued together (and idempotent across
-        // re-formats — second pass sees the same shape).
-        const trailing_ignore_comment: ?ast.Statement = blk: {
+        // Any comment on the same source line as this statement —
+        // either the trailing-ignore directive itself, or a regular
+        // note that we want to glue to a separately-protected line.
+        const trailing_comment: ?ast.Statement = blk: {
             if (stmt == .comment) break :blk null;
             if (i + 1 >= program.statements.len) break :blk null;
             const next = program.statements[i + 1];
             if (next != .comment) break :blk null;
-            if (directiveOf(next, source) != .trailing) break :blk null;
             if (!sameSourceLine(stmt.span().end, next.span().start, source)) break :blk null;
             break :blk next;
         };
+        const trailing_is_directive = trailing_comment != null and
+            directiveOf(trailing_comment.?, source) == .trailing;
 
         // ---- decide whether this statement gets source-sliced ----
         const protected = blk: {
@@ -104,14 +102,22 @@ pub fn print(
                 break :blk true;
             }
             if (ignore_next_pending and stmt != .comment) break :blk true;
-            if (trailing_ignore_comment != null) break :blk true;
+            if (trailing_is_directive) break :blk true;
             break :blk false;
         };
 
         // ---- emit ----
         if (protected) {
-            const end = if (trailing_ignore_comment) |c| c.span().end else stmt.span().end;
-            try writer.writeAll(source[stmt.span().start..end]);
+            // Walk back to the start of the line so the user's
+            // leading indent (which lives outside `stmt.span()`)
+            // is preserved verbatim, and extend through any trailing
+            // comment on the same line so it stays glued to its host
+            // (alignment + comment both preserved). Without the
+            // trailing extension a non-directive comment would
+            // demote to its own line, breaking idempotence.
+            const start = lineStartBefore(source, stmt.span().start);
+            const end = if (trailing_comment) |c| c.span().end else stmt.span().end;
+            try writer.writeAll(source[start..end]);
         } else {
             try writeStatement(writer, stmt, source, opts);
         }
@@ -125,9 +131,11 @@ pub fn print(
             .trailing, .file, .none => {},
         }
         if (protected and stmt != .comment) ignore_next_pending = false;
-        if (trailing_ignore_comment != null) skip_next = true;
+        // Skip the trailing comment on the next iteration whenever
+        // we glued it to the protected host above.
+        if (protected and trailing_comment != null) skip_next = true;
 
-        prev = if (trailing_ignore_comment) |c| c else stmt;
+        prev = if (protected and trailing_comment != null) trailing_comment.? else stmt;
     }
 }
 
@@ -164,6 +172,15 @@ fn fileIgnoreActive(program: *const ast.Program, source: []const u8) bool {
         if (directiveOf(s, source) == .file) return true;
     }
     return false;
+}
+
+/// Walk backward from `pos` to the start of the containing line
+/// (one past the previous `\n`, or 0). Used by the ignore-region
+/// emitter so leading indent is preserved verbatim.
+fn lineStartBefore(source: []const u8, pos: u32) usize {
+    var i: usize = pos;
+    while (i > 0 and source[i - 1] != '\n') i -= 1;
+    return i;
 }
 
 /// True when `end_a..start_b` in `source` is free of `\n`.

--- a/src/asm/printer.zig
+++ b/src/asm/printer.zig
@@ -18,6 +18,21 @@
 /// standalone (`hlt\n; halt`) on the first format pass and then
 /// stay stable — the blank-line rule counts newlines in the
 /// source gap so the layout is idempotent.
+///
+/// Ignore directives let users opt regions out of canonicalization
+/// (same pattern as `// prettier-ignore` / `#[rustfmt::skip]`):
+///
+///   - `; gero-fmt-ignore-file`  in the leading comment block →
+///     emit `source` verbatim, skip all canonicalization
+///   - `; gero-fmt-ignore-start` … `; gero-fmt-ignore-end` →
+///     statements between the markers are source-sliced verbatim
+///   - `; gero-fmt-ignore-next` → the following non-comment
+///     statement is source-sliced
+///   - trailing `; gero-fmt-ignore` on the same source line as a
+///     statement → that statement is source-sliced
+///
+/// The directive comments themselves stay in the output (they're
+/// just regular comments to the printer).
 const std = @import("std");
 const ast = @import("ast.zig");
 
@@ -42,15 +57,125 @@ pub fn print(
     source: []const u8,
     opts: PrintOptions,
 ) std.Io.Writer.Error!void {
+    // File-level escape hatch: a `; gero-fmt-ignore-file` directive
+    // anywhere in the leading comment block disables canonicalization
+    // for the whole file. We dump `source` as-is and bail.
+    if (fileIgnoreActive(program, source)) {
+        try writer.writeAll(source);
+        return;
+    }
+
     var prev: ?ast.Statement = null;
-    for (program.statements) |stmt| {
+    var in_block_ignore = false;
+    var ignore_next_pending = false;
+    var skip_next = false; // set by trailing-ignore — consume the trailing comment as part of the host's slice
+    for (program.statements, 0..) |stmt, i| {
+        if (skip_next) {
+            skip_next = false;
+            continue;
+        }
+
         if (prev) |p| {
             if (needsBlankLineBefore(stmt, p, source)) try writer.writeByte('\n');
         }
-        try writeStatement(writer, stmt, source, opts);
+
+        const directive = directiveOf(stmt, source);
+
+        // Detect a trailing-ignore directive on the *next* statement.
+        // When present, the host statement's protection extends to
+        // cover the trailing comment too — we source-slice through
+        // its end and skip the comment on the next loop iteration,
+        // so the line stays glued together (and idempotent across
+        // re-formats — second pass sees the same shape).
+        const trailing_ignore_comment: ?ast.Statement = blk: {
+            if (stmt == .comment) break :blk null;
+            if (i + 1 >= program.statements.len) break :blk null;
+            const next = program.statements[i + 1];
+            if (next != .comment) break :blk null;
+            if (directiveOf(next, source) != .trailing) break :blk null;
+            if (!sameSourceLine(stmt.span().end, next.span().start, source)) break :blk null;
+            break :blk next;
+        };
+
+        // ---- decide whether this statement gets source-sliced ----
+        const protected = blk: {
+            if (in_block_ignore) {
+                if (directive == .block_end) break :blk false;
+                break :blk true;
+            }
+            if (ignore_next_pending and stmt != .comment) break :blk true;
+            if (trailing_ignore_comment != null) break :blk true;
+            break :blk false;
+        };
+
+        // ---- emit ----
+        if (protected) {
+            const end = if (trailing_ignore_comment) |c| c.span().end else stmt.span().end;
+            try writer.writeAll(source[stmt.span().start..end]);
+        } else {
+            try writeStatement(writer, stmt, source, opts);
+        }
         try writer.writeByte('\n');
-        prev = stmt;
+
+        // ---- update state for next iteration ----
+        switch (directive) {
+            .block_start => in_block_ignore = true,
+            .block_end => in_block_ignore = false,
+            .next => ignore_next_pending = true,
+            .trailing, .file, .none => {},
+        }
+        if (protected and stmt != .comment) ignore_next_pending = false;
+        if (trailing_ignore_comment != null) skip_next = true;
+
+        prev = if (trailing_ignore_comment) |c| c else stmt;
     }
+}
+
+/// `; gero-fmt-...` directive flavors recognized by the printer.
+const Directive = enum { none, file, block_start, block_end, next, trailing };
+
+/// Identify the ignore-directive flavor (if any) of a statement.
+/// Non-comment statements always return `.none`.
+fn directiveOf(stmt: ast.Statement, source: []const u8) Directive {
+    if (stmt != .comment) return .none;
+    const body = commentBody(stmt.comment, source);
+    if (std.mem.eql(u8, body, "gero-fmt-ignore-file")) return .file;
+    if (std.mem.eql(u8, body, "gero-fmt-ignore-start")) return .block_start;
+    if (std.mem.eql(u8, body, "gero-fmt-ignore-end")) return .block_end;
+    if (std.mem.eql(u8, body, "gero-fmt-ignore-next")) return .next;
+    if (std.mem.eql(u8, body, "gero-fmt-ignore")) return .trailing;
+    return .none;
+}
+
+/// Trimmed body of a `;` comment — strips the leading `;` and any
+/// surrounding ASCII whitespace.
+fn commentBody(c: ast.Comment, source: []const u8) []const u8 {
+    var body = source[c.span.start..c.span.end];
+    if (body.len > 0 and body[0] == ';') body = body[1..];
+    return std.mem.trim(u8, body, " \t");
+}
+
+/// `true` when any statement in the leading **comment block** is
+/// the file-level ignore directive. A non-comment statement
+/// terminates the lookup.
+fn fileIgnoreActive(program: *const ast.Program, source: []const u8) bool {
+    for (program.statements) |s| {
+        if (s != .comment) return false;
+        if (directiveOf(s, source) == .file) return true;
+    }
+    return false;
+}
+
+/// True when `end_a..start_b` in `source` is free of `\n`.
+fn sameSourceLine(end_a: u32, start_b: u32, source: []const u8) bool {
+    if (start_b <= end_a) return true;
+    const lo: usize = end_a;
+    // @as: widen u32 → usize so the slice indexes line up.
+    const hi: usize = @min(@as(usize, start_b), source.len);
+    for (source[lo..hi]) |b| {
+        if (b == '\n') return false;
+    }
+    return true;
 }
 
 /// True when the canonical layout puts a blank line between `prev`

--- a/tests/asm/printer.test.zig
+++ b/tests/asm/printer.test.zig
@@ -313,6 +313,24 @@ test "printProgram: ignore-next protects only the immediately-following statemen
     , p.text);
 }
 
+test "printProgram: ignore-next preserves leading indent" {
+    // The protected statement's source-slice must walk back to
+    // the start of its source line — otherwise an indented
+    // statement loses its 2-space gutter.
+    const src =
+        \\main:
+        \\  ; gero-fmt-ignore-next
+        \\  mov $0A, r1                ; n = 10
+        \\  hlt
+        \\
+    ;
+    var p = try parseAndPrint(src);
+    defer p.deinit();
+    // The mov line keeps its 2-space indent + trailing alignment.
+    // The hlt line canonicalizes (2-space indent, no trailing).
+    try std.testing.expect(std.mem.indexOf(u8, p.text, "  mov $0A, r1                ; n = 10") != null);
+}
+
 test "printProgram: trailing ignore protects its host statement" {
     const src =
         \\const PRINT   = $10  ; gero-fmt-ignore

--- a/tests/asm/printer.test.zig
+++ b/tests/asm/printer.test.zig
@@ -242,3 +242,119 @@ test "printProgram: handles include resolution markers cleanly" {
     defer p.deinit();
     try std.testing.expect(std.mem.indexOfScalar(u8, p.text, '\x0c') == null);
 }
+
+// ---------- ignore directives ----------
+
+test "printProgram: file-level ignore disables all canonicalization" {
+    const src =
+        \\; gero-fmt-ignore-file
+        \\const PRINT   = $10
+        \\const NEWLINE = $0A
+        \\main:
+        \\  mov  $00, r1
+        \\
+    ;
+    var p = try parseAndPrint(src);
+    defer p.deinit();
+    // No reformatting — output is byte-identical to input.
+    try std.testing.expectEqualStrings(src, p.text);
+}
+
+test "printProgram: file-level ignore tolerates a leading non-directive comment" {
+    const src =
+        \\; copyright 2026
+        \\; gero-fmt-ignore-file
+        \\const PRINT   = $10
+        \\
+    ;
+    var p = try parseAndPrint(src);
+    defer p.deinit();
+    try std.testing.expectEqualStrings(src, p.text);
+}
+
+test "printProgram: block ignore preserves contents verbatim" {
+    const src =
+        \\; gero-fmt-ignore-start
+        \\const PRINT   = $10
+        \\const NEWLINE = $0A
+        \\; gero-fmt-ignore-end
+        \\const TAIL = $FF
+        \\
+    ;
+    var p = try parseAndPrint(src);
+    defer p.deinit();
+    // The block contents keep their hand-alignment; TAIL after the
+    // block goes through canonicalization (single-space `= `).
+    try std.testing.expectEqualStrings(
+        \\; gero-fmt-ignore-start
+        \\const PRINT   = $10
+        \\const NEWLINE = $0A
+        \\; gero-fmt-ignore-end
+        \\const TAIL = $FF
+        \\
+    , p.text);
+}
+
+test "printProgram: ignore-next protects only the immediately-following statement" {
+    const src =
+        \\; gero-fmt-ignore-next
+        \\const PRINT   = $10
+        \\const NEWLINE = $0A
+        \\
+    ;
+    var p = try parseAndPrint(src);
+    defer p.deinit();
+    // PRINT keeps its alignment; NEWLINE canonicalizes.
+    try std.testing.expectEqualStrings(
+        \\; gero-fmt-ignore-next
+        \\const PRINT   = $10
+        \\const NEWLINE = $0A
+        \\
+    , p.text);
+}
+
+test "printProgram: trailing ignore protects its host statement" {
+    const src =
+        \\const PRINT   = $10  ; gero-fmt-ignore
+        \\const NEWLINE = $0A
+        \\
+    ;
+    var p = try parseAndPrint(src);
+    defer p.deinit();
+    // PRINT line stays as-written (alignment + trailing comment
+    // both preserved). NEWLINE canonicalizes (single space).
+    try std.testing.expectEqualStrings(
+        \\const PRINT   = $10  ; gero-fmt-ignore
+        \\const NEWLINE = $0A
+        \\
+    , p.text);
+}
+
+test "printProgram: ignore-next idempotent across re-formats" {
+    const src =
+        \\; gero-fmt-ignore-next
+        \\const PRINT   = $10
+        \\const X = $20
+        \\
+    ;
+    var p1 = try parseAndPrint(src);
+    defer p1.deinit();
+    var p2 = try parseAndPrint(p1.text);
+    defer p2.deinit();
+    try std.testing.expectEqualStrings(p1.text, p2.text);
+}
+
+test "printProgram: block ignore idempotent across re-formats" {
+    const src =
+        \\; gero-fmt-ignore-start
+        \\const A   = $01
+        \\const BBB = $02
+        \\; gero-fmt-ignore-end
+        \\
+    ;
+    var p1 = try parseAndPrint(src);
+    defer p1.deinit();
+    var p2 = try parseAndPrint(p1.text);
+    defer p2.deinit();
+    try std.testing.expectEqualStrings(p1.text, p2.text);
+}


### PR DESCRIPTION
## Summary

`gero fmt` now respects four `; gero-fmt-ignore-*` directives — same opt-out pattern as `// prettier-ignore` / `#[rustfmt::skip]` — so hand-formatted regions survive canonicalization:

| Directive | Scope |
|---|---|
| `; gero-fmt-ignore-file` (in leading comment block) | whole file passed through verbatim |
| `; gero-fmt-ignore-start` / `; gero-fmt-ignore-end` | statements between the markers |
| `; gero-fmt-ignore-next` | next non-comment statement |
| trailing `; gero-fmt-ignore` (same line as host) | host line, alignment + trailing comment both preserved |

The directive comments themselves stay in the output. All four shapes are idempotent across re-formats.

## Smoke demo

```
$ head -3 /tmp/hello-ignored.gas
; gero-fmt-ignore-file
; hello.gas — smallest meaningful gero program.
;

$ gero fmt --check /tmp/hello-ignored.gas
✓ /tmp/hello-ignored.gas
    Finished in < 1 ms
$ echo $?
0
```

Without the directive, fmt would reformat (loses the hand-tuned `const PRINT   = $10` alignment).

## Parallel parser fix

Required a one-line fix to `src/asm/expr.zig::skipBlanks` — it was silently eating `;`-comments mid-expression (so trailing comments after a `const RHS` or inside `data8` value lists never reached the AST). Now it stops at `;` matching the parser's `skipBlanksInLine`, and trailing comments surface through the outer-loop capture. Latent bug that's been there since the parser landed — caught while implementing the trailing-ignore semantic.

## Self-review

- Step 1 — issue #139 AC: ✓ 4 directive shapes recognized + tested, ✓ idempotence checks (block + next), ✓ docs/cli.md §3.8 documents the directives, ✓ strict-mode + doc comments, ✓ changeset (patch). Bonus: latent expr.zig bug surfaced + fixed.
- Step 2 — \`zig build ci\` local: EXIT=0
- Step 3 — diff walk: 5 files / ~300 lines. Printer state machine clean (no allocator added — inline state). 1 \`@as\` carries justification. End-to-end smoke verified on hello.gas + ignore-file.
- Step 4 — hygiene: \`feat(asm)\`, no AI attribution, changeset (patch), README unchanged (no API surface change).

## After this lands

`examples/asm/*.gas` can keep their hand-formatted alignment by adding `; gero-fmt-ignore-file` at the top — opt-in per file. Then #118 (CI/lefthook wiring) can wire `gero fmt --check` on examples/ without forcing mass canonicalization.

Closes #139.