### PR TITLE
refactor(asm)!: drop unused E008 reserved-opcode error code

### DIFF
--- a/.changeset/asm-drop-e008.md
+++ b/.changeset/asm-drop-e008.md
@@ -1,0 +1,30 @@
+---
+bump: patch
+breaking: true
+---
+
+`asm.ErrorCode.reserved_opcode` (E008) removed — never emitted by
+any code path, lingering placeholder for ISA additions that never
+materialized.
+
+The numeric ID `8` is intentionally left dead (no enum variant
+reuses it) so any tool that parsed the asm error-code table by
+number stays stable. The asm spec §8 error table loses the E008
+row.
+
+## Migration
+
+Anyone exhaustively switching on `asm.ErrorCode` needs to drop
+the `.reserved_opcode` arm. No production code in this repo had
+such a match; no tests exercised it. The change is detectable
+at compile time — the Zig compiler will complain if a downstream
+crate matched the removed variant.
+
+## Context
+
+The ZP pass (`feat(vm,asm): zero-page mov forms`) filled the
+previously-reserved opcode slots 0x19/0x1A/0x1B and 0x2A..0x2D.
+With no reserved-but-unimplemented opcodes left in the ISA,
+E008 had nothing to gate against. Removing the variant matches
+the asm-complete v0.2 philosophy — no half-features, no dead
+hooks.

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -687,7 +687,6 @@ Common errors:
 | `E005` | Duplicate label |
 | `E006` | Hex literal out of range |
 | `E007` | Address out of range (would emit > 0xFFFF) |
-| `E008` | Reserved opcode used (placeholder for future ISA additions; no opcode is currently reserved-but-unimplemented today) |
 | `E009` | Division by zero in a compile-time expression |
 | `E010` | Unknown escape sequence in string or char literal |
 | `E011` | Unterminated string literal (newline or EOF before closing `"`) |

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -137,7 +137,7 @@ pub const Diagnostic = struct {
     note: ?[]const u8 = null,
 };
 
-/// Asm spec §8 error codes. Numerical IDs match the spec's
+/// Asm spec §7 error codes. Numerical IDs match the spec's
 /// `E001..E016` table — `@intFromEnum(ErrorCode.unknown_mnemonic) == 1`.
 pub const ErrorCode = enum(u8) {
     /// E001: unknown mnemonic.
@@ -154,8 +154,11 @@ pub const ErrorCode = enum(u8) {
     hex_out_of_range = 6,
     /// E007: address out of range.
     addr_out_of_range = 7,
-    /// E008: reserved opcode used.
-    reserved_opcode = 8,
+    // E008 was "reserved opcode used" — never emitted; removed once
+    // the ZP pass filled the previously-reserved 0x19/0x1A/0x1B and
+    // 0x2A..0x2D slots. The numeric ID is kept dead (no reuse) to
+    // avoid breaking error-code stability for anyone who parsed the
+    // table in the asm spec.
     /// E009: division by zero in compile-time expression.
     div_by_zero = 9,
     /// E010: unknown escape sequence in string or char literal.
@@ -207,7 +210,7 @@ pub const ErrorCode = enum(u8) {
             .duplicate_label => "E005",
             .hex_out_of_range => "E006",
             .addr_out_of_range => "E007",
-            .reserved_opcode => "E008",
+            // E008 intentionally absent — see enum comment above.
             .div_by_zero => "E009",
             .unknown_escape => "E010",
             .unterminated_string => "E011",


### PR DESCRIPTION
## Summary

`ErrorCode.reserved_opcode` (E008) is defined in `src/asm/include.zig` and exposed through the asm spec §8 table, but **never emitted** by any code path. Originally a placeholder for ISA additions that would land in previously-reserved opcode slots — the ZP pass shipped 0x19/0x1A/0x1B + 0x2A..0x2D in PR #166, leaving the variant with nothing to gate against.

Spotted while auditing what to ship for v0.2 closeout. Dead code goes.

## Changes

- Drop `ErrorCode.reserved_opcode` from the enum. Numeric ID `8` is intentionally left dead (no variant reuses it) so any tool that parsed the asm error-code table by number stays stable.
- Drop the corresponding arm in `shortLabel`.
- Drop the E008 row from `docs/asm.md §8`.

`grep -rn 'reserved_opcode\\|E008' src tests apps` returns zero matches after the patch.

## Marked breaking

`asm.ErrorCode` is a `pub enum` — anyone exhaustively switching on it loses the `.reserved_opcode` arm. No production code in this repo matched. Caught at compile time by Zig's exhaustive switch.

## Test plan

- [x] `zig build ci` clean locally (Debug + ReleaseSafe + ReleaseFast + ReleaseSmall + lint + strict + naming + mirror + imports + cross-target compile + examples + check-examples + check-broken + fmt).
- [x] Verified no test asserts on `.reserved_opcode` or the string `E008`.

## Self-review

- ✅ AC re-read: dead code, no behavior change, doc table updated, no production-side reference left
- ✅ `zig build ci` green
- ✅ Public API impact: ErrorCode public enum loses one variant — covered by breaking marker in changeset
- ✅ Doc propagation: asm.md §8 table row removed
- ✅ Changeset: `patch` bump + `breaking: true` per the public-enum surface change
- ✅ Hygiene: no leftover debug prints, comment in include.zig explains the dead numeric ID, conventional-commit header has scope + `!` marker, no AI attribution