### PR TITLE
chore(editors): wire vscode-gero v0.1.0 as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "editors/tree-sitter-gero-asm"]
 	path = editors/tree-sitter-gero-asm
 	url = git@github.com:salty-max/tree-sitter-gero-asm.git
+[submodule "editors/vscode-gero"]
+	path = editors/vscode-gero
+	url = git@github.com:salty-max/vscode-gero.git


### PR DESCRIPTION
Closes #120.

## Summary

Second slice of Phase 7 (editor support, #111) lands: a VS Code extension contributing `.gas` syntax highlighting via a TextMate grammar, wired here as a submodule pinned at v0.1.0.

The extension work happened upstream:
- [salty-max/vscode-gero#1](https://github.com/salty-max/vscode-gero/pull/1) — merged
- Tagged [`v0.1.0`](https://github.com/salty-max/vscode-gero/releases/tag/v0.1.0)

This PR just wires the submodule pointer + bumps `.gitmodules`.

## Changes

| File | Why |
|---|---|
| `.gitmodules` | Add the `editors/vscode-gero` entry |
| `editors/vscode-gero` (new) | Submodule at v0.1.0 (commit `9348ae3`) |

## Extension coverage (upstream PR)

- `.gas` file association via `contributes.languages.extensions`
- TextMate grammar (`grammars/gero-asm.tmLanguage.json`) covering:
  - 52 ISA mnemonics in 6 separate scopes (`keyword.control`, `keyword.operator.{move,arithmetic,bitwise,test}`, `keyword.other.flag`) so themes can color them independently
  - 9 directives (`const`/`data8`/`data16`/`struct`/`reserve` as `storage.type`, `org`/`bank`/`sram_banks`/`include` as `keyword.other.directive`)
  - Global + local labels, registers, hex/address/char/string literals, `@SYM` refs, `<Type> obj.prop` casts
- Language config: line comment (`;`), bracket pairs (`[]/{}/()/<>`), auto-closing pairs (incl. quotes), indent-under-label rule

Manually verified by symlinking `~/.vscode/extensions/salty-max.gero-asm-dev` → this submodule path, reloading VS Code, and opening `examples/asm/hello.gas` — keywords / labels / literals / comments all color correctly under default Dark+.

## Self-review

**Step 1 (#120 AC):**
- ✅ Repo public (`salty-max/vscode-gero`), MIT
- ✅ `.gas` files syntax-highlight in local VS Code post-install
- ✅ Comment toggle works
- ✅ Brackets auto-pair
- ✅ README has install path
- ⏭️ Linguist contribution PR — separate, will reference back here
- ⏭️ Marketplace publish — separate sub-issue (#121)

**Step 2** (`zig build test`): the submodule is dev tooling, no build path impact. Test pass remains green.

**Step 3 (diff walk, 2 files, +4):** `.gitmodules` adds the entry; `editors/vscode-gero` is the submodule pointer. Both `editors/<name>` paths now match the convention documented in CLAUDE.md.

**Step 4 (hygiene):** no AI attribution, conventional `chore(editors/vscode-gero):` scope (matches the regex shipped in #151).

## Next in Phase 7

- #121 — Marketplace publish (needs publisher account setup + `vsce publish`)
- #122 / #123 — `gero lsp` stretch