### PR TITLE
feat(apps/gero-cli): gero.toml [fmt] section — per-project printer overrides

### DIFF
--- a/.changeset/gero-toml-fmt-section.md
+++ b/.changeset/gero-toml-fmt-section.md
@@ -1,0 +1,33 @@
+---
+bump: minor
+---
+
+`gero.toml` gains a `[fmt]` section — per-project printer
+overrides for `gero fmt`.
+
+```toml
+[fmt]
+indent = 2                   # default 2
+comment_column = 30          # default 30 — 0 disables alignment
+align_kv = true              # default true
+hex_case = "upper"           # upper | lower | preserve
+```
+
+Inside a project, `gero fmt` (and `gero fmt --check`) reads the
+section and applies the overrides; outside a project (or with no
+`[fmt]` section), compile-time defaults are used — preserves the
+single-file CLI behavior.
+
+Same pattern as Rust's `rustfmt.toml` / Black's `pyproject.toml
+[tool.black]`: one canonical shape per project, no in-file
+overrides, no editor-side `.editorconfig` discovery.
+
+TOML parser extended with integer + boolean value shapes (keys
+`indent`, `comment_column` parse as integers; `align_kv` as a
+bool; `hex_case` as one of three allowed strings).
+
+`Diagnostic` storage moved inline (embedded `[256]u8 +
+message_len`) so the message slice survives `parseWithDiagnostic`
+returning — fixes a latent dangling-slice bug that only surfaced
+with longer error messages (the existing tests happened to use
+short messages and read intact stack memory by luck).

--- a/apps/gero-cli/build.zig
+++ b/apps/gero-cli/build.zig
@@ -52,7 +52,7 @@ pub fn execute(
     var manifest = switch (try project.parseWithDiagnostic(arena, source)) {
         .ok => |m| m,
         .err => |diag| {
-            try term.err("gero build: {s}:{d}:{d}: {s}", .{ manifest_path, diag.line, diag.col, diag.message });
+            try term.err("gero build: {s}:{d}:{d}: {s}", .{ manifest_path, diag.line, diag.col, diag.message() });
             return 3;
         },
     };

--- a/apps/gero-cli/fmt.zig
+++ b/apps/gero-cli/fmt.zig
@@ -26,6 +26,7 @@ const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const footer = @import("footer.zig");
 const manifest_loader = @import("manifest_loader.zig");
+const project = @import("project.zig");
 
 /// Per-file outcome.
 const Outcome = enum {
@@ -49,28 +50,43 @@ pub fn execute(
     const positionals = opts.positional();
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
 
-    var files: std.ArrayList([]const u8) = .empty;
-    if (positionals.len == 0) {
-        // Project-aware fallback: load gero.toml from cwd or any
-        // ancestor and use [build].entry + [test].include as the
-        // implicit file list. No manifest → usage error.
+    // Always try to load gero.toml — both [fmt] overrides and the
+    // implicit file list (when no positionals are passed) come
+    // from the manifest. `not_found` is normal (single-file CLI
+    // use case); `failed` means a read/parse error was already
+    // printed.
+    var print_options: gero.asm_.PrintOptions = gero.asm_.default_print_options;
+    var manifest_files: ?[]const []const u8 = null;
+    {
         const outcome = try manifest_loader.load(io, arena, term, "gero fmt");
         switch (outcome) {
-            .not_found => {
-                try term.err("gero fmt: missing source file or directory path (or run inside a gero project)", .{});
-                return 2;
-            },
+            .not_found => {},
             .failed => return 1,
             .ok => |loaded| {
                 var loaded_mut = loaded;
                 defer loaded_mut.deinit(arena);
-                const entry_path = try manifest_loader.joinUnderRoot(arena, loaded.project_root, loaded.manifest.build.entry);
-                try files.append(arena, entry_path);
-                manifest_loader.expandIncludes(io, arena, term, "gero fmt", loaded.project_root, loaded.manifest.test_.include, &files) catch |err| switch (err) {
-                    error.LoadFailed => return 1,
-                    else => |e| return e,
-                };
+                print_options = printOptionsFromManifest(loaded.manifest.fmt);
+                if (positionals.len == 0) {
+                    var files_buf: std.ArrayList([]const u8) = .empty;
+                    const entry_path = try manifest_loader.joinUnderRoot(arena, loaded.project_root, loaded.manifest.build.entry);
+                    try files_buf.append(arena, entry_path);
+                    manifest_loader.expandIncludes(io, arena, term, "gero fmt", loaded.project_root, loaded.manifest.test_.include, &files_buf) catch |err| switch (err) {
+                        error.LoadFailed => return 1,
+                        else => |e| return e,
+                    };
+                    manifest_files = try files_buf.toOwnedSlice(arena);
+                }
             },
+        }
+    }
+
+    var files: std.ArrayList([]const u8) = .empty;
+    if (positionals.len == 0) {
+        if (manifest_files) |mf| {
+            try files.appendSlice(arena, mf);
+        } else {
+            try term.err("gero fmt: missing source file or directory path (or run inside a gero project)", .{});
+            return 2;
         }
     } else {
         for (positionals) |path| {
@@ -92,7 +108,7 @@ pub fn execute(
     var changed: usize = 0;
     var parse_failed: usize = 0;
     for (files.items) |path| {
-        const outcome = formatOne(io, arena, stdout, term, style, path, opts.check, single, opts.quiet) catch |err| {
+        const outcome = formatOne(io, arena, stdout, term, style, path, opts.check, single, opts.quiet, print_options) catch |err| {
             try term.err("gero fmt: cannot read/write {s} ({s})", .{ path, @errorName(err) });
             return 1;
         };
@@ -116,6 +132,22 @@ pub fn execute(
     return 0;
 }
 
+/// Translate the manifest's `[fmt]` shape into the printer's
+/// `PrintOptions`. Same fields one-to-one; `HexCase` is a
+/// disjoint enum so we map per-variant.
+pub fn printOptionsFromManifest(fmt: project.Manifest.Fmt) gero.asm_.PrintOptions {
+    return .{
+        .indent = fmt.indent,
+        .comment_column = fmt.comment_column,
+        .align_kv = fmt.align_kv,
+        .hex_case = switch (fmt.hex_case) {
+            .upper => .upper,
+            .lower => .lower,
+            .preserve => .preserve,
+        },
+    };
+}
+
 fn formatOne(
     io: std.Io,
     arena: std.mem.Allocator,
@@ -126,6 +158,7 @@ fn formatOne(
     check_mode: bool,
     single: bool,
     quiet: bool,
+    print_options: gero.asm_.PrintOptions,
 ) !Outcome {
     const src = try std.Io.Dir.cwd().readFileAlloc(io, path, arena, .unlimited);
 
@@ -150,7 +183,7 @@ fn formatOne(
     // Re-emit through the canonical printer, then compare bytes
     // against the source. Equal → already canonical.
     var allocating = std.Io.Writer.Allocating.init(arena);
-    try gero.asm_.printProgram(&allocating.writer, &pt.program, src, gero.asm_.default_print_options);
+    try gero.asm_.printProgram(&allocating.writer, &pt.program, src, print_options);
     const formatted = allocating.written();
 
     if (std.mem.eql(u8, src, formatted)) {

--- a/apps/gero-cli/manifest_loader.zig
+++ b/apps/gero-cli/manifest_loader.zig
@@ -73,7 +73,7 @@ pub fn load(
         .err => |diag| {
             try term.err(
                 "{s}: {s}:{d}:{d}: {s}",
-                .{ command_name, manifest_path, diag.line, diag.col, diag.message },
+                .{ command_name, manifest_path, diag.line, diag.col, diag.message() },
             );
             return .failed;
         },

--- a/apps/gero-cli/project.zig
+++ b/apps/gero-cli/project.zig
@@ -33,6 +33,7 @@ pub const Manifest = struct {
     package: Package,
     build: Build,
     test_: Test,
+    fmt: Fmt,
 
     pub const Package = struct {
         name: []const u8,
@@ -50,6 +51,19 @@ pub const Manifest = struct {
         include: []const []const u8,
     };
 
+    /// `[fmt]` overrides for the canonical printer. Shape mirrors
+    /// `gero.asm_.PrintOptions`; the CLI converts between the two
+    /// at fmt-time so this module stays library-dep-free.
+    pub const Fmt = struct {
+        indent: usize,
+        comment_column: usize,
+        align_kv: bool,
+        hex_case: HexCase,
+    };
+
+    /// Case policy for hex literals — mirrors `printer.HexCase`.
+    pub const HexCase = enum { upper, lower, preserve };
+
     /// Free the heap-allocated string-array slices. String contents
     /// themselves borrow from the source buffer, so the caller
     /// keeps responsibility for that.
@@ -64,14 +78,28 @@ pub const defaults = struct {
     pub const package_target: []const u8 = "vm";
     pub const build_out: []const u8 = "out/";
     pub const build_optimize: []const u8 = "debug";
+    pub const fmt_indent: usize = 2;
+    pub const fmt_comment_column: usize = 30;
+    pub const fmt_align_kv: bool = true;
+    pub const fmt_hex_case: Manifest.HexCase = .upper;
 };
 
 /// One parse-time diagnostic with line / column for the
-/// renderer.
+/// renderer. `message_storage` holds the formatted message inline
+/// so the slice returned by `message()` survives the parser's
+/// stack teardown (the union is copied by value out of
+/// `parseWithDiagnostic`).
 pub const Diagnostic = struct {
     line: usize,
     col: usize,
-    message: []const u8,
+    message_storage: [256]u8 = undefined,
+    message_len: usize = 0,
+
+    /// Borrow the formatted-message slice. Valid for the lifetime
+    /// of the surrounding `ParseResult` value.
+    pub fn message(self: *const Diagnostic) []const u8 {
+        return self.message_storage[0..self.message_len];
+    }
 };
 
 /// Error set for `parse`. The diagnostic accompanying a
@@ -192,7 +220,7 @@ fn isIdentCont(c: u8) bool {
 
 /// Which `[section]` the parser is currently inside, so the key-
 /// value handler can route into the right pending bucket.
-const Section = enum { none, package, build, test_, unknown };
+const Section = enum { none, package, build, test_, fmt, unknown };
 
 const Parser = struct {
     source: []const u8,
@@ -201,11 +229,7 @@ const Parser = struct {
     col: usize,
     allocator: std.mem.Allocator,
     current_section: Section = .none,
-    diag: Diagnostic = .{ .line = 0, .col = 0, .message = "" },
-    /// 256-byte scratch for the parser's diagnostic message. We
-    /// only ever emit one error per parse, so reusing the buffer
-    /// is safe.
-    diag_buf: [256]u8 = undefined,
+    diag: Diagnostic = .{ .line = 0, .col = 0 },
 
     fn advance(self: *Parser, n: usize) void {
         var i: usize = 0;
@@ -286,6 +310,7 @@ const Parser = struct {
         if (std.mem.eql(u8, name, "package")) return .package;
         if (std.mem.eql(u8, name, "build")) return .build;
         if (std.mem.eql(u8, name, "test")) return .test_;
+        if (std.mem.eql(u8, name, "fmt")) return .fmt;
         // Forward-compat: skip unknown sections instead of failing.
         return .unknown;
     }
@@ -320,8 +345,16 @@ const Parser = struct {
                 const value = try self.parseStringArray();
                 try pending.recordStringArray(self, key, value);
             },
+            '0'...'9' => {
+                const value = try self.parseInteger(key);
+                try pending.recordInteger(self, key, value);
+            },
+            't', 'f' => {
+                const value = try self.parseBool(key);
+                try pending.recordBool(self, key, value);
+            },
             else => {
-                self.reportf("unsupported value for key '{s}' — expected string or array", .{key});
+                self.reportf("unsupported value for key '{s}' — expected string, array, integer, or boolean", .{key});
                 return error.ParseFailed;
             },
         }
@@ -390,16 +423,54 @@ const Parser = struct {
         }
     }
 
+    /// Unsigned decimal integer literal. `key` is only used for
+    /// the diagnostic message; the parsed value is returned as
+    /// `usize`. No size suffix / radix prefix support — keep the
+    /// surface tight.
+    fn parseInteger(self: *Parser, key: []const u8) ParseError!usize {
+        const start = self.index;
+        while (self.index < self.source.len) {
+            const c = self.source[self.index];
+            if (c < '0' or c > '9') break;
+            self.advance(1);
+        }
+        const text = self.source[start..self.index];
+        return std.fmt.parseInt(usize, text, 10) catch {
+            self.reportf("invalid integer literal for key '{s}'", .{key});
+            return error.ParseFailed;
+        };
+    }
+
+    /// `true` / `false` keyword. Anything else under `t`/`f`
+    /// produces a clean diagnostic.
+    fn parseBool(self: *Parser, key: []const u8) ParseError!bool {
+        const start = self.index;
+        while (self.index < self.source.len) {
+            const c = self.source[self.index];
+            if (!((c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z'))) break;
+            self.advance(1);
+        }
+        const text = self.source[start..self.index];
+        if (std.mem.eql(u8, text, "true")) return true;
+        if (std.mem.eql(u8, text, "false")) return false;
+        self.reportf("invalid boolean literal '{s}' for key '{s}' (expected true or false)", .{ text, key });
+        return error.ParseFailed;
+    }
+
     fn reportf(
         self: *Parser,
         comptime fmt: []const u8,
         args: anytype,
     ) void {
-        // The message slice points into a small static buffer so
-        // we don't need to allocate. v0.2 surfaces only the first
-        // error per parse; long-form messages aren't needed.
-        const buf = std.fmt.bufPrint(&self.diag_buf, fmt, args) catch &self.diag_buf;
-        self.diag = .{ .line = self.line, .col = self.col, .message = buf };
+        // Format into the diagnostic's inline storage. v0.2
+        // surfaces only the first error per parse, so the buffer
+        // is single-shot. `bufPrint` truncation on a >256-byte
+        // message degrades to whatever fit — acceptable for the
+        // pathologically-long edge case.
+        self.diag.line = self.line;
+        self.diag.col = self.col;
+        const text = std.fmt.bufPrint(&self.diag.message_storage, fmt, args) catch self.diag.message_storage[0..];
+        self.diag.message_len = text.len;
     }
 };
 
@@ -414,6 +485,10 @@ const Pending = struct {
     build_out: ?[]const u8 = null,
     build_optimize: ?[]const u8 = null,
     test_include: ?[]const []const u8 = null,
+    fmt_indent: ?usize = null,
+    fmt_comment_column: ?usize = null,
+    fmt_align_kv: ?bool = null,
+    fmt_hex_case: ?[]const u8 = null,
 
     fn recordString(self: *Pending, parser: *Parser, key: []const u8, value: []const u8) ParseError!void {
         switch (parser.current_section) {
@@ -433,8 +508,44 @@ const Pending = struct {
                 parser.reportf("unknown string key '[test].{s}' (only 'include' is supported)", .{key});
                 return error.ParseFailed;
             },
+            .fmt => {
+                if (std.mem.eql(u8, key, "hex_case")) self.fmt_hex_case = value else {
+                    parser.reportf("unknown string key '[fmt].{s}' (only 'hex_case' is a string)", .{key});
+                    return error.ParseFailed;
+                }
+            },
             .unknown, .none => {
                 parser.reportf("key '{s}' outside a known section", .{key});
+                return error.ParseFailed;
+            },
+        }
+    }
+
+    fn recordInteger(self: *Pending, parser: *Parser, key: []const u8, value: usize) ParseError!void {
+        switch (parser.current_section) {
+            .fmt => {
+                if (std.mem.eql(u8, key, "indent")) self.fmt_indent = value else if (std.mem.eql(u8, key, "comment_column")) self.fmt_comment_column = value else {
+                    parser.reportf("unknown integer key '[fmt].{s}'", .{key});
+                    return error.ParseFailed;
+                }
+            },
+            else => {
+                parser.reportf("integer values aren't expected under section for key '{s}'", .{key});
+                return error.ParseFailed;
+            },
+        }
+    }
+
+    fn recordBool(self: *Pending, parser: *Parser, key: []const u8, value: bool) ParseError!void {
+        switch (parser.current_section) {
+            .fmt => {
+                if (std.mem.eql(u8, key, "align_kv")) self.fmt_align_kv = value else {
+                    parser.reportf("unknown boolean key '[fmt].{s}'", .{key});
+                    return error.ParseFailed;
+                }
+            },
+            else => {
+                parser.reportf("boolean values aren't expected under section for key '{s}'", .{key});
                 return error.ParseFailed;
             },
         }
@@ -474,6 +585,18 @@ const Pending = struct {
             break :blk empty;
         };
 
+        // Validate hex_case against the three allowed values. Any
+        // other string is a hard parse error with a clear
+        // diagnostic — the printer's three-way enum has no escape
+        // hatch.
+        const hex_case: Manifest.HexCase = if (self.fmt_hex_case) |s| blk: {
+            if (std.mem.eql(u8, s, "upper")) break :blk .upper;
+            if (std.mem.eql(u8, s, "lower")) break :blk .lower;
+            if (std.mem.eql(u8, s, "preserve")) break :blk .preserve;
+            parser.reportf("invalid '[fmt].hex_case' value '{s}' (expected 'upper', 'lower', or 'preserve')", .{s});
+            return error.ParseFailed;
+        } else defaults.fmt_hex_case;
+
         return .{
             .package = .{
                 .name = name,
@@ -486,6 +609,12 @@ const Pending = struct {
                 .optimize = self.build_optimize orelse defaults.build_optimize,
             },
             .test_ = .{ .include = include_slice },
+            .fmt = .{
+                .indent = self.fmt_indent orelse defaults.fmt_indent,
+                .comment_column = self.fmt_comment_column orelse defaults.fmt_comment_column,
+                .align_kv = self.fmt_align_kv orelse defaults.fmt_align_kv,
+                .hex_case = hex_case,
+            },
         };
     }
 };
@@ -554,7 +683,7 @@ test "project: missing required key surfaces diagnostic" {
     ;
     const result = try parseWithDiagnostic(testing.allocator, src);
     try testing.expect(result == .err);
-    try testing.expect(std.mem.indexOf(u8, result.err.message, "version") != null);
+    try testing.expect(std.mem.indexOf(u8, result.err.message(), "version") != null);
 }
 
 test "project: unknown key surfaces diagnostic" {
@@ -570,7 +699,7 @@ test "project: unknown key surfaces diagnostic" {
     ;
     const result = try parseWithDiagnostic(testing.allocator, src);
     try testing.expect(result == .err);
-    try testing.expect(std.mem.indexOf(u8, result.err.message, "bogus_key") != null);
+    try testing.expect(std.mem.indexOf(u8, result.err.message(), "bogus_key") != null);
 }
 
 test "project: comments are skipped" {
@@ -599,7 +728,7 @@ test "project: unterminated string fails with diagnostic" {
     ;
     const result = try parseWithDiagnostic(testing.allocator, src);
     try testing.expect(result == .err);
-    try testing.expect(std.mem.indexOf(u8, result.err.message, "unterminated") != null);
+    try testing.expect(std.mem.indexOf(u8, result.err.message(), "unterminated") != null);
 }
 
 test "project: empty string array parses cleanly" {
@@ -659,4 +788,107 @@ test "project: unknown section is tolerated (forward-compat)" {
     // can be relaxed if forward-compat needs grow.
     const result = try parseWithDiagnostic(testing.allocator, src);
     try testing.expect(result == .err);
+}
+
+test "project: [fmt] section parses int / bool / string keys" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+        \\[fmt]
+        \\indent = 4
+        \\comment_column = 40
+        \\align_kv = false
+        \\hex_case = "lower"
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 4), m.fmt.indent);
+    try testing.expectEqual(@as(usize, 40), m.fmt.comment_column);
+    try testing.expectEqual(false, m.fmt.align_kv);
+    try testing.expectEqual(Manifest.HexCase.lower, m.fmt.hex_case);
+}
+
+test "project: [fmt] section defaults when absent" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expectEqual(defaults.fmt_indent, m.fmt.indent);
+    try testing.expectEqual(defaults.fmt_comment_column, m.fmt.comment_column);
+    try testing.expectEqual(defaults.fmt_align_kv, m.fmt.align_kv);
+    try testing.expectEqual(defaults.fmt_hex_case, m.fmt.hex_case);
+}
+
+test "project: [fmt] hex_case validates against the three allowed values" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+        \\[fmt]
+        \\hex_case = "bogus"
+        \\
+    ;
+    const result = try parseWithDiagnostic(testing.allocator, src);
+    try testing.expect(result == .err);
+    try testing.expect(std.mem.indexOf(u8, result.err.message(), "hex_case") != null);
+    try testing.expect(std.mem.indexOf(u8, result.err.message(), "upper") != null);
+}
+
+test "project: [fmt] partial overrides keep defaults for absent keys" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+        \\[fmt]
+        \\comment_column = 32
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expectEqual(defaults.fmt_indent, m.fmt.indent);
+    try testing.expectEqual(@as(usize, 32), m.fmt.comment_column);
+    try testing.expectEqual(defaults.fmt_align_kv, m.fmt.align_kv);
+    try testing.expectEqual(defaults.fmt_hex_case, m.fmt.hex_case);
+}
+
+test "project: [fmt] rejects invalid boolean value" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+        \\[fmt]
+        \\align_kv = yes
+        \\
+    ;
+    const result = try parseWithDiagnostic(testing.allocator, src);
+    try testing.expect(result == .err);
+    try testing.expect(std.mem.indexOf(u8, result.err.message(), "align_kv") != null);
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -250,7 +250,9 @@ debug:       yes (symbols: 142)
 ### 3.8 `gero fmt <files...>` — format source
 
 Canonical formatter for `.gas` (and eventually `.gr`). Style is
-fixed — no config file, no flags (like `gofmt` / `zig fmt`).
+fixed per-invocation — no `--option`s, no `.editorconfig` lookup.
+Inside a gero project, the manifest's `[fmt]` section overrides
+the compile-time defaults (see below).
 
 ```bash
 gero fmt main.gas                 # format in place
@@ -303,6 +305,31 @@ const FOO = $20  ; gero-fmt-ignore   ; this single line preserved (trailing)
 ```
 
 The directive comments themselves stay in the output.
+
+#### `[fmt]` section in `gero.toml`
+
+Override the printer's canonical defaults per-project. Same
+pattern as Rust's `rustfmt.toml` / Black's `pyproject.toml
+[tool.black]` — one canonical shape per project, no in-file
+overrides.
+
+```toml
+[fmt]
+indent = 2                   # default 2 — spaces of label-body indent
+comment_column = 30          # default 30 — 0 disables alignment
+align_kv = true              # default true — align `=` in const/data blocks
+hex_case = "upper"           # default "upper" — upper | lower | preserve
+```
+
+Inside a project, `gero fmt` (and `gero fmt --check`) reads the
+section and applies the overrides. Outside a project (or with no
+`[fmt]` section), compile-time defaults are used — preserves the
+single-file CLI behavior.
+
+Invalid `hex_case` values produce a clean diagnostic with line/col;
+the parser rejects any other shape (integer keys for
+`indent` / `comment_column`, boolean for `align_kv`, string for
+`hex_case`).
 
 ### 3.9 `gero check <file>` — validate without producing output
 


### PR DESCRIPTION
Closes #142.

## Summary

`gero.toml` gains a `[fmt]` section that overrides the canonical printer's defaults per-project:

```toml
[fmt]
indent = 2                   # default 2 — spaces of label-body indent
comment_column = 30          # default 30 — 0 disables alignment
align_kv = true              # default true — align `=` in const/data blocks
hex_case = "upper"           # default "upper" — upper | lower | preserve
```

Inside a project, `gero fmt` (and `gero fmt --check`) reads the section and applies the overrides. Outside a project (or with no `[fmt]` section), compile-time defaults are used — preserves the single-file CLI behavior.

## TOML parser extensions

The parser now accepts integer + boolean value shapes:
- Keys `indent` / `comment_column` parse as integers
- `align_kv` parses as `true` / `false`
- `hex_case` parses as a string then validates against the three allowed values; invalid → diagnostic at finalize time

## Smoke tests (manual)

| Case | Result |
|---|---|
| Append `comment_column = 50` to a scaffold's gero.toml, `gero fmt --check` | ✅ exit 8 (drift detected) |
| Then `gero fmt`, then `gero fmt --check` | ✅ exit 0 (idempotent at col 50) |
| `hex_case = "lower"` → `$0A` becomes `$0a` after format | ✅ |
| `align_kv = false` → `const PRINT = $10` (no padding) | ✅ |
| `hex_case = "screaming"` → exit 1 with clean line:col diagnostic | ✅ |
| `align_kv = yes` (invalid bool) | ✅ exit 1 with diag mentioning the key |
| No `[fmt]` section → compile-time defaults | ✅ |
| Outside a project → compile-time defaults | ✅ |

## Dangling-slice fix (drive-by)

While writing the [fmt] tests I hit a bug where the parser's `Diagnostic.message` slice pointed into stack-allocated buffer that got reclaimed when `parseWithDiagnostic` returned. The existing short-message tests happened to read intact stack memory by luck; the new 80-char hex_case validation message extended into stack slots the testing harness was about to clobber, so the slice came back as garbage.

Fix: embedded the message buffer inline in `Diagnostic` (`message_storage: [256]u8` + `message_len: usize` + `message()` accessor). The union now carries the bytes with it across the return. Touches every existing `.message` reader site (3 tests + manifest_loader + build.zig diagnostic plumbing).

## Self-review

**Step 1 (#142 AC):**
- ✅ `[fmt]` section parses cleanly into a typed struct (Manifest.Fmt)
- ✅ `gero fmt` inside a project respects the overrides
- ✅ Outside a project, `gero fmt` uses defaults
- ✅ Invalid `hex_case` value emits a clear diagnostic (with line/col)
- ✅ `docs/cli.md` §3.8 documents the section
- ⏭️ `docs/tooling.md` not updated — that file lands in #126 (Phase 8); link will resolve there
- ✅ Strict-mode + doc comments, changeset added (minor bump)

**Step 2** (`zig build ci`): EXIT=0 — lint + test-modes + test-all (5 cross-targets) + check-examples + check-broken + fmt-check-examples + test-examples all green.

**Step 3 (diff walk, 6 files, +362/-37):**
- `apps/gero-cli/project.zig` — `Manifest.Fmt` + `HexCase` enum + `Section.fmt` + int/bool value-shape dispatch (`parseInteger`, `parseBool`) + recordInteger/recordBool on Pending + finalize validates hex_case + 5 new inline tests + Diagnostic dangling-slice fix
- `apps/gero-cli/fmt.zig` — always-try-load pattern (manifest used for both [fmt] overrides AND implicit file list); new `printOptionsFromManifest` helper; `formatOne` takes print_options param
- `apps/gero-cli/manifest_loader.zig` — diag.message → diag.message() (one call site)
- `apps/gero-cli/build.zig` — same one-line change
- `docs/cli.md` §3.8 — new [fmt] subsection + updated intro line
- `.changeset/gero-toml-fmt-section.md` — minor bump

**Step 4 (hygiene):** no stray `std.debug.print` (one was added during debugging, removed), no commented-out code, no TODO, no AI attribution, single commit with conventional `feat(apps/gero-cli):` scope.