### PR TITLE
feat(apps/gero-cli): project-aware gero check / fmt / test

### DIFF
--- a/.changeset/gero-project-aware-commands.md
+++ b/.changeset/gero-project-aware-commands.md
@@ -1,0 +1,35 @@
+---
+bump: minor
+---
+
+`gero check` / `gero fmt` / `gero test` — project-aware fallback.
+
+Invoked with no positional args inside a gero project (cwd or
+any ancestor has `gero.toml`), each command resolves its target
+file list from the manifest:
+
+- **`gero check`** — walks `[build].entry` + every entry in
+  `[test].include` so the whole project type-checks in one pass
+- **`gero fmt` / `gero fmt --check`** — same shape, formats or
+  diff-checks the same union
+- **`gero test`** — walks `[test].include` for `.gas` programs
+  paired with sibling `.expected`. The previous hardcoded
+  `tests/asm/` root is gone — `gero test` is now binary-portable
+  to user projects
+
+No manifest + no positional args → exit 2 with a usage hint
+("missing source file or directory path (or run inside a gero
+project)"). `gero test` outside any project always errors —
+there's no sensible default root for a CLI shipped as a binary.
+
+Explicit positional args keep their current single-file /
+directory-walk semantics — no behavior change for existing
+invocations.
+
+Shared manifest-loading + include-expansion logic lives in
+`apps/gero-cli/manifest_loader.zig` (load + parse-error
+reporting + file-or-directory expansion). `project.zig` stays
+the pure-parser module.
+
+Template scaffolds re-canonicalized so `gero fmt --check`
+reports zero drift on a freshly-scaffolded project.

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -19,6 +19,7 @@ const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const diagnostics = @import("diagnostics.zig");
 const footer = @import("footer.zig");
+const manifest_loader = @import("manifest_loader.zig");
 
 /// Drive `gero check` end-to-end against `opts.positional()`.
 /// Caller owns `arena`; every allocation is short-lived.
@@ -31,20 +32,40 @@ pub fn execute(
 ) !u8 {
     const t_start = std.Io.Timestamp.now(io, .awake);
     const positionals = opts.positional();
-    if (positionals.len < 1) {
-        try term.err("gero check: missing source file or directory path", .{});
-        return 2;
-    }
-
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
 
     var files: std.ArrayList([]const u8) = .empty;
-    for (positionals) |path| {
-        if (std.mem.endsWith(u8, path, ".gr")) {
-            try term.err("gero check: .gr support lands in v0.3 (gero-lang front-end)", .{});
-            return 1;
+    if (positionals.len == 0) {
+        // Project-aware fallback: load gero.toml from cwd or any
+        // ancestor and use [build].entry + [test].include as the
+        // implicit file list. No manifest → usage error (exit 2)
+        // since we have nothing to check.
+        const outcome = try manifest_loader.load(io, arena, term, "gero check");
+        switch (outcome) {
+            .not_found => {
+                try term.err("gero check: missing source file or directory path (or run inside a gero project)", .{});
+                return 2;
+            },
+            .failed => return 1,
+            .ok => |loaded| {
+                var loaded_mut = loaded;
+                defer loaded_mut.deinit(arena);
+                const entry_path = try manifest_loader.joinUnderRoot(arena, loaded.project_root, loaded.manifest.build.entry);
+                try files.append(arena, entry_path);
+                manifest_loader.expandIncludes(io, arena, term, "gero check", loaded.project_root, loaded.manifest.test_.include, &files) catch |err| switch (err) {
+                    error.LoadFailed => return 1,
+                    else => |e| return e,
+                };
+            },
         }
-        try collectGasFiles(io, arena, term, path, &files);
+    } else {
+        for (positionals) |path| {
+            if (std.mem.endsWith(u8, path, ".gr")) {
+                try term.err("gero check: .gr support lands in v0.3 (gero-lang front-end)", .{});
+                return 1;
+            }
+            try collectGasFiles(io, arena, term, path, &files);
+        }
     }
 
     if (files.items.len == 0) {

--- a/apps/gero-cli/fmt.zig
+++ b/apps/gero-cli/fmt.zig
@@ -25,6 +25,7 @@ const gero = @import("gero");
 const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const footer = @import("footer.zig");
+const manifest_loader = @import("manifest_loader.zig");
 
 /// Per-file outcome.
 const Outcome = enum {
@@ -46,20 +47,39 @@ pub fn execute(
 ) !u8 {
     const t_start = std.Io.Timestamp.now(io, .awake);
     const positionals = opts.positional();
-    if (positionals.len < 1) {
-        try term.err("gero fmt: missing source file or directory path", .{});
-        return 2;
-    }
-
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
 
     var files: std.ArrayList([]const u8) = .empty;
-    for (positionals) |path| {
-        if (std.mem.endsWith(u8, path, ".gr")) {
-            try term.err("gero fmt: .gr support lands in v0.3 (gero-lang front-end)", .{});
-            return 1;
+    if (positionals.len == 0) {
+        // Project-aware fallback: load gero.toml from cwd or any
+        // ancestor and use [build].entry + [test].include as the
+        // implicit file list. No manifest → usage error.
+        const outcome = try manifest_loader.load(io, arena, term, "gero fmt");
+        switch (outcome) {
+            .not_found => {
+                try term.err("gero fmt: missing source file or directory path (or run inside a gero project)", .{});
+                return 2;
+            },
+            .failed => return 1,
+            .ok => |loaded| {
+                var loaded_mut = loaded;
+                defer loaded_mut.deinit(arena);
+                const entry_path = try manifest_loader.joinUnderRoot(arena, loaded.project_root, loaded.manifest.build.entry);
+                try files.append(arena, entry_path);
+                manifest_loader.expandIncludes(io, arena, term, "gero fmt", loaded.project_root, loaded.manifest.test_.include, &files) catch |err| switch (err) {
+                    error.LoadFailed => return 1,
+                    else => |e| return e,
+                };
+            },
         }
-        try collectGasFiles(io, arena, term, path, &files);
+    } else {
+        for (positionals) |path| {
+            if (std.mem.endsWith(u8, path, ".gr")) {
+                try term.err("gero fmt: .gr support lands in v0.3 (gero-lang front-end)", .{});
+                return 1;
+            }
+            try collectGasFiles(io, arena, term, path, &files);
+        }
     }
     if (files.items.len == 0) {
         try term.err("gero fmt: no .gas files found in the given paths", .{});

--- a/apps/gero-cli/manifest_loader.zig
+++ b/apps/gero-cli/manifest_loader.zig
@@ -1,0 +1,177 @@
+/// Project-aware glue for `gero check` / `gero fmt` / `gero test`:
+/// walk ancestors for `gero.toml`, parse it, and expand
+/// manifest-relative include lists into a flat `.gas` file list.
+///
+/// `load` is the thin wrapper that does manifest discovery + parse
+/// + read-error reporting; `expandIncludes` walks each entry like
+/// a positional path would be walked (single `.gas` file or a
+/// directory recursed for `.gas`). Errors are printed via `term`
+/// with a `<command_name>: …` prefix so each consuming subcommand
+/// keeps its diagnostic voice.
+///
+/// Lives next to the consuming subcommands (under `apps/gero-cli/`)
+/// because it pulls in `term.zig` for diagnostics. `project.zig`
+/// stays pure-parser; this module is the CLI flavor.
+const std = @import("std");
+const project = @import("project.zig");
+const term_mod = @import("term.zig");
+
+/// Successfully loaded manifest + the paths used to resolve it.
+/// `project_root` is `dirname(manifest_path)`, empty when
+/// `gero.toml` lives in the cwd.
+pub const Loaded = struct {
+    manifest: project.Manifest,
+    manifest_path: []const u8,
+    project_root: []const u8,
+
+    pub fn deinit(self: *Loaded, allocator: std.mem.Allocator) void {
+        self.manifest.deinit(allocator);
+    }
+};
+
+/// What `load` returned. `failed` means a read or parse error was
+/// already printed via `term`; the caller picks the exit code.
+pub const Outcome = union(enum) {
+    ok: Loaded,
+    not_found,
+    failed,
+};
+
+/// Find + read + parse `gero.toml`. Prints read / parse diagnostics
+/// via `term` with the given `command_name` prefix. Returns the
+/// `Outcome` for the caller to pattern-match on.
+pub fn load(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    term: *term_mod.Term,
+    command_name: []const u8,
+) !Outcome {
+    const manifest_path = (try project.findManifest(io, arena)) orelse return .not_found;
+
+    const source = std.Io.Dir.cwd().readFileAlloc(io, manifest_path, arena, .unlimited) catch |err| {
+        try term.err("{s}: cannot read {s} ({s})", .{ command_name, manifest_path, @errorName(err) });
+        return .failed;
+    };
+
+    const parse_result = project.parseWithDiagnostic(arena, source) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.ParseFailed => {
+            try term.err("{s}: {s}: malformed manifest", .{ command_name, manifest_path });
+            return .failed;
+        },
+    };
+
+    switch (parse_result) {
+        .ok => |m| {
+            const project_root = std.fs.path.dirname(manifest_path) orelse "";
+            return .{ .ok = .{
+                .manifest = m,
+                .manifest_path = manifest_path,
+                .project_root = project_root,
+            } };
+        },
+        .err => |diag| {
+            try term.err(
+                "{s}: {s}:{d}:{d}: {s}",
+                .{ command_name, manifest_path, diag.line, diag.col, diag.message },
+            );
+            return .failed;
+        },
+    }
+}
+
+/// Resolve a manifest-relative path under the project root. Empty
+/// root means cwd — return `rel` verbatim so we don't sprinkle
+/// `./` prefixes on every invocation from the project root.
+pub fn joinUnderRoot(
+    arena: std.mem.Allocator,
+    project_root: []const u8,
+    rel: []const u8,
+) std.mem.Allocator.Error![]const u8 {
+    if (project_root.len == 0) return arena.dupe(u8, rel);
+    return std.fs.path.join(arena, &.{ project_root, rel });
+}
+
+/// For each entry in `includes` (manifest-relative path), append
+/// to `out` either the single `.gas` file it points to or every
+/// `.gas` found by walking the directory recursively. Errors are
+/// printed via `term` and propagated as `error.LoadFailed`.
+///
+/// Mirrors the in-place `.gas` collector each subcommand has for
+/// its own positional args — same file-or-directory semantics, so
+/// users can drop either path shape into `[test].include`.
+pub fn expandIncludes(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    term: *term_mod.Term,
+    command_name: []const u8,
+    project_root: []const u8,
+    includes: []const []const u8,
+    out: *std.ArrayList([]const u8),
+) !void {
+    for (includes) |rel| {
+        const full = try joinUnderRoot(arena, project_root, rel);
+        const stat = std.Io.Dir.cwd().statFile(io, full, .{}) catch |err| {
+            try term.err("{s}: cannot stat {s} ({s})", .{ command_name, full, @errorName(err) });
+            return error.LoadFailed;
+        };
+        if (stat.kind == .directory) {
+            var dir = std.Io.Dir.cwd().openDir(io, full, .{ .iterate = true }) catch |err| {
+                try term.err("{s}: cannot open dir {s} ({s})", .{ command_name, full, @errorName(err) });
+                return error.LoadFailed;
+            };
+            defer dir.close(io);
+            var walker = try dir.walk(arena);
+            defer walker.deinit();
+            while (try walker.next(io)) |entry| {
+                if (entry.kind != .file) continue;
+                if (!std.mem.endsWith(u8, entry.path, ".gas")) continue;
+                const joined = try std.fs.path.join(arena, &.{ full, entry.path });
+                try out.append(arena, joined);
+            }
+        } else if (stat.kind == .file) {
+            if (!std.mem.endsWith(u8, full, ".gas")) {
+                try term.err(
+                    "{s}: include entry '{s}' is not a .gas file or directory",
+                    .{ command_name, full },
+                );
+                return error.LoadFailed;
+            }
+            try out.append(arena, full);
+        } else {
+            try term.err(
+                "{s}: include entry '{s}' is neither a file nor a directory",
+                .{ command_name, full },
+            );
+            return error.LoadFailed;
+        }
+    }
+}
+
+/// Sentinel for `expandIncludes` after a host IO / shape
+/// diagnostic has already been printed — the caller maps it to
+/// its own exit code rather than printing again.
+pub const LoadFailedError = error{LoadFailed};
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "joinUnderRoot: empty root keeps the path verbatim" {
+    const out = try joinUnderRoot(testing.allocator, "", "src/main.gas");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("src/main.gas", out);
+}
+
+test "joinUnderRoot: parent root prefixes correctly" {
+    const out = try joinUnderRoot(testing.allocator, "..", "tests/");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("../tests/", out);
+}
+
+test "Outcome union: pattern-matches cleanly" {
+    const a: Outcome = .not_found;
+    const b: Outcome = .failed;
+    try testing.expectEqual(@as(std.meta.Tag(Outcome), .not_found), a);
+    try testing.expectEqual(@as(std.meta.Tag(Outcome), .failed), b);
+}

--- a/apps/gero-cli/templates/main.gas
+++ b/apps/gero-cli/templates/main.gas
@@ -7,7 +7,7 @@ const PRINT   = $10
 const NEWLINE = $0A
 
 main:
-  mov $00, r3                          ; index = 0
+  mov $00, r3                ; index = 0
 .loop:
   mov8 [@GREETING + r3], r1
   cmp r1, $00

--- a/apps/gero-cli/templates/smoke.gas
+++ b/apps/gero-cli/templates/smoke.gas
@@ -7,10 +7,10 @@
 const PRINT = $10
 
 main:
-  mov $6F, r1                          ; 'o'
+  mov $6F, r1                ; 'o'
   int PRINT
-  mov $6B, r1                          ; 'k'
+  mov $6B, r1                ; 'k'
   int PRINT
-  mov $0A, r1                          ; '\n'
+  mov $0A, r1                ; '\n'
   int PRINT
   hlt

--- a/apps/gero-cli/test.zig
+++ b/apps/gero-cli/test.zig
@@ -12,10 +12,7 @@ const std = @import("std");
 const gero = @import("gero");
 const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
-
-/// Root walked for `.gas` test programs. Recursive — files in any
-/// subdirectory are picked up.
-const tests_root: []const u8 = "tests/asm";
+const manifest_loader = @import("manifest_loader.zig");
 
 /// Hard cap on dispatched instructions per test, to prevent an
 /// infinite loop in a buggy program from hanging the runner. Each
@@ -79,16 +76,43 @@ pub fn execute(
     }
     const pattern: ?[]const u8 = if (positionals.len == 1) positionals[0] else null;
 
-    const programs = collectPrograms(io, arena, term, pattern) catch |err| {
-        try term.err("gero test: cannot walk {s} ({s})", .{ tests_root, @errorName(err) });
-        return 1;
+    // Project-driven test discovery: load gero.toml from cwd or an
+    // ancestor and walk [test].include for `.gas` + sibling
+    // `.expected` pairs. No manifest → usage error: there's no
+    // sensible default root for a CLI shipped as a binary.
+    const outcome = try manifest_loader.load(io, arena, term, "gero test");
+    var loaded = switch (outcome) {
+        .not_found => {
+            try term.err("gero test: no gero.toml in this directory or any parent (run `gero new` to scaffold a project, or `gero asm` + `gero run` for single-file programs)", .{});
+            return 2;
+        },
+        .failed => return 1,
+        .ok => |l| l,
+    };
+    defer loaded.deinit(arena);
+
+    if (loaded.manifest.test_.include.len == 0) {
+        try term.err("gero test: gero.toml has no [test].include entries — add at least one directory or .gas path to discover tests", .{});
+        return 2;
+    }
+
+    const programs = collectPrograms(
+        io,
+        arena,
+        term,
+        loaded.project_root,
+        loaded.manifest.test_.include,
+        pattern,
+    ) catch |err| switch (err) {
+        error.LoadFailed => return 1,
+        else => |e| return e,
     };
 
     if (programs.len == 0) {
         if (pattern) |p| {
-            try stdout.print("no tests matching '{s}' under {s}\n", .{ p, tests_root });
+            try stdout.print("no tests matching '{s}' under [test].include\n", .{p});
         } else {
-            try stdout.print("no tests under {s}\n", .{tests_root});
+            try stdout.print("no tests under [test].include\n", .{});
         }
         return 0;
     }
@@ -114,28 +138,25 @@ pub fn execute(
     return if (fail > 0) 7 else 0;
 }
 
-/// Walk `tests_root` recursively, collect `.gas` programs that
-/// have a sibling `.expected`, optionally filtered by `pattern`.
+/// Resolve every entry in `includes` (manifest-relative, file or
+/// directory) and collect `.gas` programs that have a sibling
+/// `.expected`. Optionally filtered by `pattern`.
 fn collectPrograms(
     io: std.Io,
     arena: std.mem.Allocator,
     term: *term_mod.Term,
+    project_root: []const u8,
+    includes: []const []const u8,
     pattern: ?[]const u8,
 ) ![]Program {
-    var dir = try std.Io.Dir.cwd().openDir(io, tests_root, .{ .iterate = true });
-    defer dir.close(io);
-    var walker = try dir.walk(arena);
-    defer walker.deinit();
+    var gas_files: std.ArrayList([]const u8) = .empty;
+    try manifest_loader.expandIncludes(io, arena, term, "gero test", project_root, includes, &gas_files);
 
     var list: std.ArrayList(Program) = .empty;
-    while (try walker.next(io)) |entry| {
-        if (entry.kind != .file) continue;
-        if (!std.mem.endsWith(u8, entry.path, ".gas")) continue;
-
-        const name_borrowed = stem(std.fs.path.basename(entry.path));
+    for (gas_files.items) |gas_path| {
+        const name_borrowed = stem(std.fs.path.basename(gas_path));
         if (pattern) |p| if (std.mem.indexOf(u8, name_borrowed, p) == null) continue;
 
-        const gas_path = try std.fmt.allocPrint(arena, "{s}/{s}", .{ tests_root, entry.path });
         const expected_path = try std.fmt.allocPrint(
             arena,
             "{s}.expected",

--- a/build.zig
+++ b/build.zig
@@ -150,6 +150,15 @@ pub fn build(b: *std.Build) void {
         .name = "test-cli-project",
         .root_module = project_mod,
     });
+    const manifest_loader_mod = b.createModule(.{
+        .root_source_file = b.path("apps/gero-cli/manifest_loader.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const manifest_loader_test = b.addTest(.{
+        .name = "test-cli-manifest-loader",
+        .root_module = manifest_loader_mod,
+    });
     const new_cli_mod = b.createModule(.{
         .root_source_file = b.path("apps/gero-cli/new.zig"),
         .target = target,
@@ -243,6 +252,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(check_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(fmt_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(project_test).step);
+    test_step.dependOn(&b.addRunArtifact(manifest_loader_test).step);
     test_step.dependOn(&b.addRunArtifact(new_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(init_cli_test).step);
     test_step.dependOn(&b.addRunArtifact(build_cli_test).step);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,19 +109,24 @@ mismatch).
 
 ### 3.4 `gero test [pattern]` — run tests
 
-> **v0.1 shape (shipped):** asm-level golden-stdout harness. The
-> runner walks `tests/asm/` for `.gas` programs paired with a
-> sibling `<name>.expected` file, assembles each, boots a fresh VM,
+> **v0.2 shape (shipped):** asm-level golden-stdout harness. The
+> runner reads `[test].include` from `gero.toml`, walks each
+> declared path for `.gas` programs paired with a sibling
+> `<name>.expected` file, assembles each, boots a fresh VM,
 > captures stdout (via the host `int $10` print syscall), and diffs
 > against the golden. The lang-level form described below (`@test`
 > functions, structured assertion diagnostics) lands with the
-> language compiler in v0.2.
+> language compiler in v0.3.
 
 ```bash
-gero test                         # all .gas tests under tests/asm/
+gero test                         # all .gas tests under [test].include
 gero test loop                    # only tests with "loop" in the name
 gero test --verbose               # show per-test duration
 ```
+
+`gero test` is project-aware: it requires a `gero.toml` in the
+cwd or an ancestor (run `gero new` to scaffold one). No fall-back
+to a hardcoded root.
 
 **Output format (v0.1, asm-level):**
 
@@ -252,11 +257,16 @@ gero fmt main.gas                 # format in place
 gero fmt --check main.gas         # check only (exit 8 if changes needed)
 gero fmt src/                     # recurse into directory
 gero fmt a.gas b.gas src/         # any mix of files and directories
+gero fmt                          # project-aware: [build].entry + [test].include
 ```
 
 **Behavior:**
 - In-place edit by default. Files already in canonical form are
   left untouched.
+- **Project-aware fallback**: invoked with no positional args
+  inside a gero project (cwd or any ancestor has `gero.toml`),
+  walks `[build].entry` + every entry in `[test].include`. No
+  manifest + no positional args → exit 2 with a usage hint.
 - `--check` is non-destructive: exits 0 if every file is canonical,
   8 if any file would be reformatted, 3 on a genuine parse error.
   CI use case.
@@ -306,10 +316,16 @@ run round-trip.
 gero check main.gas               # one .gas file
 gero check src/                   # walk recursively for *.gas
 gero check a.gas b.gas src/       # any mix of files + dirs
+gero check                        # project-aware: [build].entry + [test].include
 gero check main.gr                # → "not yet implemented" until v0.3
 gero check main.gas --quiet       # suppress per-file lines + summary
 gero check main.gas --verbose     # per-phase timings (single-file only)
 ```
+
+**Project-aware fallback**: invoked with no positional args
+inside a gero project (cwd or any ancestor has `gero.toml`),
+walks `[build].entry` + every entry in `[test].include`. No
+manifest + no positional args → exit 2 with a usage hint.
 
 **Output (default):**
 


### PR DESCRIPTION
Closes #135.

## Summary

The three lint / check commands gain a manifest-driven fallback. Invoked with no positional args inside a gero project (cwd or any ancestor has `gero.toml`), they resolve their target file list from the manifest instead of erroring out.

| Command | No-args behavior inside a project |
|---|---|
| `gero check` | walks `[build].entry` + every entry in `[test].include` — whole project type-checked in one pass |
| `gero fmt` / `gero fmt --check` | same — formats / diff-checks the same union |
| `gero test` | walks `[test].include` for `.gas` + sibling `.expected`; **hardcoded `tests/asm/` root is gone** |

Explicit positional args keep their current single-file / directory-walk semantics — no behavior change for existing invocations.

`gero test` outside any project now always errors (exit 2) — there's no sensible default root for a CLI shipped as a binary. Resolves the long-standing external-usability gap.

## Architecture

Shared manifest-loading + include-expansion logic lives in `apps/gero-cli/manifest_loader.zig` (load + parse-error reporting + file-or-directory expansion). `project.zig` stays the pure-parser module.

## Smoke tests (manual)

| Case | Result |
|---|---|
| `gero new my-cart && cd my-cart && gero check` | ✅ exit 0, walks `src/main.gas` + `tests/smoke.gas` |
| same with `gero fmt --check` | ✅ exit 0, both unchanged (templates re-canonicalized) |
| same with `gero test` | ✅ exit 0, smoke test passes |
| `cd my-cart/src && gero check` | ✅ ancestor walk works |
| `gero check` outside any project | ✅ exit 2, "missing source file … (or run inside a gero project)" |
| `gero test` outside any project | ✅ exit 2, "no gero.toml … (run \`gero new\` or use \`gero asm\` + \`gero run\` for single-file)" |
| `gero check src/main.gas` (explicit positional) | ✅ single-file semantics preserved |

## Self-review

**Step 1 (#135 AC):**
- ✅ `gero check` from inside a scaffolded project (no args) walks every declared `.gas` file
- ✅ `gero check src/foo.gas` still works as a single-file call
- ✅ `gero test` honors `gero.toml`'s `[test].include`; the hardcoded path is gone
- ✅ `gero fmt` same shape
- ✅ All three commands fail gracefully outside a project with no positionals (exit 2 with hint)
- ✅ Strict-mode + doc comments, changeset added (minor bump)

**Step 2** (`zig build ci`): EXIT=0 — lint + test-modes + test-all (5 cross-targets) + check-examples + check-broken + fmt-check-examples + test-examples all green.

**Step 3 (diff walk, 9 files, +350/-50):**
- `apps/gero-cli/manifest_loader.zig` (new) — `load`, `joinUnderRoot`, `expandIncludes`, `Outcome` union + 3 inline tests
- `apps/gero-cli/check.zig` — positional-empty branch routes through manifest_loader
- `apps/gero-cli/fmt.zig` — same shape
- `apps/gero-cli/test.zig` — hardcoded `tests/asm/` removed; `collectPrograms` refactored to take `(project_root, includes)`; require manifest
- `apps/gero-cli/templates/main.gas` + `smoke.gas` — re-canonicalized (trailing-comment column was too wide)
- `build.zig` — `manifest_loader_test` artifact registered
- `docs/cli.md` §3.4 / §3.8 / §3.9 — document the project-aware fallback
- `.changeset/gero-project-aware-commands.md` — minor bump

**Step 4 (hygiene):** no stray `std.debug.print`, no commented-out code, no TODO, no AI attribution, single commit with conventional `feat(apps/gero-cli):` scope.