### PR TITLE
docs: strip v0.X / Phase X attribution from in-code comments

### DIFF
--- a/apps/gero-cli/build.zig
+++ b/apps/gero-cli/build.zig
@@ -60,11 +60,11 @@ pub fn execute(
     defer manifest.deinit(arena);
 
     // 2. Target gate. `--target=<vm|gtx-16>` overrides the manifest;
-    //    only `vm` is wired in v0.2 — `gtx-16` lights up later.
+    //    only `vm` is wired today — `gtx-16` is a downstream target.
     const target = opts.target orelse manifest.package.target;
     if (!std.mem.eql(u8, target, "vm")) {
         if (std.mem.eql(u8, target, "gtx-16")) {
-            try term.err("gero build: target `gtx-16` is not yet implemented (lights up later — only `vm` works in v0.2)", .{});
+            try term.err("gero build: target `gtx-16` is not yet implemented (only `vm` is currently wired)", .{});
         } else {
             try term.err("gero build: unknown target `{s}` (expected `vm` or `gtx-16`)", .{target});
         }

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -11,8 +11,8 @@
 ///   - `4` ≥ 1 diagnostic from any file
 ///
 /// `.gr` positional paths dispatch to a "not yet implemented" stub
-/// until the gero-lang front-end lands in v0.3 (#7). Directory
-/// walks ignore `.gr` extensions entirely until then.
+/// until the gero-lang front-end ships. Directory walks ignore
+/// `.gr` extensions entirely until then.
 const std = @import("std");
 const gero = @import("gero");
 const cli = @import("cli.zig");
@@ -61,7 +61,7 @@ pub fn execute(
     } else {
         for (positionals) |path| {
             if (std.mem.endsWith(u8, path, ".gr")) {
-                try term.err("gero check: .gr support lands in v0.3 (gero-lang front-end)", .{});
+                try term.err("gero check: .gr support is not yet implemented (waits on the gero-lang front-end)", .{});
                 return 1;
             }
             try collectGasFiles(io, arena, term, path, &files);

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -35,7 +35,7 @@ pub const ColorChoice = enum { auto, always, never };
 /// consume.
 pub const Format = enum { human, json };
 
-/// Maximum positional args a single invocation can hold. v0.1
+/// Maximum positional args a single invocation can hold. Today's
 /// commands top out at 1-2; keep it generous to absorb future
 /// `gero build` multi-source forms without re-architecting.
 pub const max_positionals: usize = 16;

--- a/apps/gero-cli/fmt.zig
+++ b/apps/gero-cli/fmt.zig
@@ -10,8 +10,8 @@
 ///   - `3` parse error in source
 ///   - `8` `--check` mode and at least one file would change
 ///
-/// `.gr` sources route to a "not yet implemented" stub until v0.3
-/// wires the gero-lang front-end.
+/// `.gr` sources route to a "not yet implemented" stub until the
+/// gero-lang front-end ships.
 ///
 /// Notes
 /// -----
@@ -105,7 +105,7 @@ pub fn execute(
     } else {
         for (positionals) |path| {
             if (std.mem.endsWith(u8, path, ".gr")) {
-                try term.err("gero fmt: .gr support lands in v0.3 (gero-lang front-end)", .{});
+                try term.err("gero fmt: .gr support is not yet implemented (waits on the gero-lang front-end)", .{});
                 return 1;
             }
             try collectGasFiles(io, arena, term, path, &files);

--- a/apps/gero-cli/init.zig
+++ b/apps/gero-cli/init.zig
@@ -1,4 +1,4 @@
-/// `gero init` — scaffold a v0.2 asm project **into the current
+/// `gero init` — scaffold an asm project **into the current
 /// directory**. Mirror of `gero new <name>` (see `new.zig`) but
 /// in-place: the cwd's basename becomes the project name. Match
 /// to cargo / poetry / yarn / zig: `new` creates a fresh

--- a/apps/gero-cli/new.zig
+++ b/apps/gero-cli/new.zig
@@ -1,4 +1,4 @@
-/// `gero new <name>` — scaffold a fresh v0.2 asm project in a new
+/// `gero new <name>` — scaffold a fresh asm project in a new
 /// sub-directory. The in-place form (cwd as the project root) is
 /// `gero init` — see `init.zig`. Both subcommands consume the
 /// shared scaffolding primitives exported below.

--- a/apps/gero-cli/project.zig
+++ b/apps/gero-cli/project.zig
@@ -2,7 +2,7 @@
 /// project-aware subcommands (`gero new`, `gero build`, and the
 /// project-mode of `gero check` / `fmt` / `test`).
 ///
-/// Scope: a TOML subset sufficient for the v0.2 manifest shape —
+/// Scope: a TOML subset sufficient for today's manifest shape —
 /// section headers, key=value with string literals, string arrays,
 /// `#`-comments. **Not** full TOML: no integers, booleans, inline
 /// tables, dotted keys, multi-line strings/arrays, dates. Those
@@ -103,8 +103,8 @@ pub const Manifest = struct {
     }
 };
 
-/// Default values populated when a section / key is absent. The
-/// canonical layout per v0.2 conventions.
+/// Default values populated when a section / key is absent —
+/// the canonical layout.
 pub const defaults = struct {
     pub const package_target: []const u8 = "vm";
     pub const build_out: []const u8 = "out/";
@@ -363,7 +363,7 @@ const Parser = struct {
         self.skipHorizontalBlanks();
 
         // Dispatch on value shape: `"..."` for strings, `[...]`
-        // for arrays. No other forms supported in v0.2.
+        // for arrays. No other forms supported.
         if (self.index >= self.source.len) {
             self.reportf("expected value after '='", .{});
             return error.ParseFailed;
@@ -401,8 +401,8 @@ const Parser = struct {
         }
     }
 
-    /// `"..."` — basic string, no escapes for v0.2 (filenames
-    /// don't need them). Returns a slice into `source`.
+    /// `"..."` — basic string, no escapes (filenames don't need
+    /// them). Returns a slice into `source`.
     fn parseString(self: *Parser) ParseError![]const u8 {
         // Consume `"`
         self.advance(1);
@@ -470,8 +470,8 @@ const Parser = struct {
         }
         const text = self.source[start..self.index];
         // Strip underscores into a stack-local buffer before
-        // handing the digits to `parseInt`. v0.2 manifest values
-        // are short (cycle budgets, columns) — 32 bytes is plenty.
+        // handing the digits to `parseInt`. Manifest values are
+        // short (cycle budgets, columns) — 32 bytes is plenty.
         var scratch: [32]u8 = undefined;
         var n: usize = 0;
         for (text) |c| {
@@ -514,7 +514,7 @@ const Parser = struct {
         comptime fmt: []const u8,
         args: anytype,
     ) void {
-        // Format into the diagnostic's inline storage. v0.2
+        // Format into the diagnostic's inline storage. The parser
         // surfaces only the first error per parse, so the buffer
         // is single-shot. `bufPrint` truncation on a >256-byte
         // message degrades to whatever fit — acceptable for the
@@ -747,7 +747,7 @@ const Pending = struct {
 
 const testing = std.testing;
 
-test "project: parses the canonical v0.2 manifest shape" {
+test "project: parses the canonical manifest shape" {
     const src =
         \\[package]
         \\name = "my-cart"

--- a/src/asm/ast.zig
+++ b/src/asm/ast.zig
@@ -246,7 +246,7 @@ pub const StructField = struct {
     /// Span of the field's identifier.
     name: Span,
     /// `u8` (1 byte) or `u16` (2 bytes). Per asm spec §2.2 these
-    /// are the only field types in v0.1.
+    /// are the only supported field types.
     ty: FieldType,
     /// Byte offset within the struct.
     offset: u16,
@@ -255,8 +255,8 @@ pub const StructField = struct {
 };
 
 /// Field type per asm spec §2.2. The width values are 1 byte for
-/// `u8`, 2 bytes for `u16`; nothing wider in v0.1. Variant names
-/// match the source-level keyword so `std.meta.stringToEnum`
+/// `u8`, 2 bytes for `u16` — the only supported widths. Variant
+/// names match the source-level keyword so `std.meta.stringToEnum`
 /// resolves them directly.
 pub const FieldType = enum {
     u8,

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -1,6 +1,6 @@
 /// Asm codegen — takes a parsed `ParseTree` and produces a
-/// complete `.gx` byte image (header + image bytes). Single-file,
-/// single-bank for the v0.1 first cut; banked emission lands later.
+/// complete `.gx` byte image (header + image bytes). Banked
+/// emission is supported via the `bank N` directive.
 ///
 /// Two-pass model:
 ///   Pass 1 (layout): walk statements, compute each statement's
@@ -47,8 +47,7 @@ pub const Codegen = struct {
     }
 };
 
-/// Configuration knobs for `assemble`. v0.1 just exposes the
-/// entry point; banking + SRAM land later.
+/// Configuration knobs for `assemble`.
 pub const Options = struct {
     /// `ip` value at boot per ISA §7.1. `null` (default) triggers
     /// auto-detection: if the program defines a `main:` label, its

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -49,13 +49,13 @@ pub const Shape = struct {
     opcode: u8,
 };
 
-/// Maximum operand count per instruction in v0.1 (`mov` indexed
-/// has 2 source-level operands; bcpy/bset have 3 register operands).
+/// Maximum operand count per instruction — `bcpy` / `bset` have
+/// 3 register operands; everything else has 2 or fewer.
 const max_operands: usize = 3;
 
 /// The dispatch table. Order matters: more-specific shapes go
-/// first when shapes share a prefix (none in v0.1, but the rule
-/// is good hygiene). Mnemonics use lowercase, matching the lexer.
+/// first when shapes share a prefix. Mnemonics use lowercase,
+/// matching the lexer.
 const shapes: []const Shape = &.{
     // mov family
     .{ .mnemonic = "mov", .kinds = &.{ .imm16, .reg }, .opcode = 0x10 },
@@ -196,7 +196,7 @@ const shapes: []const Shape = &.{
 
 /// 256-entry reverse lookup: opcode byte → asm-side `Shape`.
 /// Built once at comptime by walking `shapes`. `null` slots are
-/// opcodes the v0.1 ISA doesn't define. The disassembler indexes
+/// opcode bytes the ISA doesn't define. The disassembler indexes
 /// this directly to render bytes back into asm syntax.
 pub const shape_by_opcode: [256]?Shape = blk: {
     var t = [_]?Shape{null} ** 256;
@@ -214,8 +214,8 @@ pub const shape_by_opcode: [256]?Shape = blk: {
 /// `.imm16`, so layout is correct either way).
 ///
 /// `addr_lit` operands with `value ≤ 0xFF` classify as `.zp` so the
-/// resolver picks the 1-byte zero-page variants when they exist
-/// (peephole optimization — shipped from v0.2 onward). Other Addr
+/// resolver picks the 1-byte zero-page variants when they exist —
+/// peephole optimization, transparent to the user. Other Addr
 /// shapes (sym_ref, addr_expr, cast) stay `.addr` because their
 /// values aren't always known at classify time.
 pub fn classify(op: ast.Operand, symbols: ?*const symtab.SymbolTable) Kind {

--- a/src/asm/parser.zig
+++ b/src/asm/parser.zig
@@ -839,7 +839,7 @@ fn parseStructField(
             .parse_error = core.parseError(
                 "struct",
                 type_token.start,
-                "unknown field type (v0.1 supports `u8` and `u16` only)",
+                "unknown field type (only `u8` and `u16` are supported)",
                 .{ .expected = "u8 | u16", .actual = type_lex, .kind = .semantic },
             ),
         });

--- a/src/asm/printer.zig
+++ b/src/asm/printer.zig
@@ -67,7 +67,7 @@ pub const PrintOptions = struct {
 
 /// Case policy for hex literals.
 pub const HexCase = enum {
-    /// `$ABCD`, `&FFFF` — canonical for v0.1 examples.
+    /// `$ABCD`, `&FFFF` — the canonical default.
     upper,
     /// `$abcd`, `&ffff` — lowercase (some C / Rust shops).
     lower,

--- a/src/disasm/decoder.zig
+++ b/src/disasm/decoder.zig
@@ -50,7 +50,7 @@ pub const Instruction = struct {
 
 /// Failure modes when decoding a single instruction.
 pub const DecodeError = error{
-    /// Opcode byte isn't in the v0.1 ISA's reverse table.
+    /// Opcode byte isn't in the ISA's reverse table.
     UnknownOpcode,
     /// Bytes ran out before the operands could be fully read.
     Truncated,

--- a/src/disasm/header.zig
+++ b/src/disasm/header.zig
@@ -40,7 +40,7 @@ pub const Symbols = struct {
 
     /// `null` when no symbol covers `addr`. Linear scan — the
     /// symbol count tops out at ~thousands per cart so binary
-    /// search isn't worth the complexity for v0.1.
+    /// search isn't worth the complexity yet.
     pub fn lookup(self: Symbols, addr: u16) ?[]const u8 {
         for (self.entries) |e| if (e.address == addr) return e.name;
         return null;
@@ -57,7 +57,7 @@ pub const Symbols = struct {
 /// One file's worth of decoded header info + section slices, all
 /// borrowed from the caller's `bytes` buffer.
 pub const Header = struct {
-    /// Cart version (`0x0001` for v0.1).
+    /// Bytecode format version — currently `0x0001`.
     version: u16,
     /// Bit-set per ISA §7.1 (bit 0 = banked, bit 1 = has-debug).
     flags: u16,
@@ -77,7 +77,7 @@ pub const Header = struct {
     /// Concatenated bank bytes (length == `bank_count * 0x4000`).
     /// Empty when the cart is unbanked.
     banks: []const u8,
-    /// Trailing debug-symbol bytes — opaque blob for v0.1.
+    /// Trailing debug-symbol bytes — opaque blob.
     /// Empty when the cart has no debug symbols.
     debug: []const u8,
 

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -13,7 +13,7 @@ const gero = @import("../gero.zig");
 const decoder = @import("decoder.zig");
 const header = @import("header.zig");
 
-/// Mnemonic column width in characters — covers every v0.1
+/// Mnemonic column width in characters — covers every ISA
 /// mnemonic plus one trailing space.
 const mnemonic_col_width: usize = 6;
 
@@ -323,7 +323,7 @@ fn writeZeroRunComment(
 }
 
 /// `XXXX:  ` address column + optional hex-bytes column. Width
-/// of the hex column is fixed at 5 bytes (max v0.1 instruction
+/// of the hex column is fixed at 5 bytes (max ISA instruction
 /// width) so subsequent columns align.
 fn writePrefix(
     writer: *std.Io.Writer,

--- a/src/gero.zig
+++ b/src/gero.zig
@@ -5,8 +5,9 @@ pub const VERSION = "0.0.0";
 /// VM kernel — register file, memory, and the composing `VM` type.
 pub const vm = @import("vm/vm.zig");
 
-/// Assembler — text `.gas` source → `.gx` bytecode. Scaffold;
-/// real parser / codegen lands in follow-up PRs.
+/// Assembler — text `.gas` source → `.gx` bytecode. Re-exports
+/// `parse` / `assemble`, the `ParseTree` / `Codegen` types, and
+/// `ErrorCode` (asm spec §7).
 pub const asm_ = @import("asm.zig");
 
 /// Disassembler — `.gx` bytecode → `.gas` source. Inverse of

--- a/src/vm/loader.zig
+++ b/src/vm/loader.zig
@@ -121,9 +121,9 @@ pub fn parse(bytes: []const u8) LoaderError!LoadedProgram {
 
     var debug: []const u8 = bytes[cursor..cursor];
     if ((flags & flag_has_debug) != 0) {
-        // Debug symbols are variable-length; for v0.1 the loader
-        // just exposes the trailing slice. The disassembler will
-        // parse it on demand.
+        // Debug symbols are variable-length; the loader exposes
+        // the trailing slice as-is. The disassembler parses it on
+        // demand.
         debug = bytes[cursor..];
     }
 

--- a/tests/asm/lexer.test.zig
+++ b/tests/asm/lexer.test.zig
@@ -160,7 +160,7 @@ test "lex: @ followed by digit rejected — both bytes flagged" {
 }
 
 test "lex: legacy '!sym' no longer recognized after spec revision" {
-    // '!' is no longer the sym-ref prefix (replaced by '@' in v0.1-final).
+    // '!' is no longer the sym-ref prefix (replaced by '@').
     // The bare '!' surfaces as an unknown byte; the rest still lexes.
     var ts = try tokenize("!hasFrame");
     defer ts.deinit();

--- a/tests/disasm/decoder.test.zig
+++ b/tests/disasm/decoder.test.zig
@@ -54,7 +54,7 @@ test "decoder: int (imm8) decodes 2 bytes" {
 }
 
 test "decoder: unknown opcode returns error.UnknownOpcode" {
-    const bytes = [_]u8{0x00}; // 0x00 is not in the v0.1 ISA
+    const bytes = [_]u8{0x00}; // 0x00 isn't a defined opcode
     try std.testing.expectError(error.UnknownOpcode, gero.disasm.decodeOne(alloc, &bytes, 0));
 }
 

--- a/tests/disasm/printer.test.zig
+++ b/tests/disasm/printer.test.zig
@@ -58,7 +58,7 @@ test "printer: int imm8 → \"int $XX\\n\"" {
 }
 
 test "printer: unknown opcode emits a `.byte $XX` comment + continues" {
-    // 0x00 isn't in the v0.1 ISA; the disasm comments it then
+    // 0x00 isn't a defined opcode; the disasm comments it then
     // resumes with the next byte (0xFF = hlt).
     const out = try renderBytes(&.{ 0x00, 0xFF });
     defer alloc.free(out);

--- a/tests/disasm/roundtrip.test.zig
+++ b/tests/disasm/roundtrip.test.zig
@@ -6,8 +6,8 @@
 ///
 /// Programs that mix code + data are NOT round-trippable without
 /// debug symbols (the disasm can't tell where code ends and data
-/// begins by inspecting bytes alone). Those land when debug
-/// symbols ship — for v0.1 we test the pure-code case only.
+/// begins by inspecting bytes alone). Until debug-symbol-aware
+/// disassembly ships, we test the pure-code case only.
 const std = @import("std");
 const gero = @import("gero");
 const examples = @import("examples");

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -116,7 +116,7 @@ test "opcodes: unused byte values are null" {
 }
 
 test "opcodes: schema sizes never overflow a u8 instruction" {
-    // No instruction in v0.1 is wider than 5 bytes.
+    // No instruction in the ISA is wider than 5 bytes.
     for (table) |entry| {
         if (entry) |info| try std.testing.expect(info.size() <= 5);
     }


### PR DESCRIPTION
Closes #127.

## Summary

Same cleanup pass as #167 (which stripped `v0.X` / Roadmap framing from `docs/` + `README.md`), now applied to the source tree. The no-versioning rule applies to:

- `///` doc comments
- `//` inline comments
- User-facing error message strings

> Describe what works today, factually. Doc comments are not a changelog and not a roadmap. Per-feature 'v0.X / Phase Y / Roadmap:' framing has no place in `src/`.

## Scope

22 mentions stripped across `src/` + `apps/` + `tests/`, plus 4 user-facing error strings:

| Surface | Files | Hits |
|---------|-------|------|
| `src/` doc comments | asm/codegen, asm/parser, asm/ast (×2), asm/opcode_resolver (×4), asm/printer, disasm/decoder, disasm/header (×3), disasm/printer (×2), vm/loader | 17 |
| `apps/` doc comments + error strings + comments | build.zig (×2), check.zig (×2), cli.zig, fmt.zig (×2), init.zig, new.zig, project.zig (×6) | 15 |
| `tests/` test names + comments | asm/lexer, disasm/decoder, disasm/printer, disasm/roundtrip, vm/opcodes | 5 |

## Notable rewrites

- **User-facing error strings** (visible on stderr) like `'.gr support lands in v0.3 (gero-lang front-end)'` → `'.gr support is not yet implemented (waits on the gero-lang front-end)'`. Factual + no version pin that goes stale.
- **`disasm/header.zig`**: `'Cart version (0x0001 for v0.1)'` → `'Bytecode format version — currently 0x0001'`. The literal field value is the concrete fact; the `v0.1` attribution was incidental noise.
- **`opcode_resolver.zig`**: `'(peephole optimization — shipped from v0.2 onward)'` → `'peephole optimization, transparent to the user'`. History attribution belongs in CHANGELOG / commit log, not in source-code doc comments.

## Drive-by — #127 public-API doc-comment audit

`src/gero.zig` pub `asm_` doc said `'Scaffold; real parser / codegen lands in follow-up PRs'`. Drift — the asm has shipped parser + codegen + opcode resolver for many releases. Updated to factual:

```zig
/// Assembler — text `.gas` source → `.gx` bytecode. Re-exports
/// `parse` / `assemble`, the `ParseTree` / `Codegen` types, and
/// `ErrorCode` (asm spec §7).
pub const asm_ = @import("asm.zig");
```

## #127 README updates — already covered

The #127 issue body called for `gero check` / `gero fmt` in the "What's here" table + `asm-cookbook.md` / `tooling.md` in "Learn more". Both were already done by #167 — verified in the current README. The "What's new in v0.2 callout" part of the issue is explicitly violated by our no-versioning rule; not adding it.

## Test plan

- [x] `zig build ci` clean locally (lint + strict + mirror + naming + imports + test-modes + test-all + check-examples + check-broken + fmt-check-examples + test-examples).
- [x] Verification grep: `grep -rn 'v0\\.[0-9]\\|v1\\.0\\|Phase [0-9]\\|Roadmap\\|TBD' src apps tests` returns zero hits.

## Self-review

- ✅ AC re-read: every `v0.X` mention in `src/` / `apps/` / `tests/` either stripped or rewritten as factual prose.
- ✅ `zig build ci` green
- ✅ Public API impact: doc-comment only — no signatures changed.
- ✅ Changeset: not needed (`docs`-scoped PR per CLAUDE.md skip list).
- ✅ Hygiene: no AI attribution, conventional-commit scope `docs`.