### PR TITLE
feat(apps/gero-cli): editor surface — fmt --stdin + check --format=json

### DIFF
--- a/.changeset/cli-editor-surface.md
+++ b/.changeset/cli-editor-surface.md
@@ -1,0 +1,69 @@
+---
+bump: minor
+---
+
+`gero fmt --stdin` and `gero check --format=json` ship — two
+small CLI surfaces that unblock first-class editor integration
+**without** needing the LSP server.
+
+## `gero fmt --stdin`
+
+Read source from stdin, write canonical-formatted bytes to
+stdout. Standard editor format-on-save pattern (gofmt, `rustfmt
+--emit=stdout`, `black -`).
+
+```bash
+cat main.gas | gero fmt --stdin           # → canonical output
+cat main.gas | gero fmt --stdin --check   # exit 8 if non-canonical
+```
+
+- Mutually exclusive with positional paths (`--stdin foo.gas` →
+  exit 2 with usage message).
+- Manifest `[fmt]` overrides are not consulted — no project root
+  context. Compile-time defaults apply.
+- Parse errors render plain `<line>:<col>: <message>` on stderr,
+  exit 3. No file-path prefix (there's no file).
+- `--check` mode: exit 0 silent if canonical, 8 silent otherwise,
+  no stdout written.
+
+## `gero check --format=json`
+
+Emit a single JSON object to stdout (instead of the caret-style
+human report). Stable schema for editor integration.
+
+```bash
+gero check --format=json src/      # one JSON object covering every file
+```
+
+```json
+{
+  "version": 1,
+  "diagnostics": [
+    {
+      "file": "src/main.gas",
+      "line": 12,
+      "column": 5,
+      "severity": "error",
+      "code": "E004",
+      "message": "undefined symbol"
+    }
+  ],
+  "files_checked": 4,
+  "files_failed": 1
+}
+```
+
+- `code` omitted for syntax errors without an E-code.
+- `note` omitted when absent.
+- Exit codes preserved from `human` mode (0 / 4 / 1 / 2) — editors
+  branch on exit code, then `JSON.parse(stdout)`.
+- Stderr is reserved for host I/O failures (file missing).
+
+## Why now
+
+The LSP server (#122) blocks on the gero-lang front-end, which
+won't ship for several minor versions. `fmt --stdin` +
+`check --format=json` give editors enough surface to wire
+**format-on-save** and **inline diagnostics** through plain pipe
+plumbing — no protocol, no daemon. Same idiom every major
+editor already supports for gofmt / prettier / black.

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -83,12 +83,25 @@ pub fn execute(
     // ParseTree slices, Codegen image) stay live until the arena
     // resets, so the failures collected here keep their source-map
     // + diagnostic references valid across the loop.
+    //
+    // JSON-format mode suppresses all per-file output during the
+    // loop (✓ lines, read-error stderr) and emits a single JSON
+    // object after the loop. Host-IO failures get captured as
+    // ReadErrorEntry rows so they show up in the JSON.
+    const json_mode = opts.format == .json;
+    var read_errors: std.ArrayList(diagnostics.ReadErrorEntry) = .empty;
     var pass: usize = 0;
     var failures: std.ArrayList(FileEntry) = .empty;
     for (files.items) |path| {
         const t_phase_start_include = std.Io.Timestamp.now(io, .awake);
         const fused = gero.asm_.resolveIncludes(io, arena, path) catch |err| {
-            try term.err("gero check: cannot read {s} ({s})", .{ path, @errorName(err) });
+            const err_name = @errorName(err);
+            if (json_mode) {
+                const msg = try std.fmt.allocPrint(arena, "cannot read ({s})", .{err_name});
+                try read_errors.append(arena, .{ .path = path, .message = msg });
+            } else {
+                try term.err("gero check: cannot read {s} ({s})", .{ path, err_name });
+            }
             // Synthesize a single-diagnostic failure so the merged
             // report has something to render. Skipping the failure
             // would mis-count totals.
@@ -127,13 +140,27 @@ pub fn execute(
         }
 
         pass += 1;
-        if (!opts.quiet) {
+        if (!opts.quiet and !json_mode) {
             try printPass(stdout, style, path, cg, single, opts.verbose, .{
                 .include = t_phase_start_include.durationTo(t_after_include).nanoseconds,
                 .parse = t_after_include.durationTo(t_after_parse).nanoseconds,
                 .codegen = t_after_parse.durationTo(t_after_codegen).nanoseconds,
             });
         }
+    }
+
+    const fail = failures.items.len;
+
+    // JSON mode emits one object covering every diagnostic + read
+    // error, then exits. No human-readable header / summary / footer.
+    if (json_mode) {
+        var pipeline_failures: std.ArrayList(diagnostics.FileFailure) = .empty;
+        for (failures.items) |f| switch (f.info) {
+            .read_error => {}, // surfaced via read_errors list instead
+            .from_pipeline => |pf| try pipeline_failures.append(arena, pf),
+        };
+        try diagnostics.printJsonReport(stdout, pipeline_failures.items, read_errors.items, files.items.len, fail);
+        return if (fail > 0) 4 else 0;
     }
 
     // Pass 2: render the merged diagnostic report (if any failure).
@@ -153,7 +180,6 @@ pub fn execute(
         }
     }
 
-    const fail = failures.items.len;
     if (!single and !opts.quiet) {
         const pass_noun: []const u8 = if (pass == 1) "file" else "files";
         const fail_noun: []const u8 = if (fail == 1) "failure" else "failures";

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -29,6 +29,12 @@ pub const Optimize = enum { debug, release, size };
 /// `--color` values: `auto` (TTY + `NO_COLOR`), `always`, `never`.
 pub const ColorChoice = enum { auto, always, never };
 
+/// `--format` values per `cli.md` §3.9 — output renderer for
+/// commands that produce diagnostics. `human` is the default
+/// caret-style; `json` is the machine-parseable shape editors
+/// consume.
+pub const Format = enum { human, json };
+
 /// Maximum positional args a single invocation can hold. v0.1
 /// commands top out at 1-2; keep it generous to absorb future
 /// `gero build` multi-source forms without re-architecting.
@@ -62,6 +68,15 @@ pub const Options = struct {
     /// files that would be reformatted (exit 8) without writing.
     /// Editor / CI use case.
     check: bool = false,
+    /// `--stdin` for `gero fmt` — read source from stdin, write
+    /// formatted output to stdout. Unblocks editor format-on-save
+    /// without needing the LSP. Mutually exclusive with positional
+    /// path args.
+    stdin: bool = false,
+    /// `--format=<m>` for `gero check` — output renderer.
+    /// `human` (default) is the caret-style report; `json` is a
+    /// machine-parseable shape for editor integration.
+    format: Format = .human,
     /// `--target=<vm|gtx-16>` for `gero build` — overrides the
     /// manifest's `package.target`. `null` = inherit from manifest;
     /// `gtx-16` is reserved (errors with "not yet implemented").
@@ -278,20 +293,22 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero test --verbose{s}          {s}# show per-test duration{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         .check => {
-            try out.print("  {s}gero check{s} <path...> [--quiet] [-v]\n\n", .{ a.cyan, a.reset });
+            try out.print("  {s}gero check{s} <path...> [--format=<m>] [--quiet] [-v]\n\n", .{ a.cyan, a.reset });
             try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
             try out.print("  {s}gero check prog.gas{s}             {s}# parse + codegen-validate, no .gx written{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero check src/{s}                 {s}# walk a directory recursively for *.gas{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero check a.gas b.gas src/{s}     {s}# any mix of files and directories{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero check --format=json src/{s}   {s}# editor-friendly JSON diagnostics on stdout{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero check prog.gas --quiet{s}     {s}# suppress the ok summary (exit code only){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero check prog.gas -v{s}          {s}# per-phase timings (include / parse / codegen){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         .fmt => {
-            try out.print("  {s}gero fmt{s} <path...> [--check] [--quiet]\n\n", .{ a.cyan, a.reset });
+            try out.print("  {s}gero fmt{s} <path...> [--check] [--stdin] [--quiet]\n\n", .{ a.cyan, a.reset });
             try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
             try out.print("  {s}gero fmt prog.gas{s}               {s}# rewrite in place if not canonical{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero fmt src/{s}                   {s}# recurse + format every .gas{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero fmt --check src/{s}           {s}# CI mode — exit 8 if any file would change{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}cat prog.gas | gero fmt --stdin{s} {s}# editor format-on-save (stdin → stdout){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         .new => {
             try out.print("  {s}gero new{s} <name> [--quiet]\n\n", .{ a.cyan, a.reset });
@@ -344,6 +361,8 @@ fn flagHelpLine(kind: FlagKind) FlagHelpLine {
         .no_show_bytes => .{ .sig = "--no-show-bytes", .desc = "Strip the hex-bytes column for a cleaner view." },
         .check_roundtrip => .{ .sig = "--check-roundtrip", .desc = "Verify asm → disasm → asm yields identical bytes (CI gate)." },
         .check => .{ .sig = "--check", .desc = "Non-destructive — exit 8 if any file would be reformatted." },
+        .stdin => .{ .sig = "--stdin", .desc = "Read source from stdin, write formatted bytes to stdout." },
+        .format => .{ .sig = "--format=<m>", .desc = "human (default) / json. JSON output suppresses human messages." },
         .target => .{ .sig = "--target=<m>", .desc = "vm (default) / gtx-16. Overrides manifest's [package].target." },
     };
 }
@@ -358,8 +377,8 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .info => &.{ .help, .color, .no_color },
         .disasm => &.{ .help, .bank, .no_show_bytes, .check_roundtrip, .quiet, .color, .no_color },
         .test_ => &.{ .help, .verbose, .color, .no_color },
-        .check => &.{ .help, .quiet, .verbose, .color, .no_color },
-        .fmt => &.{ .help, .check, .quiet, .color, .no_color },
+        .check => &.{ .help, .format, .quiet, .verbose, .color, .no_color },
+        .fmt => &.{ .help, .check, .stdin, .quiet, .color, .no_color },
         .new => &.{ .help, .quiet, .color, .no_color },
         .init => &.{ .help, .quiet, .color, .no_color },
         .build => &.{ .help, .target, .quiet, .verbose, .color, .no_color },
@@ -386,7 +405,13 @@ fn parseColor(s: []const u8) ParseError!ColorChoice {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check, target };
+fn parseFormat(s: []const u8) ParseError!Format {
+    if (std.mem.eql(u8, s, "human")) return .human;
+    if (std.mem.eql(u8, s, "json")) return .json;
+    return error.InvalidEnumValue;
+}
+
+const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check, stdin, format, target };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
@@ -402,6 +427,8 @@ fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "no-show-bytes")) return .no_show_bytes;
     if (std.mem.eql(u8, s, "check-roundtrip")) return .check_roundtrip;
     if (std.mem.eql(u8, s, "check")) return .check;
+    if (std.mem.eql(u8, s, "stdin")) return .stdin;
+    if (std.mem.eql(u8, s, "format")) return .format;
     if (std.mem.eql(u8, s, "target")) return .target;
     return null;
 }
@@ -432,6 +459,8 @@ fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void
         .no_show_bytes => opts.show_bytes = false,
         .check_roundtrip => opts.check_roundtrip = true,
         .check => opts.check = true,
+        .stdin => opts.stdin = true,
+        .format => opts.format = try parseFormat(value orelse return error.MissingFlagValue),
         .target => opts.target = value orelse return error.MissingFlagValue,
     }
 }
@@ -442,7 +471,7 @@ fn parseBank(s: []const u8) ParseError!u8 {
 
 fn needsValue(kind: FlagKind) bool {
     return switch (kind) {
-        .optimize, .out, .color, .bank, .target => true,
+        .optimize, .out, .color, .bank, .format, .target => true,
         else => false,
     };
 }

--- a/apps/gero-cli/diagnostics.zig
+++ b/apps/gero-cli/diagnostics.zig
@@ -104,6 +104,152 @@ pub fn pathOf(source_map: gero.asm_.SourceMap, d: gero.asm_.Diagnostic) []const 
     return "<unknown>";
 }
 
+/// Resolve a diagnostic's fused-source offset back to its
+/// `(file_path, line, column)` triple. Falls back to
+/// `(<unknown>, 0, 0)` when the source-map misses.
+pub fn locationOf(source_map: gero.asm_.SourceMap, d: gero.asm_.Diagnostic) Location {
+    // @as: ParseError indexes fit in u32 — bounded by max_file_size (16 MiB) per include.zig.
+    const offset: u32 = @as(u32, @intCast(d.parse_error.index));
+    if (source_map.lookup(offset)) |loc| {
+        const lc = lineColIn(loc.file.content, loc.file_offset);
+        return .{ .path = loc.file.path, .line = lc.line, .column = lc.col };
+    }
+    return .{ .path = "<unknown>", .line = 0, .column = 0 };
+}
+
+/// `(line, column)` 1-based pair for a byte offset inside `content`.
+/// Linear scan — fine while individual files stay under the
+/// 16 MiB cap, which they always do.
+pub fn lineColIn(content: []const u8, file_offset: u32) struct { line: usize, col: usize } {
+    var line: usize = 1;
+    var col: usize = 1;
+    const target: usize = @as(usize, file_offset);
+    var i: usize = 0;
+    while (i < content.len and i < target) : (i += 1) {
+        if (content[i] == '\n') {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    return .{ .line = line, .col = col };
+}
+
+/// Resolved diagnostic location used by the JSON renderer + any
+/// future structured-output consumer.
+pub const Location = struct {
+    path: []const u8,
+    line: usize,
+    column: usize,
+};
+
+/// Emit a single JSON object summarizing the run — stable contract
+/// for editor integration (`gero check --format=json`). Schema:
+///
+/// ```json
+/// {
+///   "version": 1,
+///   "diagnostics": [
+///     {
+///       "file": "<path>",
+///       "line": <1-based>,
+///       "column": <1-based>,
+///       "severity": "error",
+///       "code": "E004",          // omitted when the diagnostic has no E-code
+///       "message": "<text>",
+///       "note": "<hint>"          // omitted when absent
+///     }
+///   ],
+///   "files_checked": <N>,
+///   "files_failed": <M>
+/// }
+/// ```
+///
+/// Stdout is reserved for this object — no human-readable output is
+/// emitted in JSON mode. Stderr stays free for host I/O failures.
+pub fn printJsonReport(
+    stdout: *std.Io.Writer,
+    failures: []const FileFailure,
+    read_errors: []const ReadErrorEntry,
+    files_checked: usize,
+    files_failed: usize,
+) !void {
+    var jw = std.json.Stringify{ .writer = stdout, .options = .{ .whitespace = .minified } };
+    try jw.beginObject();
+
+    try jw.objectField("version");
+    try jw.write(@as(u32, 1));
+
+    try jw.objectField("diagnostics");
+    try jw.beginArray();
+    for (failures) |f| {
+        for (f.parse_errors) |d| try writeDiagnosticJson(&jw, f.source_map, d);
+        for (f.codegen_errors) |d| try writeDiagnosticJson(&jw, f.source_map, d);
+    }
+    for (read_errors) |re| {
+        try jw.beginObject();
+        try jw.objectField("file");
+        try jw.write(re.path);
+        try jw.objectField("line");
+        try jw.write(@as(u32, 1));
+        try jw.objectField("column");
+        try jw.write(@as(u32, 1));
+        try jw.objectField("severity");
+        try jw.write("error");
+        try jw.objectField("message");
+        try jw.write(re.message);
+        try jw.endObject();
+    }
+    try jw.endArray();
+
+    try jw.objectField("files_checked");
+    try jw.write(files_checked);
+    try jw.objectField("files_failed");
+    try jw.write(files_failed);
+
+    try jw.endObject();
+    try stdout.writeByte('\n');
+}
+
+/// A file that couldn't be read at all (host-IO failure). Carries
+/// the synthetic message the JSON renderer emits in place of a
+/// pipeline diagnostic.
+pub const ReadErrorEntry = struct {
+    path: []const u8,
+    message: []const u8,
+};
+
+fn writeDiagnosticJson(
+    jw: *std.json.Stringify,
+    source_map: gero.asm_.SourceMap,
+    d: gero.asm_.Diagnostic,
+) !void {
+    const loc = locationOf(source_map, d);
+    try jw.beginObject();
+
+    try jw.objectField("file");
+    try jw.write(loc.path);
+    try jw.objectField("line");
+    try jw.write(loc.line);
+    try jw.objectField("column");
+    try jw.write(loc.column);
+    try jw.objectField("severity");
+    try jw.write("error");
+    if (d.code) |c| {
+        try jw.objectField("code");
+        try jw.write(c.shortLabel());
+    }
+    try jw.objectField("message");
+    try jw.write(d.parse_error.message);
+    if (d.note) |n| {
+        try jw.objectField("note");
+        try jw.write(n);
+    }
+
+    try jw.endObject();
+}
+
 /// Sort comparator: by path lex order, then by fused-source
 /// offset within the same path. Used by `printMerged`.
 pub fn byPathThenIndex(_: void, a: Keyed, b: Keyed) bool {
@@ -128,6 +274,87 @@ test "diagnostics: byPathThenIndex breaks ties on parse_error.index" {
     const b: Keyed = .{ .diag = mkDiag(10), .path = "same.gas" };
     try testing.expect(byPathThenIndex({}, a, b));
     try testing.expect(!byPathThenIndex({}, b, a));
+}
+
+test "diagnostics: lineColIn 1-indexes lines and columns" {
+    const content = "abc\ndef\nghi";
+    const r1 = lineColIn(content, 0);
+    try testing.expectEqual(@as(usize, 1), r1.line);
+    try testing.expectEqual(@as(usize, 1), r1.col);
+
+    const r2 = lineColIn(content, 4); // first char of "def"
+    try testing.expectEqual(@as(usize, 2), r2.line);
+    try testing.expectEqual(@as(usize, 1), r2.col);
+
+    const r3 = lineColIn(content, 10); // 'i' in "ghi"
+    try testing.expectEqual(@as(usize, 3), r3.line);
+    try testing.expectEqual(@as(usize, 3), r3.col);
+}
+
+test "diagnostics: printJsonReport — empty run" {
+    var out = std.Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    try printJsonReport(&out.writer, &.{}, &.{}, 3, 0);
+    try testing.expectEqualStrings(
+        "{\"version\":1,\"diagnostics\":[],\"files_checked\":3,\"files_failed\":0}\n",
+        out.written(),
+    );
+}
+
+test "diagnostics: printJsonReport — read-error-only run" {
+    var out = std.Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    const errs = [_]ReadErrorEntry{.{ .path = "missing.gas", .message = "cannot read (FileNotFound)" }};
+    try printJsonReport(&out.writer, &.{}, &errs, 1, 1);
+    const expected =
+        "{\"version\":1,\"diagnostics\":[{\"file\":\"missing.gas\",\"line\":1,\"column\":1,\"severity\":\"error\"," ++
+        "\"message\":\"cannot read (FileNotFound)\"}],\"files_checked\":1,\"files_failed\":1}\n";
+    try testing.expectEqualStrings(expected, out.written());
+}
+
+test "diagnostics: writeDiagnosticJson — code + note both serialized when present" {
+    // Build a synthetic SourceMap covering one file so locationOf
+    // resolves cleanly.
+    var sm: gero.asm_.SourceMap = .{
+        .files = .empty,
+        .regions = .empty,
+        .allocator = testing.allocator,
+    };
+    defer sm.deinit();
+    const path = try testing.allocator.dupeZ(u8, "foo.gas");
+    const content = try testing.allocator.dupe(u8, "mov $00, r1\n");
+    try sm.files.append(testing.allocator, .{ .path = path, .content = content });
+    try sm.regions.append(testing.allocator, .{
+        .fused_start = 0,
+        .fused_end = @as(u32, @intCast(content.len)),
+        .file_id = 0,
+        .file_offset = 0,
+    });
+
+    const d: gero.asm_.Diagnostic = .{
+        .code = .duplicate_label,
+        .note = "did you mean `bar`?",
+        .parse_error = .{
+            .parser = "test",
+            .index = 4, // points at `$`
+            .message = "undefined symbol",
+            .expected = "",
+            .actual = "",
+            .kind = .semantic,
+        },
+    };
+
+    var out = std.Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    var jw: std.json.Stringify = .{ .writer = &out.writer, .options = .{ .whitespace = .minified } };
+    try jw.beginArray();
+    try writeDiagnosticJson(&jw, sm, d);
+    try jw.endArray();
+
+    const expected =
+        "[{\"file\":\"foo.gas\",\"line\":1,\"column\":5,\"severity\":\"error\"," ++
+        "\"code\":\"E005\",\"message\":\"undefined symbol\",\"note\":\"did you mean `bar`?\"}]";
+    try testing.expectEqualStrings(expected, out.written());
 }
 
 fn mkDiag(index: u32) gero.asm_.Diagnostic {

--- a/apps/gero-cli/fmt.zig
+++ b/apps/gero-cli/fmt.zig
@@ -50,6 +50,20 @@ pub fn execute(
     const positionals = opts.positional();
     const style: gero.asm_.Style = if (term.color) .ansi else .plain;
 
+    // `--stdin` is mutually exclusive with positional paths AND with
+    // the project-aware manifest fallback. Routes to a separate
+    // formatter that reads stdin, writes stdout, never touches the
+    // disk, and never consults `gero.toml`. Exit codes per cli.md
+    // §3.8: 0 (formatted / canonical), 8 (--check would-modify),
+    // 3 (parse error), 2 (usage).
+    if (opts.stdin) {
+        if (positionals.len > 0) {
+            try term.err("gero fmt: --stdin is mutually exclusive with positional paths", .{});
+            return 2;
+        }
+        return try formatStdin(io, arena, stdout, term, style, opts.check);
+    }
+
     // Always try to load gero.toml — both [fmt] overrides and the
     // implicit file list (when no positionals are passed) come
     // from the manifest. `not_found` is normal (single-file CLI
@@ -146,6 +160,65 @@ pub fn printOptionsFromManifest(fmt: project.Manifest.Fmt) gero.asm_.PrintOption
             .preserve => .preserve,
         },
     };
+}
+
+/// `--stdin` mode: read source from stdin, run the canonical
+/// printer, write the result to stdout. `check_mode` flips behavior
+/// to exit 8 (no stdout) when the input would reformat.
+///
+/// The manifest's `[fmt]` overrides are **not** consulted — stdin
+/// mode has no project root context. Always uses compile-time
+/// defaults.
+///
+/// Diagnostics on stderr in plain `<line>:<col>: <message>` form
+/// (no file path — there is no file). Stdout stays reserved for
+/// formatted bytes so editors can pipe it directly.
+fn formatStdin(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+    style: gero.asm_.Style,
+    check_mode: bool,
+) !u8 {
+    _ = style;
+
+    // 16 MiB ceiling matches src/asm/include.zig::max_file_size.
+    const max_stdin_bytes: usize = 16 * 1024 * 1024;
+    var read_buf: [4096]u8 = undefined;
+    var stdin_reader = std.Io.File.stdin().reader(io, &read_buf);
+    const src = stdin_reader.interface.allocRemaining(arena, .limited(max_stdin_bytes)) catch |err| {
+        try term.err("gero fmt: cannot read stdin ({s})", .{@errorName(err)});
+        return 1;
+    };
+
+    var pt = try gero.asm_.parse(arena, src);
+
+    var real_errors: std.ArrayList(gero.asm_.Diagnostic) = .empty;
+    for (pt.errors) |d| {
+        if (!errorIsFromIncludeLine(src, d)) try real_errors.append(arena, d);
+    }
+    if (real_errors.items.len > 0) {
+        // No file path → plain `<line>:<col>: <message>` on stderr.
+        for (real_errors.items) |d| {
+            // @as: ParseError.index fits in u32 — bounded by max_stdin_bytes.
+            const lc = lineColAt(src, @as(u32, @intCast(d.parse_error.index)));
+            try term.err("{d}:{d}: {s}", .{ lc.line, lc.col, d.parse_error.message });
+        }
+        return 3;
+    }
+
+    var allocating = std.Io.Writer.Allocating.init(arena);
+    try gero.asm_.printProgram(&allocating.writer, &pt.program, src, gero.asm_.default_print_options);
+    const formatted = allocating.written();
+
+    if (check_mode) {
+        // Canonical → exit 0 silent; otherwise exit 8, also silent.
+        return if (std.mem.eql(u8, src, formatted)) 0 else 8;
+    }
+
+    try stdout.writeAll(formatted);
+    return 0;
 }
 
 fn formatOne(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -256,6 +256,7 @@ gero fmt --check main.gas         # check only (exit 8 if changes needed)
 gero fmt src/                     # recurse into directory
 gero fmt a.gas b.gas src/         # any mix of files and directories
 gero fmt                          # project-aware: [build].entry + [test].include
+cat main.gas | gero fmt --stdin   # editor format-on-save (stdin → stdout)
 ```
 
 **Behavior:**
@@ -268,6 +269,13 @@ gero fmt                          # project-aware: [build].entry + [test].includ
 - `--check` is non-destructive: exits 0 if every file is canonical,
   8 if any file would be reformatted, 3 on a genuine parse error.
   CI use case.
+- `--stdin` reads source from stdin, writes formatted bytes to
+  stdout. Mutually exclusive with positional paths (exit 2).
+  Manifest `[fmt]` overrides are **not** consulted in stdin mode
+  — there's no project root context, so compile-time defaults
+  apply. `--stdin --check` exits 0 if already canonical, 8 if it
+  would reformat (no stdout in `--check` mode). Use case: editor
+  format-on-save (VS Code / Neovim / Helix).
 - Recurses into directories, formats every `.gas` found. `.gr`
   sources route to "not yet implemented" until the
   gero-lang front-end.
@@ -340,6 +348,7 @@ gero check                        # project-aware: [build].entry + [test].includ
 gero check main.gr                # → "not yet implemented" while gero-lang is not yet implemented
 gero check main.gas --quiet       # suppress per-file lines + summary
 gero check main.gas --verbose     # per-phase timings (single-file only)
+gero check --format=json src/     # editor-friendly JSON diagnostics
 ```
 
 **Project-aware fallback**: invoked with no positional args
@@ -360,6 +369,40 @@ manifest + no positional args → exit 2 with a usage hint.
   noise.
 - `--quiet` suppresses per-file ok lines + the summary but keeps
   failure diagnostics + the footer.
+
+**`--format=json` mode:**
+
+Emits a single JSON object to stdout (no per-file ✓ lines, no
+summary, no footer). Stderr stays reserved for host I/O failures
+(file missing, stat error). Schema:
+
+```json
+{
+  "version": 1,
+  "diagnostics": [
+    {
+      "file": "src/main.gas",
+      "line": 12,
+      "column": 5,
+      "severity": "error",
+      "code": "E004",
+      "message": "undefined symbol",
+      "note": "did you mean `foo_bar`?"
+    }
+  ],
+  "files_checked": 4,
+  "files_failed": 1
+}
+```
+
+- `code` is omitted for plain syntax errors that don't map to an
+  E-code.
+- `note` is omitted when absent.
+- Exit codes are unchanged from `human` mode (0 / 4 / 1 / 2) —
+  editors can branch on the code, then `JSON.parse(stdout)` for
+  the diagnostic list.
+- The `version` field lets the schema evolve while keeping the
+  contract stable.
 
 **Exit:** `0` if clean; `4` on any diagnostic; `1` on host IO
 problem; `2` on usage error.


### PR DESCRIPTION
Closes #169, closes #170.

## Summary

Two small CLI surfaces that unblock first-class editor integration **without** needing the LSP server (which blocks on the gero-lang front-end per #122). Combined into one PR because both serve the same use case (editor enablement) and touch the same code surface (`apps/gero-cli/`).

### `gero fmt --stdin`

Read source from stdin, write canonical-formatted bytes to stdout. Standard editor format-on-save pattern (gofmt, `rustfmt --emit=stdout`, `black -`).

```bash
cat main.gas | gero fmt --stdin           # canonical output on stdout
cat main.gas | gero fmt --stdin --check   # exit 8 if non-canonical, no stdout
```

- Mutually exclusive with positional paths (`--stdin foo.gas` → exit 2 with usage).
- Manifest `[fmt]` overrides **not** consulted — no project root context, compile-time defaults apply.
- Parse errors render plain `<line>:<col>: <message>` on stderr (no file-path prefix), exit 3.
- `--check` mode: exit 0 silent if canonical, 8 silent otherwise, no stdout written.

### `gero check --format=json`

Emit a single JSON object to stdout (instead of the caret-style human report). Stable schema for editor integration.

```json
{
  "version": 1,
  "diagnostics": [
    {
      "file": "src/main.gas",
      "line": 12,
      "column": 5,
      "severity": "error",
      "code": "E004",
      "message": "undefined symbol"
    }
  ],
  "files_checked": 4,
  "files_failed": 1
}
```

- `code` omitted for syntax errors without an E-code; `note` omitted when absent.
- Exit codes preserved from `human` mode (0 / 4 / 1 / 2) — editors branch on exit code, then `JSON.parse(stdout)`.
- Stderr reserved for host I/O failures (file missing, stat error).

## Implementation

- `apps/gero-cli/cli.zig` — new `Format` enum, `stdin` bool + `format` value flag wired through `Options` / `longFlag` / `applyFlag` / `flagsForCommand` / `flagHelpLine`. Per-command help updated.
- `apps/gero-cli/fmt.zig` — `formatStdin` helper using `std.Io.File.stdin().reader(...).allocRemaining(...)` with the 16 MiB cap matching include.zig's max_file_size. Routed before manifest loader.
- `apps/gero-cli/check.zig` — `json_mode` branch suppresses per-file ✓ + summary + footer; read errors captured as synthetic ReadErrorEntry rows instead of stderr-only.
- `apps/gero-cli/diagnostics.zig` — new `printJsonReport` using `std.json.Stringify` + `locationOf` / `lineColIn` helpers (resolve fused-source offset → file path + 1-based line/col).
- `docs/cli.md` §3.8 / §3.9 — examples + behavior blocks added for both flags.

## Test plan

- [x] Unit tests for `lineColIn`, `printJsonReport` empty/read-error/full-diagnostic shapes — `apps/gero-cli/diagnostics.zig` inline test block.
- [x] Manual smoke:
  - canonical stdin in → exit 0, identical bytes out
  - non-canonical stdin + `--check` → exit 8, no stdout
  - parse-error stdin → exit 3, stderr message, no stdout
  - `--stdin foo.gas` collision → exit 2 with usage
  - JSON output on clean file: `{...,"diagnostics":[],...}`, exit 0
  - JSON output on error file: structured shape with code + message, exit 4
  - JSON output on directory walk: all errors gathered into one object
- [x] `zig build ci` clean locally.

## Self-review

- ✅ AC re-read: both issues' acceptance criteria fully covered (`--check` shapes, mutual exclusivity, exit codes, schema, severity always "error", optional fields omitted when absent)
- ✅ `zig build ci` green
- ✅ Public API impact: new CLI flags only — no library API changes, no `*anyopaque` / `anyerror` introduced
- ✅ Docs propagated: `docs/cli.md` §3.8 + §3.9 updated with examples + behavior + JSON schema block
- ✅ Changeset: `minor` bump documenting both flags + the "why now" (editor enablement without LSP)
- ✅ Hygiene: no leftover debug prints, conventional-commit scope (`apps/gero-cli`), no AI attribution