### PR TITLE
feat(apps/gero-cli): gero build — project-aware compile

### DIFF
--- a/.changeset/gero-build.md
+++ b/.changeset/gero-build.md
@@ -1,0 +1,35 @@
+---
+bump: minor
+---
+
+`gero build` — project-aware compile. Walks the ancestor chain
+for `gero.toml`, reads `[package]` + `[build]` from the manifest,
+runs the asm pipeline against `build.entry`, and writes the
+resulting `.gx` to `<project_root>/<build.out>/<package.name>.gx`.
+
+Closes the loop for the v0.2 "100% gero project" experience:
+
+```bash
+gero new my-cart && cd my-cart && gero build && gero run out/my-cart.gx
+```
+
+Output filename comes from `[package].name`, not the entry's
+basename — the manifest is the single source of truth. `out/` is
+created if missing.
+
+Resolves the manifest by ancestor walk, so `gero build` works
+from any subdirectory of the project. Manifest-relative
+`build.entry` / `build.out` are joined under
+`dirname(gero.toml)`.
+
+`--target=<vm|gtx-16>` overrides the manifest's
+`[package].target`. Only `vm` ships in v0.2; `gtx-16` errors with
+a clear "not yet implemented" diagnostic.
+
+Reuses the same `resolveIncludes` → `parse` → `assemble` pipeline
+as `gero asm`, with the same `✓ <path> (N bytes, M banks)` + footer
+shape and the same exit codes (`0` ok, `1` host IO, `2` usage,
+`3` parse / asm error).
+
+Per-phase `--verbose` timings mirror `gero asm`: include / parse
+/ codegen / write.

--- a/apps/gero-cli/build.zig
+++ b/apps/gero-cli/build.zig
@@ -1,0 +1,203 @@
+/// `gero build` — project-aware compile. Walks the ancestor
+/// chain for `gero.toml`, reads `[build]` + `[package]`, runs the
+/// asm pipeline against `build.entry`, and writes the resulting
+/// `.gx` to `<project_root>/<build.out>/<package.name>.gx`.
+///
+/// `gero build` is essentially `gero asm` wrapped with manifest
+/// resolution + output-path discipline. Reuses every existing
+/// asm-pipeline piece (`resolveIncludes` → `parse` → `assemble`).
+///
+/// Exit codes per cli.md §3.12 + §5:
+///   - `0` clean
+///   - `1` host IO problem (manifest missing, unreadable, write failed)
+///   - `2` usage error (unsupported target override)
+///   - `3` manifest parse error or asm pipeline error
+const std = @import("std");
+const gero = @import("gero");
+const cli = @import("cli.zig");
+const term_mod = @import("term.zig");
+const project = @import("project.zig");
+const diagnostics = @import("diagnostics.zig");
+const footer = @import("footer.zig");
+
+/// Drive the `gero build` flow against the gero.toml found by
+/// ancestor-walk. Caller owns `arena`.
+pub fn execute(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+) !u8 {
+    const t_start = std.Io.Timestamp.now(io, .awake);
+    const positionals = opts.positional();
+    if (positionals.len > 0) {
+        try term.err("gero build: takes no positional args (entry point comes from gero.toml's [build].entry)", .{});
+        return 2;
+    }
+
+    const style: gero.asm_.Style = if (term.color) .ansi else .plain;
+
+    // 1. Find + read + parse the manifest.
+    const manifest_path = (try project.findManifest(io, arena)) orelse {
+        try term.err("gero build: no gero.toml in this directory or any parent (run `gero new` to scaffold, or `gero asm <file>` for single-file mode)", .{});
+        return 1;
+    };
+
+    const source = std.Io.Dir.cwd().readFileAlloc(io, manifest_path, arena, .unlimited) catch |err| {
+        try term.err("gero build: cannot read {s} ({s})", .{ manifest_path, @errorName(err) });
+        return 1;
+    };
+
+    var manifest = switch (try project.parseWithDiagnostic(arena, source)) {
+        .ok => |m| m,
+        .err => |diag| {
+            try term.err("gero build: {s}:{d}:{d}: {s}", .{ manifest_path, diag.line, diag.col, diag.message });
+            return 3;
+        },
+    };
+    defer manifest.deinit(arena);
+
+    // 2. Target gate. `--target=<vm|gtx-16>` overrides the manifest;
+    //    only `vm` is wired in v0.2 — `gtx-16` lights up later.
+    const target = opts.target orelse manifest.package.target;
+    if (!std.mem.eql(u8, target, "vm")) {
+        if (std.mem.eql(u8, target, "gtx-16")) {
+            try term.err("gero build: target `gtx-16` is not yet implemented (lights up later — only `vm` works in v0.2)", .{});
+        } else {
+            try term.err("gero build: unknown target `{s}` (expected `vm` or `gtx-16`)", .{target});
+        }
+        return 2;
+    }
+
+    // 3. Resolve project-relative paths.
+    const project_root = std.fs.path.dirname(manifest_path) orelse "";
+    const entry_path = try joinUnderRoot(arena, project_root, manifest.build.entry);
+    const out_dir = try joinUnderRoot(arena, project_root, manifest.build.out);
+
+    // 4. Ensure the output directory exists. `createDirPath` is
+    //    idempotent — no-op when `out/` already exists.
+    std.Io.Dir.cwd().createDirPath(io, out_dir) catch |err| {
+        try term.err("gero build: cannot create {s} ({s})", .{ out_dir, @errorName(err) });
+        return 1;
+    };
+
+    // 5. Asm pipeline against the entry.
+    const t_phase_start_include = std.Io.Timestamp.now(io, .awake);
+    var fused = gero.asm_.resolveIncludes(io, arena, entry_path) catch |err| {
+        try term.err("gero build: cannot read {s} ({s})", .{ entry_path, @errorName(err) });
+        return 1;
+    };
+    defer fused.deinit();
+    const t_after_include = std.Io.Timestamp.now(io, .awake);
+
+    if (fused.errors.len > 0) {
+        try diagnostics.printSingle(stdout, fused.source_map, fused.errors, style);
+        try footer.writeFooter(stdout, io, style, t_start, .failed);
+        return 3;
+    }
+
+    var pt = try gero.asm_.parse(arena, fused.source);
+    defer pt.deinit();
+    const t_after_parse = std.Io.Timestamp.now(io, .awake);
+
+    var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
+    defer cg.deinit();
+    const t_after_codegen = std.Io.Timestamp.now(io, .awake);
+
+    if (pt.hasErrors() or cg.hasErrors()) {
+        try diagnostics.printAllFailures(arena, stdout, style, &.{
+            .{
+                .source_map = fused.source_map,
+                .parse_errors = pt.errors,
+                .codegen_errors = cg.errors,
+            },
+        });
+        try footer.writeFooter(stdout, io, style, t_start, .failed);
+        return 3;
+    }
+
+    // 6. Write `<out_dir>/<package.name>.gx`.
+    const gx_name = try std.fmt.allocPrint(arena, "{s}.gx", .{manifest.package.name});
+    const out_path = try std.fs.path.join(arena, &.{ out_dir, gx_name });
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = out_path, .data = cg.image }) catch |err| {
+        try term.err("gero build: cannot write {s} ({s})", .{ out_path, @errorName(err) });
+        return 1;
+    };
+    const t_after_write = std.Io.Timestamp.now(io, .awake);
+
+    if (!opts.quiet) {
+        const loaded = gero.vm.parseGx(cg.image) catch unreachable; // allow-strict: codegen just emitted these bytes — they're well-formed by construction
+        try stdout.print("{s} ({d} bytes, {d} banks, debug: {s})\n", .{
+            out_path,
+            cg.image.len,
+            loaded.header.bank_count,
+            if (loaded.header.hasDebugSymbols()) "yes" else "no",
+        });
+        if (opts.verbose) {
+            try writePhaseTimings(stdout, style, .{
+                .include = t_phase_start_include.durationTo(t_after_include).nanoseconds,
+                .parse = t_after_include.durationTo(t_after_parse).nanoseconds,
+                .codegen = t_after_parse.durationTo(t_after_codegen).nanoseconds,
+                .write = t_after_codegen.durationTo(t_after_write).nanoseconds,
+            });
+        }
+        try footer.writeFooter(stdout, io, style, t_start, .ok);
+    }
+
+    return 0;
+}
+
+/// Per-phase timings printed under `--verbose` — mirrors `gero asm`.
+const PhaseTimings = struct {
+    include: i96,
+    parse: i96,
+    codegen: i96,
+    write: i96,
+};
+
+fn writePhaseTimings(stdout: *std.Io.Writer, style: gero.asm_.Style, t: PhaseTimings) !void {
+    const phases = [_]struct { label: []const u8, ns: i96 }{
+        .{ .label = "    include", .ns = t.include },
+        .{ .label = "    parse  ", .ns = t.parse },
+        .{ .label = "    codegen", .ns = t.codegen },
+        .{ .label = "    write  ", .ns = t.write },
+    };
+    for (phases) |p| {
+        try stdout.print("{s}{s}{s} ", .{ style.gutter, p.label, style.reset });
+        try footer.writeDuration(stdout, p.ns);
+        try stdout.writeByte('\n');
+    }
+}
+
+/// Join a manifest-relative path under the project root. The root
+/// is `dirname(manifest_path)` — empty when `gero.toml` sits in
+/// the cwd. An empty root means "current directory"; we return
+/// the bare path so `gero build` from the project root doesn't
+/// accumulate spurious `./` prefixes.
+pub fn joinUnderRoot(arena: std.mem.Allocator, project_root: []const u8, rel: []const u8) ![]const u8 {
+    if (project_root.len == 0) return arena.dupe(u8, rel);
+    return std.fs.path.join(arena, &.{ project_root, rel });
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "joinUnderRoot: empty root keeps the relative path verbatim" {
+    const out = try joinUnderRoot(testing.allocator, "", "src/main.gas");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("src/main.gas", out);
+}
+
+test "joinUnderRoot: parent root prefixes correctly" {
+    const out = try joinUnderRoot(testing.allocator, "..", "src/main.gas");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("../src/main.gas", out);
+}
+
+test "joinUnderRoot: deeper root prefixes correctly" {
+    const out = try joinUnderRoot(testing.allocator, "../..", "out/");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("../../out/", out);
+}

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -62,6 +62,10 @@ pub const Options = struct {
     /// files that would be reformatted (exit 8) without writing.
     /// Editor / CI use case.
     check: bool = false,
+    /// `--target=<vm|gtx-16>` for `gero build` — overrides the
+    /// manifest's `package.target`. `null` = inherit from manifest;
+    /// `gtx-16` is reserved (errors with "not yet implemented").
+    target: ?[]const u8 = null,
     positional_buf: [max_positionals][]const u8 = undefined,
     positional_count: usize = 0,
 
@@ -156,8 +160,8 @@ fn commandSummary(cmd: Command) []const u8 {
 /// discoverable, but split into a separate "planned" section.
 fn commandIsImplemented(cmd: Command) bool {
     return switch (cmd) {
-        .asm_, .run, .info, .disasm, .test_, .check, .fmt, .new, .init => true,
-        .compile, .bench, .build => false,
+        .asm_, .run, .info, .disasm, .test_, .check, .fmt, .new, .init, .build => true,
+        .compile, .bench => false,
     };
 }
 
@@ -303,6 +307,14 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero init --quiet{s}               {s}# suppress the next-steps banner{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("\nRefuses to overwrite any pre-existing gero.toml / src/ / tests/ files.\n", .{});
         },
+        .build => {
+            try out.print("  {s}gero build{s} [--target=<vm|gtx-16>] [--quiet] [-v]\n\n", .{ a.cyan, a.reset });
+            try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
+            try out.print("  {s}gero build{s}                      {s}# project build → out/<name>.gx{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero build -v{s}                   {s}# per-phase timings (include / parse / codegen / write){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero build --target=vm{s}          {s}# explicit target override (default is the manifest's){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("\nResolves gero.toml via ancestor walk. Run `gero new <name>` to scaffold.\n", .{});
+        },
         else => unreachable, // allow-strict: commandIsImplemented() filtered above
     }
 
@@ -332,6 +344,7 @@ fn flagHelpLine(kind: FlagKind) FlagHelpLine {
         .no_show_bytes => .{ .sig = "--no-show-bytes", .desc = "Strip the hex-bytes column for a cleaner view." },
         .check_roundtrip => .{ .sig = "--check-roundtrip", .desc = "Verify asm → disasm → asm yields identical bytes (CI gate)." },
         .check => .{ .sig = "--check", .desc = "Non-destructive — exit 8 if any file would be reformatted." },
+        .target => .{ .sig = "--target=<m>", .desc = "vm (default) / gtx-16. Overrides manifest's [package].target." },
     };
 }
 
@@ -349,7 +362,8 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .fmt => &.{ .help, .check, .quiet, .color, .no_color },
         .new => &.{ .help, .quiet, .color, .no_color },
         .init => &.{ .help, .quiet, .color, .no_color },
-        .compile, .bench, .build => &.{.help},
+        .build => &.{ .help, .target, .quiet, .verbose, .color, .no_color },
+        .compile, .bench => &.{.help},
     };
 }
 
@@ -372,7 +386,7 @@ fn parseColor(s: []const u8) ParseError!ColorChoice {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check };
+const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check, target };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
@@ -388,6 +402,7 @@ fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "no-show-bytes")) return .no_show_bytes;
     if (std.mem.eql(u8, s, "check-roundtrip")) return .check_roundtrip;
     if (std.mem.eql(u8, s, "check")) return .check;
+    if (std.mem.eql(u8, s, "target")) return .target;
     return null;
 }
 
@@ -417,6 +432,7 @@ fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void
         .no_show_bytes => opts.show_bytes = false,
         .check_roundtrip => opts.check_roundtrip = true,
         .check => opts.check = true,
+        .target => opts.target = value orelse return error.MissingFlagValue,
     }
 }
 
@@ -426,7 +442,7 @@ fn parseBank(s: []const u8) ParseError!u8 {
 
 fn needsValue(kind: FlagKind) bool {
     return switch (kind) {
-        .optimize, .out, .color, .bank => true,
+        .optimize, .out, .color, .bank, .target => true,
         else => false,
     };
 }

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -13,6 +13,7 @@ const check_cmd = @import("check.zig");
 const fmt_cmd = @import("fmt.zig");
 const new_cmd = @import("new.zig");
 const init_cmd = @import("init.zig");
+const build_cmd = @import("build.zig");
 
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
@@ -85,6 +86,7 @@ pub fn main(init: std.process.Init) !u8 {
         .fmt => fmt_cmd.execute(io, arena, parsed.options, stdout, &term),
         .new => new_cmd.execute(io, arena, parsed.options, stdout, &term),
         .init => init_cmd.execute(io, arena, parsed.options, stdout, &term),
+        .build => build_cmd.execute(io, arena, parsed.options, stdout, &term),
         else => blk: {
             try term.err("gero {s}: not yet implemented", .{cli.commandName(cmd)});
             break :blk 1;

--- a/build.zig
+++ b/build.zig
@@ -170,6 +170,17 @@ pub fn build(b: *std.Build) void {
         .name = "test-cli-init",
         .root_module = init_cli_mod,
     });
+    const build_cli_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/build.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    build_cli_mod.addImport("gero", gero_mod);
+    build_cli_mod.addOptions("build_options", cli_options);
+    const build_cli_test = b.addTest(.{
+        .name = "test-cli-build",
+        .root_module = build_cli_mod,
+    });
     const diagnostics_mod = b.createModule(.{
         .root_source_file = b.path("apps/gero-cli/diagnostics.zig"),
         .target = target,
@@ -234,6 +245,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(project_test).step);
     test_step.dependOn(&b.addRunArtifact(new_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(init_cli_test).step);
+    test_step.dependOn(&b.addRunArtifact(build_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(diagnostics_test).step);
     test_step.dependOn(&b.addRunArtifact(footer_test).step);
     for (test_files) |rel| {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -402,32 +402,41 @@ gero init --quiet                 # skip the next-steps banner
 
 ### 3.12 `gero build` — build project
 
-Builds the project rooted at the current working directory using
-v0.1 conventions (no `gero.toml` yet).
+Walks the ancestor chain for `gero.toml`, reads `[package]` +
+`[build]`, runs the asm pipeline against `build.entry`, and
+writes the resulting `.gx` to `<project_root>/<build.out>/<package.name>.gx`.
 
-**Project conventions (v0.1):**
-
-```
-<project>/
-├── main.gr   OR   main.gas       # entry point — exactly one required
-├── src/                          # additional .gr / .gas modules (optional)
-└── out/                          # output dir, created if missing
-```
+Essentially `gero asm` wrapped with manifest resolution +
+output-path discipline. Reuses every existing asm-pipeline piece.
 
 ```bash
-gero build                        # → out/<project-basename>.gx
-gero build --optimize=release
+gero build                        # → out/<package.name>.gx
+gero build -v                     # per-phase timings
+gero build --target=vm            # explicit target override
 ```
 
 **Behavior:**
-- Detects entry point: `main.gr` (compile) or `main.gas` (asm).
-  Errors if both present (ambiguous) or neither.
-- Resolves all imports / includes from `src/` + stdlib.
-- Outputs `out/<basename>.gx`. Creates `out/` if missing.
-- Caches per-module builds in `out/.cache/` for incremental builds.
+- Resolves `gero.toml` by ancestor walk — `gero build` works from
+  any subdirectory of the project.
+- Manifest-relative `[build].entry` and `[build].out` are joined
+  under the project root (`dirname(gero.toml)`). `out/` is
+  created if missing.
+- Output filename is `<package.name>.gx`, not the entry's
+  basename — the manifest is the single source of truth.
+- `--target=<vm|gtx-16>` overrides the manifest's `[package].target`.
+  Only `vm` ships in v0.2; `gtx-16` is reserved (errors with
+  "not yet implemented").
+- Takes no positional args — entry comes from the manifest.
+  Single-file use is what `gero asm` covers.
 
-**Exit:** 0 on success; 3 on parse error; 4 on type error; 5 on link
-error.
+**Exit:** 0 on success; 1 on host IO / missing manifest; 2 on
+usage (unknown target, positional); 3 on manifest parse error or
+asm pipeline error.
+
+**Roadmap:** `gero build --optimize=release` becomes meaningful
+once the lang back-end (v0.3) lands; today the asm pipeline has
+no optimizer to drive, so the `[build].optimize` key is read but
+its only consumer ships in v0.3+.
 
 ---
 


### PR DESCRIPTION
Closes #136.

## Summary

Closes the v0.2 "100% gero project" loop: `gero new my-cart && cd my-cart && gero build && gero run out/my-cart.gx` works end-to-end. Wraps the existing asm pipeline with manifest resolution + output-path discipline — no new compilation logic, just the project wiring.

## Behavior

- **Manifest resolution** via ancestor walk (`project.findManifest`), so `gero build` runs from any subdir of the project
- **Manifest-relative paths**: `build.entry` and `build.out` are joined under `dirname(gero.toml)`
- **Output filename** is `<package.name>.gx` (not the entry's basename — manifest = source of truth)
- **`out/` auto-created** if missing
- **`--target=<vm|gtx-16>`** overrides the manifest's `[package].target`. Only `vm` ships in v0.2; `gtx-16` errors with "not yet implemented"
- **No positional args** — entry comes from the manifest. Single-file use is `gero asm <file>`'s job

## Smoke tests (manual)

| Case | Result |
|---|---|
| `gero new my-cart && cd my-cart && gero build` | ✅ `out/my-cart.gx (81 bytes, 0 banks, debug: yes)` + footer, exit 0 |
| `gero run out/my-cart.gx` after build | ✅ prints `Hello, gero!`, exit 0 |
| `cd my-cart/src && gero build` | ✅ ancestor walk works, writes `../out/my-cart.gx` |
| `gero build --target=gtx-16` | ✅ exit 2, "not yet implemented" |
| `gero build` outside any project | ✅ exit 1, "no gero.toml … (run \`gero new\` or use \`gero asm\` for single-file mode)" |
| `gero build foo` (positional rejected) | ✅ exit 2, "takes no positional args" |

## Self-review

**Step 1 (#136 AC):**
- ✅ `gero build` inside a scaffolded project produces `out/<name>.gx`
- ✅ Same `✓ <path> (N bytes, M banks)` + footer shape as `gero asm`
- ✅ `gero build --target=gtx-16` emits a clear "not yet implemented" diagnostic
- ✅ Exit codes per cli.md §5: 0 ok, 3 asm error, 1 host IO, 2 usage
- ✅ `docs/cli.md` §3.12 fully rewritten to reflect what shipped (replaced the v0.1 placeholder body)
- ✅ Strict-mode + doc comments + changeset added (minor bump)

**Step 2** (`zig build ci`): EXIT=0 — lint + test-modes (4 release modes) + test-all (5 cross-targets) + check-examples + check-broken + fmt-check-examples + test-examples all green.

**Step 3 (diff walk, 6 files, +302/-25):**
- `apps/gero-cli/build.zig` (new) — execute + joinUnderRoot + writePhaseTimings + 3 inline tests
- `apps/gero-cli/cli.zig` — `.build` moved from planned → implemented, `--target=<m>` flag wired (FlagKind/longFlag/applyFlag/needsValue/flagHelpLine/flagsForCommand), Options gains `target: ?[]const u8`
- `apps/gero-cli/main.zig` — `.build` dispatch
- `build.zig` — `build_cli_test` artifact registered
- `docs/cli.md` §3.12 — replaced the v0.1 placeholder body with what shipped
- `.changeset/gero-build.md` — minor bump

**Step 4 (hygiene):** no stray `std.debug.print`, no commented-out code, no TODO, no AI attribution, single commit with conventional `feat(apps/gero-cli):` scope. The `unreachable` in the `parseGx` post-codegen call carries an `// allow-strict:` justification.