### PR TITLE
fix(asm)!: unify bitwise reg-imm operand order to (src, dst)

### DIFF
--- a/.changeset/operand-order-bitwise-fix.md
+++ b/.changeset/operand-order-bitwise-fix.md
@@ -1,0 +1,51 @@
+---
+bump: minor
+breaking: true
+---
+
+`and` / `or` / `xor` reg-imm variants now follow gero's canonical
+`(src, dst)` operand-order convention.
+
+**Breaking change** for the asm source surface (bytecode shape
+unchanged):
+
+```asm
+; before
+and r1, $0F                  ; (dst, src) — Intel-style, the wart
+or  r1, $80
+xor r1, $FF
+
+; after
+and $0F, r1                  ; (src, dst) — matches every other store/arith op
+or  $80, r1
+xor $FF, r1
+```
+
+## Why
+
+While auditing `isa.md` for #125, found that `and`/`or`/`xor` had
+**different operand-order conventions across their own variants**:
+
+- `or r1, r2` (reg-reg) → `r2 = r2 | r1` — `(src, dst)` ✅ canonical
+- `or r1, $FF` (reg-imm) → `r1 = r1 | $FF` — `(dst, src)` ❌ Intel wart
+
+Same wart for `and` / `xor`. The reg-imm forms accidentally drifted
+to Intel-style ordering at some point in early gero (PR #36-era);
+the reg-reg forms always followed AT&T (matching `mov` / `add` /
+`sub` / `mul` / etc).
+
+`cmp` and `tst` are unchanged — they use `(subject, value)` because
+they have no destination operand (test ops, flags-only).
+
+## Migration
+
+Search for `\b(and|or|xor)\s+r\d+,\s*\$` in your `.gas` sources
+and swap the two operands. The only such call site inside the
+gero repo was `examples/asm/fib.gas:30` (`and r1, $0F` →
+`and $0F, r1`), now migrated.
+
+## Why now
+
+Per the v0.2 = "asm complete" philosophy: leaving operand-order
+inconsistent across variants of the same mnemonic was unprofessional.
+Gero has 0 external users today — the right moment to fix the wart.

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -394,6 +394,9 @@ add $10, r1            ; r1 ← r1 + $10        (src=$10, dst=r1)
 add r2, r1             ; r1 ← r1 + r2         (src=r2, dst=r1)
 sub r2, r1             ; r1 ← r1 - r2         (src=r2, dst=r1)
 and r2, r1             ; r1 ← r1 & r2         (src=r2, dst=r1)
+and $0F, r1            ; r1 ← r1 & $0F        (src=$0F, dst=r1 — bitwise mask)
+or  $80, r1            ; r1 ← r1 | $80        (src=$80, dst=r1 — bit-set)
+xor $FF, r1            ; r1 ← r1 ^ $FF        (src=$FF, dst=r1 — bitwise NOT byte)
 ```
 
 Two families are intentionally different:

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -377,11 +377,11 @@ Set `Z`, `N`. Clear `C`, `V`.
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
-| `0x50` | `and`    | `Reg, Imm16`  | reg ← reg & imm |
+| `0x50` | `and`    | `Imm16, Reg`  | reg ← reg & imm |
 | `0x51` | `and`    | `Reg, Reg`    | dst ← dst & src |
-| `0x52` | `or`     | `Reg, Imm16`  | reg ← reg \| imm |
+| `0x52` | `or`     | `Imm16, Reg`  | reg ← reg \| imm |
 | `0x53` | `or`     | `Reg, Reg`    | dst ← dst \| src |
-| `0x54` | `xor`    | `Reg, Imm16`  | reg ← reg ^ imm |
+| `0x54` | `xor`    | `Imm16, Reg`  | reg ← reg ^ imm |
 | `0x55` | `xor`    | `Reg, Reg`    | dst ← dst ^ src |
 | `0x56` | `not`    | `Reg`         | reg ← ~reg |
 

--- a/examples/asm/fib.gas
+++ b/examples/asm/fib.gas
@@ -27,7 +27,7 @@ main:
   shr r1, $04                ; r1 = high nibble
   call print_nibble
   mov r2, r1                 ; r1 ← r2 (restore)
-  and r1, $0F                ; r1 = low nibble
+  and $0F, r1                ; r1 = low nibble
   call print_nibble
 
   mov NEWLINE, r1

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -108,12 +108,16 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "sbc", .kinds = &.{ .imm16, .reg }, .opcode = 0x66 },
     .{ .mnemonic = "sbc", .kinds = &.{ .reg, .reg }, .opcode = 0x67 },
 
-    // logical
-    .{ .mnemonic = "and", .kinds = &.{ .reg, .imm16 }, .opcode = 0x50 },
+    // logical — operand order unified to (src, dst) like every other
+    // store / arith family. Previously the reg-imm variants had `(reg,
+    // imm16)` (dst-first) while the reg-reg variants used `(src, dst)` —
+    // a real internal inconsistency. Asm syntax for reg-imm is now
+    // `and $FF, r1` / `or $FF, r1` / `xor $FF, r1`.
+    .{ .mnemonic = "and", .kinds = &.{ .imm16, .reg }, .opcode = 0x50 },
     .{ .mnemonic = "and", .kinds = &.{ .reg, .reg }, .opcode = 0x51 },
-    .{ .mnemonic = "or", .kinds = &.{ .reg, .imm16 }, .opcode = 0x52 },
+    .{ .mnemonic = "or", .kinds = &.{ .imm16, .reg }, .opcode = 0x52 },
     .{ .mnemonic = "or", .kinds = &.{ .reg, .reg }, .opcode = 0x53 },
-    .{ .mnemonic = "xor", .kinds = &.{ .reg, .imm16 }, .opcode = 0x54 },
+    .{ .mnemonic = "xor", .kinds = &.{ .imm16, .reg }, .opcode = 0x54 },
     .{ .mnemonic = "xor", .kinds = &.{ .reg, .reg }, .opcode = 0x55 },
     .{ .mnemonic = "not", .kinds = &.{.reg}, .opcode = 0x56 },
 

--- a/src/vm/handlers/bitwise.zig
+++ b/src/vm/handlers/bitwise.zig
@@ -33,11 +33,11 @@ fn writeLogical(vm: *VM, dst: u8, result: u16) StepResult {
 
 // ---------- and / or / xor / not ----------
 
-/// `0x50` — `and Reg, Imm16` → `reg ← reg & imm`.
+/// `0x50` — `and Imm16, Reg` → `reg ← reg & imm` (asm: `and src, dst`).
 pub fn andRegImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.readByte(ip +% 1);
-    const imm = vm.readWord(ip +% 2);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, reg, a & imm);
 }
@@ -52,11 +52,11 @@ pub fn andRegReg(vm: *VM) StepResult {
     return writeLogical(vm, dst, a & b);
 }
 
-/// `0x52` — `or Reg, Imm16` → `reg ← reg | imm`.
+/// `0x52` — `or Imm16, Reg` → `reg ← reg | imm` (asm: `or src, dst`).
 pub fn orRegImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.readByte(ip +% 1);
-    const imm = vm.readWord(ip +% 2);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, reg, a | imm);
 }
@@ -71,11 +71,11 @@ pub fn orRegReg(vm: *VM) StepResult {
     return writeLogical(vm, dst, a | b);
 }
 
-/// `0x54` — `xor Reg, Imm16` → `reg ← reg ^ imm`.
+/// `0x54` — `xor Imm16, Reg` → `reg ← reg ^ imm` (asm: `xor src, dst`).
 pub fn xorRegImm16(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
-    const reg = vm.readByte(ip +% 1);
-    const imm = vm.readWord(ip +% 2);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
     const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
     return writeLogical(vm, reg, a ^ imm);
 }

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -96,11 +96,11 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x67] = .{ .mnemonic = "sbc", .operands = &.{ .reg, .reg } };
 
     // logical
-    t[0x50] = .{ .mnemonic = "and", .operands = &.{ .reg, .imm16 } };
+    t[0x50] = .{ .mnemonic = "and", .operands = &.{ .imm16, .reg } };
     t[0x51] = .{ .mnemonic = "and", .operands = &.{ .reg, .reg } };
-    t[0x52] = .{ .mnemonic = "or", .operands = &.{ .reg, .imm16 } };
+    t[0x52] = .{ .mnemonic = "or", .operands = &.{ .imm16, .reg } };
     t[0x53] = .{ .mnemonic = "or", .operands = &.{ .reg, .reg } };
-    t[0x54] = .{ .mnemonic = "xor", .operands = &.{ .reg, .imm16 } };
+    t[0x54] = .{ .mnemonic = "xor", .operands = &.{ .imm16, .reg } };
     t[0x55] = .{ .mnemonic = "xor", .operands = &.{ .reg, .reg } };
     t[0x56] = .{ .mnemonic = "not", .operands = &.{.reg} };
 

--- a/tests/vm/handlers/bitwise.test.zig
+++ b/tests/vm/handlers/bitwise.test.zig
@@ -20,11 +20,11 @@ fn flags(vm: *VM) struct { z: bool, n: bool, c: bool, v: bool } {
 
 // ---------- and ----------
 
-test "and 0x50 reg,imm16" {
+test "and 0x50 imm16,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFF0F);
-    loadProgram(&vm, &.{ 0x50, 0x02, 0xF0, 0x00 }); // and r1, 0x00F0
+    loadProgram(&vm, &.{ 0x50, 0xF0, 0x00, 0x02 }); // and 0x00F0, r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.r1));
     const f = flags(&vm);
@@ -35,7 +35,7 @@ test "and 0x50: high bit set marks N" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFFFF);
-    loadProgram(&vm, &.{ 0x50, 0x02, 0x00, 0x80 }); // and r1, 0x8000
+    loadProgram(&vm, &.{ 0x50, 0x00, 0x80, 0x02 }); // and 0x8000, r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x8000), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).n);
@@ -57,11 +57,11 @@ test "and 0x51 reg,reg clears C+V even if preset" {
 
 // ---------- or ----------
 
-test "or 0x52 reg,imm16" {
+test "or 0x52 imm16,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x000F);
-    loadProgram(&vm, &.{ 0x52, 0x02, 0xF0, 0x00 }); // or r1, 0x00F0
+    loadProgram(&vm, &.{ 0x52, 0xF0, 0x00, 0x02 }); // or 0x00F0, r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x00FF), vm.regs.read(.r1));
 }
@@ -78,11 +78,11 @@ test "or 0x53 reg,reg" {
 
 // ---------- xor ----------
 
-test "xor 0x54 reg,imm16" {
+test "xor 0x54 imm16,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xAAAA);
-    loadProgram(&vm, &.{ 0x54, 0x02, 0xFF, 0xFF }); // xor r1, 0xFFFF (= not)
+    loadProgram(&vm, &.{ 0x54, 0xFF, 0xFF, 0x02 }); // xor 0xFFFF, r1 (= not)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5555), vm.regs.read(.r1));
 }


### PR DESCRIPTION
Closes #161.

## Summary

`and` / `or` / `xor` had **different operand-order conventions across their own variants** — caught while auditing `isa.md` for #125.

| Variant | Asm syntax | Effect | Convention |
|---|---|---|---|
| `or Reg, Reg` (0x53) | `or r1, r2` | `r2 = r2 \| r1` | `(src, dst)` ✅ canonical |
| `or Reg, Imm16` (0x52) | `or r1, $FF` | `r1 = r1 \| $FF` | `(dst, src)` ❌ Intel-style wart |

Same wart for `and` / `xor`. Fix unifies the reg-imm variants to `(src, dst)` like every other store / arith op in gero (`mov`, `add`, `sub`, `mul`, `div`, `adc`, `sbc`).

`cmp` and `tst` keep their `(subject, value)` convention — they have no destination operand (test ops, flags-only).

## Asm syntax change

```asm
; before
and r1, $0F        ; (dst, src) — the wart
or  r1, $80
xor r1, $FF

; after
and $0F, r1        ; (src, dst) — matches every other store/arith op
or  $80, r1
xor $FF, r1
```

## Bytecode change

Wire format byte order swaps for opcodes 0x50 / 0x52 / 0x54:

```
before:  [opcode] [reg_idx] [imm_lo] [imm_hi]
after:   [opcode] [imm_lo]  [imm_hi] [reg_idx]
```

Same length, just operand order. Disasm + VM handlers updated accordingly.

## Migration

The only callsite inside the gero repo was `examples/asm/fib.gas:30` — migrated. Full sweep via `grep -rn '\b(and|or|xor)\s+r[0-9]+,\s*\$'` confirmed clean across `examples/`, `tests/`, and `docs/`.

## Files

- `src/asm/opcode_resolver.zig` — 3 entries flipped to `(imm16, reg)`
- `src/vm/handlers/bitwise.zig` — 3 handlers: read imm word first, then reg byte
- `src/vm/opcodes.zig` — disasm operand shapes for 0x50/0x52/0x54
- `tests/vm/handlers/bitwise.test.zig` — test bytecode bytes regenerated against new shape
- `examples/asm/fib.gas` — one line migrated
- `docs/isa.md` §5.5 — schemas updated
- `docs/asm.md` §2.4 — example block extended with bitwise reg-imm cases
- `.changeset/operand-order-bitwise-fix.md` — minor + breaking

## Self-review

**Step 1 (#161 AC):**
- ✅ All bitwise reg-imm variants follow `(src, dst)` post-fix
- ✅ `fib.gas` reformatted; `gero asm fib.gas` produces same final stdout (`37` for fib(10))
- ✅ All `examples/asm/**/*.gas` parse + execute cleanly via `gero check` + `gero test`
- ✅ isa.md / asm.md schemas updated
- ✅ Changeset added with `breaking: true`

**Step 2** (`zig build ci`): EXIT=0.

**Step 3 (diff walk, 8 files, +85/-27):** opcode_resolver swap + 3 VM handlers + disasm shape + 4 corpus tests regenerated + 1 example + 2 doc files + changeset.

**Step 4 (hygiene):** no AI attribution, single commit, conventional `fix(asm)!:` scope (breaking marker via `!`).

## Why now

Per the v0.2 = "asm complete, no half-features" philosophy. Gero has 0 external users today — right moment to fix the wart before v0.2 ships and migration becomes painful.

## Next in Phase 8

- #162 — ZP implementation (peephole pass + opcodes + handlers + tests)
- #163 — doc cleanup pass (remove TBD/deferred cruft, audit scope completeness)
- #127 — README upgrades (last)