### PR TITLE
docs: add asm syntax-overview file (companion to .gr)

### DIFF
--- a/docs/asm.md
+++ b/docs/asm.md
@@ -11,6 +11,10 @@ For semantics (what each mnemonic does at runtime), see `isa.md` §5.
 > [tree-sitter-gero-asm](https://github.com/salty-max/tree-sitter-gero-asm)
 > grammar. This document is the human-readable companion.
 
+> **All-in-one syntax tour:** [`docs/examples/syntax_overview.gas`](./examples/syntax_overview.gas)
+> exercises every construct in one file — useful when verifying
+> editor highlighting or skim-reading the surface.
+
 ---
 
 ## 1. Lexical structure

--- a/docs/examples/syntax_overview.gas
+++ b/docs/examples/syntax_overview.gas
@@ -11,9 +11,8 @@
 ; group) without committing to a coherent program. The runnable
 ; examples under `examples/asm/*.gas` cover end-to-end flows.
 ;
-; Note: multi-line `struct` body is grammar-side TBD on the
-; tree-sitter parser (gero's own parser accepts it). For now the
-; single-line struct form is shown.
+; Tracks tree-sitter-gero-asm@v0.1.2+ which supports the full
+; multi-line struct form (matching gero's parser).
 ; ====================================================================
 
 ; -------------------- directives ----------------------------
@@ -32,7 +31,11 @@ data8  STRING8  = "Hello", $00
 data16 STRING16 = $1234, $5678
 data8  CHAR_DATA = 'X', 'Y', 'Z', $00
 
-struct Sprite { pos: $00, size: $02, attr: $04 }
+struct Sprite {
+  pos:  u16,                 ; sprite x:y packed
+  size: u8,
+  attr: u8
+}
 
 ; -------------------- global + local labels -----------------
 

--- a/docs/examples/syntax_overview.gas
+++ b/docs/examples/syntax_overview.gas
@@ -1,0 +1,154 @@
+; ====================================================================
+; syntax_overview.gas
+;
+; A near-complete tour of gero's v0.1-final assembly syntax. Read this
+; top-to-bottom to see every construct from `docs/asm.md` at least
+; once. Companion to `docs/examples/syntax_overview.gr` (the
+; gero-lang side).
+;
+; This file is documentation, not a runnable example — it exercises
+; the syntax surface (directives, addressing modes, every mnemonic
+; group) without committing to a coherent program. The runnable
+; examples under `examples/asm/*.gas` cover end-to-end flows.
+;
+; Note: multi-line `struct` body is grammar-side TBD on the
+; tree-sitter parser (gero's own parser accepts it). For now the
+; single-line struct form is shown.
+; ====================================================================
+
+; -------------------- directives ----------------------------
+
+org $1000                    ; place next bytes at $1000
+bank $00                     ; sticky — every statement under bank 0
+sram_banks $02               ; reserve 2 sram-backed banks
+reserve $20                  ; pad 32 bytes of zeros
+include "shared.gas"         ; pull in another source file
+
+const PRINT   = $10
+const NEWLINE = $0A
++const EXPORTED = $42         ; leading + = export marker
+
+data8  STRING8  = "Hello", $00
+data16 STRING16 = $1234, $5678
+data8  CHAR_DATA = 'X', 'Y', 'Z', $00
+
+struct Sprite { pos: $00, size: $02, attr: $04 }
+
+; -------------------- global + local labels -----------------
+
+main:
+  mov $00, r3                ; index = 0
+.loop:                       ; local label definition
+  mov8 [@STRING8 + r3], r1
+  cmp r1, $00
+  jeq .done                  ; local-label-ref as operand
+  int PRINT
+  inc r3
+  jmp .loop
+.done:
+  hlt
+
+; -------------------- every mnemonic group ------------------
+
+mnemonic_kitchen_sink:
+  ; moves
+  mov  r1, r2
+  mov8 $FF, r3
+  movh r4, &2020
+  movl r5, &2022
+  push r1
+  pop  r2
+  swap r3, r4
+  bcpy
+
+  ; arithmetic
+  add  $0001, r1
+  adc  r2, r3
+  sub  r4, r5
+  sbc  $0010, r6
+  mul  r7, r8
+  div  r1, r2
+  divs r3, r4
+  neg  r5
+  inc  r6
+  dec  r7
+
+  ; bitwise + shift
+  and  $FFFF, r1
+  or   $0F0F, r2
+  xor  r3, r4
+  not  r5
+  shl  r6, $04
+  shr  r7, $02
+  rol  r8, $01
+  ror  r1, $08
+
+  ; compare / test / bit
+  cmp  r1, $42
+  tst  r2
+  bset r3, $07
+
+  ; control flow
+  jmp  $1234
+  jeq  $1235
+  jne  $1236
+  jlt  $1237
+  jgt  $1238
+  jle  $1239
+  jge  $123A
+  jz   $123B
+  jnz  $123C
+  jcc  $123D
+  jcs  $123E
+  jvc  $123F
+  jvs  $1240
+  jr   $0008
+  djnz r4, $1242
+  call routine
+  ret
+
+  ; flag control
+  clc
+  sec
+  cli
+  sei
+  clv
+
+  ; interrupts & misc
+  nop
+  int PRINT
+  rti
+  brk
+  hlt
+
+routine:
+  ret
+
+; -------------------- addressing modes ----------------------
+
+addressing_kitchen_sink:
+  mov  r1, r2                          ; reg, reg
+  mov  $00, r1                         ; imm16, reg
+  mov  r1, &2020                       ; reg, addr
+  mov  $00, &2020                      ; imm16, addr
+  mov  &r1, r2                         ; reg-ptr operand
+  mov  @SYMBOL, r1                     ; symbol-ref operand
+  mov  [r1], r2                        ; indirect via register
+  mov  [@SYMBOL], r1                   ; indirect via symbol-ref
+  mov  [@SYMBOL + r3], r1              ; indexed (no &)
+  mov  &[@SYMBOL + r3], r1             ; indexed (legacy &-prefix form)
+  mov  &[ (@SYMBOL) + ($0004 * $42) ], &3030  ; nested parens
+  mov  &[ <Sprite> obj.pos ], r1       ; cast inside bracket expr
+  mov  &[ <Word> mem.ptr ], r2
+
+; -------------------- literals ------------------------------
+
+literals_showcase:
+  mov $00,   r1      ; tiny hex
+  mov $FFFF, r1      ; full 16-bit hex
+  mov &1234, r1      ; address literal
+  mov 'A',   r1      ; char literal
+  mov '\n',  r1      ; escape char literal
+  data8 ESCAPED = "He said \"hi\"\n", $00   ; string with escapes
+
+; -------------------- nothing should be uncolored below -----


### PR DESCRIPTION
## Summary

Adds `docs/examples/syntax_overview.gas` — a single comprehensive file that tours every gero v0.1-final asm construct in one place. Mirrors the existing `docs/examples/syntax_overview.gr` on the gero-lang side.

## Why

Useful for:
- **Editor highlight verification** — open the file in any editor with tree-sitter-gero-asm or vscode-gero installed; every construct should color correctly. If anything renders as plain text, that's a grammar / query gap.
- **Skim-reading the asm surface** — single file, grouped sections, comments explaining each construct.

## Coverage

- All 9 directives (`org`, `bank`, `sram_banks`, `reserve`, `include`, `const` w/ `+` export marker, `data8`, `data16`, `struct`)
- Global + local label definitions + local-label refs in operand position
- Every mnemonic group: moves, arithmetic (incl. `adc`/`sbc`/`div`/`divs`), bitwise + shift (incl. `rol`/`ror`), compare/test/bit, control flow (incl. carry/overflow conditional jumps + `djnz` + `jr`), flag control, interrupts/misc
- All addressing modes: reg, imm16, addr, reg-ptr, `@SYM`, indirect, indexed (`[…]` + `&[…]`), nested-paren arithmetic, `<Type> obj.prop` casts
- All literals: hex (1-4 nibbles), address, char (incl. escapes), string (incl. escaped quotes + newlines)

## Location rationale

Under `docs/` rather than `examples/asm/` because the file isn't a runnable example — it references undefined symbols (`@SYMBOL`, `<Sprite>`, `routine`) deliberately to show the syntax shape without committing to a coherent program. If it lived under `examples/asm/`, `gero check` / `gero fmt --check` / `gero test` would all walk it and fail. The runnable examples under `examples/asm/*.gas` keep their tight "what does it test" contract.

Linked from `docs/asm.md` directly under the "source of truth for the formal grammar" callout so readers find it next to the human-readable spec.

## Known gap

Tree-sitter parser doesn't yet handle multi-line `struct` bodies (gero's own parser does). Filed as a v0.1.2 follow-up on tree-sitter-gero-asm. The file uses the single-line `struct Foo { … }` form for now.

## Self-review

- ✅ docs-only change, no runtime / build impact
- ✅ Conventional `docs:` scope (auto-skipped by changeset-check workflow)
- ✅ No AI attribution