### PR TITLE
chore(editors): wire tree-sitter-gero-asm v0.1.0 as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "editors/tree-sitter-gero-asm"]
+	path = editors/tree-sitter-gero-asm
+	url = git@github.com:salty-max/tree-sitter-gero-asm.git

--- a/.versionrc
+++ b/.versionrc
@@ -1,4 +1,4 @@
 {
-  "scopeRegex": "^(vm|asm|disasm|lang|common|tooling|ci|docs|meta|vm/[a-z][a-z0-9-]*|asm/[a-z][a-z0-9-]*|disasm/[a-z][a-z0-9-]*|lang/[a-z][a-z0-9-]*|apps/[a-z][a-z0-9-]*)$",
+  "scopeRegex": "^(vm|asm|disasm|lang|common|tooling|ci|docs|meta|vm/[a-z][a-z0-9-]*|asm/[a-z][a-z0-9-]*|disasm/[a-z][a-z0-9-]*|lang/[a-z][a-z0-9-]*|apps/[a-z][a-z0-9-]*|editors/[a-z][a-z0-9-]*)$",
   "lineLength": 100
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,11 @@ tests/
 
 apps/                      # CLIs land here when needed
 docs/                      # ISA spec + lang spec live here
+editors/                   # Editor tooling — tree-sitter grammar (submodule), VS Code ext
 scripts/                   # Bash helpers for build.zig + lefthook
 .changeset/                # *.md changeset files
 .github/                   # workflows + templates
+.gitmodules                # Submodule pinning (tree-sitter-gero-asm, vscode-gero in v0.2)
 ```
 
 The `src/gero.zig` barrel and any `src/<module>.zig` (top-level
@@ -209,6 +211,7 @@ asm/<sub>           → a specific sub-module under src/asm/<sub>/
 disasm/<sub>        → a specific sub-module under src/disasm/<sub>/
 lang/<sub>          → a specific sub-module under src/lang/<sub>/
 apps/<name>         → a specific binary under apps/<name>/
+editors/<name>      → an editor-tooling submodule under editors/<name>/
 ```
 
 ### Rules


### PR DESCRIPTION
Closes #119.

## Summary

First slice of Phase 7 (editor support, #111) lands: a tree-sitter grammar for `.gas` files, in lockstep with the gero v0.1-final asm spec, exposed to editors via a pinned submodule.

The grammar work itself happened upstream:
- [salty-max/tree-sitter-gero-asm#1](https://github.com/salty-max/tree-sitter-gero-asm/pull/1) — merged
- Tagged [`v0.1.0`](https://github.com/salty-max/tree-sitter-gero-asm/releases/tag/v0.1.0)

This PR just wires the submodule pointer here.

## Changes

| File | Why |
|---|---|
| `.gitmodules` (new) | Submodule pinning |
| `editors/tree-sitter-gero-asm` (new) | Submodule at v0.1.0 (commit `3e2149b`) |
| `CLAUDE.md` | Documents `editors/` as a top-level dir + scope convention |
| `.versionrc` | Adds `editors/<name>` to the convco scope regex |

## Grammar coverage (upstream PR)

- **5 mnemonic renames**: `lsh→shl`, `rsh→shr`, `lmov→movl`, `hmov→movh`, `swp→swap`
- **22 mnemonics added** to match `src/asm/opcode_resolver.zig` (`adc`, `sbc`, `div`, `divs`, `rol`, `ror`, `cmp`, `tst`, `bset`, `bcpy`, `nop`, `jcc`, `jcs`, `jvc`, `jvs`, `jr`, `djnz`, `clc`, `sec`, `cli`, `sei`, `clv`)
- **Local labels** — `.loop:` (definition) and `.loop` (operand reference)
- **Character literals** `'A'` and **string literals** `"…"`
- **`@SYM` symbol references** (was `!SYM` — the v0.1-final form)
- **Bracketed addressing** `[…]` / `&[…]` (`bracket_expr` rule)
- **Directives** `org`, `bank`, `sram_banks`, `reserve`, `include`
- **Queries**: `highlights.scm` refreshed, new `folds.scm` + `indents.scm`
- **Corpus**: 11 tests, 100% pass; new `v0_1_features.txt` covering the new syntax

Every `examples/asm/**/*.gas` from this repo parses cleanly through the regenerated grammar (manually verified before tagging).

## Self-review

**Step 1 (#119 AC):**
- ✅ All 5 mnemonic renames applied in `grammar.js`
- ✅ Test corpus parses every `examples/asm/*.gas` cleanly
- ✅ Highlight queries follow tree-sitter conventions (`@keyword`, `@function`, `@constant.numeric`, `@comment`, plus `@character`, `@string`, `@label`)
- ✅ Indent + fold queries land (new `indents.scm` + `folds.scm`)
- ✅ `tree-sitter generate` is clean
- ✅ Tagged release `v0.1.0` cut on tree-sitter-gero-asm
- ✅ README documents which gero spec version the grammar tracks

**Step 2** (`zig build ci`): not run yet — submodule addition doesn't touch the build. Will run before merge.

**Step 3 (diff walk, gero side, 4 files, +8/-1):** `.gitmodules` adds the submodule; `editors/tree-sitter-gero-asm` is the submodule pointer at `3e2149b` (the merge commit upstream); `CLAUDE.md` documents the new top-level dir; `.versionrc` allows `editors/<name>` as a commit scope.

**Step 4 (hygiene):** no AI attribution, no commented-out code, conventional commit with `feat(editors/tree-sitter-gero-asm):` scope (newly allowed via this PR's `.versionrc` update).

## Next in Phase 7

- #120 — `vscode-gero` extension scaffold (TextMate grammar + language config + bundle this submodule)
- #121 — Publish to marketplace
- #122/#123 — `gero lsp` stretch (deferrable to v0.3)