### PR TITLE
fix(asm): validate sram_banks <= bank_count at codegen time

### DIFF
--- a/.changeset/asm-sram-banks-without-banks.md
+++ b/.changeset/asm-sram-banks-without-banks.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+`gero asm` / `gero build` / `gero check` now report a clean
+diagnostic ([E017] `sram_banks` count exceeds declared `bank`
+count) when a `.gas` file declares `sram_banks N` without enough
+matching `bank` directives, instead of panicking in `vm.parseGx`
+on the just-emitted image. Codegen catches the loader invariant
+(`sram_bank_count <= bank_count`) at layout time and points the
+caret at the offending `sram_banks` directive.

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -727,5 +727,6 @@ Common errors:
 | `E014` | Backward `org` would overlap already-emitted bytes |
 | `E015` | `include` target file not found |
 | `E016` | Char literal must be exactly one byte (empty `''` or multi-char) |
+| `E017` | `sram_banks N` exceeds the declared `bank N` count (loader invariant — SRAM banks live in the trailing slots of the bank pool, so they need at least N total banks to occupy) |
 
 Errors print with caret-style snippets (knit's `formatParseErrorPretty`).

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -85,9 +85,11 @@ pub fn assemble(
         .bank_sizes = std.AutoHashMap(u8, u32).init(allocator),
         .max_bank = null,
         .sram_banks = 0,
+        .sram_banks_span = null,
     };
     defer layout.bank_sizes.deinit();
     try layoutPass(&symbols, &errors, source, tree, &layout);
+    try validateSramBanks(&errors, &layout, allocator);
 
     // Pass 2: emit. Per-bank buffers; the same `current_bank` state
     // walks alongside the layout state.
@@ -134,12 +136,15 @@ pub fn assemble(
 /// (0-based, accessed at runtime by `mb = N`). `max_bank == null`
 /// means no `bank N` directive was seen; otherwise it's the
 /// highest 0-based slot index declared. `sram_banks` is the
-/// latest `sram_banks N` value.
+/// latest `sram_banks N` value; `sram_banks_span` is the source
+/// span of the directive that set it (carried so the post-layout
+/// validator can caret-point at the offending line).
 const Layout = struct {
     base_size: u32,
     bank_sizes: std.AutoHashMap(u8, u32),
     max_bank: ?u8,
     sram_banks: u8,
+    sram_banks_span: ?ast.Span,
 };
 
 /// Per-bank emit buffers. Base image lives outside the banks
@@ -439,7 +444,10 @@ fn layoutPass(
                 }
             },
             .sram_banks_decl => |s| {
-                if (s.count) |n| layout.sram_banks = n;
+                if (s.count) |n| {
+                    layout.sram_banks = n;
+                    layout.sram_banks_span = s.span;
+                }
             },
             .instruction => |i| {
                 const mnem = source[i.mnemonic.start..i.mnemonic.end];
@@ -468,6 +476,38 @@ fn layoutPass(
             .comment, .unknown => {},
         }
     }
+}
+
+/// E017 — enforce the loader's invariant (`sram_bank_count <=
+/// bank_count`) at codegen time. Without this check, writing
+/// `sram_banks $01` without any `bank $XX` produces an image whose
+/// header fails `vm.parseGx` with `error.InvalidSramCount`, which
+/// the `gero asm`/`gero build` CLIs then trip over with a panic.
+/// Catching it here turns the failure into a normal caret-rendered
+/// diagnostic on the offending directive.
+fn validateSramBanks(
+    errors: *std.ArrayList(include.Diagnostic),
+    layout: *const Layout,
+    allocator: std.mem.Allocator,
+) !void {
+    if (layout.sram_banks == 0) return;
+    // @as: widen u8 → u16 so `m + 1` for a max-index of 255 fits without wrap.
+    const bank_count: u16 = if (layout.max_bank) |m| @as(u16, m) + 1 else 0;
+    if (layout.sram_banks <= bank_count) return;
+    // Span fallback: a stray `sram_banks` with no count (parse
+    // failure upstream) already raised a parser diagnostic and
+    // never updates the span — bail out so we don't double-report
+    // with a meaningless caret.
+    const span = layout.sram_banks_span orelse return;
+    try errors.append(allocator, .{
+        .code = .sram_without_banks,
+        .parse_error = core.parseError(
+            "sram_banks",
+            span.start,
+            "`sram_banks` count exceeds declared `bank` count — SRAM banks live in the trailing slots of the cart, so add at least one `bank $XX` directive per SRAM bank",
+            .{ .expected = "at least one `bank $XX` directive per SRAM bank", .kind = .semantic },
+        ),
+    });
 }
 
 fn sizeOfDataValues(

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -172,6 +172,10 @@ pub const ErrorCode = enum(u8) {
     include_not_found = 15,
     /// E016: char literal must be exactly one byte.
     char_literal_size = 16,
+    /// E017: `sram_banks N` exceeds the declared `bank N` count
+    /// (loader invariant — SRAM banks live in the trailing N slots
+    /// of the cart, so they need at least N total banks to occupy).
+    sram_without_banks = 17,
 
     /// Map a lexer-level `ParseError.message` to the asm spec §8
     /// code, or `null` when the message isn't one of the four
@@ -212,6 +216,7 @@ pub const ErrorCode = enum(u8) {
             .backward_org => "E014",
             .include_not_found => "E015",
             .char_literal_size => "E016",
+            .sram_without_banks => "E017",
         };
     }
 };

--- a/tests/asm/check-broken/sram-without-banks.gas
+++ b/tests/asm/check-broken/sram-without-banks.gas
@@ -1,0 +1,11 @@
+; sram-without-banks.gas — `sram_banks` declared without any
+; `bank` directive. Expected: `gero check` exits non-zero with
+; an [E017] "sram_banks count exceeds declared bank count"
+; diagnostic. Pre-fix this image-shape caused `gero asm` /
+; `gero build` to panic in `parseGx` because the loader rejects
+; `sram_bank_count > bank_count`.
+
+sram_banks $01
+
+main:
+  hlt

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -370,6 +370,53 @@ test "codegen: sram_banks N populates the header byte" {
     try std.testing.expectEqual(@as(u8, 2), out.cg.image[0x0C]); // bank_count
 }
 
+test "codegen: sram_banks without any bank declaration is E017" {
+    var out = try assemble(
+        \\sram_banks $01
+        \\main:
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var found = false;
+    for (out.cg.errors) |e| if (e.code == .sram_without_banks) {
+        found = true;
+    };
+    try std.testing.expect(found);
+}
+
+test "codegen: sram_banks exceeding bank_count is E017" {
+    var out = try assemble(
+        \\sram_banks $03
+        \\bank $00
+        \\  hlt
+        \\bank $01
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    var found = false;
+    for (out.cg.errors) |e| if (e.code == .sram_without_banks) {
+        found = true;
+    };
+    try std.testing.expect(found);
+}
+
+test "codegen: sram_banks equal to bank_count passes" {
+    var out = try assemble(
+        \\sram_banks $02
+        \\bank $00
+        \\  hlt
+        \\bank $01
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+}
+
 test "codegen: org in base image targeting bank window is E007" {
     var out = try assemble(
         \\org $C100


### PR DESCRIPTION
## Summary

- `sram_banks N` without enough matching `bank N` directives no longer panics `gero asm` / `gero build` / `gero check`.
- Codegen now validates the loader's invariant (`sram_bank_count <= bank_count`) after the layout pass and emits a new [E017] diagnostic on the offending `sram_banks` line.
- Adds regression fixture under `tests/asm/check-broken/`.

## Background

Repro pre-fix:

```bash
cat > /tmp/bad.gas <<'GAS'
sram_banks $01

main:
  hlt
GAS
gero asm /tmp/bad.gas    # panics in vm.parseGx catch unreachable
```

`vm.parseGx` rejects `sram_bank_count > bank_count` with `error.InvalidSramCount`. The CLIs called it with `catch unreachable` on the success path (post-codegen "image is well-formed by construction" assumption), turning a perfectly recoverable user mistake into a stack trace.

Post-fix:

```
8:1: [E017] `sram_banks` count exceeds declared `bank` count — SRAM banks live in the trailing slots of the cart, so add at least one `bank $XX` directive per SRAM bank
   8 | sram_banks $01
     | ^
```

Exit 3 for `gero asm` / `gero build`, exit 4 for `gero check`. The `catch unreachable` lines stay — they are now load-bearing-true because the codegen-time check rules out the only path that could trip them.

## Changes

- `src/asm/include.zig` — new `ErrorCode.sram_without_banks` (E017) variant + `shortLabel` mapping.
- `src/asm/codegen.zig` — `Layout` tracks the `sram_banks` directive's span; new `validateSramBanks` runs after `layoutPass`.
- `docs/asm.md` — E017 row in the §8 error-code table.
- `tests/asm/codegen.test.zig` — three unit tests (zero banks, too-few banks, equal counts pass).
- `tests/asm/check-broken/sram-without-banks.gas` — picked up by `scripts/check-broken.sh` (5 caught, 0 missed).
- `.changeset/asm-sram-banks-without-banks.md` — patch-level.

## Test plan

- [x] `zig build ci` — clean
- [x] `gero asm tests/asm/check-broken/sram-without-banks.gas` — exit 3, E017 diagnostic
- [x] `gero check tests/asm/check-broken/sram-without-banks.gas` — exit 4, E017 diagnostic
- [x] `gero build` in a project pointing at the bad fixture — exit 3, E017 diagnostic
- [x] Equal `sram_banks` / `bank_count` still assembles cleanly