### PR TITLE
feat(apps/gero-cli): manifest polish — metadata, build.name, per-profile output, test exclude + cycle budget

### DIFF
--- a/.changeset/manifest-polish.md
+++ b/.changeset/manifest-polish.md
@@ -1,0 +1,63 @@
+---
+bump: minor
+---
+
+`gero.toml` polish — extends every section with low-cost, high-leverage
+config that was sitting in TBD column:
+
+**`[package]` metadata** (all optional, no behavior today but
+parser-ready for a future registry / doc generator)
+
+```toml
+[package]
+description = "..."
+license = "MIT"
+repository = "https://github.com/..."
+authors = ["Jane Doe <jane@..>"]
+keywords = ["vm", "demo"]
+```
+
+**`[build]` — decouple binary name, strip debug symbols, per-profile output**
+
+```toml
+[build]
+name = "cart-cli"         # output filename stem; default = package.name
+debug_symbols = false     # strip debug blob; default true
+```
+
+Output path is now `<build.out>/<build.optimize>/<stem>.gx` —
+Cargo's `target/{debug,release}/` pattern. Rebuilding in release
+no longer clobbers the debug artifact; both coexist
+side by side. `<stem>` is `[build].name` if set, else
+`[package].name` (Cargo's `[[bin]].name` convention).
+`debug_symbols = false` shaves the `(address, name)` table out
+of the `.gx` for release builds.
+
+`[build].optimize` is validated against `{debug, release, size}`
+at parse time so a typo doesn't silently land artifacts in
+`out/relase/`. Invalid → clean diagnostic with line:col.
+
+**`[test]` — exclude + cycle budget**
+
+```toml
+[test]
+exclude = ["tests/wip"]     # subtract paths (file or dir prefix)
+cycle_budget = 5_000_000    # per-test cycle cap; default 1M
+```
+
+Exclude matches as a directory prefix (`tests/wip` excludes
+`tests/wip/foo.gas` and `tests/wip/sub/bar.gas`) or as an exact
+`.gas` path. The previously-hardcoded 1M cycle budget is now a
+manifest knob.
+
+**TOML parser**: integer literals accept underscore separators
+(`1_000_000`) so the cycle-budget shape matches what users
+already write in TOML. Boolean values added under `[build]`
+(was `[fmt]`-only).
+
+Wired into `gero build` (uses `build.name` + `build.debug_symbols`
+when assembling) and `gero test` (uses `test.cycle_budget` +
+filters out `test.exclude` paths). `gero check` / `gero fmt` keep
+walking the full `[test].include` (exclude only narrows the test
+set, not the lint set — gives users a knob to keep WIP code
+under fmt/check while skipping it in `gero test`).

--- a/apps/gero-cli/build.zig
+++ b/apps/gero-cli/build.zig
@@ -1,7 +1,8 @@
 /// `gero build` — project-aware compile. Walks the ancestor
 /// chain for `gero.toml`, reads `[build]` + `[package]`, runs the
 /// asm pipeline against `build.entry`, and writes the resulting
-/// `.gx` to `<project_root>/<build.out>/<package.name>.gx`.
+/// `.gx` to `<project_root>/<build.out>/<stem>.gx`, where `<stem>`
+/// is `[build].name` if set, else `[package].name`.
 ///
 /// `gero build` is essentially `gero asm` wrapped with manifest
 /// resolution + output-path discipline. Reuses every existing
@@ -70,13 +71,18 @@ pub fn execute(
         return 2;
     }
 
-    // 3. Resolve project-relative paths.
+    // 3. Resolve project-relative paths. Output lives under a
+    //    per-profile subdir (`out/<optimize>/`) so rebuilding in
+    //    release mode doesn't clobber the debug artifact, à la
+    //    Cargo's `target/{debug,release}/` layout.
     const project_root = std.fs.path.dirname(manifest_path) orelse "";
     const entry_path = try joinUnderRoot(arena, project_root, manifest.build.entry);
-    const out_dir = try joinUnderRoot(arena, project_root, manifest.build.out);
+    const out_root = try joinUnderRoot(arena, project_root, manifest.build.out);
+    const out_dir = try std.fs.path.join(arena, &.{ out_root, manifest.build.optimize });
 
     // 4. Ensure the output directory exists. `createDirPath` is
-    //    idempotent — no-op when `out/` already exists.
+    //    idempotent — creates `out/<optimize>/` plus any missing
+    //    parents in one shot.
     std.Io.Dir.cwd().createDirPath(io, out_dir) catch |err| {
         try term.err("gero build: cannot create {s} ({s})", .{ out_dir, @errorName(err) });
         return 1;
@@ -101,7 +107,9 @@ pub fn execute(
     defer pt.deinit();
     const t_after_parse = std.Io.Timestamp.now(io, .awake);
 
-    var cg = try gero.asm_.assemble(arena, fused.source, pt, .{});
+    var cg = try gero.asm_.assemble(arena, fused.source, pt, .{
+        .debug_symbols = manifest.build.debug_symbols,
+    });
     defer cg.deinit();
     const t_after_codegen = std.Io.Timestamp.now(io, .awake);
 
@@ -117,8 +125,11 @@ pub fn execute(
         return 3;
     }
 
-    // 6. Write `<out_dir>/<package.name>.gx`.
-    const gx_name = try std.fmt.allocPrint(arena, "{s}.gx", .{manifest.package.name});
+    // 6. Write `<out_dir>/<stem>.gx`. Stem is `[build].name` if
+    //    set, else `[package].name` — Cargo's `[[bin]].name`
+    //    convention so the binary can decouple from the crate.
+    const stem = manifest.build.name orelse manifest.package.name;
+    const gx_name = try std.fmt.allocPrint(arena, "{s}.gx", .{stem});
     const out_path = try std.fs.path.join(arena, &.{ out_dir, gx_name });
     std.Io.Dir.cwd().writeFile(io, .{ .sub_path = out_path, .data = cg.image }) catch |err| {
         try term.err("gero build: cannot write {s} ({s})", .{ out_path, @errorName(err) });

--- a/apps/gero-cli/init.zig
+++ b/apps/gero-cli/init.zig
@@ -73,7 +73,7 @@ pub fn execute(
 
     if (!opts.quiet) {
         try term.success("    Initialized `{s}` project in current directory", .{name});
-        try stdout.print("\n  gero build\n  gero run out/{s}.gx\n", .{name});
+        try stdout.print("\n  gero build\n  gero run out/debug/{s}.gx\n", .{name});
     }
     return 0;
 }

--- a/apps/gero-cli/new.zig
+++ b/apps/gero-cli/new.zig
@@ -91,7 +91,7 @@ pub fn execute(
 
     if (!opts.quiet) {
         try term.success("    Created `{s}` project", .{name});
-        try stdout.print("\n  cd {s}\n  gero build\n  gero run out/{s}.gx\n", .{ name, name });
+        try stdout.print("\n  cd {s}\n  gero build\n  gero run out/debug/{s}.gx\n", .{ name, name });
     }
     return 0;
 }

--- a/apps/gero-cli/project.zig
+++ b/apps/gero-cli/project.zig
@@ -39,16 +39,44 @@ pub const Manifest = struct {
         name: []const u8,
         version: []const u8,
         target: []const u8,
+        /// Optional one-line package description. Surfaces in
+        /// future tooling (registry, doc generator) — has no
+        /// effect on the build today.
+        description: ?[]const u8,
+        /// Optional SPDX-style license identifier.
+        license: ?[]const u8,
+        /// Optional canonical repository URL.
+        repository: ?[]const u8,
+        /// Optional authors — `["Jane Doe <jane@example.com>"]` shape.
+        /// Empty slice when absent.
+        authors: []const []const u8,
+        /// Optional keywords for future search / registry use.
+        /// Empty slice when absent.
+        keywords: []const []const u8,
     };
 
     pub const Build = struct {
         entry: []const u8,
         out: []const u8,
         optimize: []const u8,
+        /// Output filename stem — the `.gx` lands at
+        /// `<out>/<name>.gx`. `null` falls back to `[package].name`
+        /// (mirrors Cargo's `[[bin]].name` convention).
+        name: ?[]const u8,
+        /// Emit a debug-symbol blob into the `.gx` so `gero info` /
+        /// `gero disasm` can print friendly names. Defaults to `true`.
+        debug_symbols: bool,
     };
 
     pub const Test = struct {
         include: []const []const u8,
+        /// Optional list of manifest-relative paths (file or
+        /// directory) to subtract from the discovered include set.
+        /// Empty slice when absent.
+        exclude: []const []const u8,
+        /// Per-test cycle budget enforced by `gero test`. Caps a
+        /// buggy program from hanging the runner. Defaults to 1M.
+        cycle_budget: usize,
     };
 
     /// `[fmt]` overrides for the canonical printer. Shape mirrors
@@ -69,6 +97,9 @@ pub const Manifest = struct {
     /// keeps responsibility for that.
     pub fn deinit(self: *Manifest, allocator: std.mem.Allocator) void {
         allocator.free(self.test_.include);
+        allocator.free(self.test_.exclude);
+        allocator.free(self.package.authors);
+        allocator.free(self.package.keywords);
     }
 };
 
@@ -78,10 +109,12 @@ pub const defaults = struct {
     pub const package_target: []const u8 = "vm";
     pub const build_out: []const u8 = "out/";
     pub const build_optimize: []const u8 = "debug";
+    pub const build_debug_symbols: bool = true;
     pub const fmt_indent: usize = 2;
     pub const fmt_comment_column: usize = 30;
     pub const fmt_align_kv: bool = true;
     pub const fmt_hex_case: Manifest.HexCase = .upper;
+    pub const test_cycle_budget: usize = 1_000_000;
 };
 
 /// One parse-time diagnostic with line / column for the
@@ -425,17 +458,36 @@ const Parser = struct {
 
     /// Unsigned decimal integer literal. `key` is only used for
     /// the diagnostic message; the parsed value is returned as
-    /// `usize`. No size suffix / radix prefix support — keep the
-    /// surface tight.
+    /// `usize`. Accepts TOML-style underscore separators
+    /// (`1_000_000`) — they're stripped before `parseInt`. No
+    /// radix prefix / sign support — keep the surface tight.
     fn parseInteger(self: *Parser, key: []const u8) ParseError!usize {
         const start = self.index;
         while (self.index < self.source.len) {
             const c = self.source[self.index];
-            if (c < '0' or c > '9') break;
+            if ((c < '0' or c > '9') and c != '_') break;
             self.advance(1);
         }
         const text = self.source[start..self.index];
-        return std.fmt.parseInt(usize, text, 10) catch {
+        // Strip underscores into a stack-local buffer before
+        // handing the digits to `parseInt`. v0.2 manifest values
+        // are short (cycle budgets, columns) — 32 bytes is plenty.
+        var scratch: [32]u8 = undefined;
+        var n: usize = 0;
+        for (text) |c| {
+            if (c == '_') continue;
+            if (n >= scratch.len) {
+                self.reportf("integer literal for key '{s}' is too long", .{key});
+                return error.ParseFailed;
+            }
+            scratch[n] = c;
+            n += 1;
+        }
+        if (n == 0) {
+            self.reportf("expected digits in integer literal for key '{s}'", .{key});
+            return error.ParseFailed;
+        }
+        return std.fmt.parseInt(usize, scratch[0..n], 10) catch {
             self.reportf("invalid integer literal for key '{s}'", .{key});
             return error.ParseFailed;
         };
@@ -481,10 +533,19 @@ const Pending = struct {
     pkg_name: ?[]const u8 = null,
     pkg_version: ?[]const u8 = null,
     pkg_target: ?[]const u8 = null,
+    pkg_description: ?[]const u8 = null,
+    pkg_license: ?[]const u8 = null,
+    pkg_repository: ?[]const u8 = null,
+    pkg_authors: ?[]const []const u8 = null,
+    pkg_keywords: ?[]const []const u8 = null,
     build_entry: ?[]const u8 = null,
     build_out: ?[]const u8 = null,
     build_optimize: ?[]const u8 = null,
+    build_name: ?[]const u8 = null,
+    build_debug_symbols: ?bool = null,
     test_include: ?[]const []const u8 = null,
+    test_exclude: ?[]const []const u8 = null,
+    test_cycle_budget: ?usize = null,
     fmt_indent: ?usize = null,
     fmt_comment_column: ?usize = null,
     fmt_align_kv: ?bool = null,
@@ -493,19 +554,39 @@ const Pending = struct {
     fn recordString(self: *Pending, parser: *Parser, key: []const u8, value: []const u8) ParseError!void {
         switch (parser.current_section) {
             .package => {
-                if (std.mem.eql(u8, key, "name")) self.pkg_name = value else if (std.mem.eql(u8, key, "version")) self.pkg_version = value else if (std.mem.eql(u8, key, "target")) self.pkg_target = value else {
+                if (std.mem.eql(u8, key, "name")) {
+                    self.pkg_name = value;
+                } else if (std.mem.eql(u8, key, "version")) {
+                    self.pkg_version = value;
+                } else if (std.mem.eql(u8, key, "target")) {
+                    self.pkg_target = value;
+                } else if (std.mem.eql(u8, key, "description")) {
+                    self.pkg_description = value;
+                } else if (std.mem.eql(u8, key, "license")) {
+                    self.pkg_license = value;
+                } else if (std.mem.eql(u8, key, "repository")) {
+                    self.pkg_repository = value;
+                } else {
                     parser.reportf("unknown key 'package.{s}'", .{key});
                     return error.ParseFailed;
                 }
             },
             .build => {
-                if (std.mem.eql(u8, key, "entry")) self.build_entry = value else if (std.mem.eql(u8, key, "out")) self.build_out = value else if (std.mem.eql(u8, key, "optimize")) self.build_optimize = value else {
+                if (std.mem.eql(u8, key, "entry")) {
+                    self.build_entry = value;
+                } else if (std.mem.eql(u8, key, "out")) {
+                    self.build_out = value;
+                } else if (std.mem.eql(u8, key, "optimize")) {
+                    self.build_optimize = value;
+                } else if (std.mem.eql(u8, key, "name")) {
+                    self.build_name = value;
+                } else {
                     parser.reportf("unknown key 'build.{s}'", .{key});
                     return error.ParseFailed;
                 }
             },
             .test_ => {
-                parser.reportf("unknown string key '[test].{s}' (only 'include' is supported)", .{key});
+                parser.reportf("unknown string key '[test].{s}' (only 'include' / 'exclude' arrays + 'cycle_budget' are accepted)", .{key});
                 return error.ParseFailed;
             },
             .fmt => {
@@ -529,6 +610,12 @@ const Pending = struct {
                     return error.ParseFailed;
                 }
             },
+            .test_ => {
+                if (std.mem.eql(u8, key, "cycle_budget")) self.test_cycle_budget = value else {
+                    parser.reportf("unknown integer key '[test].{s}'", .{key});
+                    return error.ParseFailed;
+                }
+            },
             else => {
                 parser.reportf("integer values aren't expected under section for key '{s}'", .{key});
                 return error.ParseFailed;
@@ -544,6 +631,12 @@ const Pending = struct {
                     return error.ParseFailed;
                 }
             },
+            .build => {
+                if (std.mem.eql(u8, key, "debug_symbols")) self.build_debug_symbols = value else {
+                    parser.reportf("unknown boolean key '[build].{s}'", .{key});
+                    return error.ParseFailed;
+                }
+            },
             else => {
                 parser.reportf("boolean values aren't expected under section for key '{s}'", .{key});
                 return error.ParseFailed;
@@ -553,14 +646,20 @@ const Pending = struct {
 
     fn recordStringArray(self: *Pending, parser: *Parser, key: []const u8, value: []const []const u8) ParseError!void {
         switch (parser.current_section) {
+            .package => {
+                if (std.mem.eql(u8, key, "authors")) self.pkg_authors = value else if (std.mem.eql(u8, key, "keywords")) self.pkg_keywords = value else {
+                    parser.reportf("unknown array key '[package].{s}'", .{key});
+                    return error.ParseFailed;
+                }
+            },
             .test_ => {
-                if (std.mem.eql(u8, key, "include")) self.test_include = value else {
+                if (std.mem.eql(u8, key, "include")) self.test_include = value else if (std.mem.eql(u8, key, "exclude")) self.test_exclude = value else {
                     parser.reportf("unknown array key '[test].{s}'", .{key});
                     return error.ParseFailed;
                 }
             },
             else => {
-                parser.reportf("array values only supported under [test].include", .{});
+                parser.reportf("array values aren't expected under this section for key '{s}'", .{key});
                 return error.ParseFailed;
             },
         }
@@ -580,10 +679,10 @@ const Pending = struct {
             return error.ParseFailed;
         };
 
-        const include_slice: []const []const u8 = if (self.test_include) |v| v else blk: {
-            const empty = try parser.allocator.alloc([]const u8, 0);
-            break :blk empty;
-        };
+        const include_slice: []const []const u8 = if (self.test_include) |v| v else try parser.allocator.alloc([]const u8, 0);
+        const exclude_slice: []const []const u8 = if (self.test_exclude) |v| v else try parser.allocator.alloc([]const u8, 0);
+        const authors_slice: []const []const u8 = if (self.pkg_authors) |v| v else try parser.allocator.alloc([]const u8, 0);
+        const keywords_slice: []const []const u8 = if (self.pkg_keywords) |v| v else try parser.allocator.alloc([]const u8, 0);
 
         // Validate hex_case against the three allowed values. Any
         // other string is a hard parse error with a clear
@@ -597,18 +696,43 @@ const Pending = struct {
             return error.ParseFailed;
         } else defaults.fmt_hex_case;
 
+        // Validate optimize too — it gates the per-profile output
+        // subdirectory (`out/<optimize>/...`), so a typo would
+        // silently land artifacts in `out/relase/` and confuse the
+        // user. Keep the surface in sync with the CLI's
+        // `--optimize` enum.
+        const optimize = self.build_optimize orelse defaults.build_optimize;
+        if (!std.mem.eql(u8, optimize, "debug") and
+            !std.mem.eql(u8, optimize, "release") and
+            !std.mem.eql(u8, optimize, "size"))
+        {
+            parser.reportf("invalid '[build].optimize' value '{s}' (expected 'debug', 'release', or 'size')", .{optimize});
+            return error.ParseFailed;
+        }
+
         return .{
             .package = .{
                 .name = name,
                 .version = version,
                 .target = self.pkg_target orelse defaults.package_target,
+                .description = self.pkg_description,
+                .license = self.pkg_license,
+                .repository = self.pkg_repository,
+                .authors = authors_slice,
+                .keywords = keywords_slice,
             },
             .build = .{
                 .entry = entry,
                 .out = self.build_out orelse defaults.build_out,
-                .optimize = self.build_optimize orelse defaults.build_optimize,
+                .optimize = optimize,
+                .name = self.build_name,
+                .debug_symbols = self.build_debug_symbols orelse defaults.build_debug_symbols,
             },
-            .test_ = .{ .include = include_slice },
+            .test_ = .{
+                .include = include_slice,
+                .exclude = exclude_slice,
+                .cycle_budget = self.test_cycle_budget orelse defaults.test_cycle_budget,
+            },
             .fmt = .{
                 .indent = self.fmt_indent orelse defaults.fmt_indent,
                 .comment_column = self.fmt_comment_column orelse defaults.fmt_comment_column,
@@ -891,4 +1015,145 @@ test "project: [fmt] rejects invalid boolean value" {
     const result = try parseWithDiagnostic(testing.allocator, src);
     try testing.expect(result == .err);
     try testing.expect(std.mem.indexOf(u8, result.err.message(), "align_kv") != null);
+}
+
+test "project: [package] metadata fields parse + default to null/empty" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\description = "demo cart"
+        \\license = "MIT"
+        \\repository = "https://github.com/me/p"
+        \\authors = ["Jane Doe <jane@example.com>", "John"]
+        \\keywords = ["vm", "demo"]
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("demo cart", m.package.description.?);
+    try testing.expectEqualStrings("MIT", m.package.license.?);
+    try testing.expectEqualStrings("https://github.com/me/p", m.package.repository.?);
+    try testing.expectEqual(@as(usize, 2), m.package.authors.len);
+    try testing.expectEqualStrings("Jane Doe <jane@example.com>", m.package.authors[0]);
+    try testing.expectEqual(@as(usize, 2), m.package.keywords.len);
+    try testing.expectEqualStrings("vm", m.package.keywords[0]);
+}
+
+test "project: [package] metadata is fully optional" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expect(m.package.description == null);
+    try testing.expect(m.package.license == null);
+    try testing.expect(m.package.repository == null);
+    try testing.expectEqual(@as(usize, 0), m.package.authors.len);
+    try testing.expectEqual(@as(usize, 0), m.package.keywords.len);
+}
+
+test "project: [build].name + debug_symbols override" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\name = "p-cli"
+        \\debug_symbols = false
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("p-cli", m.build.name.?);
+    try testing.expectEqual(false, m.build.debug_symbols);
+}
+
+test "project: [build].name defaults to null, debug_symbols to true" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expect(m.build.name == null);
+    try testing.expectEqual(true, m.build.debug_symbols);
+}
+
+test "project: [test] exclude + cycle_budget" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+        \\[test]
+        \\include = ["tests/"]
+        \\exclude = ["tests/wip", "tests/skip.gas"]
+        \\cycle_budget = 5_000_000
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), m.test_.exclude.len);
+    try testing.expectEqualStrings("tests/wip", m.test_.exclude[0]);
+    try testing.expectEqualStrings("tests/skip.gas", m.test_.exclude[1]);
+    try testing.expectEqual(@as(usize, 5_000_000), m.test_.cycle_budget);
+}
+
+test "project: [test] exclude / cycle_budget default to empty / 1M" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\
+    ;
+    var m = try parse(testing.allocator, src);
+    defer m.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 0), m.test_.exclude.len);
+    try testing.expectEqual(defaults.test_cycle_budget, m.test_.cycle_budget);
+}
+
+test "project: [build].optimize validates against debug | release | size" {
+    const src =
+        \\[package]
+        \\name = "p"
+        \\version = "0.0.1"
+        \\
+        \\[build]
+        \\entry = "main.gas"
+        \\optimize = "fast"
+        \\
+    ;
+    const result = try parseWithDiagnostic(testing.allocator, src);
+    try testing.expect(result == .err);
+    try testing.expect(std.mem.indexOf(u8, result.err.message(), "optimize") != null);
+    try testing.expect(std.mem.indexOf(u8, result.err.message(), "debug") != null);
 }

--- a/apps/gero-cli/templates/README.md.tmpl
+++ b/apps/gero-cli/templates/README.md.tmpl
@@ -4,9 +4,14 @@ A gero project. The asm-level entry point is `src/main.gas` —
 edit it, then build and run with:
 
 ```bash
-gero build                        # → out/{name}.gx
-gero run out/{name}.gx
+gero build                        # → out/debug/{name}.gx
+gero run out/debug/{name}.gx
 ```
+
+The `.gx` lands under a per-profile subdirectory
+(`out/debug/`, `out/release/`, `out/size/`) so swapping
+`[build].optimize` in `gero.toml` doesn't clobber the previous
+build.
 
 ## Tests
 

--- a/apps/gero-cli/test.zig
+++ b/apps/gero-cli/test.zig
@@ -14,10 +14,9 @@ const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const manifest_loader = @import("manifest_loader.zig");
 
-/// Hard cap on dispatched instructions per test, to prevent an
-/// infinite loop in a buggy program from hanging the runner. Each
-/// real test should bottom out in `hlt` well before this.
-const cycle_budget: u64 = 1_000_000;
+// Per-test cycle budget comes from the manifest's `[test].cycle_budget`
+// (default 1,000,000 per `project.defaults`). Threaded through
+// `runOne` / `runImage` so it can vary per-project without a recompile.
 
 /// Discovered test program — assembled lazily, paired with its
 /// golden `.expected` body.
@@ -102,6 +101,7 @@ pub fn execute(
         term,
         loaded.project_root,
         loaded.manifest.test_.include,
+        loaded.manifest.test_.exclude,
         pattern,
     ) catch |err| switch (err) {
         error.LoadFailed => return 1,
@@ -124,8 +124,9 @@ pub fn execute(
     const results = try arena.alloc(Result, programs.len);
     var pass: usize = 0;
     var fail: usize = 0;
+    const budget: u64 = @intCast(loaded.manifest.test_.cycle_budget);
     for (programs, 0..) |prog, i| {
-        results[i] = try runOne(io, arena, prog);
+        results[i] = try runOne(io, arena, prog, budget);
         if (results[i].outcome == .ok) pass += 1 else fail += 1;
         try writeStatusLine(stdout, style, results[i], opts.verbose);
     }
@@ -140,20 +141,35 @@ pub fn execute(
 
 /// Resolve every entry in `includes` (manifest-relative, file or
 /// directory) and collect `.gas` programs that have a sibling
-/// `.expected`. Optionally filtered by `pattern`.
+/// `.expected`. Optionally filtered by `pattern`. `excludes`
+/// subtracts manifest-relative paths from the discovered set —
+/// each exclude entry is either a `.gas` file or a directory
+/// prefix.
 fn collectPrograms(
     io: std.Io,
     arena: std.mem.Allocator,
     term: *term_mod.Term,
     project_root: []const u8,
     includes: []const []const u8,
+    excludes: []const []const u8,
     pattern: ?[]const u8,
 ) ![]Program {
     var gas_files: std.ArrayList([]const u8) = .empty;
     try manifest_loader.expandIncludes(io, arena, term, "gero test", project_root, includes, &gas_files);
 
+    // Pre-resolve excludes through the same root-joining so they
+    // line up with `gas_files` entries byte-for-byte. Each exclude
+    // is treated as a prefix: a directory excludes everything
+    // under it, a single `.gas` excludes itself.
+    var excluded: std.ArrayList([]const u8) = .empty;
+    for (excludes) |rel| {
+        const full = try manifest_loader.joinUnderRoot(arena, project_root, rel);
+        try excluded.append(arena, full);
+    }
+
     var list: std.ArrayList(Program) = .empty;
     for (gas_files.items) |gas_path| {
+        if (isExcluded(gas_path, excluded.items)) continue;
         const name_borrowed = stem(std.fs.path.basename(gas_path));
         if (pattern) |p| if (std.mem.indexOf(u8, name_borrowed, p) == null) continue;
 
@@ -184,6 +200,23 @@ fn lessByName(_: void, a: Program, b: Program) bool {
     return std.mem.lessThan(u8, a.name, b.name);
 }
 
+/// True when `gas_path` is covered by an exclude entry. Excludes
+/// match as a prefix — `tests/wip` excludes both `tests/wip/foo.gas`
+/// and `tests/wip` itself; an exact `.gas` match excludes only that
+/// file.
+fn isExcluded(gas_path: []const u8, excludes: []const []const u8) bool {
+    for (excludes) |ex| {
+        if (std.mem.eql(u8, gas_path, ex)) return true;
+        // Directory prefix: ensure the next char is a separator
+        // so `tests/wip` doesn't accidentally swallow `tests/wipe.gas`.
+        if (std.mem.startsWith(u8, gas_path, ex) and gas_path.len > ex.len) {
+            const next = gas_path[ex.len];
+            if (next == '/' or next == std.fs.path.sep) return true;
+        }
+    }
+    return false;
+}
+
 /// `foo.gas` → `foo`; `foo` → `foo`. Borrowed slice — caller dupes
 /// before storing past the source's lifetime.
 fn stem(file: []const u8) []const u8 {
@@ -194,7 +227,7 @@ fn stem(file: []const u8) []const u8 {
 /// Assemble + run a single program. Always returns a `Result` —
 /// errors land as failure outcomes rather than propagating, so the
 /// runner reports them per-test instead of bailing on first error.
-fn runOne(io: std.Io, arena: std.mem.Allocator, prog: Program) !Result {
+fn runOne(io: std.Io, arena: std.mem.Allocator, prog: Program, cycle_budget: u64) !Result {
     const t0 = std.Io.Timestamp.now(io, .awake);
 
     var fused = gero.asm_.resolveIncludes(io, arena, prog.gas_path) catch |err| {
@@ -215,7 +248,7 @@ fn runOne(io: std.Io, arena: std.mem.Allocator, prog: Program) !Result {
     }
 
     var captured: std.Io.Writer.Allocating = .init(arena);
-    const run_outcome = runImage(arena, cg.image, &captured.writer) catch |err| {
+    const run_outcome = runImage(arena, cg.image, &captured.writer, cycle_budget) catch |err| {
         return finalize(io, t0, prog, .runtime_failed, try std.fmt.allocPrint(arena, "vm error ({s})", .{@errorName(err)}));
     };
     switch (run_outcome) {
@@ -252,7 +285,7 @@ const RunOutcome = enum { halted, faulted, breakpoint, timeout };
 /// Boot a fresh VM on `image`, capture stdout-syscall output into
 /// `out`, ignore the SRAM save syscall, and step until halt or the
 /// cycle budget runs out.
-fn runImage(arena: std.mem.Allocator, image: []const u8, out: *std.Io.Writer) !RunOutcome {
+fn runImage(arena: std.mem.Allocator, image: []const u8, out: *std.Io.Writer, cycle_budget: u64) !RunOutcome {
     const loaded = try gero.vm.parseGx(image);
     var vm = gero.vm.VM.init(arena);
     defer vm.deinit();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -447,13 +447,14 @@ gero init --quiet                 # skip the next-steps banner
 
 Walks the ancestor chain for `gero.toml`, reads `[package]` +
 `[build]`, runs the asm pipeline against `build.entry`, and
-writes the resulting `.gx` to `<project_root>/<build.out>/<package.name>.gx`.
-
-Essentially `gero asm` wrapped with manifest resolution +
-output-path discipline. Reuses every existing asm-pipeline piece.
+writes the resulting `.gx` to
+`<project_root>/<build.out>/<build.optimize>/<stem>.gx`. The
+per-profile subdir (Cargo's `target/{debug,release}/` pattern)
+keeps debug and release artifacts side by side so rebuilding in
+one mode doesn't clobber the other.
 
 ```bash
-gero build                        # → out/<package.name>.gx
+gero build                        # → out/debug/<name>.gx
 gero build -v                     # per-phase timings
 gero build --target=vm            # explicit target override
 ```
@@ -462,10 +463,14 @@ gero build --target=vm            # explicit target override
 - Resolves `gero.toml` by ancestor walk — `gero build` works from
   any subdirectory of the project.
 - Manifest-relative `[build].entry` and `[build].out` are joined
-  under the project root (`dirname(gero.toml)`). `out/` is
-  created if missing.
-- Output filename is `<package.name>.gx`, not the entry's
-  basename — the manifest is the single source of truth.
+  under the project root (`dirname(gero.toml)`). The full output
+  directory is `<build.out>/<build.optimize>/` and is created if
+  missing.
+- Output filename stem is `[build].name` if set, else
+  `[package].name` — the manifest is the single source of truth,
+  matching Cargo's `[[bin]].name` convention.
+- `[build].debug_symbols = false` strips the `(address, name)`
+  debug table from the `.gx`. Default is `true`.
 - `--target=<vm|gtx-16>` overrides the manifest's `[package].target`.
   Only `vm` ships in v0.2; `gtx-16` is reserved (errors with
   "not yet implemented").
@@ -476,10 +481,11 @@ gero build --target=vm            # explicit target override
 usage (unknown target, positional); 3 on manifest parse error or
 asm pipeline error.
 
-**Roadmap:** `gero build --optimize=release` becomes meaningful
-once the lang back-end (v0.3) lands; today the asm pipeline has
-no optimizer to drive, so the `[build].optimize` key is read but
-its only consumer ships in v0.3+.
+**Roadmap:** `gero build --optimize=release` (flag override
+without editing the manifest) lands once the lang back-end (v0.3)
+has a meaningful release/debug distinction; today the asm
+pipeline doesn't optimize, so the `[build].optimize` key drives
+only the output subdirectory.
 
 ---
 
@@ -531,19 +537,60 @@ parseable by editors / CI tools.
 
 ---
 
-## 8. Future: project file (`gero.toml`)
+## 8. Project file (`gero.toml`)
 
-Once `gero init` / dependency management land, a project file
-will be needed:
+Full v0.2 shape — consumed by `gero build` / `gero check` /
+`gero fmt` / `gero test`. Walked by ancestor search, so any
+subcommand works from any subdirectory of the project. See
+`gero new` / `gero init` (§3.10 / §3.11) for the scaffold.
 
 ```toml
-[project]
-name = "my-game"
+[package]
+name = "my-cart"
 version = "0.1.0"
+target = "vm"                       # vm (default) | gtx-16 (deferred)
+description = "..."                 # optional
+license = "MIT"                     # optional, SPDX-style
+repository = "https://..."          # optional
+authors = ["Jane Doe <jane@..>"]    # optional
+keywords = ["vm", "demo"]           # optional
 
-[deps]
-loom = { git = "https://github.com/salty-max/loom" }
+[build]
+entry = "src/main.gas"              # required
+out = "out/"                        # output directory; default "out/"
+optimize = "debug"                  # debug (default) | release | size
+name = "cart-cli"                   # optional, defaults to package.name
+debug_symbols = true                # emit debug-symbol blob; default true
+
+[test]
+include = ["tests/"]                # paths walked for .gas + .expected
+exclude = ["tests/wip"]             # paths subtracted; default empty
+cycle_budget = 1_000_000            # per-test cycle cap; default 1M
+
+[fmt]                               # see §3.8 for full reference
+indent = 2
+comment_column = 30
+align_kv = true
+hex_case = "upper"
 ```
 
-Spec'd in v0.2 alongside `gero init`. For v0.1, conventions in §3.10
-suffice.
+**Defaults**: `[build].out` → `"out/"`; `[build].optimize` →
+`"debug"`; `[build].debug_symbols` → `true`; `[package].target` →
+`"vm"`; `[test].cycle_budget` → `1_000_000`. Every field outside
+those + `[package].name` / `[package].version` / `[build].entry`
+is optional.
+
+**Output path**: `<build.out>/<build.optimize>/<stem>.gx` —
+the per-profile subdir (Cargo's `target/{debug,release}/` pattern)
+keeps debug and release artifacts side by side. `<stem>` is
+`[build].name` if set, else `[package].name` (Cargo's
+`[[bin]].name` convention — decouple the binary name from the
+package name). Example: default scaffold ships
+`out/debug/my-cart.gx`.
+
+**Validation**: `[build].optimize` is checked against
+`{debug, release, size}` at parse time so a typo doesn't silently
+land artifacts in `out/relase/`. Invalid → exit 3 with line:col.
+
+**Future**: a `[deps]` / `[workspace]` section will land when a
+registry + multi-package layout exist (post-v0.3).


### PR DESCRIPTION
Stacks on top of #149 (gero.toml `[fmt]` section). After #149 merges, change base to `main`.

## Summary

Adds the next batch of high-leverage manifest knobs identified after #149 shipped. Every addition is opt-in with sensible defaults.

### `[package]` metadata (optional)

```toml
description = "..."
license = "MIT"
repository = "https://github.com/..."
authors = ["Jane Doe <jane@..>"]
keywords = ["vm", "demo"]
```

Parser-only today; ready for a future registry / doc generator without breaks.

### `[build].name` — binary name override

```toml
[build]
name = "cart-cli"     # default = [package].name
```

Cargo's `[[bin]].name` pattern. Decouples binary filename from the package.

### `[build].debug_symbols` — strip debug table

```toml
[build]
debug_symbols = false     # default true
```

Shaves the `(address, name)` debug blob from the `.gx`. ~22-byte savings on hello-world. `gero info` reports `debug: no` for stripped builds.

### Per-profile output subdir

`.gx` now lands at `<build.out>/<build.optimize>/<stem>.gx` (e.g. `out/debug/cart.gx` vs `out/release/cart.gx`), Cargo's `target/{debug,release}/` pattern. Rebuilding in release no longer clobbers the debug artifact.

`[build].optimize` is validated against `{debug, release, size}` at parse time — a typo doesn't silently land artifacts in `out/relase/`. Invalid → exit 3 with line:col diagnostic.

### `[test].exclude` + `[test].cycle_budget`

```toml
[test]
include = ["tests/"]
exclude = ["tests/wip"]      # subtract paths; default empty
cycle_budget = 5_000_000     # per-test cycle cap; default 1M
```

Exclude matches as a directory prefix (`tests/wip` excludes `tests/wip/foo.gas` and `tests/wip/sub/bar.gas`) or as an exact `.gas` path. The previously-hardcoded 1M cycle budget is now a manifest knob, threaded through `runOne` / `runImage`.

Exclude narrows the test set only — `gero check` / `gero fmt` keep walking the full `[test].include` so WIP code stays under fmt/check while skipping `gero test`.

### Parser extensions

- Integer literals accept TOML-style underscore separators (`1_000_000`)
- Boolean values land under `[build]` (was `[fmt]`-only)
- String arrays under `[package]` for `authors` / `keywords`

## Smoke tests (manual)

| Case | Result |
|---|---|
| Scaffold + `gero build` | ✅ writes `out/debug/<name>.gx` (was `out/<name>.gx`) |
| Flip `optimize = "release"`, rebuild | ✅ writes `out/release/<name>.gx`, debug artifact preserved |
| `optimize = "fast"` (invalid) | ✅ exit 3, "expected 'debug', 'release', or 'size'" |
| `[build].name = "cart-cli"` | ✅ output is `out/debug/cart-cli.gx` |
| `[build].debug_symbols = false` | ✅ `gero info` reports `debug: no`, size shrinks |
| `[test].cycle_budget = 2` | ✅ smoke test times out at 2 cycles |
| `[test].exclude = ["tests/wip"]` | ✅ `gero test` ignores `tests/wip/*.gas` |
| `[package].description / license / authors / keywords` | ✅ parses cleanly, available on Manifest |

## Self-review

**Step 1 (acceptance):**
- ✅ All new fields parse with cleanly-typed `Manifest.*` structs + tests
- ✅ Defaults applied for absent fields (every new field optional)
- ✅ Invalid `[build].optimize` emits a clear line:col diagnostic
- ✅ Per-profile output subdir works end-to-end (build → run → both modes coexist)
- ✅ Exclude / cycle_budget threaded into `gero test`
- ✅ Scaffold banner + README template updated for new path
- ✅ `docs/cli.md` §3.12 + §8 document the full manifest shape with reference example
- ✅ Strict-mode + doc comments, changeset added (minor bump)

**Step 2** (`zig build ci`): EXIT=0 — lint + test-modes (4 release modes) + test-all (5 cross-targets) + check-examples + check-broken + fmt-check-examples + test-examples all green.

**Step 3 (diff walk, 8 files, +482/-58):**
- `apps/gero-cli/project.zig` — Manifest extensions, Pending state, recordString/Integer/Bool/StringArray dispatch, finalize validation, parseInteger underscore support, 6 new inline tests covering the new fields + optimize validation
- `apps/gero-cli/build.zig` — per-profile out_dir join, `[build].name` stem override, `[build].debug_symbols` plumbed into CodegenOptions
- `apps/gero-cli/test.zig` — cycle_budget threaded through `runOne` / `runImage`, exclude filtering via new `isExcluded` helper
- `apps/gero-cli/new.zig` + `init.zig` — success-banner path updated to `out/debug/<name>.gx`
- `apps/gero-cli/templates/README.md.tmpl` — build/run commands mention `out/debug/` + explain the per-profile subdir
- `docs/cli.md` §3.12 + §8 — full reference for the new manifest shape, including the validation rules
- `.changeset/manifest-polish.md` — minor bump

**Step 4 (hygiene):** no stray `std.debug.print`, no commented-out code, no TODOs, no AI attribution, single commit with conventional `feat(apps/gero-cli):` scope.