### PR TITLE
feat(asm): bank_call / bank_jump pseudo-instructions

### DIFF
--- a/.changeset/asm-bank-call-jump.md
+++ b/.changeset/asm-bank-call-jump.md
@@ -1,0 +1,58 @@
+---
+bump: minor
+---
+
+`bank_call <label>` / `bank_jump <label>` pseudo-instructions
+ship — the assembler looks up which bank the target lives in
+and emits the equivalent `mov $bank, mb` + `call`/`jmp <addr>`
+pair automatically.
+
+```asm
+; Before — hand-track the bank
+mov $01, mb
+call render_sprite
+
+; After — assembler tracks it for you
+bank_call render_sprite
+bank_jump cleanup_path
+```
+
+## Why
+
+Cross-bank calls are the dominant footgun in multi-bank asm —
+write `mov $0X, mb` with the wrong constant and you call into
+garbage, which the VM faults on at runtime. With these pseudos,
+the assembler resolves the bank statically; rename / move a
+label across banks and every call site follows.
+
+## Semantics
+
+- 7 bytes per pseudo: 4 for `mov imm16, mb` + 3 for
+  `call`/`jmp <addr>`. Bytecode-identical to the hand-written
+  pair.
+- The redundant `mov $bank, mb` is emitted even when the target
+  lives in the same bank as the call site — consistent behavior,
+  no surprise omission.
+- Round-trip is one-way at source level: `gero disasm` emits the
+  two real instructions (not `bank_call`). Bytecode round-trips
+  identically.
+- Target must be a `label` or `data8`/`data16` symbol (those
+  carry bank-of-definition via `Symbol.bank`). Pointing at a
+  `const` raises `E003` (operand type mismatch).
+- Undefined target raises `E004` (undefined symbol).
+
+## Internal — Symbol gains a `bank` field
+
+`asm.symtab.Symbol` adds `bank: ?u8 = null` so the codegen can
+resolve label → bank at emit time. Populated by the layout pass
+for `.label` and `.data` kinds; `.const_value` and `.struct_field`
+stay `null` (they're not bank-positioned). Feature-additive —
+existing callsites still compile because the new field has a
+default.
+
+## Editor surfaces — follow-up
+
+Tree-sitter and VS Code TextMate need `bank_call` / `bank_jump`
+added to their mnemonic lists for proper highlighting. Tracked
+separately in the submodule repos; the next submodule pin bump
+in gero will pick up both.

--- a/docs/asm-cookbook.md
+++ b/docs/asm-cookbook.md
@@ -166,6 +166,27 @@ linker resolves `greet`'s address to `$C000` (the bank-window
 base), and the assembler emits the bank's bytes into the
 appropriate slot of the `.gx` file.
 
+**Sugar**: `bank_call <label>` and `bank_jump <label>` desugar to
+`mov $bank, mb` + `call`/`jmp <addr>`. The assembler looks up
+which bank the target lives in, so callers don't have to
+hand-track bank IDs across the codebase:
+
+```asm
+main:
+  bank_call greet              ; assembler emits: mov $00, mb + call greet
+  hlt
+
+bank $00
+greet:
+  mov 'B', r1
+  int PRINT
+  ret
+```
+
+Same bytecode as the manual version — just less error-prone. If
+the target moves to another bank (`bank $01 greet:`), the sugar
+follows; the manual form would silently call into the wrong bank.
+
 **See also**: [`examples/asm/banks/`](../examples/asm/banks/) — full multi-bank cart with cross-bank calls via two `bank $XX` files glued together by `include`.
 
 ---

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -646,13 +646,32 @@ See `examples/asm/banks/` for a working three-file demo.
 ### Cross-bank calls
 
 A cross-bank call is two instructions: switch `mb`, then call /
-jmp. The asm has no sugar for this — write the pair
-explicitly:
+jmp. Either write the pair by hand or use the `bank_call` /
+`bank_jump` pseudo-instructions, which look up the target label's
+bank automatically:
 
 ```asm
+; By hand — bank must match the target's actual location.
 mov $01, mb
-call <label_in_bank_1>
+call render_sprite
+
+; Sugar — assembler looks up render_sprite's bank, emits
+; `mov $01, mb` + `call render_sprite` for you. Saves a manual
+; bank-tracking step and removes a class of wrong-bank-call bugs.
+bank_call render_sprite
+bank_jump cleanup_path
 ```
+
+`bank_call <label>` and `bank_jump <label>` both desugar to 7
+bytes (4 for `mov imm16, mb` + 3 for `call`/`jmp <addr>`). The
+sugar emits the redundant `mov` even when the target lives in the
+same bank as the call site — consistent behavior, no surprise
+omission. Round-trip-wise the sugar is one-way: `gero disasm`
+recovers the two real instructions, not the `bank_call` form.
+
+The target must be a label or `data8`/`data16` symbol (those
+carry bank-of-definition); pointing at a `const` is rejected with
+`E003` since constants have no bank.
 
 ---
 

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -195,6 +195,14 @@ fn emitBuffer(allocator: std.mem.Allocator, emit: *Emit, bank: ?u8) !*std.ArrayL
     return &emit.base;
 }
 
+/// True for the two cross-bank pseudo-instructions. Both desugar
+/// to `mov $bank, mb` + `call`/`jmp <addr>` — 7 bytes total. The
+/// caller is responsible for the actual emit; this helper just
+/// gates the special-case path in layout + emit.
+fn isBankPseudo(mnem: []const u8) bool {
+    return std.mem.eql(u8, mnem, "bank_call") or std.mem.eql(u8, mnem, "bank_jump");
+}
+
 // ---------- operand classification ----------
 
 /// Classify an operand for layout / opcode selection, consulting
@@ -298,7 +306,7 @@ fn layoutPass(
                     // Local label: register as `parent.name`.
                     if (parent_label) |p| {
                         const qualified = try std.fmt.allocPrint(symbols.allocator, "{s}{s}", .{ p, name });
-                        symbols.putOwned(qualified, .{ .kind = .label, .value = addr }) catch |err| switch (err) {
+                        symbols.putOwned(qualified, .{ .kind = .label, .value = addr, .bank = current_bank }) catch |err| switch (err) {
                             error.OutOfMemory => return error.OutOfMemory,
                             error.Duplicate => {
                                 symbols.allocator.free(qualified);
@@ -325,7 +333,7 @@ fn layoutPass(
                         });
                     }
                 } else {
-                    symbols.putBorrowed(name, .{ .kind = .label, .value = addr }) catch |err| switch (err) {
+                    symbols.putBorrowed(name, .{ .kind = .label, .value = addr, .bank = current_bank }) catch |err| switch (err) {
                         error.OutOfMemory => return error.OutOfMemory,
                         error.Duplicate => try errors.append(symbols.allocator, .{
                             .code = .duplicate_label,
@@ -364,7 +372,7 @@ fn layoutPass(
             .data8, .data16 => |d| {
                 const name = source[d.name.start..d.name.end];
                 const addr: u16 = bankAddr(current_bank, cursor_ptr.*);
-                symbols.putBorrowed(name, .{ .kind = .data, .value = addr }) catch |err| switch (err) {
+                symbols.putBorrowed(name, .{ .kind = .data, .value = addr, .bank = current_bank }) catch |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
                     error.Duplicate => try errors.append(symbols.allocator, .{
                         .code = .duplicate_label,
@@ -451,26 +459,35 @@ fn layoutPass(
             },
             .instruction => |i| {
                 const mnem = source[i.mnemonic.start..i.mnemonic.end];
-                var kinds: [3]opres.Kind = undefined;
-                for (i.operands, 0..) |op, idx| kinds[idx] = classifyForLayout(op, source, symbols.*, parent_label, symbols.allocator);
-                if (opres.resolve(mnem, kinds[0..i.operands.len])) |res| {
-                    cursor_ptr.* += res.size;
+                // Pseudo-instructions desugar to a 2-instruction
+                // sequence (4-byte `mov` + 3-byte `call`/`jmp`).
+                // Layout cost is fixed at 7 bytes regardless of
+                // which bank the target lives in; the actual bank
+                // lookup happens in the emit pass.
+                if (isBankPseudo(mnem)) {
+                    cursor_ptr.* += 7;
                 } else {
-                    // Unknown mnemonic OR operand-shape mismatch.
-                    const known = opres.isKnownMnemonic(mnem);
-                    const kind: []const u8 = if (known) "operand type mismatch" else "unknown mnemonic";
-                    try errors.append(symbols.allocator, .{
-                        .code = if (known) .operand_type_mismatch else .unknown_mnemonic,
-                        .parse_error = core.parseError(
-                            "codegen",
-                            i.mnemonic.start,
-                            kind,
-                            .{ .expected = "valid instruction shape", .actual = mnem, .kind = .semantic },
-                        ),
-                    });
-                    // Best-effort cursor advance to keep subsequent
-                    // statements roughly aligned for layout.
-                    cursor_ptr.* += 1;
+                    var kinds: [3]opres.Kind = undefined;
+                    for (i.operands, 0..) |op, idx| kinds[idx] = classifyForLayout(op, source, symbols.*, parent_label, symbols.allocator);
+                    if (opres.resolve(mnem, kinds[0..i.operands.len])) |res| {
+                        cursor_ptr.* += res.size;
+                    } else {
+                        // Unknown mnemonic OR operand-shape mismatch.
+                        const known = opres.isKnownMnemonic(mnem);
+                        const kind: []const u8 = if (known) "operand type mismatch" else "unknown mnemonic";
+                        try errors.append(symbols.allocator, .{
+                            .code = if (known) .operand_type_mismatch else .unknown_mnemonic,
+                            .parse_error = core.parseError(
+                                "codegen",
+                                i.mnemonic.start,
+                                kind,
+                                .{ .expected = "valid instruction shape", .actual = mnem, .kind = .semantic },
+                            ),
+                        });
+                        // Best-effort cursor advance to keep subsequent
+                        // statements roughly aligned for layout.
+                        cursor_ptr.* += 1;
+                    }
                 }
             },
             .cond_directive, .comment, .unknown => {},
@@ -742,6 +759,17 @@ fn emitInstruction(
     parent_label: ?[]const u8,
 ) !void {
     const mnem = source[inst.mnemonic.start..inst.mnemonic.end];
+
+    // `bank_call <label>` / `bank_jump <label>` — pseudo-instructions
+    // that desugar to `mov $bank, mb` + `call`/`jmp <addr>` (7 bytes
+    // total). The assembler looks up which bank `<label>` was
+    // defined in (via Symbol.bank) so the user doesn't have to
+    // hand-track bank-of-target across the codebase.
+    if (isBankPseudo(mnem)) {
+        try emitBankPseudo(allocator, image, errors, source, inst, mnem, consts, symbols, parent_label);
+        return;
+    }
+
     var kinds: [3]opres.Kind = undefined;
     for (inst.operands, 0..) |op, idx| kinds[idx] = classifyForEmit(op, source, symbols.*, parent_label, allocator);
     const res = opres.resolve(mnem, kinds[0..inst.operands.len]) orelse {
@@ -809,6 +837,128 @@ fn emitInstruction(
             try image.append(allocator, @intFromEnum(idx.reg.id));
         },
     };
+}
+
+/// Emit a `bank_call` / `bank_jump` pseudo-instruction as a
+/// `mov $bank, mb` + `call`/`jmp <addr>` pair. The target label
+/// must be a defined label (the symbol table carries the bank
+/// the label lives in). Always emits 7 bytes — even when the
+/// target is in the same bank as the call site, the `mov` runs
+/// (no surprise omission). A later optimization could elide the
+/// redundant `mov` for same-bank targets.
+fn emitBankPseudo(
+    allocator: std.mem.Allocator,
+    image: *std.ArrayList(u8),
+    errors: *std.ArrayList(include.Diagnostic),
+    source: []const u8,
+    inst: ast.Instruction,
+    mnem: []const u8,
+    consts: expr.ConstantTable,
+    symbols: *const symtab.SymbolTable,
+    parent_label: ?[]const u8,
+) !void {
+    _ = consts;
+
+    // Operand shape: exactly one .label_ref or .sym_ref. Anything
+    // else → E003. Emit 7 bytes of `hlt` so the cursor stays
+    // aligned with the layout pass's assumption.
+    if (inst.operands.len != 1) {
+        try errors.append(allocator, .{
+            .code = .operand_type_mismatch,
+            .parse_error = core.parseError(
+                "codegen",
+                inst.mnemonic.start,
+                "operand type mismatch",
+                .{ .expected = "exactly one label operand", .actual = mnem, .kind = .semantic },
+            ),
+        });
+        try image.appendNTimes(allocator, 0xFF, 7);
+        return;
+    }
+
+    const op_span: ast.Span = switch (inst.operands[0]) {
+        .label_ref => |l| l.span,
+        .sym_ref => |s| s.span,
+        else => {
+            try errors.append(allocator, .{
+                .code = .operand_type_mismatch,
+                .parse_error = core.parseError(
+                    "codegen",
+                    inst.mnemonic.start,
+                    "bank_call / bank_jump operand must be a label reference",
+                    .{ .expected = "label or @symbol", .actual = mnem, .kind = .semantic },
+                ),
+            });
+            try image.appendNTimes(allocator, 0xFF, 7);
+            return;
+        },
+    };
+
+    var raw_lex = source[op_span.start..op_span.end];
+    if (raw_lex.len > 0 and raw_lex[0] == '@') raw_lex = raw_lex[1..];
+    const resolved = resolveLabelKey(raw_lex, parent_label, allocator) catch {
+        try errors.append(allocator, .{
+            .code = .undefined_symbol,
+            .parse_error = core.parseError(
+                "codegen",
+                op_span.start,
+                "local label reference has no enclosing global label",
+                .{ .expected = "preceding global label", .actual = raw_lex, .kind = .semantic },
+            ),
+        });
+        try image.appendNTimes(allocator, 0xFF, 7);
+        return;
+    };
+    defer if (resolved.owned) allocator.free(resolved.key);
+
+    const sym = symbols.get(resolved.key) orelse {
+        try errors.append(allocator, .{
+            .code = .undefined_symbol,
+            .note = symbols.suggestSimilar(resolved.key),
+            .parse_error = core.parseError(
+                "codegen",
+                op_span.start,
+                "undefined symbol",
+                .{ .expected = "defined label", .actual = resolved.key, .kind = .semantic },
+            ),
+        });
+        try image.appendNTimes(allocator, 0xFF, 7);
+        return;
+    };
+
+    // bank_call / bank_jump want a label (or data) — they're
+    // bank-positioned. Compile-time const_value and struct_field
+    // entries have no bank, so reject them.
+    if (sym.kind != .label and sym.kind != .data) {
+        try errors.append(allocator, .{
+            .code = .operand_type_mismatch,
+            .parse_error = core.parseError(
+                "codegen",
+                op_span.start,
+                "bank_call / bank_jump target must be a label or data symbol (not a const)",
+                .{ .expected = "label or data symbol", .actual = resolved.key, .kind = .semantic },
+            ),
+        });
+        try image.appendNTimes(allocator, 0xFF, 7);
+        return;
+    }
+
+    // Bank value for the `mov $bank, mb` step. A symbol in the
+    // base image (bank = null) gets `$00` — explicit reset rather
+    // than skip.
+    // @as: widen Symbol.bank (u8) into the u16 we need for `mov imm16`.
+    const bank_value: u16 = if (sym.bank) |b| @as(u16, b) else 0;
+
+    // 1. mov $bank, mb — opcode 0x10 (movImm16Reg), imm16 LE,
+    //    register 0x0C (mb).
+    try image.append(allocator, 0x10);
+    try emitValue(allocator, image, bank_value, 2);
+    try image.append(allocator, 0x0C);
+
+    // 2. call/jmp <addr> — opcode 0x80 / 0x70, addr LE.
+    const jump_opcode: u8 = if (std.mem.eql(u8, mnem, "bank_call")) 0x80 else 0x70;
+    try image.append(allocator, jump_opcode);
+    try emitValue(allocator, image, sym.value, 2);
 }
 
 fn emitSymRef(

--- a/src/asm/symtab.zig
+++ b/src/asm/symtab.zig
@@ -25,6 +25,15 @@ pub const SymbolKind = enum {
 pub const Symbol = struct {
     kind: SymbolKind,
     value: u16,
+    /// Bank slot the symbol was defined in. `null` = base image
+    /// (the implicit no-bank section before any `bank N` directive).
+    /// `Some(N)` = bank slot N (0-based, the value `mb` should hold
+    /// for accesses into that bank).
+    ///
+    /// Populated for `.label` and `.data` kinds only; `.const_value`
+    /// and `.struct_field` are compile-time constants with no
+    /// bank-positioned address, so they leave this `null`.
+    bank: ?u8 = null,
 };
 
 /// Name → Symbol lookup. Built incrementally by the codegen

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -836,3 +836,88 @@ test "codegen: movl reg → &XX downgrades to ZP opcode 0x2D" {
     try std.testing.expect(!out.cg.hasErrors());
     try std.testing.expectEqual(@as(u8, 0x2D), out.imageBody()[0]);
 }
+
+// ---------- bank_call / bank_jump pseudo-instructions ----------
+
+test "codegen: bank_call <label-in-bank> emits mov $bank, mb + call <addr>" {
+    var out = try assemble(
+        \\main:
+        \\  bank_call greet
+        \\  hlt
+        \\
+        \\bank $00
+        \\greet:
+        \\  ret
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    // 7-byte expansion: 0x10 (movImm16Reg) + imm16($0000) + 0x0C (mb)
+    //                 + 0x80 (call) + addr16
+    const body = out.imageBody();
+    try std.testing.expectEqual(@as(u8, 0x10), body[0]);
+    try std.testing.expectEqual(@as(u8, 0x00), body[1]); // bank low
+    try std.testing.expectEqual(@as(u8, 0x00), body[2]); // bank high
+    try std.testing.expectEqual(@as(u8, 0x0C), body[3]); // mb register
+    try std.testing.expectEqual(@as(u8, 0x80), body[4]); // call opcode
+    // Bytes 5-6 = call target address (bank-window-relative).
+}
+
+test "codegen: bank_jump emits jmp opcode (0x70) instead of call (0x80)" {
+    var out = try assemble(
+        \\main:
+        \\  bank_jump greet
+        \\
+        \\bank $00
+        \\greet:
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    try std.testing.expectEqual(@as(u8, 0x70), out.imageBody()[4]);
+}
+
+test "codegen: bank_call into a higher-numbered bank emits the bank index" {
+    var out = try assemble(
+        \\main:
+        \\  bank_call deep
+        \\  hlt
+        \\
+        \\bank $02
+        \\deep:
+        \\  ret
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(!out.cg.hasErrors());
+    const body = out.imageBody();
+    try std.testing.expectEqual(@as(u8, 0x10), body[0]);
+    try std.testing.expectEqual(@as(u8, 0x02), body[1]); // bank = 2
+    try std.testing.expectEqual(@as(u8, 0x0C), body[3]);
+}
+
+test "codegen: bank_call on a const rejects with E003" {
+    var out = try assemble(
+        \\const FOO = $42
+        \\main:
+        \\  bank_call FOO
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    try std.testing.expectEqual(gero.asm_.ErrorCode.operand_type_mismatch, out.cg.errors[0].code.?);
+}
+
+test "codegen: bank_call on undefined symbol rejects with E004" {
+    var out = try assemble(
+        \\main:
+        \\  bank_call missing
+        \\  hlt
+        \\
+    , .{});
+    defer out.deinit();
+    try std.testing.expect(out.cg.hasErrors());
+    try std.testing.expectEqual(gero.asm_.ErrorCode.undefined_symbol, out.cg.errors[0].code.?);
+}


### PR DESCRIPTION
Closes #171.

## Summary

Cross-bank calls used to require hand-tracked bank IDs:

```asm
mov $01, mb              ; manually track which bank greet lives in
call greet               ; wrong constant → call into garbage → VM fault
```

`bank_call` and `bank_jump` remove that footgun. The assembler looks up the target label's bank via the symbol table and emits the equivalent `mov $bank, mb` + `call`/`jmp <addr>` pair (7 bytes total, bytecode-identical to the hand-written form).

```asm
bank_call greet          ; → mov $01, mb + call greet
bank_jump cleanup        ; → mov $01, mb + jmp cleanup
```

## Semantics

- **7 bytes per pseudo**: 4 for `mov imm16, mb` + 3 for `call`/`jmp <addr>`. Bytecode-identical to hand-written pair.
- **Always emits the redundant `mov $bank, mb`** even when the target lives in the same bank as the call site — consistent behavior, no surprise omission. A future optimization could elide it for same-bank targets.
- **Round-trip is one-way at source level**: `gero disasm` emits the two real instructions (not `bank_call`). Bytecode round-trips identically.
- **Target must be a label or `data8`/`data16` symbol** (those carry bank-of-definition). Pointing at a `const` raises `E003` (operand type mismatch). Undefined target raises `E004`.

## Internal — `Symbol.bank` field

`asm.symtab.Symbol` gains a `bank: ?u8 = null` field. Populated by the layout pass for `.label` and `.data` kinds (bank-positioned ones); `.const_value` / `.struct_field` stay `null` (compile-time values with no bank). Feature-additive — the new field has a default, existing callsites still compile.

## Docs

- `docs/asm.md` §5 **Cross-bank calls** subsection — introduces both pseudos with worked examples comparing manual vs sugar forms.
- `docs/asm-cookbook.md` §4 banking recipe — adds a **Sugar** subsection demonstrating `bank_call` and the bug-class it removes.

## Test plan

- [x] 5 inline tests in `tests/asm/codegen.test.zig`:
  - bank_call into bank $00 → exact opcode-byte sequence `10 00 00 0C 80 ...`
  - bank_jump → 0x70 instead of 0x80
  - higher-numbered bank index (bank $02) → `10 02 00 0C ...`
  - bank_call on a `const` → E003
  - bank_call on undefined symbol → E004
- [x] Manual end-to-end: `gero asm` + `gero run` produces correct output on a base-image `main` calling into bank 0 via `bank_call`.
- [x] `gero fmt --stdin` round-trips `bank_call <label>` verbatim.
- [x] `zig build ci` clean locally.

## Editor surface follow-up

Tree-sitter and VS Code TextMate grammars need `bank_call` / `bank_jump` added to their mnemonic lists for proper highlighting. Tracked as separate submodule PRs; the next submodule pin bump in gero will pick both up.

## Self-review

- ✅ AC re-read: every bullet from #171 covered (operand-shape resolution, same-bank consistency, round-trip semantics, error paths).
- ✅ `zig build ci` green (lint + strict + mirror + naming + imports + test-modes + test-all + check-examples + check-broken + fmt-check-examples + test-examples).
- ✅ Public API impact: `Symbol.bank` is additive; `isBankPseudo` / `emitBankPseudo` are private helpers.
- ✅ Docs propagated: `asm.md` §5 + cookbook §4 both updated.
- ✅ Changeset (`minor` bump, additive feature, no breaking flag).
- ✅ Hygiene: no leftover debug prints, conventional-commit scope `asm`, no AI attribution. One new `@as` carries a `// @as:` comment per CLAUDE.md.

## v0.2 closeout

This was the last v0.2 closeout item. With #171 merged, the v0.2 = 'asm complete for gtx-16 cart-scale work' philosophy is **fully shipped**:

- ✅ ZP downgrade (PR #166)
- ✅ Operand-order convention unified (#164)
- ✅ E008 dead code removed (#168)
- ✅ `fmt --stdin` + `check --format=json` for editors without LSP (#174)
- ✅ syntax_overview.gas drift fix + CI gate (#175 + #176)
- ✅ `ifdef`/`ifndef`/`endif` include guards (#177 + #178)
- ✅ `bank_call` / `bank_jump` cross-bank sugar (this PR)

Ready for a v0.2.0 tag once the editor submodule pins land for the bank_call mnemonics.