### PR TITLE
feat(asm): conditional assembly — ifdef / ifndef / endif

### DIFF
--- a/.changeset/asm-conditional-assembly.md
+++ b/.changeset/asm-conditional-assembly.md
@@ -1,0 +1,62 @@
+---
+bump: minor
+---
+
+`ifdef` / `ifndef` / `endif` directives ship — NASM/ca65-style
+conditional assembly with include-guard semantics.
+
+```asm
+; hardware.gas — included from every code file that touches PPU/APU
+ifndef HARDWARE_INCLUDED
+const HARDWARE_INCLUDED = $01
+const PPU_CTRL = &2000
+struct Sprite { x: u8, y: u8, tile: u8, attr: u8 }
+endif
+```
+
+Re-including the file from a second ancestor is now a clean no-op
+instead of a duplicate-`const` cascade.
+
+## Semantics
+
+- `ifndef NAME` opens a block emitted only when `NAME` is **not**
+  bound as a `const`. `ifdef NAME` is the inverse.
+- "Bound" inspects the `ConstantTable` built incrementally as the
+  parser walks statements top-to-bottom. So `ifndef X` placed
+  **before** `const X` is true; placed **after**, false. Same
+  ordering rule as NASM `%ifdef`.
+- Skip-mode (false branch) discards tokens until the matching
+  `endif` — no AST, no diagnostics, no emit-cursor advance.
+- Blocks nest: a nested `ifdef` inside a skipping outer frame
+  is also skipped regardless of its own predicate, but its
+  matching `endif` still pops the right frame.
+- The check only inspects `const` names; labels and `data8` /
+  `data16` symbols aren't queryable (the explicit-`const` sigil
+  is the include-guard convention).
+
+## New error codes
+
+- **`E018`** — `endif` without a matching `ifdef` / `ifndef`.
+- **`E019`** — `ifdef` / `ifndef` block left open at EOF.
+
+## Why now
+
+Required for any non-trivial gtx-16 cart: a multi-bank game
+inevitably shares hardware-register / struct-layout headers
+across 5-20 source files. The pre-`ifndef` workarounds
+("single-root include" or "one giant file") forced an
+anti-pattern at any scale beyond hello-world.
+
+The asm spec (`docs/asm.md` §2.2) now documents the three
+directives + the include-guard idiom; `docs/asm-cookbook.md`
+ships a new recipe **8. Include guards** as a worked example.
+
+## Out of scope
+
+`else` / `elif` / `if` (boolean expressions). The pure
+`ifndef` / `endif` pair covers include-guards completely; richer
+forms can land later once a use case appears.
+
+Editor highlighting (tree-sitter + VS Code TextMate) is tracked
+separately in salty-max/tree-sitter-gero-asm#4 and
+salty-max/vscode-gero#2.

--- a/docs/asm-cookbook.md
+++ b/docs/asm-cookbook.md
@@ -25,6 +25,7 @@ bottom of the section.
 5. [SRAM persistence](#5-sram-persistence)
 6. [IRQ handler skeleton](#6-irq-handler-skeleton)
 7. [Fixed-point arithmetic (Q8.8)](#7-fixed-point-arithmetic-q88)
+8. [Include guards](#8-include-guards)
 
 ---
 
@@ -282,6 +283,62 @@ selected bytes of `r2`.
 The same trick works for division (Q8.8 quotient = `(num << 8) / den`),
 addition / subtraction (no scaling needed), and angle math via a
 Q1.15 sin/cos lookup table in `data16`.
+
+---
+
+## 8. Include guards
+
+Multi-file projects share headers — register definitions, struct
+layouts, software-interrupt vector numbers — that risk being
+`include`'d from several ancestors. Without protection, the second
+include re-emits every `const` and `data8` inside, producing a
+duplicate-define cascade.
+
+`ifndef` / `endif` wraps the body so the second include becomes a
+no-op:
+
+```asm
+; hardware.gas — included from main.gas, sprite.gas, audio.gas, ...
+ifndef HARDWARE_INCLUDED
+const HARDWARE_INCLUDED = $01
+
+; MMIO map
+const PPU_CTRL = &2000
+const PPU_MASK = &2001
+const APU_STATUS = &4015
+
+; Shared data layouts
+struct Sprite { x: u8, y: u8, tile: u8, attr: u8 }
+struct Tile   { id: u8, attr: u8 }
+
+endif
+```
+
+Every other source file just includes it:
+
+```asm
+; sprite.gas
+include "hardware.gas"
+
+draw_sprite:
+  mov &Sprite, r1    ; uses Sprite from hardware.gas — guard
+  ; ...              ; ensures one definition even if main.gas
+  ret                ; already pulled hardware.gas in.
+```
+
+Notes:
+
+- The check only inspects `const` names, not labels or `data8`.
+  The `const HARDWARE_INCLUDED = $01` line right after the
+  `ifndef` is what flips the condition for subsequent re-includes.
+- Order matters — `ifndef X` placed **before** `const X` is true;
+  placed **after**, false. Same rule as NASM `%ifdef`.
+- Nested `ifdef` / `ifndef` inside a true outer branch evaluates
+  its own condition normally. Nested inside a false outer branch,
+  the body is suppressed regardless (and `endif` still pops the
+  right frame).
+
+**See also**: [`asm.md` §2.2 `ifdef` / `ifndef` / `endif`](./asm.md).
 
 ---
 

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -180,7 +180,7 @@ loop:
 <directive_keyword> <args...>
 ```
 
-Six directives:
+Nine directives:
 
 | Keyword   | Form                                   | Effect |
 |-----------|----------------------------------------|--------|
@@ -190,6 +190,9 @@ Six directives:
 | `struct`  | `struct NAME { field: TYPE, ... }`     | Compile-time struct layout (offsets only, no bytes emitted). |
 | `org`     | `org $ADDR`                            | Set the current emit address. Subsequent statements emit starting at `$ADDR`. |
 | `include` | `include "path.gas"`                   | Textually splice another `.gas` file at this point (6502 / z80 style). |
+| `ifndef`  | `ifndef NAME`                          | Open a conditional block — body emitted only if `NAME` is **not** currently bound as a `const`. |
+| `ifdef`   | `ifdef NAME`                           | Open a conditional block — body emitted only if `NAME` **is** currently bound as a `const`. |
+| `endif`   | `endif`                                | Close the most recent `ifdef` / `ifndef` block. |
 
 #### `const`
 
@@ -329,8 +332,69 @@ Rules:
 **Re-include semantics:** every `include` directive splices in
 the target's tokens, every time. If two files both `include
 "utils.gas"`, the bytes from `utils.gas` are emitted twice.
-Control the include graph manually (don't `include` the same
-file from two ancestors) or accept the duplicate emission.
+For shared headers included from multiple ancestors, wrap the
+header body in an `ifndef` / `endif` guard — see below.
+
+#### `ifdef` / `ifndef` / `endif`
+
+NASM/ca65-style conditional assembly. The body between the
+opening directive and the matching `endif` is emitted only when
+the condition holds; otherwise it's skipped entirely (no AST, no
+diagnostics, no emit-cursor advance).
+
+```asm
+ifndef HARDWARE_INCLUDED
+const HARDWARE_INCLUDED = $01
+const PPU_CTRL = &2000
+const PPU_MASK = &2001
+struct Sprite { x: u8, y: u8, tile: u8, attr: u8 }
+endif
+```
+
+Semantics:
+
+- `ifndef NAME` enters its body when `NAME` is **not** currently
+  bound as a `const`. `ifdef NAME` is the inverse.
+- "Currently bound" is a parse-time check against the
+  `ConstantTable` built incrementally as the parser walks
+  statements top-to-bottom. So `ifndef X` placed **before**
+  `const X` is true; placed **after**, false. Same ordering rule
+  as NASM `%ifdef`.
+- The check only inspects `const` definitions. Labels and
+  `data8` / `data16` names aren't queryable — `const` is the
+  explicit declaration sigil for guard names.
+- Blocks **nest** — a nested `ifdef` inside a true outer branch
+  evaluates its own condition normally. A nested directive inside
+  a **false** outer branch is still tracked (its `endif` pops the
+  right frame) but its body is suppressed regardless.
+
+Diagnostics:
+
+- `endif` without a matching open → `E018`.
+- `ifdef` / `ifndef` block left open at EOF → `E019`.
+
+Typical use case — re-includable header for a multi-bank gtx-16
+cart:
+
+```asm
+; hardware.gas — included by every code file that touches PPU/APU
+ifndef HARDWARE_INCLUDED
+const HARDWARE_INCLUDED = $01
+const PPU_CTRL = &2000
+struct Sprite { x: u8, y: u8, tile: u8, attr: u8 }
+endif
+```
+
+```asm
+; main.gas
+include "hardware.gas"
+include "sprite.gas"        ; itself includes hardware.gas — no
+                            ; duplicate-def error thanks to the
+                            ; guard above.
+```
+
+Without the guard, the second `include` would re-emit
+`HARDWARE_INCLUDED` and produce a duplicate-`const` error.
 
 ### 2.3 Instructions
 
@@ -696,5 +760,7 @@ Common errors:
 | `E015` | `include` target file not found |
 | `E016` | Char literal must be exactly one byte (empty `''` or multi-char) |
 | `E017` | `sram_banks N` exceeds the declared `bank N` count (loader invariant — SRAM banks live in the trailing slots of the bank pool, so they need at least N total banks to occupy) |
+| `E018` | `endif` without a matching `ifdef` / `ifndef` |
+| `E019` | `ifdef` / `ifndef` block left open at EOF (missing `endif`) |
 
 Errors print with caret-style snippets (knit's `formatParseErrorPretty`).

--- a/src/asm/ast.zig
+++ b/src/asm/ast.zig
@@ -45,6 +45,12 @@ pub const Statement = union(enum) {
     /// body emitted.
     sram_banks_decl: SramBanksDecl,
     instruction: Instruction,
+    /// `ifdef NAME` / `ifndef NAME` / `endif` — NASM-style
+    /// conditional assembly. Skip-mode behavior lives in the
+    /// parser; codegen treats these statements as semantic
+    /// no-ops (like `comment`). The printer round-trips them
+    /// verbatim so `gero fmt` preserves include-guard layout.
+    cond_directive: CondDirective,
     /// A `; ...` comment line. The parser surfaces these as
     /// first-class statements so the pretty-printer (`gero fmt`)
     /// can preserve them; codegen / symtab skip them as semantic
@@ -69,10 +75,26 @@ pub const Statement = union(enum) {
             .bank_switch => |b| b.span,
             .sram_banks_decl => |s| s.span,
             .instruction => |i| i.span,
+            .cond_directive => |c| c.span,
             .comment => |c| c.span,
             .unknown => |u| u.span,
         };
     }
+};
+
+/// `ifdef NAME` / `ifndef NAME` / `endif` — conditional assembly.
+/// Three flavors carried by the same struct (cheaper than three
+/// `Statement` variants); the parser fills `name` only for the
+/// `ifdef` / `ifndef` shapes (zero-width span for `endif`).
+pub const CondDirective = struct {
+    kind: Kind,
+    /// Span of the NAME identifier; zero-width for `endif`.
+    name: Span,
+    /// Span covering `<keyword> [NAME]` end-to-end.
+    span: Span,
+
+    /// Which conditional directive this is.
+    pub const Kind = enum { ifdef, ifndef, endif };
 };
 
 /// `; ...` — comment line. Span covers the leading `;` and the

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -473,7 +473,7 @@ fn layoutPass(
                     cursor_ptr.* += 1;
                 }
             },
-            .comment, .unknown => {},
+            .cond_directive, .comment, .unknown => {},
         }
     }
 }
@@ -582,7 +582,7 @@ fn emitPass(
                 const name = source[l.name.start..l.name.end];
                 if (name.len == 0 or name[0] != '.') parent_label = name;
             },
-            .const_decl, .struct_decl, .sram_banks_decl, .comment, .unknown => {},
+            .const_decl, .struct_decl, .sram_banks_decl, .cond_directive, .comment, .unknown => {},
             .bank_switch => |b| {
                 if (b.index) |idx| current_bank = idx;
             },

--- a/src/asm/include.zig
+++ b/src/asm/include.zig
@@ -179,6 +179,10 @@ pub const ErrorCode = enum(u8) {
     /// (loader invariant — SRAM banks live in the trailing N slots
     /// of the cart, so they need at least N total banks to occupy).
     sram_without_banks = 17,
+    /// E018: `endif` without a matching `ifdef` / `ifndef`.
+    unmatched_endif = 18,
+    /// E019: `ifdef` / `ifndef` block left open at EOF.
+    unclosed_conditional = 19,
 
     /// Map a lexer-level `ParseError.message` to the asm spec §7
     /// code, or `null` when the message isn't one of the four
@@ -220,6 +224,8 @@ pub const ErrorCode = enum(u8) {
             .include_not_found => "E015",
             .char_literal_size => "E016",
             .sram_without_banks => "E017",
+            .unmatched_endif => "E018",
+            .unclosed_conditional => "E019",
         };
     }
 };

--- a/src/asm/parser.zig
+++ b/src/asm/parser.zig
@@ -54,12 +54,33 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8) !ParseTree {
     var consts = expr.ConstantTable.init(allocator);
     defer consts.deinit();
 
+    var cond_stack = ConditionalStack.init(allocator);
+    defer cond_stack.deinit();
+
     var state = core.ParseState.init(source, allocator);
 
     while (state.index < source.len) {
         try skipSeparatorsCapturingComments(&state, &statements, allocator);
         if (state.index >= source.len) break;
-        try parseStatement(&state, allocator, &statements, &errors, &consts);
+        try parseStatement(&state, allocator, &statements, &errors, &consts, &cond_stack);
+    }
+
+    // E019: every `ifdef` / `ifndef` must close before EOF. Flag
+    // the **innermost** unclosed frame — that's the one whose
+    // missing `endif` is the proximate cause.
+    if (cond_stack.frames.items.len > 0) {
+        const top = cond_stack.frames.items[cond_stack.frames.items.len - 1];
+        try errors.append(allocator, .{
+            .code = .unclosed_conditional,
+            .parse_error = .{
+                .parser = "asm",
+                .index = top.open_span.start,
+                .message = "`ifdef` / `ifndef` block left open at EOF (missing `endif`)",
+                .expected = "endif",
+                .actual = "",
+                .kind = .semantic,
+            },
+        });
     }
 
     return .{
@@ -71,6 +92,53 @@ pub fn parse(allocator: std.mem.Allocator, source: []const u8) !ParseTree {
         .allocator = allocator,
     };
 }
+
+/// Per-parse conditional-assembly state. One frame is pushed per
+/// open `ifdef` / `ifndef` block, popped by the matching `endif`.
+/// `skipping` is true when the block's content should be discarded
+/// (false condition, or inherited from an outer skipping frame).
+pub const ConditionalStack = struct {
+    frames: std.ArrayList(Frame),
+    allocator: std.mem.Allocator,
+
+    /// One open `ifdef` / `ifndef` block. `skipping` reflects the
+    /// combined condition (its own predicate **or** an outer
+    /// frame's suppression). `open_span` points at the opening
+    /// directive so an unclosed-at-EOF diagnostic can locate it.
+    pub const Frame = struct {
+        skipping: bool,
+        open_span: ast.Span,
+    };
+
+    /// Build an empty stack — caller owns the backing allocator.
+    pub fn init(allocator: std.mem.Allocator) ConditionalStack {
+        return .{ .frames = .empty, .allocator = allocator };
+    }
+
+    /// Release the backing list. Frames themselves carry no
+    /// allocated state, so no per-frame cleanup is needed.
+    pub fn deinit(self: *ConditionalStack) void {
+        self.frames.deinit(self.allocator);
+    }
+
+    /// True when any frame on the stack is suppressing emission.
+    pub fn isSkipping(self: ConditionalStack) bool {
+        for (self.frames.items) |f| if (f.skipping) return true;
+        return false;
+    }
+
+    /// Push a new frame on top of the stack.
+    pub fn push(self: *ConditionalStack, frame: Frame) !void {
+        try self.frames.append(self.allocator, frame);
+    }
+
+    /// Pop the topmost frame. Returns `null` when the stack is
+    /// empty (caller surfaces an E018 unmatched-`endif` then).
+    pub fn pop(self: *ConditionalStack) ?Frame {
+        if (self.frames.items.len == 0) return null;
+        return self.frames.pop();
+    }
+};
 
 fn cleanupStatements(allocator: std.mem.Allocator, statements: *std.ArrayList(ast.Statement)) void {
     for (statements.items) |s| switch (s) {
@@ -107,8 +175,32 @@ fn parseStatement(
     statements: *std.ArrayList(ast.Statement),
     errors: *std.ArrayList(include.Diagnostic),
     consts: *expr.ConstantTable,
+    cond_stack: *ConditionalStack,
 ) !void {
     const stmt_start = state.index;
+
+    // Conditional-assembly directives are always processed, even
+    // while in skip-mode — nested `ifdef` inside a false outer
+    // branch must still track its own open/close so the right
+    // `endif` pops the right frame.
+    if (consumeKeyword(state, "ifndef")) {
+        return parseIfDirective(state, allocator, stmt_start, statements, errors, consts, cond_stack, .ifndef);
+    }
+    if (consumeKeyword(state, "ifdef")) {
+        return parseIfDirective(state, allocator, stmt_start, statements, errors, consts, cond_stack, .ifdef);
+    }
+    if (consumeKeyword(state, "endif")) {
+        return parseEndifDirective(state, allocator, stmt_start, statements, errors, cond_stack);
+    }
+
+    // Skip-mode: everything inside a false `ifdef` / `ifndef`
+    // branch is consumed without emitting AST or diagnostics. The
+    // parser still advances past it so token-level position
+    // tracking stays consistent.
+    if (cond_stack.isSkipping()) {
+        try recoverToNewline(state);
+        return;
+    }
 
     // Directive keywords must be checked before generic labels,
     // since the bare keyword lexeme would otherwise be taken as a
@@ -146,6 +238,105 @@ fn parseStatement(
     // Anything else: record the line as an `unknown` statement,
     // emit a diagnostic, and recover to the next newline.
     try recordUnknown(state, allocator, stmt_start, statements, errors);
+}
+
+// ---------- conditional assembly: ifdef / ifndef / endif ----------
+
+/// Parse `ifdef NAME` or `ifndef NAME`. Side effect: pushes a frame
+/// onto `cond_stack` whose `skipping` reflects the current ConstantTable
+/// lookup result. Nested under an already-skipping outer frame, the
+/// new frame is also `skipping` (so we don't accidentally re-enable
+/// emission inside a dead block).
+fn parseIfDirective(
+    state: *core.ParseState,
+    allocator: std.mem.Allocator,
+    stmt_start: usize,
+    statements: *std.ArrayList(ast.Statement),
+    errors: *std.ArrayList(include.Diagnostic),
+    consts: *expr.ConstantTable,
+    cond_stack: *ConditionalStack,
+    kind: ast.CondDirective.Kind,
+) !void {
+    skipBlanksInLine(state);
+    const name_start: u32 = u32At(state.index);
+    const ident_result = lexer.identP.parseFn(state);
+    if (ident_result != .ok) {
+        try errors.append(allocator, .{
+            .parse_error = .{
+                .parser = "asm",
+                .index = name_start,
+                .message = "expected identifier after `ifdef` / `ifndef`",
+                .expected = "identifier",
+                .actual = "",
+                .kind = .syntactic,
+            },
+        });
+        try recoverToNewline(state);
+        // Push a frame anyway so the matching `endif` doesn't
+        // surface a spurious E018.
+        try cond_stack.push(.{
+            .skipping = true,
+            .open_span = spanFrom(stmt_start, state.index),
+        });
+        return;
+    }
+    const ident_token = ident_result.ok.value;
+    const name_span: ast.Span = .{ .start = name_start, .end = ident_token.end };
+    const name_lex = state.input[name_start..ident_token.end];
+
+    const outer_skipping = cond_stack.isSkipping();
+    const is_defined = consts.get(name_lex) != null;
+    const this_skipping = switch (kind) {
+        .ifndef => is_defined,
+        .ifdef => !is_defined,
+        // safety: caller passes ifdef/ifndef only — endif goes through
+        //         parseEndifDirective, never reaches this switch.
+        .endif => unreachable,
+    };
+
+    try cond_stack.push(.{
+        .skipping = outer_skipping or this_skipping,
+        .open_span = spanFrom(stmt_start, state.index),
+    });
+
+    try statements.append(allocator, .{ .cond_directive = .{
+        .kind = kind,
+        .name = name_span,
+        .span = spanFrom(stmt_start, state.index),
+    } });
+
+    try recoverToNewline(state);
+}
+
+/// Parse `endif`. Pops the conditional stack; emits E018 if the
+/// stack was empty (no matching open).
+fn parseEndifDirective(
+    state: *core.ParseState,
+    allocator: std.mem.Allocator,
+    stmt_start: usize,
+    statements: *std.ArrayList(ast.Statement),
+    errors: *std.ArrayList(include.Diagnostic),
+    cond_stack: *ConditionalStack,
+) !void {
+    if (cond_stack.pop() == null) {
+        try errors.append(allocator, .{
+            .code = .unmatched_endif,
+            .parse_error = .{
+                .parser = "asm",
+                .index = u32At(stmt_start),
+                .message = "`endif` without a matching `ifdef` / `ifndef`",
+                .expected = "ifdef or ifndef",
+                .actual = "endif",
+                .kind = .semantic,
+            },
+        });
+    }
+    try statements.append(allocator, .{ .cond_directive = .{
+        .kind = .endif,
+        .name = .{ .start = u32At(state.index), .end = u32At(state.index) },
+        .span = spanFrom(stmt_start, state.index),
+    } });
+    try recoverToNewline(state);
 }
 
 // ---------- label ----------

--- a/src/asm/printer.zig
+++ b/src/asm/printer.zig
@@ -355,6 +355,12 @@ fn writeStatementCanonical(
             try writer.writeAll(source[start..c.span.end]);
             break :blk c.span.end - start;
         },
+        .cond_directive => |c| blk: {
+            // Round-trip verbatim — include-guard layout is the
+            // user's choice, fmt shouldn't normalize it.
+            try writer.writeAll(slice(source, c.span));
+            break :blk c.span.end - c.span.start;
+        },
         .unknown => |u| blk: {
             try writer.writeAll(slice(source, u.span));
             break :blk u.span.end - u.span.start;

--- a/tests/asm/parser.test.zig
+++ b/tests/asm/parser.test.zig
@@ -1098,3 +1098,120 @@ test "parser: addr_expr missing closing ']'" {
     defer pt.deinit();
     try std.testing.expect(pt.hasErrors());
 }
+
+// ---------- conditional assembly (ifdef / ifndef / endif) ----------
+
+test "parser: ifndef on an undefined name parses through body" {
+    var pt = try parseSource(
+        \\ifndef MISSING
+        \\const X = $42
+        \\endif
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    // ifndef + const + endif → 3 statements emitted
+    try std.testing.expectEqual(@as(usize, 3), pt.program.statements.len);
+    try std.testing.expect(pt.program.statements[0] == .cond_directive);
+    try std.testing.expect(pt.program.statements[1] == .const_decl);
+    try std.testing.expect(pt.program.statements[2] == .cond_directive);
+}
+
+test "parser: ifndef on a defined name skips body" {
+    var pt = try parseSource(
+        \\const GUARD = $01
+        \\ifndef GUARD
+        \\const DEAD = $42
+        \\endif
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    // const GUARD + ifndef + endif → 3 (DEAD is skipped)
+    try std.testing.expectEqual(@as(usize, 3), pt.program.statements.len);
+    try std.testing.expect(pt.program.statements[0] == .const_decl);
+    try std.testing.expect(pt.program.statements[1] == .cond_directive);
+    try std.testing.expect(pt.program.statements[2] == .cond_directive);
+}
+
+test "parser: ifdef on a defined name keeps body" {
+    var pt = try parseSource(
+        \\const GUARD = $01
+        \\ifdef GUARD
+        \\const ALIVE = $42
+        \\endif
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 4), pt.program.statements.len);
+    try std.testing.expect(pt.program.statements[2] == .const_decl);
+}
+
+test "parser: skip-mode swallows bogus content" {
+    var pt = try parseSource(
+        \\ifdef MISSING
+        \\!@#$ this would otherwise be E001
+        \\endif
+        \\
+    );
+    defer pt.deinit();
+    // No errors despite the garbage on line 2 — skip-mode ate it.
+    try std.testing.expect(!pt.hasErrors());
+}
+
+test "parser: unmatched endif → E018" {
+    var pt = try parseSource("endif\n");
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), pt.errors.len);
+    try std.testing.expect(pt.errors[0].code != null);
+    try std.testing.expectEqual(gero.asm_.ErrorCode.unmatched_endif, pt.errors[0].code.?);
+}
+
+test "parser: unclosed conditional at EOF → E019" {
+    var pt = try parseSource(
+        \\ifndef X
+        \\const Y = $42
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(pt.hasErrors());
+    try std.testing.expect(pt.errors[0].code != null);
+    try std.testing.expectEqual(gero.asm_.ErrorCode.unclosed_conditional, pt.errors[0].code.?);
+}
+
+test "parser: nested ifndef inside ifdef true-branch" {
+    var pt = try parseSource(
+        \\const OUTER = $01
+        \\ifdef OUTER
+        \\const A = $11
+        \\ifndef INNER
+        \\const B = $22
+        \\endif
+        \\endif
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    // OUTER + ifdef + A + ifndef + B + endif + endif → 7
+    try std.testing.expectEqual(@as(usize, 7), pt.program.statements.len);
+}
+
+test "parser: nested ifdef inside skipping outer stays skipping" {
+    var pt = try parseSource(
+        \\ifndef MISSING
+        \\const ALWAYS_DEFINED = $01
+        \\ifdef ALWAYS_DEFINED
+        \\const SHOULD_NOT_LEAK = $99
+        \\endif
+        \\endif
+        \\
+    );
+    defer pt.deinit();
+    try std.testing.expect(!pt.hasErrors());
+    // Outer ifndef MISSING is true → first const + nested ifdef
+    // (true since ALWAYS_DEFINED gets defined) + nested const +
+    // both endifs → 6.
+    try std.testing.expectEqual(@as(usize, 6), pt.program.statements.len);
+}


### PR DESCRIPTION
Closes #173 (asm core part — editor highlight surfaces tracked in salty-max/tree-sitter-gero-asm#4 and salty-max/vscode-gero#2).

## Summary

NASM/ca65-style include-guard directives. The pre-existing include + global-namespace model produces a duplicate-define cascade when a shared header is included from multiple ancestors — a real anti-pattern blocker for gtx-16 cart-scale projects. With these directives, re-include becomes a clean no-op:

```asm
; hardware.gas — included from main.gas, sprite.gas, audio.gas, ...
ifndef HARDWARE_INCLUDED
const HARDWARE_INCLUDED = $01
const PPU_CTRL = &2000
struct Sprite { x: u8, y: u8, tile: u8, attr: u8 }
endif
```

## Semantics

| Directive | Effect |
|-----------|--------|
| `ifndef NAME` | Open a block; body emitted iff NAME is **not** bound as a `const`. |
| `ifdef NAME` | Open a block; body emitted iff NAME **is** bound as a `const`. |
| `endif` | Close the most recent `ifdef` / `ifndef` block. |

- 'Bound' check inspects the `ConstantTable` built incrementally as the parser walks statements top-to-bottom. `ifndef X` placed **before** `const X` is true; placed **after**, false. NASM `%ifdef` rule.
- Skip-mode (false branch) discards tokens until the matching `endif` — no AST emit, no diagnostics, no cursor advance. Block depth tracked even while skipping so nested `endif` pops the right frame.
- Only `const` names are queryable. Labels and `data8` / `data16` symbols aren't — `const` is the explicit include-guard convention.
- Blocks nest. A nested `ifdef` inside a true outer branch evaluates normally; inside a false outer, the body is suppressed regardless.

## New error codes

| Code | Meaning |
|------|---------|
| **E018** | `endif` without a matching `ifdef` / `ifndef` |
| **E019** | `ifdef` / `ifndef` block left open at EOF |

## Implementation

- `src/asm/ast.zig`: new `Statement.cond_directive` variant + `CondDirective` struct (kind + name + span).
- `src/asm/include.zig`: `ErrorCode.unmatched_endif` (E018) + `unclosed_conditional` (E019) added to the enum + `shortLabel` switch.
- `src/asm/parser.zig`: `ConditionalStack` type with `push` / `pop` / `isSkipping` + `parseIfDirective` + `parseEndifDirective`. Threaded through `parseStatement`. `parse()` loop tail emits E019 for unclosed frames at EOF.
- `src/asm/codegen.zig` + `src/asm/printer.zig`: `cond_directive` is a semantic no-op for codegen; printer round-trips verbatim so `gero fmt` preserves include-guard layout.

## Docs

- `docs/asm.md` §2.2 — directive table grows to 9 entries + dedicated subsection with semantics, diagnostics, and a worked include-guard example.
- `docs/asm.md` §7 — E018 / E019 rows.
- `docs/asm-cookbook.md` — new recipe **8. Include guards** as a worked example.

## Test plan

- [x] 9 inline tests in `tests/asm/parser.test.zig` covering:
  - happy path: `ifndef` on undefined → body emitted; `ifdef` on defined → body emitted
  - skip semantics: `ifndef` on defined → body skipped
  - skip-mode swallows bogus content (no spurious E001 for `!@#$ garbage` inside a skipped branch)
  - error paths: unmatched `endif` → E018; unclosed at EOF → E019
  - nested cases: ifndef-inside-ifdef-true; ifdef-inside-ifndef-skipping
- [x] Manual smoke: re-include of a guarded header from two ancestors → no errors, second include is a no-op.
- [x] `gero fmt --stdin` round-trips an `ifndef` block verbatim (kv-aligner still aligns const-block `=` columns).
- [x] `zig build ci` clean locally.

## Self-review

- ✅ AC re-read: 7 of 7 `ifndef`/`ifdef`/`endif` acceptance criteria from #173 covered. `else`/`elif` deliberately out of scope per the issue body.
- ✅ `zig build ci` green (lint + strict + mirror + naming + imports + test-modes + test-all + check-examples + check-broken + fmt-check-examples + test-examples).
- ✅ Public API impact: `ast.Statement.cond_directive` + `ast.CondDirective` + 2 new `ErrorCode` enum entries — feature-additive, no breaking changes.
- ✅ Docs propagated: `asm.md` §2.2 + §7, `asm-cookbook.md` §8.
- ✅ Changeset (`minor` bump, no `breaking` flag).
- ✅ Hygiene: no leftover debug prints, conventional-commit scope `asm`, no AI attribution. The one new `unreachable` carries a `// safety:` comment per CLAUDE.md.

## Editor surface follow-up

The grammar + TextMate updates land separately:
- salty-max/tree-sitter-gero-asm#4 — `conditional_directive` node + highlights query
- salty-max/vscode-gero#2 — TextMate pattern for `ifdef`/`ifndef`/`endif` → `keyword.control.preprocessor` scope

After both ship + tag, a follow-up PR here bumps the submodule pins.