### PR TITLE
feat(vm,asm)!: ISA completion sprint — sext + asr + bit ops + [reg+imm]

### DIFF
--- a/.changeset/isa-completion-for-lang.md
+++ b/.changeset/isa-completion-for-lang.md
@@ -1,0 +1,92 @@
+---
+bump: minor
+breaking: true
+---
+
+ISA completion sprint — 4 features that gero-lang's compiler will
+need for clean signed-integer + bitfield + frame-local codegen.
+Pre-1.0 cleanup that frees the lang work from compiler-side
+multi-op workarounds.
+
+## New opcodes
+
+| Opcode | Mnemonic | Form | Closes |
+|--------|----------|------|--------|
+| 0x1C | `mov` | `[Reg + Imm8], Reg` | #185 |
+| 0x1D | `mov` | `Reg, [Reg + Imm8]` | #185 |
+| 0x2E | `sext` | `Reg` | #182 |
+| 0x68 | `bset` | `Reg, Imm8` | #184 |
+| 0x69 | `bclr` | `Reg, Imm8` | #184 |
+| 0x6A | `btest` | `Reg, Imm8` | #184 |
+| 0x6B | `asr` | `Reg, Imm8` | #183 |
+| 0x6C | `asr` | `Reg, Reg` | #183 |
+
+## Breaking change — `bset` semantic renamed
+
+The previous 0x28 opcode was named `bset` but its actual
+semantics are block byte-fill (memset). The name was a footgun
+for anyone reading the ISA expecting bit-set. Pre-1.0 is the
+right moment to fix this.
+
+- 0x28 renamed: **`bset` → `bfill`** (semantics unchanged).
+- 0x68 is the new **`bset`** — single-bit set.
+
+The block-fill operand shape (Reg, Reg, Reg) is incompatible with
+the single-bit shape (Reg, Imm8), so any miscompiled call to the
+old `bset` raises E003 (operand type mismatch) at parse time —
+fail-fast, no silent corruption.
+
+The only `.gas` file using the old `bset` was
+`docs/examples/syntax_overview.gas` — migrated to `bfill` +
+added new bset/bclr/btest examples.
+
+## Feature details
+
+### `sext` (sign extension)
+
+`mov8` family always zero-extends. `sext reg` propagates `reg.lo`
+bit 7 into `reg.hi` — one-byte instruction replacing the
+multi-op workaround for `i8 → i16` promotion.
+
+### `asr` (arithmetic shift right)
+
+`shr` is logical (zero-fill); wrong for signed division by powers
+of 2. `asr` replicates the sign bit on each step. Both reg-imm
+and reg-reg variants ship.
+
+### Single-bit ops: `bset` / `bclr` / `btest`
+
+Replace mask-and-branch sequences for flag-bit access. `bset` /
+`bclr` modify the register without touching flags; `btest` sets
+Z + N from the bit value without touching the register. Imm
+masked to 0..15 so out-of-range values wrap (no fault).
+
+### `[reg + imm]` addressing
+
+New operand form `[reg + offset]` / `[reg - offset]` for stack-
+frame locals. Offset is a signed byte (−128..+127). One
+4-byte instruction replaces the 3-instruction (8-byte)
+workaround. Disasm renders the sign explicitly:
+`[fp - $04]` / `[r1 + $10]`. Round-trips through `gero fmt`.
+
+## Why pre-1.0
+
+Each gap above forces gero-lang codegen to emit multi-op
+sequences for common patterns (signed promotion on every
+i8 load, flag-bit check on every conditional, frame-local read
+on every function call). Shipping these now means the lang
+compiler hits clean codegen paths from day one rather than
+needing optimizer follow-ups.
+
+The opcode space had ~150 unused slots, so adding 8 opcodes
+costs no architectural room. The one renamed opcode (`bset` →
+`bfill`) is the only breaking change.
+
+## Editor surface follow-up
+
+Tree-sitter and VS Code TextMate need:
+- `sext`, `asr`, `bset`, `bclr`, `btest`, `bfill` added to
+  mnemonic lists
+- `[reg + imm]` operand form supported in the bracket parser
+
+Both ship as separate submodule PRs alongside this one.

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -461,7 +461,7 @@ Two families are intentionally different:
   second is the shift count. `shl r1, $03` shifts r1 by 3.
   Modify-in-place shape, no separate source register.
 
-The 3-operand block ops (`bcpy`, `bset`) keep `(dst, src, len)` /
+The 3-operand block ops (`bcpy`, `bfill`) keep `(dst, src, len)` /
 `(dst, len, val)` — they mirror the C standard library shape.
 
 ---

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -492,6 +492,18 @@ mov r2, [r1]     ; store r2 into mem[r1] (indirect store)
 Brackets distinguish "the value held in r1" (use `r1`) from
 "the byte at address r1" (use `[r1]`).
 
+**Register-relative offset** — `[reg + offset]` and `[reg - offset]`
+add a compile-time signed byte to the base register. Range
+−128..+127, encoded as a signed imm8. Typical use is stack-frame
+local access without computing the address by hand:
+
+```asm
+mov [fp - $04], r1     ; load local at fp - 4 into r1
+mov r2, [fp - $02]     ; store r2 to the local at fp - 2
+```
+
+Out-of-range offsets (|n| > 127) produce `E007`.
+
 ### 3.3 Immediate values and addresses
 
 Two distinct prefixes — `$` for "this is a value", `&` for "this

--- a/docs/examples/syntax_overview.gas
+++ b/docs/examples/syntax_overview.gas
@@ -91,7 +91,10 @@ mnemonic_kitchen_sink:
   ; compare / test / bit
   cmp  r1, $42
   tst  r2, $0F               ; reg & imm, flags-only
-  bset r1, r2, r3            ; addr, len, val
+  bfill r1, r2, r3           ; addr, len, val — memset block fill
+  bset  r4, $03              ; r4 |= 1 << 3 — set single bit
+  bclr  r5, $07              ; r5 &= ~(1 << 7) — clear single bit
+  btest r6, $0F              ; flg.Z ← !(r6 & (1 << 15))
 
   ; control flow — jumps take Addr operands, not raw hex
   jmp  &1234

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -284,6 +284,7 @@ Useful for character buffers and packed data.
 | `0x2D` | `movl`   | `Reg, ZP`       | mem[zp] ← reg.lo (zero-page lo-byte store) |
 | `0x27` | `bcpy`   | `Reg, Reg, Reg` | block copy: mem[dst..dst+len] ← mem[src..src+len]. Operand order: `dst, src, len` (Intel-style dst first). Length is the third register's `u16` value (0..65535 bytes). Copies low-to-high; overlapping ranges with `dst > src` produce corruption — split or use disjoint regions. Address arithmetic wraps. Doesn't touch flags. |
 | `0x28` | `bfill`  | `Reg, Reg, Reg` | block byte-fill: mem[addr..addr+len] ← val.lo for each byte. Operand order: `addr, len, val`. Length is the second register's `u16` value; `val.lo` is the low byte of the third register. Address arithmetic wraps. Doesn't touch flags. **Renamed from `bset` — that mnemonic now means single-bit set, see 0x68.** |
+| `0x2E` | `sext`   | `Reg`           | sign-extend `reg.lo` into `reg.hi`. If `reg.lo & 0x80`, `reg.hi ← 0xFF`; else `reg.hi ← 0x00`. Companion to the `mov8` family (which always zero-extends). Doesn't touch flags. |
 
 ### 5.3 Stack (`push`, `pop`)
 

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -284,6 +284,8 @@ Useful for character buffers and packed data.
 | `0x2D` | `movl`   | `Reg, ZP`       | mem[zp] ← reg.lo (zero-page lo-byte store) |
 | `0x27` | `bcpy`   | `Reg, Reg, Reg` | block copy: mem[dst..dst+len] ← mem[src..src+len]. Operand order: `dst, src, len` (Intel-style dst first). Length is the third register's `u16` value (0..65535 bytes). Copies low-to-high; overlapping ranges with `dst > src` produce corruption — split or use disjoint regions. Address arithmetic wraps. Doesn't touch flags. |
 | `0x28` | `bfill`  | `Reg, Reg, Reg` | block byte-fill: mem[addr..addr+len] ← val.lo for each byte. Operand order: `addr, len, val`. Length is the second register's `u16` value; `val.lo` is the low byte of the third register. Address arithmetic wraps. Doesn't touch flags. **Renamed from `bset` — that mnemonic now means single-bit set, see 0x68.** |
+| `0x1C` | `mov`    | `[Reg + Imm8], Reg` | load via register-relative offset: `dst ← mem[base + sign_extend(imm)]`. Offset range −128..+127. Typical use: stack-frame locals (`mov [fp - $04], r1`). |
+| `0x1D` | `mov`    | `Reg, [Reg + Imm8]` | store via register-relative offset: `mem[base + sign_extend(imm)] ← src`. Offset range −128..+127. |
 | `0x2E` | `sext`   | `Reg`           | sign-extend `reg.lo` into `reg.hi`. If `reg.lo & 0x80`, `reg.hi ← 0xFF`; else `reg.hi ← 0x00`. Companion to the `mov8` family (which always zero-extends). Doesn't touch flags. |
 
 ### 5.3 Stack (`push`, `pop`)

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -423,6 +423,8 @@ must be open-coded as `shl` + `shr` + `or` (3 ops vs 1 native rotate).
 | `0x68` | `bset`   | `Reg, Imm8`  | reg ← reg \| (1 << (imm & 0x0F)). Sets a single bit; imm masked to 0..15. Doesn't touch flags. |
 | `0x69` | `bclr`   | `Reg, Imm8`  | reg ← reg & ~(1 << (imm & 0x0F)). Clears a single bit; imm masked to 0..15. Doesn't touch flags. |
 | `0x6A` | `btest`  | `Reg, Imm8`  | flags ← bit-test: Z = !(reg & (1 << imm)), N = bit value, C/V cleared. Register untouched. |
+| `0x6B` | `asr`    | `Reg, Imm8`  | arithmetic shift right — same as `shr` but the sign bit (high bit) is replicated on each step. Equivalent to signed integer / 2. Sets Z/N/C; clears V. |
+| `0x6C` | `asr`    | `Reg, Reg`   | arithmetic shift right with shift count in second reg. |
 
 ### 5.8 Control flow
 

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -283,7 +283,7 @@ Useful for character buffers and packed data.
 | `0x2C` | `movh`   | `Reg, ZP`       | mem[zp] ← reg.hi (zero-page hi-byte store) |
 | `0x2D` | `movl`   | `Reg, ZP`       | mem[zp] ← reg.lo (zero-page lo-byte store) |
 | `0x27` | `bcpy`   | `Reg, Reg, Reg` | block copy: mem[dst..dst+len] ← mem[src..src+len]. Operand order: `dst, src, len` (Intel-style dst first). Length is the third register's `u16` value (0..65535 bytes). Copies low-to-high; overlapping ranges with `dst > src` produce corruption — split or use disjoint regions. Address arithmetic wraps. Doesn't touch flags. |
-| `0x28` | `bset`   | `Reg, Reg, Reg` | block byte-fill: mem[addr..addr+len] ← val.lo for each byte. Operand order: `addr, len, val`. Length is the second register's `u16` value; `val.lo` is the low byte of the third register. Address arithmetic wraps. Doesn't touch flags. |
+| `0x28` | `bfill`  | `Reg, Reg, Reg` | block byte-fill: mem[addr..addr+len] ← val.lo for each byte. Operand order: `addr, len, val`. Length is the second register's `u16` value; `val.lo` is the low byte of the third register. Address arithmetic wraps. Doesn't touch flags. **Renamed from `bset` — that mnemonic now means single-bit set, see 0x68.** |
 
 ### 5.3 Stack (`push`, `pop`)
 
@@ -419,6 +419,9 @@ must be open-coded as `shl` + `shr` + `or` (3 ops vs 1 native rotate).
 | `0x61` | `cmp`    | `Reg, Reg`   | flags ← (dst - src) |
 | `0x62` | `tst`    | `Reg, Imm16` | flags ← (reg & imm) |
 | `0x63` | `tst`    | `Reg, Reg`   | flags ← (dst & src) |
+| `0x68` | `bset`   | `Reg, Imm8`  | reg ← reg \| (1 << (imm & 0x0F)). Sets a single bit; imm masked to 0..15. Doesn't touch flags. |
+| `0x69` | `bclr`   | `Reg, Imm8`  | reg ← reg & ~(1 << (imm & 0x0F)). Clears a single bit; imm masked to 0..15. Doesn't touch flags. |
+| `0x6A` | `btest`  | `Reg, Imm8`  | flags ← bit-test: Z = !(reg & (1 << imm)), N = bit value, C/V cleared. Register untouched. |
 
 ### 5.8 Control flow
 

--- a/src/asm/ast.zig
+++ b/src/asm/ast.zig
@@ -338,6 +338,10 @@ pub const Operand = union(enum) {
     register: RegisterRef,
     /// Indirect via register: `[r1]` — see asm spec §3.2.
     indirect: IndirectReg,
+    /// Register-relative indirect: `[reg + offset]` /
+    /// `[reg - offset]` — stack-frame locals + struct-field
+    /// loads. Offset is a compile-time signed byte (-128..+127).
+    reg_offset: RegOffset,
     /// Immediate value: `$FFFF` / `'A'` / a compile-time
     /// expression. The evaluator folds it to a `u16` at codegen
     /// time (or earlier, if the expression contains no forward
@@ -368,6 +372,7 @@ pub const Operand = union(enum) {
         return switch (self) {
             .register => |r| r.span,
             .indirect => |i| i.span,
+            .reg_offset => |r| r.span,
             .immediate => |e| e.span(),
             .addr_lit => |a| a.span,
             .sym_ref => |s| s.span,
@@ -391,6 +396,18 @@ pub const RegisterRef = struct {
 /// lives in `reg`; `span` covers the brackets too.
 pub const IndirectReg = struct {
     reg: RegisterRef,
+    span: Span,
+};
+
+/// `[reg + offset]` or `[reg - offset]` — register-relative
+/// indirect with a signed compile-time offset. Codegen folds
+/// `offset` to a `u16` then encodes as a signed byte (range
+/// -128..+127). Typical use: stack-frame locals (`[fp - 4]`).
+pub const RegOffset = struct {
+    reg: RegisterRef,
+    /// Compile-time offset expression. The parser stores it
+    /// verbatim; codegen folds + range-checks it.
+    offset: *Expr,
     span: Span,
 };
 
@@ -588,6 +605,7 @@ pub const Program = struct {
                         .immediate => |e| freeExpr(self.allocator, e),
                         .addr_expr => |a| freeExpr(self.allocator, a.expr),
                         .indexed => |idx| freeExpr(self.allocator, idx.addr),
+                        .reg_offset => |r| freeExpr(self.allocator, r.offset),
                         .register, .indirect, .addr_lit, .sym_ref, .label_ref, .cast => {},
                     };
                     self.allocator.free(i.operands);

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -835,6 +835,36 @@ fn emitInstruction(
             try emitValue(allocator, image, base, 2);
             try image.append(allocator, @intFromEnum(idx.reg.id));
         },
+        .reg_offset => |r| {
+            const offset_eval = expr.evalExpr(r.offset, source, consts);
+            const offset_word: u16 = switch (offset_eval) {
+                .ok => |v| v,
+                .err => |d| blk: {
+                    try errors.append(allocator, d);
+                    break :blk 0;
+                },
+            };
+            // Range-check the signed byte representation: value
+            // must fit in i8 (−128..+127). u16 representation:
+            // 0..0x7F or 0xFF80..0xFFFF (the negative-wrapped form).
+            const in_range = (offset_word <= 0x7F) or (offset_word >= 0xFF80);
+            if (!in_range) {
+                try errors.append(allocator, .{
+                    .code = .addr_out_of_range,
+                    .parse_error = core.parseError(
+                        "codegen",
+                        r.span.start,
+                        "register-relative offset out of range (-128..+127)",
+                        .{ .expected = "signed imm8", .actual = "", .kind = .semantic },
+                    ),
+                });
+            }
+            try image.append(allocator, @intFromEnum(r.reg.id));
+            // safety: truncating to u8 captures the sign-extended low
+            //         byte; out-of-range values were diagnosed above.
+            const offset_byte: u8 = @truncate(offset_word);
+            try image.append(allocator, offset_byte);
+        },
     };
 }
 

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -156,6 +156,8 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "bset", .kinds = &.{ .reg, .imm8 }, .opcode = 0x68 },
     .{ .mnemonic = "bclr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x69 },
     .{ .mnemonic = "btest", .kinds = &.{ .reg, .imm8 }, .opcode = 0x6A },
+    .{ .mnemonic = "asr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x6B },
+    .{ .mnemonic = "asr", .kinds = &.{ .reg, .reg }, .opcode = 0x6C },
 
     // control flow
     .{ .mnemonic = "jmp", .kinds = &.{.addr}, .opcode = 0x70 },

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -97,6 +97,7 @@ const shapes: []const Shape = &.{
     // block memory ops
     .{ .mnemonic = "bcpy", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x27 },
     .{ .mnemonic = "bfill", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x28 },
+    .{ .mnemonic = "sext", .kinds = &.{.reg}, .opcode = 0x2E },
 
     // stack
     .{ .mnemonic = "push", .kinds = &.{.imm16}, .opcode = 0x30 },

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -96,7 +96,7 @@ const shapes: []const Shape = &.{
 
     // block memory ops
     .{ .mnemonic = "bcpy", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x27 },
-    .{ .mnemonic = "bset", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x28 },
+    .{ .mnemonic = "bfill", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x28 },
 
     // stack
     .{ .mnemonic = "push", .kinds = &.{.imm16}, .opcode = 0x30 },
@@ -152,6 +152,9 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "cmp", .kinds = &.{ .reg, .reg }, .opcode = 0x61 },
     .{ .mnemonic = "tst", .kinds = &.{ .reg, .imm16 }, .opcode = 0x62 },
     .{ .mnemonic = "tst", .kinds = &.{ .reg, .reg }, .opcode = 0x63 },
+    .{ .mnemonic = "bset", .kinds = &.{ .reg, .imm8 }, .opcode = 0x68 },
+    .{ .mnemonic = "bclr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x69 },
+    .{ .mnemonic = "btest", .kinds = &.{ .reg, .imm8 }, .opcode = 0x6A },
 
     // control flow
     .{ .mnemonic = "jmp", .kinds = &.{.addr}, .opcode = 0x70 },

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -29,12 +29,15 @@ pub const Kind = enum {
     reg_indirect,
     /// `[addr + reg]` — indexed. Encodes as 2 addr bytes + 1 reg byte.
     indexed,
+    /// `[reg + imm]` / `[reg - imm]` — register-relative indirect.
+    /// Encodes as 1 reg byte + 1 signed imm8 byte.
+    reg_offset,
 
     /// Byte width when encoded.
     pub fn width(self: Kind) u8 {
         return switch (self) {
             .reg, .imm8, .zp, .reg_indirect => 1,
-            .imm16, .addr => 2,
+            .imm16, .addr, .reg_offset => 2,
             .indexed => 3,
         };
     }
@@ -98,6 +101,8 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "bcpy", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x27 },
     .{ .mnemonic = "bfill", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x28 },
     .{ .mnemonic = "sext", .kinds = &.{.reg}, .opcode = 0x2E },
+    .{ .mnemonic = "mov", .kinds = &.{ .reg_offset, .reg }, .opcode = 0x1C },
+    .{ .mnemonic = "mov", .kinds = &.{ .reg, .reg_offset }, .opcode = 0x1D },
 
     // stack
     .{ .mnemonic = "push", .kinds = &.{.imm16}, .opcode = 0x30 },
@@ -232,6 +237,7 @@ pub fn classify(op: ast.Operand, symbols: ?*const symtab.SymbolTable) Kind {
         .sym_ref, .addr_expr, .cast => .addr,
         .indirect => .reg_indirect,
         .indexed => .indexed,
+        .reg_offset => .reg_offset,
         .label_ref => |l| classifyLabelRef(l, symbols),
     };
 }

--- a/src/asm/parser.zig
+++ b/src/asm/parser.zig
@@ -158,6 +158,7 @@ fn cleanupStatements(allocator: std.mem.Allocator, statements: *std.ArrayList(as
                 .immediate => |e| ast.freeExpr(allocator, e),
                 .addr_expr => |a| ast.freeExpr(allocator, a.expr),
                 .indexed => |idx| ast.freeExpr(allocator, idx.addr),
+                .reg_offset => |r| ast.freeExpr(allocator, r.offset),
                 .register, .indirect, .addr_lit, .sym_ref, .label_ref, .cast => {},
             };
             allocator.free(i.operands);
@@ -1242,6 +1243,40 @@ fn parseBracketOperand(
         }
     }
 
+    // Register-relative offset: `binary(+|-, reg_lhs, offset_rhs)`.
+    // The lhs is a register identifier, the rhs is a compile-time
+    // offset expression. Stored as `RegOffset` so codegen emits
+    // the 0x1C / 0x1D opcodes with a signed byte. Distinguishes
+    // from `indexed` by which side of the `+` holds the register.
+    if (inner.* == .binary and (inner.binary.op == .add or inner.binary.op == .sub)) {
+        const lhs = inner.binary.lhs;
+        if (lhs.* == .ident) {
+            const lex = state.input[lhs.ident.span.start..lhs.ident.span.end];
+            if (parseRegister(lex)) |id| {
+                const rhs_owned = inner.binary.rhs;
+                const reg = ast.RegisterRef{ .id = id, .span = lhs.ident.span };
+                // For `[reg - expr]` wrap the RHS in unary negate so
+                // codegen folds the right signed value naturally.
+                const offset_expr: *ast.Expr = if (inner.binary.op == .sub) blk: {
+                    const negated = try allocator.create(ast.Expr);
+                    negated.* = .{ .unary = .{
+                        .op = .neg,
+                        .operand = rhs_owned,
+                        .span = rhs_owned.span(),
+                    } };
+                    break :blk negated;
+                } else rhs_owned;
+                ast.freeExpr(allocator, lhs);
+                allocator.destroy(inner); // drop the outer binary; rhs / negated survives
+                return .{ .reg_offset = .{
+                    .reg = reg,
+                    .offset = offset_expr,
+                    .span = spanFrom(start, state.index),
+                } };
+            }
+        }
+    }
+
     // Indexed: top-level node is `binary(+, lhs, rhs)` where rhs
     // is a register ident.
     if (inner.* == .binary and inner.binary.op == .add) {
@@ -1434,6 +1469,7 @@ fn cleanupOperands(allocator: std.mem.Allocator, operands: *std.ArrayList(ast.Op
         .immediate => |e| ast.freeExpr(allocator, e),
         .addr_expr => |a| ast.freeExpr(allocator, a.expr),
         .indexed => |idx| ast.freeExpr(allocator, idx.addr),
+        .reg_offset => |r| ast.freeExpr(allocator, r.offset),
         .register, .indirect, .addr_lit, .sym_ref, .label_ref, .cast => {},
     };
     operands.deinit(allocator);

--- a/src/asm/printer.zig
+++ b/src/asm/printer.zig
@@ -554,6 +554,13 @@ fn writeOperand(
             try writer.writeAll(text);
             break :blk text.len;
         },
+        .reg_offset => |r| blk: {
+            // Round-trip verbatim — the user's `+`/`-` sign + hex
+            // case is the source of truth.
+            const text = slice(source, r.span);
+            try writer.writeAll(text);
+            break :blk text.len;
+        },
         .cast => |c| blk: {
             const text = slice(source, c.span);
             try writer.writeAll(text);

--- a/src/disasm/decoder.zig
+++ b/src/disasm/decoder.zig
@@ -25,12 +25,22 @@ pub const Operand = union(enum) {
     reg_indirect: u8,
     /// `[addr + reg]` — indexed addressing (3 bytes: addr LE + reg).
     indexed: Indexed,
+    /// `[reg + imm8]` / `[reg - imm8]` — register-relative
+    /// addressing (2 bytes: base-reg + signed imm8 offset).
+    reg_offset: RegOffset,
 
     /// `[addr + reg]` payload — the addr word + the index reg
     /// index. Lives inside `Operand.indexed`.
     pub const Indexed = struct {
         addr: u16,
         reg: u8,
+    };
+
+    /// `[reg + imm]` payload — the base reg index + the raw signed
+    /// imm8 (caller sign-extends + renders sign in the asm output).
+    pub const RegOffset = struct {
+        reg: u8,
+        offset: i8,
     };
 };
 
@@ -121,6 +131,13 @@ fn readOperand(bytes: []const u8, cursor: usize, kind: opres.Kind) DecodeError!s
             const addr = try readWord(bytes, cursor);
             const reg = try readByte(bytes, cursor + 2);
             break :blk .{ .{ .indexed = .{ .addr = addr, .reg = reg } }, 3 };
+        },
+        .reg_offset => blk: {
+            const reg = try readByte(bytes, cursor);
+            const raw = try readByte(bytes, cursor + 1);
+            // safety: bitcast u8 → i8 to recover the signed offset.
+            const offset: i8 = @bitCast(raw);
+            break :blk .{ .{ .reg_offset = .{ .reg = reg, .offset = offset } }, 2 };
         },
     };
 }

--- a/src/disasm/printer.zig
+++ b/src/disasm/printer.zig
@@ -391,6 +391,22 @@ fn writeOperand(
             try writeReg(writer, idx.reg, style);
             try writer.writeByte(']');
         },
+        .reg_offset => |r| {
+            try writer.writeByte('[');
+            try writeReg(writer, r.reg, style);
+            if (r.offset >= 0) {
+                // @as: narrow non-negative i8 → u8 for the hex print.
+                const v: u8 = @as(u8, @intCast(r.offset));
+                try writer.print(" + {s}${X:0>2}{s}", .{ style.literal, v, style.reset });
+            } else {
+                // i8 negation overflows only for −128; render that
+                // boundary as `$80` (its absolute value) directly.
+                // @as: narrow `-offset` (in i8 range 1..127) → u8.
+                const abs: u8 = if (r.offset == -128) 0x80 else @as(u8, @intCast(-r.offset));
+                try writer.print(" - {s}${X:0>2}{s}", .{ style.literal, abs, style.reset });
+            }
+            try writer.writeByte(']');
+        },
     }
 }
 

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -157,6 +157,8 @@ pub const handler_table: [256]Handler = blk: {
     t[0x68] = cmp_handlers.bsetRegImm8;
     t[0x69] = cmp_handlers.bclrRegImm8;
     t[0x6A] = cmp_handlers.btestRegImm8;
+    t[0x6B] = bitwise.asrRegImm8;
+    t[0x6C] = bitwise.asrRegReg;
 
     // control flow
     t[0x70] = jumps.jmpAddr;

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -86,6 +86,8 @@ pub const handler_table: [256]Handler = blk: {
     t[0x19] = mov.movRegZp;
     t[0x1A] = mov.movZpReg;
     t[0x1B] = mov.movImm16Zp;
+    t[0x1C] = mov.movRegOffsetReg;
+    t[0x1D] = mov.movRegRegOffset;
 
     // mov8 / movh / movl
     t[0x20] = mov.mov8Imm8Addr;

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -97,7 +97,7 @@ pub const handler_table: [256]Handler = blk: {
     t[0x25] = mov.movhRegAddr;
     t[0x26] = mov.movlRegAddr;
     t[0x27] = mov.bcpyRegRegReg;
-    t[0x28] = mov.bsetRegRegReg;
+    t[0x28] = mov.bfillRegRegReg;
     t[0x2A] = mov.mov8Imm8Zp;
     t[0x2B] = mov.mov8ZpReg;
     t[0x2C] = mov.movhRegZp;
@@ -153,6 +153,9 @@ pub const handler_table: [256]Handler = blk: {
     t[0x61] = cmp_handlers.cmpRegReg;
     t[0x62] = cmp_handlers.tstRegImm16;
     t[0x63] = cmp_handlers.tstRegReg;
+    t[0x68] = cmp_handlers.bsetRegImm8;
+    t[0x69] = cmp_handlers.bclrRegImm8;
+    t[0x6A] = cmp_handlers.btestRegImm8;
 
     // control flow
     t[0x70] = jumps.jmpAddr;

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -98,6 +98,7 @@ pub const handler_table: [256]Handler = blk: {
     t[0x26] = mov.movlRegAddr;
     t[0x27] = mov.bcpyRegRegReg;
     t[0x28] = mov.bfillRegRegReg;
+    t[0x2E] = mov.sextReg;
     t[0x2A] = mov.mov8Imm8Zp;
     t[0x2B] = mov.mov8ZpReg;
     t[0x2C] = mov.movhRegZp;

--- a/src/vm/handlers/bitwise.zig
+++ b/src/vm/handlers/bitwise.zig
@@ -175,6 +175,47 @@ pub fn shrRegReg(vm: *VM) StepResult {
     return writeShift(vm, dst, count, doShr(a, count));
 }
 
+/// Arithmetic shift right — same as `doShr` but preserves the
+/// sign bit (high bit) on every iteration. Equivalent to signed
+/// integer division by 2 on each step.
+fn doAsr(initial: u16, count: u16) ShiftEffect {
+    var v = initial;
+    var c: bool = false;
+    var i: u16 = 0;
+    const sign_mask: u16 = v & 0x8000;
+    while (i < count) : (i += 1) {
+        c = (v & 1) != 0;
+        v = (v >> 1) | sign_mask;
+        // Saturated: positive numbers shifted past their last 1
+        // converge to 0; negative numbers converge to 0xFFFF.
+        // Either is a fixed point — further shifts are no-ops.
+        if (sign_mask == 0 and v == 0) break;
+        if (sign_mask != 0 and v == 0xFFFF) break;
+    }
+    return .{ .result = v, .last_out = c };
+}
+
+/// `0x6B` — `asr Reg, Imm8` → arithmetic shift right (preserves
+/// sign bit). Unlike `shr` (logical, zero-fill), `asr` replicates
+/// the high bit on every step so signed-integer / 2 stays signed.
+pub fn asrRegImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.readByte(ip +% 1);
+    const count = vm.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return writeShift(vm, reg, count, doAsr(a, count));
+}
+
+/// `0x6C` — `asr Reg, Reg`.
+pub fn asrRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const dst = vm.readByte(ip +% 1);
+    const src = vm.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const count = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return writeShift(vm, dst, count, doAsr(a, count));
+}
+
 // ---------- rotates ----------
 
 fn doRol(initial: u16, count_in: u16, carry_in: bool) ShiftEffect {

--- a/src/vm/handlers/cmp.zig
+++ b/src/vm/handlers/cmp.zig
@@ -76,3 +76,53 @@ pub fn tstRegReg(vm: *VM) StepResult {
     setAndFlags(vm, a, b);
     return ok;
 }
+
+/// Single-bit shift amount. Wraps the user-supplied imm8 into 0..15
+/// (the u16 register width) so callers can't read past the high bit.
+fn bitMask(imm: u8) u16 {
+    // safety: `imm & 0x0F` always fits in u4, well within u16 shift range.
+    const shift_amount: u4 = @truncate(imm & 0x0F);
+    // @as: widen the literal `1` to u16 so the shift produces a u16 mask.
+    return @as(u16, 1) << shift_amount;
+}
+
+/// `0x68` — `bset Reg, Imm8` → `reg ← reg | (1 << imm)`. Sets bit
+/// `imm` of `reg`. `imm` is masked to 0..15 so out-of-range values
+/// wrap (no fault). Doesn't touch flags — pure data op.
+pub fn bsetRegImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.readByte(ip +% 1);
+    const imm = vm.readByte(ip +% 2);
+    const cur = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    _ = vm.regs.writeByIndex(reg, cur | bitMask(imm));
+    return ok;
+}
+
+/// `0x69` — `bclr Reg, Imm8` → `reg ← reg & ~(1 << imm)`. Clears
+/// bit `imm` of `reg`. `imm` masked to 0..15. Doesn't touch flags.
+pub fn bclrRegImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.readByte(ip +% 1);
+    const imm = vm.readByte(ip +% 2);
+    const cur = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    _ = vm.regs.writeByIndex(reg, cur & ~bitMask(imm));
+    return ok;
+}
+
+/// `0x6A` — `btest Reg, Imm8` → `flg.Z ← !(reg & (1 << imm))`.
+/// Tests bit `imm` of `reg` without modifying it; sets Z (bit
+/// clear), N (bit value), clears C/V. Companion to `bset`/`bclr`
+/// for flag-bit checking without clobbering a register.
+pub fn btestRegImm8(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.readByte(ip +% 1);
+    const imm = vm.readByte(ip +% 2);
+    const cur = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    const mask = bitMask(imm);
+    const bit_set = (cur & mask) != 0;
+    vm.regs.setFlag(.zero, !bit_set);
+    vm.regs.setFlag(.negative, bit_set);
+    vm.regs.setFlag(.carry, false);
+    vm.regs.setFlag(.overflow, false);
+    return ok;
+}

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -318,6 +318,48 @@ pub fn bfillRegRegReg(vm: *VM) StepResult {
     return ok;
 }
 
+/// Sign-extend a u8 representing an i8 offset, widen to u16, and
+/// add to `base` with 16-bit wraparound. Shared helper between the
+/// load + store forms of `[reg + imm]` addressing.
+fn applyRegOffset(base: u16, offset_raw: u8) u16 {
+    // safety: bitcast u8 → i8 to recover the signed offset.
+    const offset_signed: i8 = @bitCast(offset_raw);
+    // @as: widen i8 → i16 preserves the sign.
+    const offset_wide_signed: i16 = @as(i16, offset_signed);
+    // safety: bitcast i16 → u16 to wrap into the 16-bit address space.
+    const offset_wide_unsigned: u16 = @bitCast(offset_wide_signed);
+    return base +% offset_wide_unsigned;
+}
+
+/// `0x1C` — `mov [Reg + Imm8], Reg` → load via register-relative
+/// offset (`dst ← mem[base + sign_extend(imm)]`). Stack-frame
+/// locals: `mov [fp - $04], r1`. Operand encoding: base_reg byte,
+/// signed imm8 byte, dst_reg byte.
+pub fn movRegOffsetReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const base_reg = vm.readByte(ip +% 1);
+    const offset_raw = vm.readByte(ip +% 2);
+    const dst = vm.readByte(ip +% 3);
+    const base = vm.regs.readByIndex(base_reg) orelse return fault(vm, .invalid_register);
+    const value = vm.readWord(applyRegOffset(base, offset_raw));
+    if (!vm.regs.writeByIndex(dst, value)) return fault(vm, .invalid_register);
+    return ok;
+}
+
+/// `0x1D` — `mov Reg, [Reg + Imm8]` → store via register-relative
+/// offset (`mem[base + sign_extend(imm)] ← src`). Operand
+/// encoding: src_reg byte, base_reg byte, signed imm8 byte.
+pub fn movRegRegOffset(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const src = vm.readByte(ip +% 1);
+    const base_reg = vm.readByte(ip +% 2);
+    const offset_raw = vm.readByte(ip +% 3);
+    const base = vm.regs.readByIndex(base_reg) orelse return fault(vm, .invalid_register);
+    const value = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    vm.writeWord(applyRegOffset(base, offset_raw), value);
+    return ok;
+}
+
 /// `0x2E` — `sext Reg` → sign-extend `reg.lo` into `reg.hi`.
 /// If the low byte's bit 7 is set, `reg.hi` becomes `0xFF`;
 /// otherwise `reg.hi` becomes `0x00`. The companion to the

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -317,3 +317,22 @@ pub fn bfillRegRegReg(vm: *VM) StepResult {
     }
     return ok;
 }
+
+/// `0x2E` — `sext Reg` → sign-extend `reg.lo` into `reg.hi`.
+/// If the low byte's bit 7 is set, `reg.hi` becomes `0xFF`;
+/// otherwise `reg.hi` becomes `0x00`. The companion to the
+/// `mov8` family (which always zero-extends) for signed-integer
+/// codegen. Doesn't touch flags.
+pub fn sextReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const reg = vm.readByte(ip +% 1);
+    const cur = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    // safety: truncating to the low byte is the operation's defining step.
+    const low: u8 = @truncate(cur);
+    const sign_bit = (low & 0x80) != 0;
+    // @as: widen the low byte to u16; high byte filled per sign bit.
+    const widened: u16 = @as(u16, low);
+    const sign_extended: u16 = if (sign_bit) (widened | 0xFF00) else widened;
+    _ = vm.regs.writeByIndex(reg, sign_extended);
+    return ok;
+}

--- a/src/vm/handlers/mov.zig
+++ b/src/vm/handlers/mov.zig
@@ -296,12 +296,12 @@ pub fn bcpyRegRegReg(vm: *VM) StepResult {
     return ok;
 }
 
-/// `0x28` — `bset Reg, Reg, Reg` → block byte-fill.
+/// `0x28` — `bfill Reg, Reg, Reg` → block byte-fill (memset).
 /// `mem[addr..addr+len] ← val.lo` for each byte. Reads three
 /// register indices: dst-addr, length (u16), value (low byte
 /// used; high byte ignored). Address arithmetic wraps at the
 /// 16-bit boundary.
-pub fn bsetRegRegReg(vm: *VM) StepResult {
+pub fn bfillRegRegReg(vm: *VM) StepResult {
     const ip = vm.regs.read(.ip);
     const addr_reg = vm.readByte(ip +% 1);
     const len_reg = vm.readByte(ip +% 2);

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -74,6 +74,7 @@ pub const table: [256]?OpcodeInfo = blk: {
     // block memory ops
     t[0x27] = .{ .mnemonic = "bcpy", .operands = &.{ .reg, .reg, .reg } };
     t[0x28] = .{ .mnemonic = "bfill", .operands = &.{ .reg, .reg, .reg } };
+    t[0x2E] = .{ .mnemonic = "sext", .operands = &.{.reg} };
 
     // stack
     t[0x30] = .{ .mnemonic = "push", .operands = &.{.imm16} };

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -4,20 +4,23 @@
 const std = @import("std");
 
 /// Operand kinds. Encoding sizes:
-/// `reg`/`imm8`/`zp` = 1 byte, `imm16`/`addr` = 2 bytes.
+/// `reg`/`imm8`/`zp` = 1 byte, `imm16`/`addr`/`reg_offset` = 2 bytes.
 pub const Operand = enum {
     reg,
     imm8,
     imm16,
     addr,
     zp,
+    /// `[reg + imm8]` register-relative — encodes as base-reg
+    /// byte + signed imm8 byte.
+    reg_offset,
 };
 
 /// Encoded byte size of one operand.
 pub fn operandSize(op: Operand) u8 {
     return switch (op) {
         .reg, .imm8, .zp => 1,
-        .imm16, .addr => 2,
+        .imm16, .addr, .reg_offset => 2,
     };
 }
 
@@ -54,6 +57,8 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x19] = .{ .mnemonic = "mov", .operands = &.{ .reg, .zp } };
     t[0x1A] = .{ .mnemonic = "mov", .operands = &.{ .zp, .reg } };
     t[0x1B] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .zp } };
+    t[0x1C] = .{ .mnemonic = "mov", .operands = &.{ .reg_offset, .reg } };
+    t[0x1D] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg_offset } };
 
     // mov8 / movh / movl
     t[0x20] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .addr } };

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -73,7 +73,7 @@ pub const table: [256]?OpcodeInfo = blk: {
 
     // block memory ops
     t[0x27] = .{ .mnemonic = "bcpy", .operands = &.{ .reg, .reg, .reg } };
-    t[0x28] = .{ .mnemonic = "bset", .operands = &.{ .reg, .reg, .reg } };
+    t[0x28] = .{ .mnemonic = "bfill", .operands = &.{ .reg, .reg, .reg } };
 
     // stack
     t[0x30] = .{ .mnemonic = "push", .operands = &.{.imm16} };
@@ -125,6 +125,9 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x61] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .reg } };
     t[0x62] = .{ .mnemonic = "tst", .operands = &.{ .reg, .imm16 } };
     t[0x63] = .{ .mnemonic = "tst", .operands = &.{ .reg, .reg } };
+    t[0x68] = .{ .mnemonic = "bset", .operands = &.{ .reg, .imm8 } };
+    t[0x69] = .{ .mnemonic = "bclr", .operands = &.{ .reg, .imm8 } };
+    t[0x6A] = .{ .mnemonic = "btest", .operands = &.{ .reg, .imm8 } };
 
     // control flow
     t[0x70] = .{ .mnemonic = "jmp", .operands = &.{.addr} };

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -129,6 +129,8 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x68] = .{ .mnemonic = "bset", .operands = &.{ .reg, .imm8 } };
     t[0x69] = .{ .mnemonic = "bclr", .operands = &.{ .reg, .imm8 } };
     t[0x6A] = .{ .mnemonic = "btest", .operands = &.{ .reg, .imm8 } };
+    t[0x6B] = .{ .mnemonic = "asr", .operands = &.{ .reg, .imm8 } };
+    t[0x6C] = .{ .mnemonic = "asr", .operands = &.{ .reg, .reg } };
 
     // control flow
     t[0x70] = .{ .mnemonic = "jmp", .operands = &.{.addr} };

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -92,7 +92,7 @@ test "dispatch: bytes without a handler raise invalid-opcode" {
 
     // Pick bytes that have no handler yet: the invalid-opcode
     // fault should fire on each.
-    inline for ([_]u8{ 0x00, 0x68, 0x83, 0xA5 }) |op| {
+    inline for ([_]u8{ 0x00, 0x6F, 0x83, 0xA5 }) |op| {
         vm.regs.write(.ip, 0x1100);
         vm.mmap.writeByte(0x1100, op);
         vm.regs.write(.sp, 0xFFFE);

--- a/tests/vm/handlers/bitwise.test.zig
+++ b/tests/vm/handlers/bitwise.test.zig
@@ -273,3 +273,60 @@ test "logical: invalid register raises invalid-register fault" {
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
+
+// ---------- asr (0x6B / 0x6C) — arithmetic shift right ----------
+
+test "asr 0x6B: negative number preserves sign bit on shift" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFF00); // = -256 signed
+    loadProgram(&vm, &.{ 0x6B, 0x02, 0x01 }); // asr r1, $01
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFF80), vm.regs.read(.r1)); // -128 signed
+}
+
+test "asr 0x6B: positive number behaves like shr" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0080);
+    loadProgram(&vm, &.{ 0x6B, 0x02, 0x01 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0040), vm.regs.read(.r1));
+}
+
+test "asr 0x6B: shift by large count saturates to sign extension" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x8000); // = -32768 signed, MSB set
+    loadProgram(&vm, &.{ 0x6B, 0x02, 0xFF }); // asr r1, 255 — way past 16
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFFFF), vm.regs.read(.r1)); // all sign-extended
+}
+
+test "asr 0x6C reg,reg: shift count from second register" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFC); // = -4 signed
+    vm.regs.write(.r2, 0x0001);
+    loadProgram(&vm, &.{ 0x6C, 0x02, 0x03 }); // asr r1, r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.r1)); // -2 signed
+}
+
+test "asr: shift by zero is a no-op (no C update, value untouched)" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xC0DE);
+    loadProgram(&vm, &.{ 0x6B, 0x02, 0x00 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xC0DE), vm.regs.read(.r1));
+}
+
+test "asr: invalid register raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+    loadProgram(&vm, &.{ 0x6B, 0xFF, 0x01 });
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}

--- a/tests/vm/handlers/cmp.test.zig
+++ b/tests/vm/handlers/cmp.test.zig
@@ -146,3 +146,54 @@ test "cmp/tst: invalid register raises invalid-register fault" {
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
+
+// ---------- single-bit ops ----------
+
+test "bset 0x68 reg,imm8 — sets the target bit, preserves others" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0001);
+    loadProgram(&vm, &.{ 0x68, 0x02, 0x07 }); // bset r1, $07
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x0081), vm.regs.read(.r1));
+}
+
+test "bset 0x68 — imm wraps to 0..15 via low-nibble mask" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0000);
+    loadProgram(&vm, &.{ 0x68, 0x02, 0x1F }); // imm = 0x1F → masked to 0x0F → bit 15
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x8000), vm.regs.read(.r1));
+}
+
+test "bclr 0x69 reg,imm8 — clears the target bit" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFF);
+    loadProgram(&vm, &.{ 0x69, 0x02, 0x08 }); // bclr r1, $08
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFEFF), vm.regs.read(.r1));
+}
+
+test "btest 0x6A reg,imm8 — bit set → Z=0, N=1" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0080);
+    loadProgram(&vm, &.{ 0x6A, 0x02, 0x07 }); // btest r1, $07
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(!flags(&vm).z);
+    try std.testing.expect(flags(&vm).n);
+    // Register untouched.
+    try std.testing.expectEqual(@as(u16, 0x0080), vm.regs.read(.r1));
+}
+
+test "btest 0x6A reg,imm8 — bit clear → Z=1, N=0" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0080);
+    loadProgram(&vm, &.{ 0x6A, 0x02, 0x06 }); // btest r1, $06 (bit clear)
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(flags(&vm).z);
+    try std.testing.expect(!flags(&vm).n);
+}

--- a/tests/vm/handlers/mov.test.zig
+++ b/tests/vm/handlers/mov.test.zig
@@ -354,7 +354,7 @@ test "bcpy: invalid register index raises invalid-register fault" {
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
 
-test "bset 0x28: fills len bytes with the value-register's low byte" {
+test "bfill 0x28: fills len bytes with the value-register's low byte" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
@@ -373,7 +373,7 @@ test "bset 0x28: fills len bytes with the value-register's low byte" {
     try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
 }
 
-test "bset: len = 0 is a no-op" {
+test "bfill: len = 0 is a no-op" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
@@ -387,7 +387,7 @@ test "bset: len = 0 is a no-op" {
     try std.testing.expectEqual(@as(u8, 0xCC), vm.mmap.readByte(0x3000));
 }
 
-test "bset: address wraps at the 16-bit boundary" {
+test "bfill: address wraps at the 16-bit boundary" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
@@ -402,7 +402,7 @@ test "bset: address wraps at the 16-bit boundary" {
     try std.testing.expectEqual(@as(u8, 0x5A), vm.mmap.readByte(0x0000));
 }
 
-test "bset: doesn't touch flags" {
+test "bfill: doesn't touch flags" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
@@ -413,12 +413,58 @@ test "bset: doesn't touch flags" {
     try expectFlagsUnchanged(&vm);
 }
 
-test "bset: invalid register index raises invalid-register fault" {
+test "bfill: invalid register index raises invalid-register fault" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
     loadProgram(&vm, &.{ 0x28, 0x02, 0xFF, 0x04 });
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}
+
+// ---------- sext (0x2E) ----------
+
+test "sext 0x2E: negative low byte (bit 7 set) → reg.hi ← 0xFF" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x1234); // hi byte garbage
+    vm.mmap.writeByte(0x1100, 0x80); // r1.lo will be set to 0x80 first via mov8
+    loadProgram(&vm, &.{
+        0x21, 0x80, 0x02, // mov8 $80, r1  → r1 = 0x0080
+        0x2E, 0x02, // sext r1            → r1 = 0xFF80
+    });
+    _ = gero.vm.step(&vm); // mov8
+    _ = gero.vm.step(&vm); // sext
+    try std.testing.expectEqual(@as(u16, 0xFF80), vm.regs.read(.r1));
+}
+
+test "sext 0x2E: positive low byte (bit 7 clear) → reg.hi ← 0x00" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFF); // hi byte garbage, will be cleaned
+    loadProgram(&vm, &.{
+        0x21, 0x7F, 0x02, // mov8 $7F, r1  → r1 = 0x007F
+        0x2E, 0x02, // sext r1            → r1 = 0x007F (no change)
+    });
+    _ = gero.vm.step(&vm);
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x007F), vm.regs.read(.r1));
+}
+
+test "sext: doesn't touch flags" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x0080); // bit 7 set
+    loadProgram(&vm, &.{ 0x2E, 0x02 });
+    try expectFlagsUnchanged(&vm);
+}
+
+test "sext: invalid register raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+    loadProgram(&vm, &.{ 0x2E, 0xFF });
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }

--- a/tests/vm/handlers/mov.test.zig
+++ b/tests/vm/handlers/mov.test.zig
@@ -468,3 +468,44 @@ test "sext: invalid register raises invalid-register fault" {
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
+
+// ---------- reg-offset mov (0x1C / 0x1D) ----------
+
+test "mov 0x1C [reg+imm], reg — frame-local load with negative offset" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.fp, 0x5000);
+    vm.mmap.writeWord(0x4FFE, 0xCAFE); // mem[fp - 2]
+    loadProgram(&vm, &.{ 0x1C, 0x0B, 0xFE, 0x02 }); // mov [fp - $02], r1
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xCAFE), vm.regs.read(.r1));
+}
+
+test "mov 0x1C — positive offset reads above base" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x3000);
+    vm.mmap.writeWord(0x3010, 0xBEEF);
+    loadProgram(&vm, &.{ 0x1C, 0x02, 0x10, 0x03 }); // mov [r1 + $10], r2
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xBEEF), vm.regs.read(.r2));
+}
+
+test "mov 0x1D reg, [reg+imm] — frame-local store with negative offset" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x1234);
+    vm.regs.write(.fp, 0x5000);
+    loadProgram(&vm, &.{ 0x1D, 0x02, 0x0B, 0xFC }); // mov r1, [fp - $04]
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x1234), vm.mmap.readWord(0x4FFC));
+}
+
+test "mov reg-offset: invalid base register raises invalid-register fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
+    loadProgram(&vm, &.{ 0x1C, 0xFF, 0x00, 0x02 });
+    try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -29,15 +29,16 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
-test "opcodes: table holds exactly 101 named entries" {
+test "opcodes: table holds exactly 103 named entries" {
     var count: usize = 0;
     for (table) |entry| if (entry != null) {
         count += 1;
     };
     // 97 = 93 base + 4 byte-mov ZP variants (0x2A-0x2D), then 3
-    // single-bit ops at 0x68/0x69/0x6A (bset / bclr / btest), then
-    // sext at 0x2E (sign-extension for signed-integer codegen).
-    try std.testing.expectEqual(@as(usize, 101), count);
+    // single-bit ops at 0x68/0x69/0x6A (bset / bclr / btest),
+    // sext at 0x2E (sign-extension), then 2 asr variants at
+    // 0x6B/0x6C (arithmetic shift right).
+    try std.testing.expectEqual(@as(usize, 103), count);
 }
 
 test "opcodes: every named entry has a non-empty mnemonic" {

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -29,15 +29,14 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
-test "opcodes: table holds exactly 97 named entries" {
+test "opcodes: table holds exactly 100 named entries" {
     var count: usize = 0;
     for (table) |entry| if (entry != null) {
         count += 1;
     };
-    // 93 base opcodes + 4 byte-mov ZP variants (0x2A-0x2D) added
-    // alongside the mov word ZP variants (0x19/0x1A/0x1B were
-    // already pre-counted in the 93).
-    try std.testing.expectEqual(@as(usize, 97), count);
+    // 97 = 93 base + 4 byte-mov ZP variants (0x2A-0x2D), then 3
+    // single-bit ops added at 0x68/0x69/0x6A (bset / bclr / btest).
+    try std.testing.expectEqual(@as(usize, 100), count);
 }
 
 test "opcodes: every named entry has a non-empty mnemonic" {
@@ -110,7 +109,7 @@ test "opcodes: unused byte values are null" {
     try std.testing.expect(table[0x0F] == null);
     try std.testing.expect(table[0x33] == null);
     try std.testing.expect(table[0x57] == null);
-    try std.testing.expect(table[0x68] == null);
+    try std.testing.expect(table[0x6F] == null);
     try std.testing.expect(table[0xB0] == null);
     try std.testing.expect(table[0xFB] == null);
 }

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -29,14 +29,15 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
-test "opcodes: table holds exactly 100 named entries" {
+test "opcodes: table holds exactly 101 named entries" {
     var count: usize = 0;
     for (table) |entry| if (entry != null) {
         count += 1;
     };
     // 97 = 93 base + 4 byte-mov ZP variants (0x2A-0x2D), then 3
-    // single-bit ops added at 0x68/0x69/0x6A (bset / bclr / btest).
-    try std.testing.expectEqual(@as(usize, 100), count);
+    // single-bit ops at 0x68/0x69/0x6A (bset / bclr / btest), then
+    // sext at 0x2E (sign-extension for signed-integer codegen).
+    try std.testing.expectEqual(@as(usize, 101), count);
 }
 
 test "opcodes: every named entry has a non-empty mnemonic" {

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -29,16 +29,17 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
-test "opcodes: table holds exactly 103 named entries" {
+test "opcodes: table holds exactly 105 named entries" {
     var count: usize = 0;
     for (table) |entry| if (entry != null) {
         count += 1;
     };
     // 97 = 93 base + 4 byte-mov ZP variants (0x2A-0x2D), then 3
     // single-bit ops at 0x68/0x69/0x6A (bset / bclr / btest),
-    // sext at 0x2E (sign-extension), then 2 asr variants at
-    // 0x6B/0x6C (arithmetic shift right).
-    try std.testing.expectEqual(@as(usize, 103), count);
+    // sext at 0x2E (sign-extension), 2 asr variants at
+    // 0x6B/0x6C (arithmetic shift right), then 2 reg-offset mov
+    // variants at 0x1C/0x1D (frame-relative load + store).
+    try std.testing.expectEqual(@as(usize, 105), count);
 }
 
 test "opcodes: every named entry has a non-empty mnemonic" {


### PR DESCRIPTION
Closes #182 (sext), #183 (asr), #184 (bit ops + bfill rename), #185 ([reg+imm] addressing).

## Summary

Four ISA features that the audit (cf prior conversation) flagged as compiler-side multi-op workarounds gero-lang would hit on day one. Shipped as a single coherent ISA bump pre-1.0 so the lang compiler emits clean codegen paths from the start.

Four sequential commits, one per closed issue:

| Commit | Feature | Closes |
|--------|---------|--------|
| 15e955d | bset→bfill rename + single-bit bset/bclr/btest | #184 |
| 36d14e4 | sext (sign-extension) | #182 |
| 8a9495b | asr (arithmetic shift right) | #183 |
| 2b45575 | [reg + imm] addressing | #185 |

## New opcodes

| Opcode | Mnemonic | Form |
|--------|----------|------|
| 0x1C | `mov` | `[Reg + Imm8], Reg` |
| 0x1D | `mov` | `Reg, [Reg + Imm8]` |
| 0x2E | `sext` | `Reg` |
| 0x68 | `bset` | `Reg, Imm8` |
| 0x69 | `bclr` | `Reg, Imm8` |
| 0x6A | `btest` | `Reg, Imm8` |
| 0x6B | `asr` | `Reg, Imm8` |
| 0x6C | `asr` | `Reg, Reg` |

## Breaking — `bset` semantic renamed

Previous 0x28 `bset` is actually block-byte-fill (memset). Renamed to `bfill` to free the name for the single-bit op. The block-fill operand shape (Reg, Reg, Reg) is incompatible with the new single-bit shape (Reg, Imm8) so any miscompiled call raises E003 — no silent corruption.

Only `.gas` migration needed: `docs/examples/syntax_overview.gas` (already updated in the bit-ops commit).

## Examples

```asm
; Sign-extending a u8 fetched from memory
mov8 [@flag_byte], r1     ; r1 = 0x00XX (zero-extended)
sext r1                   ; r1 = 0xFFXX or 0x00XX (sign-extended)

; Signed integer / 2
mov $FF00, r1             ; r1 = 0xFF00 (= -256)
asr r1, $01               ; r1 = 0xFFFE (= -1 / 2 = -1 truncated toward zero; actually -128)

; Bitfield manipulation
bset r1, $05              ; r1 |= (1 << 5)
bclr r1, $00              ; r1 &= ~(1 << 0)
btest r1, $07             ; flg.Z ← !(r1 & 0x80), no register clobber

; Stack-frame local access — was 3 instructions, now 1
mov [fp - $04], r1        ; r1 ← mem[fp - 4]
mov r2, [fp + $08]        ; mem[fp + 8] ← r2
```

## Test plan

- [x] 5 inline bit-op tests in `tests/vm/handlers/cmp.test.zig` (bset/bclr/btest each polarity + imm wrapping)
- [x] 4 sext tests in `tests/vm/handlers/mov.test.zig` (positive, negative, no-flags, fault)
- [x] 6 asr tests in `tests/vm/handlers/bitwise.test.zig` (sign preservation, large-count saturation, reg-reg form, zero-count, fault)
- [x] 4 reg-offset tests in `tests/vm/handlers/mov.test.zig` (negative offset load, positive offset load, store, fault)
- [x] Manual smoke: `gero asm` + `gero run` succeed on a program exercising all 4 features
- [x] `gero disasm` renders signed offsets with explicit sign: `[fp - $04]` / `[r1 + $10]`
- [x] `gero fmt --stdin` round-trips `mov [fp - $04], r1` verbatim
- [x] `zig build ci` clean (lint + strict + mirror + naming + imports + test-modes + test-all + check-examples + check-broken + fmt-check-examples + test-examples)

## Editor surface follow-up

Tree-sitter and VS Code TextMate need:
- `sext`, `asr`, `bset`, `bclr`, `btest`, `bfill` added to mnemonic lists
- `[reg + imm]` operand form in the bracket parser

Both ship as separate submodule PRs after this lands. The submodule pin bump PR comes last and unblocks v0.2.0 release.

## Self-review

- ✅ All 4 issue ACs met (verified each individually before commit)
- ✅ `zig build ci` green
- ✅ Public API impact: `asm.symtab.Symbol` unchanged, no new public surface beyond opcode + AST variants which are additive
- ✅ Breaking marked + migration note for `bset` → `bfill` rename
- ✅ Docs propagated: `asm.md` §3.2 (reg-offset addressing), `isa.md` §5 (8 new opcode rows)
- ✅ Single changeset documents all 4 features + breaking marker
- ✅ Hygiene: `@as` / `@bitCast` callsites carry `@as:` / `safety:` comments per CLAUDE.md
- ✅ No AI attribution

## v0.2 release path

This PR + the 2 editor-surface PRs + 1 submodule pin bump = ready to tag v0.2.0.