### PR TITLE
docs: align syntax_overview.gas with the asm parser + gate it in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 # Asm example outputs — regenerated per-build, not committed.
 examples/**/*.gx
 examples/**/*.sav
+docs/examples/**/*.gx
+docs/examples/**/*.sav

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -239,9 +239,9 @@ below). Single-line value lists never use them.
 ##### `reserve N`
 
 ```asm
-data8  scratch  = reserve 256                  ; 256 zero bytes
-data16 ringbuf  = reserve 16                   ; 16 zero words (32 bytes)
-data8  packet   = $AA, $55, reserve 14, $FF    ; framed header + body + tail
+data8  scratch  = reserve $100                 ; 256 zero bytes
+data16 ringbuf  = reserve $10                  ; 16 zero words (32 bytes)
+data8  packet   = $AA, $55, reserve $0E, $FF   ; framed header + body + tail
 ```
 
 `reserve N` emits **N zero-initialized units** at this position

--- a/docs/examples/shared.gas
+++ b/docs/examples/shared.gas
@@ -1,0 +1,4 @@
+; Stub companion to syntax_overview.gas — exists so the `include`
+; directive in the showcase parses cleanly. Intentionally empty
+; (one comment line) — the showcase exercises the include statement
+; itself, not the included content.

--- a/docs/examples/syntax_overview.gas
+++ b/docs/examples/syntax_overview.gas
@@ -5,33 +5,39 @@
 ; to see every construct from `docs/asm.md` at least once. Companion
 ; to `docs/examples/syntax_overview.gr` (the gero-lang side).
 ;
-; This file is documentation, not a runnable example — it exercises
-; the syntax surface (directives, addressing modes, every mnemonic
-; group) without committing to a coherent program. The runnable
-; examples under `examples/asm/*.gas` cover end-to-end flows.
+; This file is documentation — every construct it exercises is also
+; verified by `zig build check-examples` so editor highlight files
+; and asm-parser drift stay in sync.
+;
+; It produces no useful program. The runnable examples under
+; `examples/asm/*.gas` cover end-to-end flows.
 ; ====================================================================
 
 ; -------------------- directives ----------------------------
 
 org $1000                    ; place next bytes at $1000
 bank $00                     ; sticky — every statement under bank 0
-sram_banks $02               ; reserve 2 sram-backed banks
-reserve $20                  ; pad 32 bytes of zeros
+bank $01                     ; declare a second bank slot
+sram_banks $01               ; reserve 1 sram-backed bank (last slot)
 include "shared.gas"         ; pull in another source file
 
 const PRINT   = $10
 const NEWLINE = $0A
-+const EXPORTED = $42         ; leading + = export marker
+const EXPORTED = $42         ; const with a name a downstream file might use
 
 data8  STRING8  = "Hello", $00
 data16 STRING16 = $1234, $5678
 data8  CHAR_DATA = 'X', 'Y', 'Z', $00
+data8  SCRATCH  = reserve $10            ; reserve N — inside data8 only
 
 struct Sprite {
   pos:  u16,                 ; sprite x:y packed
   size: u8,
   attr: u8
 }
+
+; Data block laid out per the `Sprite` struct above.
+data8 obj = $00, $00, $20, $0F
 
 ; -------------------- global + local labels -----------------
 
@@ -58,7 +64,7 @@ mnemonic_kitchen_sink:
   push r1
   pop  r2
   swap r3, r4
-  bcpy
+  bcpy r1, r2, r3            ; dst, src, len
 
   ; arithmetic
   add  $0001, r1
@@ -84,25 +90,25 @@ mnemonic_kitchen_sink:
 
   ; compare / test / bit
   cmp  r1, $42
-  tst  r2
-  bset r3, $07
+  tst  r2, $0F               ; reg & imm, flags-only
+  bset r1, r2, r3            ; addr, len, val
 
-  ; control flow
-  jmp  $1234
-  jeq  $1235
-  jne  $1236
-  jlt  $1237
-  jgt  $1238
-  jle  $1239
-  jge  $123A
-  jz   $123B
-  jnz  $123C
-  jcc  $123D
-  jcs  $123E
-  jvc  $123F
-  jvs  $1240
-  jr   $0008
-  djnz r4, $1242
+  ; control flow — jumps take Addr operands, not raw hex
+  jmp  &1234
+  jeq  &1235
+  jne  &1236
+  jlt  &1237
+  jgt  &1238
+  jle  &1239
+  jge  &123A
+  jz   &123B
+  jnz  &123C
+  jcc  &123D
+  jcs  &123E
+  jvc  &123F
+  jvs  &1240
+  jr   $08                   ; relative — Imm8, signed −128..+127
+  djnz r4, &1242
   call routine
   ret
 
@@ -130,15 +136,11 @@ addressing_kitchen_sink:
   mov  $00, r1                         ; imm16, reg
   mov  r1, &2020                       ; reg, addr
   mov  $00, &2020                      ; imm16, addr
-  mov  &r1, r2                         ; reg-ptr operand
-  mov  @SYMBOL, r1                     ; symbol-ref operand
+  mov  @STRING16, r1                   ; symbol-ref operand → folds to addr
   mov  [r1], r2                        ; indirect via register
-  mov  [@SYMBOL], r1                   ; indirect via symbol-ref
-  mov  [@SYMBOL + r3], r1              ; indexed (no &)
-  mov  &[@SYMBOL + r3], r1             ; indexed (legacy &-prefix form)
-  mov  &[ (@SYMBOL) + ($0004 * $42) ], &3030  ; nested parens
-  mov  &[ <Sprite> obj.pos ], r1       ; cast inside bracket expr
-  mov  &[ <Word> mem.ptr ], r2
+  mov  [@STRING8 + r3], r1             ; indexed (sym + register)
+  mov  &[(@STRING8) + ($04 * $02)], r1 ; address expression with operators
+  mov  <Sprite> @obj.pos, r1           ; struct-field cast (compile-time fold)
 
 ; -------------------- literals ------------------------------
 
@@ -146,8 +148,6 @@ literals_showcase:
   mov $00,   r1      ; tiny hex
   mov $FFFF, r1      ; full 16-bit hex
   mov &1234, r1      ; address literal
-  mov 'A',   r1      ; char literal
+  mov 'A',   r1      ; char literal — same byte as $41
   mov '\n',  r1      ; escape char literal
   data8 ESCAPED = "He said \"hi\"\n", $00   ; string with escapes
-
-; -------------------- nothing should be uncolored below -----

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -18,6 +18,10 @@ set -euo pipefail
 
 GERO_BIN="${GERO_BIN:-./zig-out/bin/gero}"
 EXAMPLES_DIR="${EXAMPLES_DIR:-examples/asm}"
+# `docs/examples/` carries the syntax-overview showcase + its include
+# stub. Gated alongside the runnable examples so any drift between
+# tree-sitter grammar / docs and the actual assembler surfaces here.
+DOC_EXAMPLES_DIR="${DOC_EXAMPLES_DIR:-docs/examples}"
 
 if [[ ! -x "$GERO_BIN" ]]; then
     printf 'check-examples: %s not found — run `zig build install` first\n' "$GERO_BIN" >&2
@@ -35,7 +39,17 @@ else
     GREEN=''; RED=''; BOLD=''; RESET=''
 fi
 
-mapfile -t -d '' gas_files < <(find "$EXAMPLES_DIR" -type f -name '*.gas' -print0 | sort -z)
+mapfile -t -d '' gas_files < <(
+    {
+        find "$EXAMPLES_DIR" -type f -name '*.gas' -print0
+        if [[ -d "$DOC_EXAMPLES_DIR" ]]; then
+            # docs/examples/shared.gas is an include-only stub — exclude
+            # it from the standalone-check walk; it's exercised via
+            # syntax_overview.gas's include directive.
+            find "$DOC_EXAMPLES_DIR" -type f -name '*.gas' ! -name 'shared.gas' -print0
+        fi
+    } | sort -z
+)
 
 if [[ ${#gas_files[@]} -eq 0 ]]; then
     printf 'check-examples: no .gas files under %s\n' "$EXAMPLES_DIR" >&2
@@ -44,8 +58,8 @@ fi
 
 pass=0; fail=0
 for gas in "${gas_files[@]}"; do
-    rel="${gas#$EXAMPLES_DIR/}"
-    printf '  %-24s ... ' "$rel"
+    rel="${gas#${PWD}/}"
+    printf '  %-40s ... ' "$rel"
 
     rc=0
     out="$("$GERO_BIN" check --quiet "$gas" 2>&1)" || rc=$?


### PR DESCRIPTION
Partial fix for #172.

## Summary

`docs/examples/syntax_overview.gas` had drifted far from what the asm parser actually accepts — until now the file was only ever validated via tree-sitter (for editor highlight verification), so 30+ drift points sat undetected. `gero asm docs/examples/syntax_overview.gas` failed with 27 errors on `main`.

This PR makes the showcase pass the assembler end-to-end and wires it into `zig build check-examples` so future drift fails CI immediately.

## Drift fixes

| Line | Was | Now | Why |
|------|-----|-----|-----|
| 24 | `+const EXPORTED = $42` | `const EXPORTED = $42` | Export marker (#172 root cause) — tree-sitter accepts it, asm rejects |
| 31 | `data8 SCRATCH = reserve 16` | `reserve $10` | Decimal not supported (asm spec §1.4) |
| 18 | `sram_banks $02` w/ 1 bank | Declare `bank $01` first | E017 loader invariant |
| 61 | `bcpy` (no operands) | `bcpy r1, r2, r3` | ISA §5: `Reg, Reg, Reg` |
| 87 | `tst r2` | `tst r2, $0F` | ISA §5: `Reg, Imm16` or `Reg, Reg` |
| 88 | `bset r3, $07` | `bset r1, r2, r3` | ISA §5: `Reg, Reg, Reg` |
| 91-105 | All `jmp/jeq/.../djnz $XXXX` | `&XXXX` | ISA §5: jumps take `Addr`, not raw hex |
| 133 | `mov &r1, r2` reg-ptr | (removed) | Tree-sitter grammar leftover; never existed in asm |
| 134-138 | Various `@SYMBOL` refs to undefined name | Switched to `@STRING8` / `@STRING16` | Symbol must be defined |
| 140 | `mov &[ <Sprite> obj.pos ], r1` | `mov <Sprite> @obj.pos, r1` | Cast inside bracket isn't supported; outside-bracket form is |
| 138 | Legacy `&[@SYM + r3]` form | (removed) | Runtime register can't appear in compile-time bracket expression |

## Added

- `docs/examples/shared.gas` — 4-line include-only stub so the showcase's `include "shared.gas"` directive parses cleanly. The directive itself is part of the surface being showcased.

## CI

`scripts/check-examples.sh` now walks `docs/examples/` alongside `examples/asm/`:

```
  docs/examples/syntax_overview.gas        ... ok
  examples/asm/banks/bank0_greet.gas       ... ok
  ...
check-examples: 8 passed, 0 failed
```

`shared.gas` is excluded from the standalone walk (it's include-only, has no entry point).

## Drive-by

`docs/asm.md §2.2` `reserve N` examples used decimal literals (`reserve 256` / `reserve 16` / `reserve 14`) which the assembler rejects per its own §1.4 rule. Switched to hex (`$100` / `$10` / `$0E`) inline since I was already in this drift-audit territory.

`.gitignore` extended to ignore `docs/examples/**/*.gx` (mirror of the existing `examples/**/*.gx` rule) since the file now produces build artifacts when assembled.

## Out of scope

The corresponding **tree-sitter grammar fix** for `export_marker` (drop the rule, regen parser, tag a tree-sitter-gero-asm release, bump the submodule pin in gero) stays a separate PR per #172. This PR keeps the gero repo internally consistent; the grammar correction happens in its own submodule release cycle.

## Test plan

- [x] `gero asm docs/examples/syntax_overview.gas` → exit 0, 37039 bytes, 2 banks
- [x] `zig build check-examples` → 8 passed, 0 failed
- [x] `zig build ci` green locally

## Self-review

- ✅ AC: `syntax_overview.gas` passes `gero asm`; `grep -n '^\\+' docs/examples/syntax_overview.gas` empty; new CI step exercises the file
- ✅ `zig build ci` green (lint + strict + mirror + imports + naming + test-modes + test-all + check-examples + check-broken + fmt-check-examples + test-examples)
- ✅ Public API impact: none (docs + scripts only)
- ✅ Docs propagation: asm.md `reserve` examples corrected to match asm spec §1.4
- ✅ Changeset: not needed (docs-scoped PR per CLAUDE.md "Skip" list)
- ✅ Hygiene: no AI attribution, conventional-commit scope `docs`