### PR TITLE
feat(vm,asm)!: ISA repagination — one role per 16-slot page

### DIFF
--- a/.changeset/isa-repagination.md
+++ b/.changeset/isa-repagination.md
@@ -1,0 +1,11 @@
+---
+bump: major
+---
+
+ISA repagination: one 16-slot page per role. All opcode bytes outside the `mov`,
+stack, and primary-arithmetic families are renumbered — logical/bitwise moves to
+`0x6X`, shifts/rotates to `0x7X` (with `asr` reunited with its siblings), `cmp`/`tst`
+to `0x8X`, branches to `0x9X`, subroutines to `0xAX`, flags to `0xBX`, misc to `0xCX`.
+`adc`/`sbc` get a dedicated `0x5X` carry-arithmetic page; `sext` rejoins arithmetic
+at `0x4F`. `Operand` gains `reg_indirect` and `indexed` so the VM schema matches
+the resolver's kind enum — disassembly stops special-casing by opcode byte.

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -541,7 +541,7 @@ time, producing an `Addr` operand the regular mov-with-Addr opcodes
 
 Form **(b)** keeps the register addend at runtime — the assembler
 checks that the rest is a compile-time-resolvable `Addr` and emits
-opcode `0x17` (`mov Addr, Reg, Reg`) with the runtime addend wired
+opcode `0x17` (`mov [Addr + Reg], Reg`) with the runtime addend wired
 to the register index.
 
 #### Casts
@@ -710,8 +710,8 @@ Assembled output (annotated; addresses assume image starts at `0x0000`):
 ```
 0x0000  10 00 00 02      mov $0000, r1     ; r1 = 0  (Imm16 -> Reg)
 0x0004  48 02            inc r1             ; loop:
-0x0006  60 02 10 00      cmp r1, $0010
-0x000A  73 04 00         jne &0004
+0x0006  80 02 10 00      cmp r1, $0010
+0x000A  93 04 00         jne &0004
 0x000D  FF               hlt
 ```
 

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -233,16 +233,39 @@ Operand types:
 The `Schema` column lists operand encoding using a mix of the
 type names from §4 (`Reg`, `Imm8`, `Imm16`, `Addr`) and the asm-
 syntax shorthand for indirect / indexed forms (`[Reg]` for
-`RegIndirect`, `[Addr + Reg]` for `Indexed`). Read left to right
-in asm-source order: `Schema: A, B` means the asm form is
-`mnemonic A, B` (e.g. `mov $00, r1`).
+`RegIndirect`, `[Addr + Reg]` for `Indexed`, `[Reg + Imm8]` for
+`RegOffset`). Read left to right in asm-source order: `Schema:
+A, B` means the asm form is `mnemonic A, B` (e.g. `mov $00, r1`).
 
 Operand order convention:
 
 - **Stores and arithmetic** (`mov`, `add`, `sub`, `mul`, `div`, `adc`, `sbc`, bitwise `and`/`or`/`xor`) — `(src, dst)`. Reads naturally: "add X to r1".
 - **Tests** (`cmp`, `tst`) — `(subject, value)`. Reads naturally: "compare r1 to 42". No destination operand.
 
-### 5.1 Data movement (`mov` family)
+### Pagination — one page, one role
+
+Opcode bytes are organized by 16-slot pages. Each page hosts a
+single role; reading the high nibble of a byte tells you what
+family of instruction you're looking at.
+
+| Page         | Role                                  | §    |
+|--------------|---------------------------------------|------|
+| `0x10-0x1F`  | Mouvement mot (`mov`)                 | 5.1  |
+| `0x20-0x2F`  | Mouvement octet (`mov8`/`movh`/`movl` + block) | 5.2  |
+| `0x30-0x3F`  | Pile (`push` / `pop`)                 | 5.3  |
+| `0x40-0x4F`  | Arithmétique principale               | 5.4  |
+| `0x50-0x5F`  | Arithmétique avec retenue (`adc` / `sbc`) | 5.5 |
+| `0x60-0x6F`  | Bitwise (logique mot + bit ops)       | 5.6  |
+| `0x70-0x7F`  | Décalages / rotations                 | 5.7  |
+| `0x80-0x8F`  | Comparaison (`cmp` / `tst`)           | 5.8  |
+| `0x90-0x9F`  | Branchements (sauts)                  | 5.9  |
+| `0xA0-0xAF`  | Sous-routines (`call` / `ret`)        | 5.10 |
+| `0xB0-0xBF`  | Manipulation de flags                 | 5.11 |
+| `0xC0-0xCF`  | Divers (`swap` / `nop`)               | 5.12 |
+| `0xD0-0xEF`  | **Réservées** pour extensions futures | —    |
+| `0xF0-0xFF`  | Système (`int` / `rti` / `brk` / `hlt`) | 5.13 |
+
+### 5.1 Data movement (`mov` family) — `0x1X`
 
 Every `mov` variant writes the source to the destination without
 affecting flags. Multiple opcodes share the `mov` mnemonic — the
@@ -262,11 +285,14 @@ assembler picks the correct one from operand types.
 | `0x19` | `mov`    | `Reg, ZP`       | mem[zp] ← reg (zero-page store, 1-byte addr) |
 | `0x1A` | `mov`    | `ZP, Reg`       | reg ← mem[zp] (zero-page load) |
 | `0x1B` | `mov`    | `Imm16, ZP`     | mem[zp] ← imm (zero-page immediate store) |
+| `0x1C` | `mov`    | `[Reg + Imm8], Reg` | load via register-relative offset: `dst ← mem[base + sign_extend(imm)]`. Offset range −128..+127. Typical use: stack-frame locals (`mov [fp - $04], r1`). |
+| `0x1D` | `mov`    | `Reg, [Reg + Imm8]` | store via register-relative offset: `mem[base + sign_extend(imm)] ← src`. Offset range −128..+127. |
 
-### 5.2 Byte-sized data movement (`mov8` family)
+### 5.2 Byte-sized data movement (`mov8` family) — `0x2X`
 
 Reads and writes a single byte (low half) instead of the full word.
-Useful for character buffers and packed data.
+Useful for character buffers, packed data, and bulk memory transfers
+(`bcpy` / `bfill`).
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
@@ -275,20 +301,17 @@ Useful for character buffers and packed data.
 | `0x22` | `mov8`   | `Addr, Reg`     | reg.lo ← mem[addr]; reg.hi ← 0 |
 | `0x23` | `mov8`   | `Reg, [Reg]`    | mem[ptr] ← reg.lo |
 | `0x24` | `mov8`   | `[Reg], Reg`    | reg.lo ← mem[ptr]; reg.hi ← 0 |
-| `0x29` | `mov8`   | `[Addr + Reg], Reg` | reg.lo ← mem[addr + idx]; reg.hi ← 0 (byte-level indexed load — useful for stepping through `data8` arrays) |
-| `0x25` | `movh`   | `Reg, Addr`     | mem[addr] ← reg.hi |
-| `0x26` | `movl`   | `Reg, Addr`     | mem[addr] ← reg.lo |
-| `0x2A` | `mov8`   | `Imm8, ZP`      | mem[zp] ← imm (1 byte, zero-page store) |
-| `0x2B` | `mov8`   | `ZP, Reg`       | reg.lo ← mem[zp]; reg.hi ← 0 (zero-page byte load) |
-| `0x2C` | `movh`   | `Reg, ZP`       | mem[zp] ← reg.hi (zero-page hi-byte store) |
-| `0x2D` | `movl`   | `Reg, ZP`       | mem[zp] ← reg.lo (zero-page lo-byte store) |
-| `0x27` | `bcpy`   | `Reg, Reg, Reg` | block copy: mem[dst..dst+len] ← mem[src..src+len]. Operand order: `dst, src, len` (Intel-style dst first). Length is the third register's `u16` value (0..65535 bytes). Copies low-to-high; overlapping ranges with `dst > src` produce corruption — split or use disjoint regions. Address arithmetic wraps. Doesn't touch flags. |
-| `0x28` | `bfill`  | `Reg, Reg, Reg` | block byte-fill: mem[addr..addr+len] ← val.lo for each byte. Operand order: `addr, len, val`. Length is the second register's `u16` value; `val.lo` is the low byte of the third register. Address arithmetic wraps. Doesn't touch flags. **Renamed from `bset` — that mnemonic now means single-bit set, see 0x68.** |
-| `0x1C` | `mov`    | `[Reg + Imm8], Reg` | load via register-relative offset: `dst ← mem[base + sign_extend(imm)]`. Offset range −128..+127. Typical use: stack-frame locals (`mov [fp - $04], r1`). |
-| `0x1D` | `mov`    | `Reg, [Reg + Imm8]` | store via register-relative offset: `mem[base + sign_extend(imm)] ← src`. Offset range −128..+127. |
-| `0x2E` | `sext`   | `Reg`           | sign-extend `reg.lo` into `reg.hi`. If `reg.lo & 0x80`, `reg.hi ← 0xFF`; else `reg.hi ← 0x00`. Companion to the `mov8` family (which always zero-extends). Doesn't touch flags. |
+| `0x25` | `mov8`   | `[Addr + Reg], Reg` | reg.lo ← mem[addr + idx]; reg.hi ← 0 (byte-level indexed load — useful for stepping through `data8` arrays) |
+| `0x26` | `movh`   | `Reg, Addr`     | mem[addr] ← reg.hi |
+| `0x27` | `movl`   | `Reg, Addr`     | mem[addr] ← reg.lo |
+| `0x28` | `mov8`   | `Imm8, ZP`      | mem[zp] ← imm (1 byte, zero-page store) |
+| `0x29` | `mov8`   | `ZP, Reg`       | reg.lo ← mem[zp]; reg.hi ← 0 (zero-page byte load) |
+| `0x2A` | `movh`   | `Reg, ZP`       | mem[zp] ← reg.hi (zero-page hi-byte store) |
+| `0x2B` | `movl`   | `Reg, ZP`       | mem[zp] ← reg.lo (zero-page lo-byte store) |
+| `0x2C` | `bcpy`   | `Reg, Reg, Reg` | block copy: mem[dst..dst+len] ← mem[src..src+len]. Operand order: `dst, src, len` (Intel-style dst first). Length is the third register's `u16` value (0..65535 bytes). Copies low-to-high; overlapping ranges with `dst > src` produce corruption — split or use disjoint regions. Address arithmetic wraps. Doesn't touch flags. |
+| `0x2D` | `bfill`  | `Reg, Reg, Reg` | block byte-fill: mem[addr..addr+len] ← val.lo for each byte. Operand order: `addr, len, val`. Length is the second register's `u16` value; `val.lo` is the low byte of the third register. Address arithmetic wraps. Doesn't touch flags. **Renamed from `bset` — that mnemonic now means single-bit set, see `0x68`.** |
 
-### 5.3 Stack (`push`, `pop`)
+### 5.3 Stack (`push`, `pop`) — `0x3X`
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
@@ -296,11 +319,12 @@ Useful for character buffers and packed data.
 | `0x31` | `push`   | `Reg`   | sp ← sp - 2; mem[sp] ← reg |
 | `0x32` | `pop`    | `Reg`   | reg ← mem[sp]; sp ← sp + 2 |
 
-### 5.4 Arithmetic
+### 5.4 Arithmetic — `0x4X`
 
 All arithmetic ops set `Z`, `N`, `C`, `V` flags (with the documented
 exceptions for `inc` / `dec`). Implicit-`acu` short forms save 1 byte
-over the `Reg, Reg` form.
+over the `Reg, Reg` form. `sext` is the only single-operand op
+beyond `inc` / `dec` / `neg` — sign-extends `reg.lo` into `reg.hi`.
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
@@ -319,23 +343,7 @@ over the `Reg, Reg` form.
 | `0x4C` | `div`    | `Reg, Reg`    | unsigned 32÷16: acu:dst ÷ src → quotient in dst, remainder in acu |
 | `0x4D` | `divs`   | `Imm16, Reg`  | signed 32÷16, same shape as `div` |
 | `0x4E` | `divs`   | `Reg, Reg`    | signed 32÷16, same shape as `div` |
-| `0x64` | `adc`    | `Imm16, Reg`  | reg ← reg + imm + C (add with carry — multi-precision arithmetic) |
-| `0x65` | `adc`    | `Reg, Reg`    | dst ← dst + src + C |
-| `0x66` | `sbc`    | `Imm16, Reg`  | reg ← reg - imm - C (sub with borrow — multi-precision arithmetic) |
-| `0x67` | `sbc`    | `Reg, Reg`    | dst ← dst - src - C |
-
-`adc` / `sbc` are the canonical 6502 / Z80 / 8086 primitive for
-arithmetic wider than the native register width. A 32-bit add via
-two 16-bit registers:
-
-```asm
-add  r1, r3      ; low half ; sets C if overflow
-adc  r2, r4      ; high half + carry-from-low ✨
-```
-
-Same for 32-bit subtraction with `sub` + `sbc`. Without these,
-multi-precision math requires explicit branch-on-carry sequences
-(slower, larger code).
+| `0x4F` | `sext`   | `Reg`         | sign-extend `reg.lo` into `reg.hi`. If `reg.lo & 0x80`, `reg.hi ← 0xFF`; else `reg.hi ← 0x00`. Companion to the `mov8` family (which always zero-extends). Doesn't touch flags. |
 
 `div` / `divs` faults:
 - Divisor is 0 → vector `0x03` (division by zero).
@@ -375,116 +383,144 @@ If profiling later shows fixed-point or saturating math is a real
 hot path, native ops can be added later as an additive minor
 version bump (existing code keeps working).
 
-### 5.5 Logical / bitwise
+### 5.5 Arithmetic carry-propagating (`adc`, `sbc`) — `0x5X`
 
-Set `Z`, `N`. Clear `C`, `V`.
+Add/subtract with carry — the canonical 6502 / Z80 / 8086 primitive
+for arithmetic wider than the native register width.
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
-| `0x50` | `and`    | `Imm16, Reg`  | reg ← reg & imm |
-| `0x51` | `and`    | `Reg, Reg`    | dst ← dst & src |
-| `0x52` | `or`     | `Imm16, Reg`  | reg ← reg \| imm |
-| `0x53` | `or`     | `Reg, Reg`    | dst ← dst \| src |
-| `0x54` | `xor`    | `Imm16, Reg`  | reg ← reg ^ imm |
-| `0x55` | `xor`    | `Reg, Reg`    | dst ← dst ^ src |
-| `0x56` | `not`    | `Reg`         | reg ← ~reg |
+| `0x50` | `adc`    | `Imm16, Reg`  | reg ← reg + imm + C (add with carry — multi-precision arithmetic) |
+| `0x51` | `adc`    | `Reg, Reg`    | dst ← dst + src + C |
+| `0x52` | `sbc`    | `Imm16, Reg`  | reg ← reg - imm - C (sub with borrow — multi-precision arithmetic) |
+| `0x53` | `sbc`    | `Reg, Reg`    | dst ← dst - src - C |
 
-### 5.6 Shifts and rotates
+A 32-bit add via two 16-bit registers:
 
-Shifts: `C` receives the last bit shifted out; `Z`, `N` set on result.
-Rotates: bits cycle **through `C`** (the standard 6502 / Z80 / 8086
+```asm
+add  r1, r3      ; low half ; sets C if overflow
+adc  r2, r4      ; high half + carry-from-low ✨
+```
+
+Same for 32-bit subtraction with `sub` + `sbc`. Without these,
+multi-precision math requires explicit branch-on-carry sequences
+(slower, larger code).
+
+### 5.6 Bitwise — `0x6X`
+
+Word-level logical ops set `Z` and `N`, clear `C` and `V`. Single-bit
+ops (`btest` / `bset` / `bclr`) operate on bit positions 0..15 (`imm`
+is masked to 4 bits) — `bset` / `bclr` don't touch flags, `btest`
+sets `Z` / `N` and clears `C` / `V`.
+
+| Opcode | Mnemonic | Schema | Effect |
+|--------|----------|--------|--------|
+| `0x60` | `and`    | `Imm16, Reg`  | reg ← reg & imm |
+| `0x61` | `and`    | `Reg, Reg`    | dst ← dst & src |
+| `0x62` | `or`     | `Imm16, Reg`  | reg ← reg \| imm |
+| `0x63` | `or`     | `Reg, Reg`    | dst ← dst \| src |
+| `0x64` | `xor`    | `Imm16, Reg`  | reg ← reg ^ imm |
+| `0x65` | `xor`    | `Reg, Reg`    | dst ← dst ^ src |
+| `0x66` | `not`    | `Reg`         | reg ← ~reg |
+| `0x67` | `btest`  | `Reg, Imm8`   | flags ← bit-test: Z = !(reg & (1 << imm)), N = bit value, C/V cleared. Register untouched. |
+| `0x68` | `bset`   | `Reg, Imm8`   | reg ← reg \| (1 << (imm & 0x0F)). Sets a single bit; imm masked to 0..15. Doesn't touch flags. |
+| `0x69` | `bclr`   | `Reg, Imm8`   | reg ← reg & ~(1 << (imm & 0x0F)). Clears a single bit; imm masked to 0..15. Doesn't touch flags. |
+
+### 5.7 Shifts and rotates — `0x7X`
+
+Logical shifts: `C` receives the last bit shifted out; `Z`, `N` set
+on result. Arithmetic shift right (`asr`) replicates the sign bit
+into the high bit on each step — equivalent to signed integer / 2.
+Rotates cycle bits **through `C`** (the standard 6502 / Z80 / 8086
 behavior — `C` is both source for the bit shifted in and destination
 for the bit shifted out, so a 17-bit chain).
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
-| `0x58` | `shl`    | `Reg, Imm8` | reg ← reg << imm (shift left) |
-| `0x59` | `shl`    | `Reg, Reg`  | dst ← dst << src |
-| `0x5A` | `shr`    | `Reg, Imm8` | reg ← reg >> imm (logical shift right; high bit zero-filled) |
-| `0x5B` | `shr`    | `Reg, Reg`  | dst ← dst >> src |
-| `0x5C` | `rol`    | `Reg, Imm8` | rotate left through C (bit_out → C → bit_in) |
-| `0x5D` | `rol`    | `Reg, Reg`  | same with src as count |
-| `0x5E` | `ror`    | `Reg, Imm8` | rotate right through C (bit_out → C → bit_in) |
-| `0x5F` | `ror`    | `Reg, Reg`  | same with src as count |
+| `0x70` | `shl`    | `Reg, Imm8` | reg ← reg << imm (shift left) |
+| `0x71` | `shl`    | `Reg, Reg`  | dst ← dst << src |
+| `0x72` | `shr`    | `Reg, Imm8` | reg ← reg >> imm (logical shift right; high bit zero-filled) |
+| `0x73` | `shr`    | `Reg, Reg`  | dst ← dst >> src |
+| `0x74` | `asr`    | `Reg, Imm8` | arithmetic shift right — sign bit replicated on each step. Sets Z/N/C; clears V. |
+| `0x75` | `asr`    | `Reg, Reg`  | arithmetic shift right with shift count in second reg. |
+| `0x76` | `rol`    | `Reg, Imm8` | rotate left through C (bit_out → C → bit_in) |
+| `0x77` | `rol`    | `Reg, Reg`  | same with src as count |
+| `0x78` | `ror`    | `Reg, Imm8` | rotate right through C (bit_out → C → bit_in) |
+| `0x79` | `ror`    | `Reg, Reg`  | same with src as count |
 
 Rotates are the natural primitive for bit-twiddling (sprite flag
 packing, hash steps, simple permutations). Without them, equivalent
 must be open-coded as `shl` + `shr` + `or` (3 ops vs 1 native rotate).
 
-### 5.7 Compare and test
+### 5.8 Compare and test — `0x8X`
 
 `cmp` computes `dst - src`, sets flags, **discards the result**.
 `tst` computes `dst & src`, sets `Z` and `N`, **discards the result**.
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
-| `0x60` | `cmp`    | `Reg, Imm16` | flags ← (reg - imm) |
-| `0x61` | `cmp`    | `Reg, Reg`   | flags ← (dst - src) |
-| `0x62` | `tst`    | `Reg, Imm16` | flags ← (reg & imm) |
-| `0x63` | `tst`    | `Reg, Reg`   | flags ← (dst & src) |
-| `0x68` | `bset`   | `Reg, Imm8`  | reg ← reg \| (1 << (imm & 0x0F)). Sets a single bit; imm masked to 0..15. Doesn't touch flags. |
-| `0x69` | `bclr`   | `Reg, Imm8`  | reg ← reg & ~(1 << (imm & 0x0F)). Clears a single bit; imm masked to 0..15. Doesn't touch flags. |
-| `0x6A` | `btest`  | `Reg, Imm8`  | flags ← bit-test: Z = !(reg & (1 << imm)), N = bit value, C/V cleared. Register untouched. |
-| `0x6B` | `asr`    | `Reg, Imm8`  | arithmetic shift right — same as `shr` but the sign bit (high bit) is replicated on each step. Equivalent to signed integer / 2. Sets Z/N/C; clears V. |
-| `0x6C` | `asr`    | `Reg, Reg`   | arithmetic shift right with shift count in second reg. |
+| `0x80` | `cmp`    | `Reg, Imm16` | flags ← (reg - imm) |
+| `0x81` | `cmp`    | `Reg, Reg`   | flags ← (dst - src) |
+| `0x82` | `tst`    | `Reg, Imm16` | flags ← (reg & imm) |
+| `0x83` | `tst`    | `Reg, Reg`   | flags ← (dst & src) |
 
-### 5.8 Control flow
+### 5.9 Branches — `0x9X`
 
 Jumps and branches read flags (set by the most recent `cmp` / `tst`
-or any flag-affecting ALU op).
+or any flag-affecting ALU op). The 16 slots are exactly filled.
 
 | Opcode | Mnemonic | Schema | Branch when |
 |--------|----------|--------|-------------|
-| `0x70` | `jmp`    | `Addr` | always |
-| `0x71` | `jmp`    | `Reg`  | always — `ip ← reg` |
-| `0x72` | `jeq`    | `Addr` | `Z = 1` (equal) |
-| `0x73` | `jne`    | `Addr` | `Z = 0` (not equal) |
-| `0x74` | `jlt`    | `Addr` | `N ≠ V` (signed less-than) |
-| `0x75` | `jle`    | `Addr` | `Z = 1 ∨ N ≠ V` (signed less-or-equal) |
-| `0x76` | `jgt`    | `Addr` | `Z = 0 ∧ N = V` (signed greater) |
-| `0x77` | `jge`    | `Addr` | `N = V` (signed greater-or-equal) |
-| `0x78` | `jcc`    | `Addr` | `C = 0` (unsigned less / no carry) |
-| `0x79` | `jcs`    | `Addr` | `C = 1` (unsigned greater-or-equal / carry set) |
-| `0x7A` | `jvc`    | `Addr` | `V = 0` |
-| `0x7B` | `jvs`    | `Addr` | `V = 1` |
-| `0x7C` | `jz`     | `Addr` | `Z = 1` (alias for `jeq`) |
-| `0x7D` | `jnz`    | `Addr` | `Z = 0` (alias for `jne`) |
-| `0x7E` | `djnz`   | `Reg, Addr` | `reg ← reg - 1`; if `reg ≠ 0` then `ip ← addr`. Z80 classic loop primitive. |
-| `0x7F` | `jr`     | `Imm8`      | relative jump: `ip ← ip + signed(imm)` (range −128..+127 from current `ip`). Saves 1 byte vs `jmp Addr` for tight branches. |
+| `0x90` | `jmp`    | `Addr` | always |
+| `0x91` | `jmp`    | `Reg`  | always — `ip ← reg` |
+| `0x92` | `jeq`    | `Addr` | `Z = 1` (equal) |
+| `0x93` | `jne`    | `Addr` | `Z = 0` (not equal) |
+| `0x94` | `jlt`    | `Addr` | `N ≠ V` (signed less-than) |
+| `0x95` | `jle`    | `Addr` | `Z = 1 ∨ N ≠ V` (signed less-or-equal) |
+| `0x96` | `jgt`    | `Addr` | `Z = 0 ∧ N = V` (signed greater) |
+| `0x97` | `jge`    | `Addr` | `N = V` (signed greater-or-equal) |
+| `0x98` | `jcc`    | `Addr` | `C = 0` (unsigned less / no carry) |
+| `0x99` | `jcs`    | `Addr` | `C = 1` (unsigned greater-or-equal / carry set) |
+| `0x9A` | `jvc`    | `Addr` | `V = 0` |
+| `0x9B` | `jvs`    | `Addr` | `V = 1` |
+| `0x9C` | `jz`     | `Addr` | `Z = 1` (alias for `jeq`) |
+| `0x9D` | `jnz`    | `Addr` | `Z = 0` (alias for `jne`) |
+| `0x9E` | `djnz`   | `Reg, Addr` | `reg ← reg - 1`; if `reg ≠ 0` then `ip ← addr`. Z80 classic loop primitive. |
+| `0x9F` | `jr`     | `Imm8`      | relative jump: `ip ← ip + signed(imm)` (range −128..+127 from current `ip`). Saves 1 byte vs `jmp Addr` for tight branches. |
 
-### 5.9 Subroutines
-
-| Opcode | Mnemonic | Schema | Effect |
-|--------|----------|--------|--------|
-| `0x80` | `call`   | `Addr` | push fp; push (ip after-instruction); fp ← sp; ip ← addr |
-| `0x81` | `call`   | `Reg`  | same as above with `ip ← reg` |
-| `0x82` | `ret`    | (none) | sp ← fp; pop ip; pop fp |
-
-### 5.10 Misc
+### 5.10 Subroutines — `0xAX`
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
-| `0x90` | `swap`   | `Reg, Reg` | atomic swap of two registers |
-| `0x91` | `nop`    | (none)     | no operation; advance `ip` by 1 |
+| `0xA0` | `call`   | `Addr` | push fp; push (ip after-instruction); fp ← sp; ip ← addr |
+| `0xA1` | `call`   | `Reg`  | same as above with `ip ← reg` |
+| `0xA2` | `ret`    | (none) | sp ← fp; pop ip; pop fp |
 
-### 5.11 Flag manipulation
+### 5.11 Flag manipulation — `0xBX`
 
 Single-byte ops to toggle individual flag bits — saves the
 `mov flg, r1` + `or r1, mask` + `mov r1, flg` dance (5 bytes → 1).
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
-| `0xA0` | `clc`    | (none) | clear carry: `flg.C ← 0` |
-| `0xA1` | `sec`    | (none) | set carry: `flg.C ← 1` |
-| `0xA2` | `cli`    | (none) | clear interrupt-disable: `flg.I ← 0` (enables IRQs globally) |
-| `0xA3` | `sei`    | (none) | set interrupt-disable: `flg.I ← 1` (blocks IRQs globally) |
-| `0xA4` | `clv`    | (none) | clear overflow: `flg.V ← 0` |
+| `0xB0` | `clc`    | (none) | clear carry: `flg.C ← 0` |
+| `0xB1` | `sec`    | (none) | set carry: `flg.C ← 1` |
+| `0xB2` | `cli`    | (none) | clear interrupt-disable: `flg.I ← 0` (enables IRQs globally) |
+| `0xB3` | `sei`    | (none) | set interrupt-disable: `flg.I ← 1` (blocks IRQs globally) |
+| `0xB4` | `clv`    | (none) | clear overflow: `flg.V ← 0` |
 
 Direct 6502 / 8086 lineage. `cli` / `sei` are essential for ISR
 critical sections; `clc` / `sec` for setting up `adc` / `sbc`
 sequences.
 
-### 5.12 System
+### 5.12 Misc — `0xCX`
+
+| Opcode | Mnemonic | Schema | Effect |
+|--------|----------|--------|--------|
+| `0xC0` | `swap`   | `Reg, Reg` | atomic swap of two registers |
+| `0xC1` | `nop`    | (none)     | no operation; advance `ip` by 1 |
+
+### 5.13 System — `0xFX`
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -984,8 +984,8 @@ fn emitBankPseudo(
     try emitValue(allocator, image, bank_value, 2);
     try image.append(allocator, 0x0C);
 
-    // 2. call/jmp <addr> — opcode 0x80 / 0x70, addr LE.
-    const jump_opcode: u8 = if (std.mem.eql(u8, mnem, "bank_call")) 0x80 else 0x70;
+    // 2. call/jmp <addr> — opcode 0xA0 / 0x90, addr LE.
+    const jump_opcode: u8 = if (std.mem.eql(u8, mnem, "bank_call")) 0xA0 else 0x90;
     try image.append(allocator, jump_opcode);
     try emitValue(allocator, image, sym.value, 2);
 }

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -60,7 +60,7 @@ const max_operands: usize = 3;
 /// first when shapes share a prefix. Mnemonics use lowercase,
 /// matching the lexer.
 const shapes: []const Shape = &.{
-    // mov family
+    // 0x1X — mov word
     .{ .mnemonic = "mov", .kinds = &.{ .imm16, .reg }, .opcode = 0x10 },
     .{ .mnemonic = "mov", .kinds = &.{ .reg, .reg }, .opcode = 0x11 },
     .{ .mnemonic = "mov", .kinds = &.{ .reg, .addr }, .opcode = 0x12 },
@@ -78,38 +78,35 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "mov", .kinds = &.{ .reg, .zp }, .opcode = 0x19 },
     .{ .mnemonic = "mov", .kinds = &.{ .zp, .reg }, .opcode = 0x1A },
     .{ .mnemonic = "mov", .kinds = &.{ .imm16, .zp }, .opcode = 0x1B },
+    .{ .mnemonic = "mov", .kinds = &.{ .reg_offset, .reg }, .opcode = 0x1C },
+    .{ .mnemonic = "mov", .kinds = &.{ .reg, .reg_offset }, .opcode = 0x1D },
 
-    // mov8 / movh / movl
+    // 0x2X — mov byte (mov8 / movh / movl + block memory)
     .{ .mnemonic = "mov8", .kinds = &.{ .imm8, .addr }, .opcode = 0x20 },
     .{ .mnemonic = "mov8", .kinds = &.{ .imm8, .reg }, .opcode = 0x21 },
     .{ .mnemonic = "mov8", .kinds = &.{ .addr, .reg }, .opcode = 0x22 },
     .{ .mnemonic = "mov8", .kinds = &.{ .reg, .reg_indirect }, .opcode = 0x23 },
     .{ .mnemonic = "mov8", .kinds = &.{ .reg_indirect, .reg }, .opcode = 0x24 },
-    .{ .mnemonic = "mov8", .kinds = &.{ .indexed, .reg }, .opcode = 0x29 },
+    .{ .mnemonic = "mov8", .kinds = &.{ .indexed, .reg }, .opcode = 0x25 },
+    .{ .mnemonic = "movh", .kinds = &.{ .reg, .addr }, .opcode = 0x26 },
+    .{ .mnemonic = "movl", .kinds = &.{ .reg, .addr }, .opcode = 0x27 },
     // Zero-page byte-mov variants — picked when an `&XX` value
     // fits in `0..0xFF`. Same peephole pattern as the word ZP
     // forms above; saves 1 byte per access on hot byte globals
     // (per-frame counters, palette indices, scroll positions).
-    .{ .mnemonic = "mov8", .kinds = &.{ .imm8, .zp }, .opcode = 0x2A },
-    .{ .mnemonic = "mov8", .kinds = &.{ .zp, .reg }, .opcode = 0x2B },
-    .{ .mnemonic = "movh", .kinds = &.{ .reg, .addr }, .opcode = 0x25 },
-    .{ .mnemonic = "movh", .kinds = &.{ .reg, .zp }, .opcode = 0x2C },
-    .{ .mnemonic = "movl", .kinds = &.{ .reg, .addr }, .opcode = 0x26 },
-    .{ .mnemonic = "movl", .kinds = &.{ .reg, .zp }, .opcode = 0x2D },
+    .{ .mnemonic = "mov8", .kinds = &.{ .imm8, .zp }, .opcode = 0x28 },
+    .{ .mnemonic = "mov8", .kinds = &.{ .zp, .reg }, .opcode = 0x29 },
+    .{ .mnemonic = "movh", .kinds = &.{ .reg, .zp }, .opcode = 0x2A },
+    .{ .mnemonic = "movl", .kinds = &.{ .reg, .zp }, .opcode = 0x2B },
+    .{ .mnemonic = "bcpy", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x2C },
+    .{ .mnemonic = "bfill", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x2D },
 
-    // block memory ops
-    .{ .mnemonic = "bcpy", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x27 },
-    .{ .mnemonic = "bfill", .kinds = &.{ .reg, .reg, .reg }, .opcode = 0x28 },
-    .{ .mnemonic = "sext", .kinds = &.{.reg}, .opcode = 0x2E },
-    .{ .mnemonic = "mov", .kinds = &.{ .reg_offset, .reg }, .opcode = 0x1C },
-    .{ .mnemonic = "mov", .kinds = &.{ .reg, .reg_offset }, .opcode = 0x1D },
-
-    // stack
+    // 0x3X — stack
     .{ .mnemonic = "push", .kinds = &.{.imm16}, .opcode = 0x30 },
     .{ .mnemonic = "push", .kinds = &.{.reg}, .opcode = 0x31 },
     .{ .mnemonic = "pop", .kinds = &.{.reg}, .opcode = 0x32 },
 
-    // arithmetic
+    // 0x4X — arithmetic primary
     .{ .mnemonic = "add", .kinds = &.{ .imm16, .reg }, .opcode = 0x40 },
     .{ .mnemonic = "add", .kinds = &.{ .reg, .reg }, .opcode = 0x41 },
     .{ .mnemonic = "add", .kinds = &.{.reg}, .opcode = 0x42 },
@@ -125,80 +122,82 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "div", .kinds = &.{ .reg, .reg }, .opcode = 0x4C },
     .{ .mnemonic = "divs", .kinds = &.{ .imm16, .reg }, .opcode = 0x4D },
     .{ .mnemonic = "divs", .kinds = &.{ .reg, .reg }, .opcode = 0x4E },
-    .{ .mnemonic = "adc", .kinds = &.{ .imm16, .reg }, .opcode = 0x64 },
-    .{ .mnemonic = "adc", .kinds = &.{ .reg, .reg }, .opcode = 0x65 },
-    .{ .mnemonic = "sbc", .kinds = &.{ .imm16, .reg }, .opcode = 0x66 },
-    .{ .mnemonic = "sbc", .kinds = &.{ .reg, .reg }, .opcode = 0x67 },
+    .{ .mnemonic = "sext", .kinds = &.{.reg}, .opcode = 0x4F },
 
-    // logical — operand order unified to (src, dst) like every other
-    // store / arith family. Previously the reg-imm variants had `(reg,
-    // imm16)` (dst-first) while the reg-reg variants used `(src, dst)` —
-    // a real internal inconsistency. Asm syntax for reg-imm is now
-    // `and $FF, r1` / `or $FF, r1` / `xor $FF, r1`.
-    .{ .mnemonic = "and", .kinds = &.{ .imm16, .reg }, .opcode = 0x50 },
-    .{ .mnemonic = "and", .kinds = &.{ .reg, .reg }, .opcode = 0x51 },
-    .{ .mnemonic = "or", .kinds = &.{ .imm16, .reg }, .opcode = 0x52 },
-    .{ .mnemonic = "or", .kinds = &.{ .reg, .reg }, .opcode = 0x53 },
-    .{ .mnemonic = "xor", .kinds = &.{ .imm16, .reg }, .opcode = 0x54 },
-    .{ .mnemonic = "xor", .kinds = &.{ .reg, .reg }, .opcode = 0x55 },
-    .{ .mnemonic = "not", .kinds = &.{.reg}, .opcode = 0x56 },
+    // 0x5X — arithmetic carry-propagating
+    .{ .mnemonic = "adc", .kinds = &.{ .imm16, .reg }, .opcode = 0x50 },
+    .{ .mnemonic = "adc", .kinds = &.{ .reg, .reg }, .opcode = 0x51 },
+    .{ .mnemonic = "sbc", .kinds = &.{ .imm16, .reg }, .opcode = 0x52 },
+    .{ .mnemonic = "sbc", .kinds = &.{ .reg, .reg }, .opcode = 0x53 },
 
-    // shifts + rotates
-    .{ .mnemonic = "shl", .kinds = &.{ .reg, .imm8 }, .opcode = 0x58 },
-    .{ .mnemonic = "shl", .kinds = &.{ .reg, .reg }, .opcode = 0x59 },
-    .{ .mnemonic = "shr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x5A },
-    .{ .mnemonic = "shr", .kinds = &.{ .reg, .reg }, .opcode = 0x5B },
-    .{ .mnemonic = "rol", .kinds = &.{ .reg, .imm8 }, .opcode = 0x5C },
-    .{ .mnemonic = "rol", .kinds = &.{ .reg, .reg }, .opcode = 0x5D },
-    .{ .mnemonic = "ror", .kinds = &.{ .reg, .imm8 }, .opcode = 0x5E },
-    .{ .mnemonic = "ror", .kinds = &.{ .reg, .reg }, .opcode = 0x5F },
-
-    // compare / test
-    .{ .mnemonic = "cmp", .kinds = &.{ .reg, .imm16 }, .opcode = 0x60 },
-    .{ .mnemonic = "cmp", .kinds = &.{ .reg, .reg }, .opcode = 0x61 },
-    .{ .mnemonic = "tst", .kinds = &.{ .reg, .imm16 }, .opcode = 0x62 },
-    .{ .mnemonic = "tst", .kinds = &.{ .reg, .reg }, .opcode = 0x63 },
+    // 0x6X — bitwise (logical word ops + single-bit ops).
+    // Operand order unified to (src, dst) like every other store /
+    // arith family — asm syntax for reg-imm is `and $FF, r1` /
+    // `or $FF, r1` / `xor $FF, r1`.
+    .{ .mnemonic = "and", .kinds = &.{ .imm16, .reg }, .opcode = 0x60 },
+    .{ .mnemonic = "and", .kinds = &.{ .reg, .reg }, .opcode = 0x61 },
+    .{ .mnemonic = "or", .kinds = &.{ .imm16, .reg }, .opcode = 0x62 },
+    .{ .mnemonic = "or", .kinds = &.{ .reg, .reg }, .opcode = 0x63 },
+    .{ .mnemonic = "xor", .kinds = &.{ .imm16, .reg }, .opcode = 0x64 },
+    .{ .mnemonic = "xor", .kinds = &.{ .reg, .reg }, .opcode = 0x65 },
+    .{ .mnemonic = "not", .kinds = &.{.reg}, .opcode = 0x66 },
+    .{ .mnemonic = "btest", .kinds = &.{ .reg, .imm8 }, .opcode = 0x67 },
     .{ .mnemonic = "bset", .kinds = &.{ .reg, .imm8 }, .opcode = 0x68 },
     .{ .mnemonic = "bclr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x69 },
-    .{ .mnemonic = "btest", .kinds = &.{ .reg, .imm8 }, .opcode = 0x6A },
-    .{ .mnemonic = "asr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x6B },
-    .{ .mnemonic = "asr", .kinds = &.{ .reg, .reg }, .opcode = 0x6C },
 
-    // control flow
-    .{ .mnemonic = "jmp", .kinds = &.{.addr}, .opcode = 0x70 },
-    .{ .mnemonic = "jmp", .kinds = &.{.reg}, .opcode = 0x71 },
-    .{ .mnemonic = "jeq", .kinds = &.{.addr}, .opcode = 0x72 },
-    .{ .mnemonic = "jne", .kinds = &.{.addr}, .opcode = 0x73 },
-    .{ .mnemonic = "jlt", .kinds = &.{.addr}, .opcode = 0x74 },
-    .{ .mnemonic = "jle", .kinds = &.{.addr}, .opcode = 0x75 },
-    .{ .mnemonic = "jgt", .kinds = &.{.addr}, .opcode = 0x76 },
-    .{ .mnemonic = "jge", .kinds = &.{.addr}, .opcode = 0x77 },
-    .{ .mnemonic = "jcc", .kinds = &.{.addr}, .opcode = 0x78 },
-    .{ .mnemonic = "jcs", .kinds = &.{.addr}, .opcode = 0x79 },
-    .{ .mnemonic = "jvc", .kinds = &.{.addr}, .opcode = 0x7A },
-    .{ .mnemonic = "jvs", .kinds = &.{.addr}, .opcode = 0x7B },
-    .{ .mnemonic = "jz", .kinds = &.{.addr}, .opcode = 0x7C },
-    .{ .mnemonic = "jnz", .kinds = &.{.addr}, .opcode = 0x7D },
-    .{ .mnemonic = "djnz", .kinds = &.{ .reg, .addr }, .opcode = 0x7E },
-    .{ .mnemonic = "jr", .kinds = &.{.imm8}, .opcode = 0x7F },
+    // 0x7X — shifts / rotates
+    .{ .mnemonic = "shl", .kinds = &.{ .reg, .imm8 }, .opcode = 0x70 },
+    .{ .mnemonic = "shl", .kinds = &.{ .reg, .reg }, .opcode = 0x71 },
+    .{ .mnemonic = "shr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x72 },
+    .{ .mnemonic = "shr", .kinds = &.{ .reg, .reg }, .opcode = 0x73 },
+    .{ .mnemonic = "asr", .kinds = &.{ .reg, .imm8 }, .opcode = 0x74 },
+    .{ .mnemonic = "asr", .kinds = &.{ .reg, .reg }, .opcode = 0x75 },
+    .{ .mnemonic = "rol", .kinds = &.{ .reg, .imm8 }, .opcode = 0x76 },
+    .{ .mnemonic = "rol", .kinds = &.{ .reg, .reg }, .opcode = 0x77 },
+    .{ .mnemonic = "ror", .kinds = &.{ .reg, .imm8 }, .opcode = 0x78 },
+    .{ .mnemonic = "ror", .kinds = &.{ .reg, .reg }, .opcode = 0x79 },
 
-    // subroutines
-    .{ .mnemonic = "call", .kinds = &.{.addr}, .opcode = 0x80 },
-    .{ .mnemonic = "call", .kinds = &.{.reg}, .opcode = 0x81 },
-    .{ .mnemonic = "ret", .kinds = &.{}, .opcode = 0x82 },
+    // 0x8X — comparison
+    .{ .mnemonic = "cmp", .kinds = &.{ .reg, .imm16 }, .opcode = 0x80 },
+    .{ .mnemonic = "cmp", .kinds = &.{ .reg, .reg }, .opcode = 0x81 },
+    .{ .mnemonic = "tst", .kinds = &.{ .reg, .imm16 }, .opcode = 0x82 },
+    .{ .mnemonic = "tst", .kinds = &.{ .reg, .reg }, .opcode = 0x83 },
 
-    // misc
-    .{ .mnemonic = "swap", .kinds = &.{ .reg, .reg }, .opcode = 0x90 },
-    .{ .mnemonic = "nop", .kinds = &.{}, .opcode = 0x91 },
+    // 0x9X — branches
+    .{ .mnemonic = "jmp", .kinds = &.{.addr}, .opcode = 0x90 },
+    .{ .mnemonic = "jmp", .kinds = &.{.reg}, .opcode = 0x91 },
+    .{ .mnemonic = "jeq", .kinds = &.{.addr}, .opcode = 0x92 },
+    .{ .mnemonic = "jne", .kinds = &.{.addr}, .opcode = 0x93 },
+    .{ .mnemonic = "jlt", .kinds = &.{.addr}, .opcode = 0x94 },
+    .{ .mnemonic = "jle", .kinds = &.{.addr}, .opcode = 0x95 },
+    .{ .mnemonic = "jgt", .kinds = &.{.addr}, .opcode = 0x96 },
+    .{ .mnemonic = "jge", .kinds = &.{.addr}, .opcode = 0x97 },
+    .{ .mnemonic = "jcc", .kinds = &.{.addr}, .opcode = 0x98 },
+    .{ .mnemonic = "jcs", .kinds = &.{.addr}, .opcode = 0x99 },
+    .{ .mnemonic = "jvc", .kinds = &.{.addr}, .opcode = 0x9A },
+    .{ .mnemonic = "jvs", .kinds = &.{.addr}, .opcode = 0x9B },
+    .{ .mnemonic = "jz", .kinds = &.{.addr}, .opcode = 0x9C },
+    .{ .mnemonic = "jnz", .kinds = &.{.addr}, .opcode = 0x9D },
+    .{ .mnemonic = "djnz", .kinds = &.{ .reg, .addr }, .opcode = 0x9E },
+    .{ .mnemonic = "jr", .kinds = &.{.imm8}, .opcode = 0x9F },
 
-    // flag manipulation
-    .{ .mnemonic = "clc", .kinds = &.{}, .opcode = 0xA0 },
-    .{ .mnemonic = "sec", .kinds = &.{}, .opcode = 0xA1 },
-    .{ .mnemonic = "cli", .kinds = &.{}, .opcode = 0xA2 },
-    .{ .mnemonic = "sei", .kinds = &.{}, .opcode = 0xA3 },
-    .{ .mnemonic = "clv", .kinds = &.{}, .opcode = 0xA4 },
+    // 0xAX — subroutines
+    .{ .mnemonic = "call", .kinds = &.{.addr}, .opcode = 0xA0 },
+    .{ .mnemonic = "call", .kinds = &.{.reg}, .opcode = 0xA1 },
+    .{ .mnemonic = "ret", .kinds = &.{}, .opcode = 0xA2 },
 
-    // system
+    // 0xBX — flag manipulation
+    .{ .mnemonic = "clc", .kinds = &.{}, .opcode = 0xB0 },
+    .{ .mnemonic = "sec", .kinds = &.{}, .opcode = 0xB1 },
+    .{ .mnemonic = "cli", .kinds = &.{}, .opcode = 0xB2 },
+    .{ .mnemonic = "sei", .kinds = &.{}, .opcode = 0xB3 },
+    .{ .mnemonic = "clv", .kinds = &.{}, .opcode = 0xB4 },
+
+    // 0xCX — misc
+    .{ .mnemonic = "swap", .kinds = &.{ .reg, .reg }, .opcode = 0xC0 },
+    .{ .mnemonic = "nop", .kinds = &.{}, .opcode = 0xC1 },
+
+    // 0xFX — system
     .{ .mnemonic = "int", .kinds = &.{.imm8}, .opcode = 0xFC },
     .{ .mnemonic = "rti", .kinds = &.{}, .opcode = 0xFD },
     .{ .mnemonic = "brk", .kinds = &.{}, .opcode = 0xFE },

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -73,7 +73,7 @@ fn unimplemented(vm: *VM) StepResult {
 pub const handler_table: [256]Handler = blk: {
     var t = [_]Handler{unimplemented} ** 256;
 
-    // mov family
+    // 0x1X — mov word
     t[0x10] = mov.movImm16Reg;
     t[0x11] = mov.movRegReg;
     t[0x12] = mov.movRegAddr;
@@ -89,29 +89,28 @@ pub const handler_table: [256]Handler = blk: {
     t[0x1C] = mov.movRegOffsetReg;
     t[0x1D] = mov.movRegRegOffset;
 
-    // mov8 / movh / movl
+    // 0x2X — mov byte (mov8 / movh / movl + block memory)
     t[0x20] = mov.mov8Imm8Addr;
     t[0x21] = mov.mov8Imm8Reg;
     t[0x22] = mov.mov8AddrReg;
     t[0x23] = mov.mov8RegPtr;
     t[0x24] = mov.mov8PtrReg;
-    t[0x29] = mov.mov8Indexed;
-    t[0x25] = mov.movhRegAddr;
-    t[0x26] = mov.movlRegAddr;
-    t[0x27] = mov.bcpyRegRegReg;
-    t[0x28] = mov.bfillRegRegReg;
-    t[0x2E] = mov.sextReg;
-    t[0x2A] = mov.mov8Imm8Zp;
-    t[0x2B] = mov.mov8ZpReg;
-    t[0x2C] = mov.movhRegZp;
-    t[0x2D] = mov.movlRegZp;
+    t[0x25] = mov.mov8Indexed;
+    t[0x26] = mov.movhRegAddr;
+    t[0x27] = mov.movlRegAddr;
+    t[0x28] = mov.mov8Imm8Zp;
+    t[0x29] = mov.mov8ZpReg;
+    t[0x2A] = mov.movhRegZp;
+    t[0x2B] = mov.movlRegZp;
+    t[0x2C] = mov.bcpyRegRegReg;
+    t[0x2D] = mov.bfillRegRegReg;
 
-    // stack
+    // 0x3X — stack
     t[0x30] = stack_handlers.pushImm16;
     t[0x31] = stack_handlers.pushReg;
     t[0x32] = stack_handlers.popReg;
 
-    // arithmetic
+    // 0x4X — arithmetic primary
     t[0x40] = arith.addImm16Reg;
     t[0x41] = arith.addRegReg;
     t[0x42] = arith.addRegAcu;
@@ -127,76 +126,79 @@ pub const handler_table: [256]Handler = blk: {
     t[0x4C] = arith.divRegReg;
     t[0x4D] = arith.divsImm16Reg;
     t[0x4E] = arith.divsRegReg;
-    t[0x64] = arith.adcImm16Reg;
-    t[0x65] = arith.adcRegReg;
-    t[0x66] = arith.sbcImm16Reg;
-    t[0x67] = arith.sbcRegReg;
+    t[0x4F] = mov.sextReg;
 
-    // logical
-    t[0x50] = bitwise.andRegImm16;
-    t[0x51] = bitwise.andRegReg;
-    t[0x52] = bitwise.orRegImm16;
-    t[0x53] = bitwise.orRegReg;
-    t[0x54] = bitwise.xorRegImm16;
-    t[0x55] = bitwise.xorRegReg;
-    t[0x56] = bitwise.notReg;
+    // 0x5X — arithmetic carry-propagating
+    t[0x50] = arith.adcImm16Reg;
+    t[0x51] = arith.adcRegReg;
+    t[0x52] = arith.sbcImm16Reg;
+    t[0x53] = arith.sbcRegReg;
 
-    // shifts and rotates
-    t[0x58] = bitwise.shlRegImm8;
-    t[0x59] = bitwise.shlRegReg;
-    t[0x5A] = bitwise.shrRegImm8;
-    t[0x5B] = bitwise.shrRegReg;
-    t[0x5C] = bitwise.rolRegImm8;
-    t[0x5D] = bitwise.rolRegReg;
-    t[0x5E] = bitwise.rorRegImm8;
-    t[0x5F] = bitwise.rorRegReg;
-
-    // cmp / tst
-    t[0x60] = cmp_handlers.cmpRegImm16;
-    t[0x61] = cmp_handlers.cmpRegReg;
-    t[0x62] = cmp_handlers.tstRegImm16;
-    t[0x63] = cmp_handlers.tstRegReg;
+    // 0x6X — bitwise (logical word ops + single-bit ops)
+    t[0x60] = bitwise.andRegImm16;
+    t[0x61] = bitwise.andRegReg;
+    t[0x62] = bitwise.orRegImm16;
+    t[0x63] = bitwise.orRegReg;
+    t[0x64] = bitwise.xorRegImm16;
+    t[0x65] = bitwise.xorRegReg;
+    t[0x66] = bitwise.notReg;
+    t[0x67] = cmp_handlers.btestRegImm8;
     t[0x68] = cmp_handlers.bsetRegImm8;
     t[0x69] = cmp_handlers.bclrRegImm8;
-    t[0x6A] = cmp_handlers.btestRegImm8;
-    t[0x6B] = bitwise.asrRegImm8;
-    t[0x6C] = bitwise.asrRegReg;
 
-    // control flow
-    t[0x70] = jumps.jmpAddr;
-    t[0x71] = jumps.jmpReg;
-    t[0x72] = jumps.jeqAddr;
-    t[0x73] = jumps.jneAddr;
-    t[0x74] = jumps.jltAddr;
-    t[0x75] = jumps.jleAddr;
-    t[0x76] = jumps.jgtAddr;
-    t[0x77] = jumps.jgeAddr;
-    t[0x78] = jumps.jccAddr;
-    t[0x79] = jumps.jcsAddr;
-    t[0x7A] = jumps.jvcAddr;
-    t[0x7B] = jumps.jvsAddr;
-    t[0x7C] = jumps.jzAddr;
-    t[0x7D] = jumps.jnzAddr;
-    t[0x7E] = jumps.djnzRegAddr;
-    t[0x7F] = jumps.jrImm8;
+    // 0x7X — shifts / rotates
+    t[0x70] = bitwise.shlRegImm8;
+    t[0x71] = bitwise.shlRegReg;
+    t[0x72] = bitwise.shrRegImm8;
+    t[0x73] = bitwise.shrRegReg;
+    t[0x74] = bitwise.asrRegImm8;
+    t[0x75] = bitwise.asrRegReg;
+    t[0x76] = bitwise.rolRegImm8;
+    t[0x77] = bitwise.rolRegReg;
+    t[0x78] = bitwise.rorRegImm8;
+    t[0x79] = bitwise.rorRegReg;
 
-    // subroutines
-    t[0x80] = subroutine.callAddr;
-    t[0x81] = subroutine.callReg;
-    t[0x82] = subroutine.ret;
+    // 0x8X — comparison
+    t[0x80] = cmp_handlers.cmpRegImm16;
+    t[0x81] = cmp_handlers.cmpRegReg;
+    t[0x82] = cmp_handlers.tstRegImm16;
+    t[0x83] = cmp_handlers.tstRegReg;
 
-    // misc
-    t[0x90] = system_handlers.swap;
-    t[0x91] = system_handlers.nop;
+    // 0x9X — branches
+    t[0x90] = jumps.jmpAddr;
+    t[0x91] = jumps.jmpReg;
+    t[0x92] = jumps.jeqAddr;
+    t[0x93] = jumps.jneAddr;
+    t[0x94] = jumps.jltAddr;
+    t[0x95] = jumps.jleAddr;
+    t[0x96] = jumps.jgtAddr;
+    t[0x97] = jumps.jgeAddr;
+    t[0x98] = jumps.jccAddr;
+    t[0x99] = jumps.jcsAddr;
+    t[0x9A] = jumps.jvcAddr;
+    t[0x9B] = jumps.jvsAddr;
+    t[0x9C] = jumps.jzAddr;
+    t[0x9D] = jumps.jnzAddr;
+    t[0x9E] = jumps.djnzRegAddr;
+    t[0x9F] = jumps.jrImm8;
 
-    // flag manipulation
-    t[0xA0] = system_handlers.clc;
-    t[0xA1] = system_handlers.sec;
-    t[0xA2] = system_handlers.cli;
-    t[0xA3] = system_handlers.sei;
-    t[0xA4] = system_handlers.clv;
+    // 0xAX — subroutines
+    t[0xA0] = subroutine.callAddr;
+    t[0xA1] = subroutine.callReg;
+    t[0xA2] = subroutine.ret;
 
-    // system
+    // 0xBX — flag manipulation
+    t[0xB0] = system_handlers.clc;
+    t[0xB1] = system_handlers.sec;
+    t[0xB2] = system_handlers.cli;
+    t[0xB3] = system_handlers.sei;
+    t[0xB4] = system_handlers.clv;
+
+    // 0xCX — misc
+    t[0xC0] = system_handlers.swap;
+    t[0xC1] = system_handlers.nop;
+
+    // 0xFX — system
     t[0xFC] = system_handlers.intImm8;
     t[0xFD] = system_handlers.rti;
     t[0xFE] = system_handlers.brk;

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -1,26 +1,49 @@
 /// Opcode table — the canonical mapping from byte → mnemonic +
 /// operand schema. Dispatch consults this for instruction sizing;
 /// the disassembler can re-use it for textual rendering.
+///
+/// Bytes are organized by 16-slot pages, one page per role:
+///   0x1X  mov word        | 0x8X  cmp/tst
+///   0x2X  mov byte        | 0x9X  branches
+///   0x3X  stack           | 0xAX  subroutines
+///   0x4X  arith primary   | 0xBX  flag manipulation
+///   0x5X  arith carry     | 0xCX  misc
+///   0x6X  bitwise         | 0xD-EX reserved
+///   0x7X  shifts/rotates  | 0xFX  system
 const std = @import("std");
 
 /// Operand kinds. Encoding sizes:
-/// `reg`/`imm8`/`zp` = 1 byte, `imm16`/`addr`/`reg_offset` = 2 bytes.
+///   `reg`/`imm8`/`zp`/`reg_indirect`   = 1 byte
+///   `imm16`/`addr`/`reg_offset`        = 2 bytes
+///   `indexed`                          = 3 bytes
 pub const Operand = enum {
+    /// 1-byte register index.
     reg,
+    /// 1-byte immediate.
     imm8,
+    /// 2-byte little-endian immediate.
     imm16,
+    /// 2-byte little-endian address.
     addr,
+    /// 1-byte zero-page address.
     zp,
+    /// `[reg]` indirect — encodes as 1 register-index byte
+    /// treated as effective address.
+    reg_indirect,
     /// `[reg + imm8]` register-relative — encodes as base-reg
     /// byte + signed imm8 byte.
     reg_offset,
+    /// `[addr + reg]` indexed — encodes as 2 addr bytes + 1
+    /// reg byte.
+    indexed,
 };
 
 /// Encoded byte size of one operand.
 pub fn operandSize(op: Operand) u8 {
     return switch (op) {
-        .reg, .imm8, .zp => 1,
+        .reg, .imm8, .zp, .reg_indirect => 1,
         .imm16, .addr, .reg_offset => 2,
+        .indexed => 3,
     };
 }
 
@@ -44,49 +67,44 @@ pub const OpcodeInfo = struct {
 pub const table: [256]?OpcodeInfo = blk: {
     var t = [_]?OpcodeInfo{null} ** 256;
 
-    // mov family
+    // 0x1X — mov word
     t[0x10] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .reg } };
     t[0x11] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg } };
     t[0x12] = .{ .mnemonic = "mov", .operands = &.{ .reg, .addr } };
     t[0x13] = .{ .mnemonic = "mov", .operands = &.{ .addr, .reg } };
     t[0x14] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .addr } };
-    t[0x15] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg } };
-    t[0x16] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg } };
-    t[0x17] = .{ .mnemonic = "mov", .operands = &.{ .addr, .reg, .reg } };
-    t[0x18] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .reg } };
+    t[0x15] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg_indirect } };
+    t[0x16] = .{ .mnemonic = "mov", .operands = &.{ .reg_indirect, .reg } };
+    t[0x17] = .{ .mnemonic = "mov", .operands = &.{ .indexed, .reg } };
+    t[0x18] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .reg_indirect } };
     t[0x19] = .{ .mnemonic = "mov", .operands = &.{ .reg, .zp } };
     t[0x1A] = .{ .mnemonic = "mov", .operands = &.{ .zp, .reg } };
     t[0x1B] = .{ .mnemonic = "mov", .operands = &.{ .imm16, .zp } };
     t[0x1C] = .{ .mnemonic = "mov", .operands = &.{ .reg_offset, .reg } };
     t[0x1D] = .{ .mnemonic = "mov", .operands = &.{ .reg, .reg_offset } };
 
-    // mov8 / movh / movl
+    // 0x2X — mov byte (mov8 / movh / movl + block memory)
     t[0x20] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .addr } };
     t[0x21] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .reg } };
     t[0x22] = .{ .mnemonic = "mov8", .operands = &.{ .addr, .reg } };
-    t[0x23] = .{ .mnemonic = "mov8", .operands = &.{ .reg, .reg } };
-    t[0x24] = .{ .mnemonic = "mov8", .operands = &.{ .reg, .reg } };
-    t[0x29] = .{ .mnemonic = "mov8", .operands = &.{ .addr, .reg, .reg } };
-    t[0x25] = .{ .mnemonic = "movh", .operands = &.{ .reg, .addr } };
-    t[0x26] = .{ .mnemonic = "movl", .operands = &.{ .reg, .addr } };
+    t[0x23] = .{ .mnemonic = "mov8", .operands = &.{ .reg, .reg_indirect } };
+    t[0x24] = .{ .mnemonic = "mov8", .operands = &.{ .reg_indirect, .reg } };
+    t[0x25] = .{ .mnemonic = "mov8", .operands = &.{ .indexed, .reg } };
+    t[0x26] = .{ .mnemonic = "movh", .operands = &.{ .reg, .addr } };
+    t[0x27] = .{ .mnemonic = "movl", .operands = &.{ .reg, .addr } };
+    t[0x28] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .zp } };
+    t[0x29] = .{ .mnemonic = "mov8", .operands = &.{ .zp, .reg } };
+    t[0x2A] = .{ .mnemonic = "movh", .operands = &.{ .reg, .zp } };
+    t[0x2B] = .{ .mnemonic = "movl", .operands = &.{ .reg, .zp } };
+    t[0x2C] = .{ .mnemonic = "bcpy", .operands = &.{ .reg, .reg, .reg } };
+    t[0x2D] = .{ .mnemonic = "bfill", .operands = &.{ .reg, .reg, .reg } };
 
-    // mov8 / movh / movl — zero-page variants
-    t[0x2A] = .{ .mnemonic = "mov8", .operands = &.{ .imm8, .zp } };
-    t[0x2B] = .{ .mnemonic = "mov8", .operands = &.{ .zp, .reg } };
-    t[0x2C] = .{ .mnemonic = "movh", .operands = &.{ .reg, .zp } };
-    t[0x2D] = .{ .mnemonic = "movl", .operands = &.{ .reg, .zp } };
-
-    // block memory ops
-    t[0x27] = .{ .mnemonic = "bcpy", .operands = &.{ .reg, .reg, .reg } };
-    t[0x28] = .{ .mnemonic = "bfill", .operands = &.{ .reg, .reg, .reg } };
-    t[0x2E] = .{ .mnemonic = "sext", .operands = &.{.reg} };
-
-    // stack
+    // 0x3X — stack
     t[0x30] = .{ .mnemonic = "push", .operands = &.{.imm16} };
     t[0x31] = .{ .mnemonic = "push", .operands = &.{.reg} };
     t[0x32] = .{ .mnemonic = "pop", .operands = &.{.reg} };
 
-    // arithmetic
+    // 0x4X — arithmetic primary
     t[0x40] = .{ .mnemonic = "add", .operands = &.{ .imm16, .reg } };
     t[0x41] = .{ .mnemonic = "add", .operands = &.{ .reg, .reg } };
     t[0x42] = .{ .mnemonic = "add", .operands = &.{.reg} };
@@ -102,76 +120,79 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x4C] = .{ .mnemonic = "div", .operands = &.{ .reg, .reg } };
     t[0x4D] = .{ .mnemonic = "divs", .operands = &.{ .imm16, .reg } };
     t[0x4E] = .{ .mnemonic = "divs", .operands = &.{ .reg, .reg } };
-    t[0x64] = .{ .mnemonic = "adc", .operands = &.{ .imm16, .reg } };
-    t[0x65] = .{ .mnemonic = "adc", .operands = &.{ .reg, .reg } };
-    t[0x66] = .{ .mnemonic = "sbc", .operands = &.{ .imm16, .reg } };
-    t[0x67] = .{ .mnemonic = "sbc", .operands = &.{ .reg, .reg } };
+    t[0x4F] = .{ .mnemonic = "sext", .operands = &.{.reg} };
 
-    // logical
-    t[0x50] = .{ .mnemonic = "and", .operands = &.{ .imm16, .reg } };
-    t[0x51] = .{ .mnemonic = "and", .operands = &.{ .reg, .reg } };
-    t[0x52] = .{ .mnemonic = "or", .operands = &.{ .imm16, .reg } };
-    t[0x53] = .{ .mnemonic = "or", .operands = &.{ .reg, .reg } };
-    t[0x54] = .{ .mnemonic = "xor", .operands = &.{ .imm16, .reg } };
-    t[0x55] = .{ .mnemonic = "xor", .operands = &.{ .reg, .reg } };
-    t[0x56] = .{ .mnemonic = "not", .operands = &.{.reg} };
+    // 0x5X — arithmetic carry-propagating
+    t[0x50] = .{ .mnemonic = "adc", .operands = &.{ .imm16, .reg } };
+    t[0x51] = .{ .mnemonic = "adc", .operands = &.{ .reg, .reg } };
+    t[0x52] = .{ .mnemonic = "sbc", .operands = &.{ .imm16, .reg } };
+    t[0x53] = .{ .mnemonic = "sbc", .operands = &.{ .reg, .reg } };
 
-    // shifts and rotates
-    t[0x58] = .{ .mnemonic = "shl", .operands = &.{ .reg, .imm8 } };
-    t[0x59] = .{ .mnemonic = "shl", .operands = &.{ .reg, .reg } };
-    t[0x5A] = .{ .mnemonic = "shr", .operands = &.{ .reg, .imm8 } };
-    t[0x5B] = .{ .mnemonic = "shr", .operands = &.{ .reg, .reg } };
-    t[0x5C] = .{ .mnemonic = "rol", .operands = &.{ .reg, .imm8 } };
-    t[0x5D] = .{ .mnemonic = "rol", .operands = &.{ .reg, .reg } };
-    t[0x5E] = .{ .mnemonic = "ror", .operands = &.{ .reg, .imm8 } };
-    t[0x5F] = .{ .mnemonic = "ror", .operands = &.{ .reg, .reg } };
-
-    // cmp / tst
-    t[0x60] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .imm16 } };
-    t[0x61] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .reg } };
-    t[0x62] = .{ .mnemonic = "tst", .operands = &.{ .reg, .imm16 } };
-    t[0x63] = .{ .mnemonic = "tst", .operands = &.{ .reg, .reg } };
+    // 0x6X — bitwise (logical word ops + single-bit ops)
+    t[0x60] = .{ .mnemonic = "and", .operands = &.{ .imm16, .reg } };
+    t[0x61] = .{ .mnemonic = "and", .operands = &.{ .reg, .reg } };
+    t[0x62] = .{ .mnemonic = "or", .operands = &.{ .imm16, .reg } };
+    t[0x63] = .{ .mnemonic = "or", .operands = &.{ .reg, .reg } };
+    t[0x64] = .{ .mnemonic = "xor", .operands = &.{ .imm16, .reg } };
+    t[0x65] = .{ .mnemonic = "xor", .operands = &.{ .reg, .reg } };
+    t[0x66] = .{ .mnemonic = "not", .operands = &.{.reg} };
+    t[0x67] = .{ .mnemonic = "btest", .operands = &.{ .reg, .imm8 } };
     t[0x68] = .{ .mnemonic = "bset", .operands = &.{ .reg, .imm8 } };
     t[0x69] = .{ .mnemonic = "bclr", .operands = &.{ .reg, .imm8 } };
-    t[0x6A] = .{ .mnemonic = "btest", .operands = &.{ .reg, .imm8 } };
-    t[0x6B] = .{ .mnemonic = "asr", .operands = &.{ .reg, .imm8 } };
-    t[0x6C] = .{ .mnemonic = "asr", .operands = &.{ .reg, .reg } };
 
-    // control flow
-    t[0x70] = .{ .mnemonic = "jmp", .operands = &.{.addr} };
-    t[0x71] = .{ .mnemonic = "jmp", .operands = &.{.reg} };
-    t[0x72] = .{ .mnemonic = "jeq", .operands = &.{.addr} };
-    t[0x73] = .{ .mnemonic = "jne", .operands = &.{.addr} };
-    t[0x74] = .{ .mnemonic = "jlt", .operands = &.{.addr} };
-    t[0x75] = .{ .mnemonic = "jle", .operands = &.{.addr} };
-    t[0x76] = .{ .mnemonic = "jgt", .operands = &.{.addr} };
-    t[0x77] = .{ .mnemonic = "jge", .operands = &.{.addr} };
-    t[0x78] = .{ .mnemonic = "jcc", .operands = &.{.addr} };
-    t[0x79] = .{ .mnemonic = "jcs", .operands = &.{.addr} };
-    t[0x7A] = .{ .mnemonic = "jvc", .operands = &.{.addr} };
-    t[0x7B] = .{ .mnemonic = "jvs", .operands = &.{.addr} };
-    t[0x7C] = .{ .mnemonic = "jz", .operands = &.{.addr} };
-    t[0x7D] = .{ .mnemonic = "jnz", .operands = &.{.addr} };
-    t[0x7E] = .{ .mnemonic = "djnz", .operands = &.{ .reg, .addr } };
-    t[0x7F] = .{ .mnemonic = "jr", .operands = &.{.imm8} };
+    // 0x7X — shifts / rotates
+    t[0x70] = .{ .mnemonic = "shl", .operands = &.{ .reg, .imm8 } };
+    t[0x71] = .{ .mnemonic = "shl", .operands = &.{ .reg, .reg } };
+    t[0x72] = .{ .mnemonic = "shr", .operands = &.{ .reg, .imm8 } };
+    t[0x73] = .{ .mnemonic = "shr", .operands = &.{ .reg, .reg } };
+    t[0x74] = .{ .mnemonic = "asr", .operands = &.{ .reg, .imm8 } };
+    t[0x75] = .{ .mnemonic = "asr", .operands = &.{ .reg, .reg } };
+    t[0x76] = .{ .mnemonic = "rol", .operands = &.{ .reg, .imm8 } };
+    t[0x77] = .{ .mnemonic = "rol", .operands = &.{ .reg, .reg } };
+    t[0x78] = .{ .mnemonic = "ror", .operands = &.{ .reg, .imm8 } };
+    t[0x79] = .{ .mnemonic = "ror", .operands = &.{ .reg, .reg } };
 
-    // subroutines
-    t[0x80] = .{ .mnemonic = "call", .operands = &.{.addr} };
-    t[0x81] = .{ .mnemonic = "call", .operands = &.{.reg} };
-    t[0x82] = .{ .mnemonic = "ret", .operands = &.{} };
+    // 0x8X — comparison
+    t[0x80] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .imm16 } };
+    t[0x81] = .{ .mnemonic = "cmp", .operands = &.{ .reg, .reg } };
+    t[0x82] = .{ .mnemonic = "tst", .operands = &.{ .reg, .imm16 } };
+    t[0x83] = .{ .mnemonic = "tst", .operands = &.{ .reg, .reg } };
 
-    // misc
-    t[0x90] = .{ .mnemonic = "swap", .operands = &.{ .reg, .reg } };
-    t[0x91] = .{ .mnemonic = "nop", .operands = &.{} };
+    // 0x9X — branches
+    t[0x90] = .{ .mnemonic = "jmp", .operands = &.{.addr} };
+    t[0x91] = .{ .mnemonic = "jmp", .operands = &.{.reg} };
+    t[0x92] = .{ .mnemonic = "jeq", .operands = &.{.addr} };
+    t[0x93] = .{ .mnemonic = "jne", .operands = &.{.addr} };
+    t[0x94] = .{ .mnemonic = "jlt", .operands = &.{.addr} };
+    t[0x95] = .{ .mnemonic = "jle", .operands = &.{.addr} };
+    t[0x96] = .{ .mnemonic = "jgt", .operands = &.{.addr} };
+    t[0x97] = .{ .mnemonic = "jge", .operands = &.{.addr} };
+    t[0x98] = .{ .mnemonic = "jcc", .operands = &.{.addr} };
+    t[0x99] = .{ .mnemonic = "jcs", .operands = &.{.addr} };
+    t[0x9A] = .{ .mnemonic = "jvc", .operands = &.{.addr} };
+    t[0x9B] = .{ .mnemonic = "jvs", .operands = &.{.addr} };
+    t[0x9C] = .{ .mnemonic = "jz", .operands = &.{.addr} };
+    t[0x9D] = .{ .mnemonic = "jnz", .operands = &.{.addr} };
+    t[0x9E] = .{ .mnemonic = "djnz", .operands = &.{ .reg, .addr } };
+    t[0x9F] = .{ .mnemonic = "jr", .operands = &.{.imm8} };
 
-    // flag manipulation
-    t[0xA0] = .{ .mnemonic = "clc", .operands = &.{} };
-    t[0xA1] = .{ .mnemonic = "sec", .operands = &.{} };
-    t[0xA2] = .{ .mnemonic = "cli", .operands = &.{} };
-    t[0xA3] = .{ .mnemonic = "sei", .operands = &.{} };
-    t[0xA4] = .{ .mnemonic = "clv", .operands = &.{} };
+    // 0xAX — subroutines
+    t[0xA0] = .{ .mnemonic = "call", .operands = &.{.addr} };
+    t[0xA1] = .{ .mnemonic = "call", .operands = &.{.reg} };
+    t[0xA2] = .{ .mnemonic = "ret", .operands = &.{} };
 
-    // system
+    // 0xBX — flag manipulation
+    t[0xB0] = .{ .mnemonic = "clc", .operands = &.{} };
+    t[0xB1] = .{ .mnemonic = "sec", .operands = &.{} };
+    t[0xB2] = .{ .mnemonic = "cli", .operands = &.{} };
+    t[0xB3] = .{ .mnemonic = "sei", .operands = &.{} };
+    t[0xB4] = .{ .mnemonic = "clv", .operands = &.{} };
+
+    // 0xCX — misc
+    t[0xC0] = .{ .mnemonic = "swap", .operands = &.{ .reg, .reg } };
+    t[0xC1] = .{ .mnemonic = "nop", .operands = &.{} };
+
+    // 0xFX — system
     t[0xFC] = .{ .mnemonic = "int", .operands = &.{.imm8} };
     t[0xFD] = .{ .mnemonic = "rti", .operands = &.{} };
     t[0xFE] = .{ .mnemonic = "brk", .operands = &.{} };

--- a/tests/asm/codegen.test.zig
+++ b/tests/asm/codegen.test.zig
@@ -52,10 +52,10 @@ test "codegen: bare hlt emits one 0xFF byte" {
     try std.testing.expectEqualSlices(u8, &.{0xFF}, out.imageBody());
 }
 
-test "codegen: nop emits 0x91" {
+test "codegen: nop emits 0xC1" {
     var out = try assemble("nop\n", .{});
     defer out.deinit();
-    try std.testing.expectEqualSlices(u8, &.{0x91}, out.imageBody());
+    try std.testing.expectEqualSlices(u8, &.{0xC1}, out.imageBody());
 }
 
 test "codegen: mov imm16, reg → 0x10 LE imm reg" {
@@ -78,10 +78,10 @@ test "codegen: inc reg → 0x48 reg" {
     try std.testing.expectEqualSlices(u8, &.{ 0x48, 0x02 }, out.imageBody());
 }
 
-test "codegen: cmp reg, imm16 → 0x60 reg imm_lo imm_hi" {
+test "codegen: cmp reg, imm16 → 0x80 reg imm_lo imm_hi" {
     var out = try assemble("cmp r1, $0010\n", .{});
     defer out.deinit();
-    try std.testing.expectEqualSlices(u8, &.{ 0x60, 0x02, 0x10, 0x00 }, out.imageBody());
+    try std.testing.expectEqualSlices(u8, &.{ 0x80, 0x02, 0x10, 0x00 }, out.imageBody());
 }
 
 test "codegen: int $10 narrows to 1-byte imm8 operand (0xFC 0x10)" {
@@ -114,10 +114,10 @@ test "codegen: local labels resolve against the enclosing global" {
     , .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    // image: jmp(0x70) + addr LE(0x0000) — local label resolves to
+    // image: jmp(0x90) + addr LE(0x0000) — local label resolves to
     // offset 0, the address of `main:` / `.loop:` (they share the
     // same byte address since neither emits code before .loop).
-    try std.testing.expectEqualSlices(u8, &.{ 0x70, 0x00, 0x00 }, out.imageBody());
+    try std.testing.expectEqualSlices(u8, &.{ 0x90, 0x00, 0x00 }, out.imageBody());
 }
 
 test "codegen: same local-label name reuses across global scopes" {
@@ -177,11 +177,11 @@ test "codegen: int CONST errors when const value > u8" {
     try std.testing.expect(out.cg.hasErrors());
 }
 
-test "codegen: shl r1, $03 uses imm8 shape (0x58 reg imm8)" {
+test "codegen: shl r1, $03 uses imm8 shape (0x70 reg imm8)" {
     var out = try assemble("shl r1, $03\n", .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    try std.testing.expectEqualSlices(u8, &.{ 0x58, 0x02, 0x03 }, out.imageBody());
+    try std.testing.expectEqualSlices(u8, &.{ 0x70, 0x02, 0x03 }, out.imageBody());
 }
 
 test "codegen: mov $00, r1 widens imm8 → imm16 (4 bytes, not 3)" {
@@ -227,13 +227,13 @@ test "codegen: §7 worked example assembles to the spec'd 14 bytes" {
     // Documented bytecode at 0x0000:
     //   10 00 00 02            mov $0000, r1
     //   48 02                  inc r1                (loop: at 0x0004)
-    //   60 02 10 00            cmp r1, $0010
-    //   73 04 00               jne &0004
+    //   80 02 10 00            cmp r1, $0010
+    //   93 04 00               jne &0004
     //   FF                     hlt
     const expected = [_]u8{
         0x10, 0x00, 0x00, 0x02,
-        0x48, 0x02, 0x60, 0x02,
-        0x10, 0x00, 0x73, 0x04,
+        0x48, 0x02, 0x80, 0x02,
+        0x10, 0x00, 0x93, 0x04,
         0x00, 0xFF,
     };
     try std.testing.expectEqualSlices(u8, &expected, out.imageBody());
@@ -251,9 +251,9 @@ test "codegen: forward label reference resolves" {
     , .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    // jmp Addr = opcode 0x70 + addr LE. `end` is at offset 4
+    // jmp Addr = opcode 0x90 + addr LE. `end` is at offset 4
     // (jmp = 3 bytes, hlt = 1 byte). Encoding: 70 04 00.
-    try std.testing.expectEqualSlices(u8, &.{ 0x70, 0x04, 0x00, 0xFF, 0xFF }, out.imageBody());
+    try std.testing.expectEqualSlices(u8, &.{ 0x90, 0x04, 0x00, 0xFF, 0xFF }, out.imageBody());
 }
 
 // ---------- data directives ----------
@@ -472,8 +472,8 @@ test "codegen: labels inside `bank N` resolve to bank-window addresses" {
         \\
     , .{});
     defer out.deinit();
-    // image[0..3] = call $C000 → 0x80 LE($C000)
-    try std.testing.expectEqual(@as(u8, 0x80), out.cg.image[16]);
+    // image[0..3] = call $C000 → 0xA0 LE($C000)
+    try std.testing.expectEqual(@as(u8, 0xA0), out.cg.image[16]);
     try std.testing.expectEqual(@as(u8, 0x00), out.cg.image[17]);
     try std.testing.expectEqual(@as(u8, 0xC0), out.cg.image[18]);
 }
@@ -783,13 +783,13 @@ test "codegen: jmp &XX never downgrades (no ZP variant exists)" {
     , .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    // jmp opcode 0x70 + 2-byte addr — 3 bytes total.
-    try std.testing.expectEqual(@as(u8, 0x70), out.imageBody()[0]);
+    // jmp opcode 0x90 + 2-byte addr — 3 bytes total.
+    try std.testing.expectEqual(@as(u8, 0x90), out.imageBody()[0]);
     try std.testing.expectEqual(@as(u8, 0x42), out.imageBody()[1]);
     try std.testing.expectEqual(@as(u8, 0x00), out.imageBody()[2]);
 }
 
-test "codegen: mov8 imm8 → &XX downgrades to ZP opcode 0x2A" {
+test "codegen: mov8 imm8 → &XX downgrades to ZP opcode 0x28" {
     var out = try assemble(
         \\main:
         \\  mov8 $42, &0080
@@ -798,10 +798,10 @@ test "codegen: mov8 imm8 → &XX downgrades to ZP opcode 0x2A" {
     , .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    try std.testing.expectEqual(@as(u8, 0x2A), out.imageBody()[0]);
+    try std.testing.expectEqual(@as(u8, 0x28), out.imageBody()[0]);
 }
 
-test "codegen: mov8 &XX → reg downgrades to ZP opcode 0x2B" {
+test "codegen: mov8 &XX → reg downgrades to ZP opcode 0x29" {
     var out = try assemble(
         \\main:
         \\  mov8 &0042, r1
@@ -810,10 +810,10 @@ test "codegen: mov8 &XX → reg downgrades to ZP opcode 0x2B" {
     , .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    try std.testing.expectEqual(@as(u8, 0x2B), out.imageBody()[0]);
+    try std.testing.expectEqual(@as(u8, 0x29), out.imageBody()[0]);
 }
 
-test "codegen: movh reg → &XX downgrades to ZP opcode 0x2C" {
+test "codegen: movh reg → &XX downgrades to ZP opcode 0x2A" {
     var out = try assemble(
         \\main:
         \\  movh r1, &0042
@@ -822,10 +822,10 @@ test "codegen: movh reg → &XX downgrades to ZP opcode 0x2C" {
     , .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    try std.testing.expectEqual(@as(u8, 0x2C), out.imageBody()[0]);
+    try std.testing.expectEqual(@as(u8, 0x2A), out.imageBody()[0]);
 }
 
-test "codegen: movl reg → &XX downgrades to ZP opcode 0x2D" {
+test "codegen: movl reg → &XX downgrades to ZP opcode 0x2B" {
     var out = try assemble(
         \\main:
         \\  movl r1, &0042
@@ -834,7 +834,7 @@ test "codegen: movl reg → &XX downgrades to ZP opcode 0x2D" {
     , .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    try std.testing.expectEqual(@as(u8, 0x2D), out.imageBody()[0]);
+    try std.testing.expectEqual(@as(u8, 0x2B), out.imageBody()[0]);
 }
 
 // ---------- bank_call / bank_jump pseudo-instructions ----------
@@ -853,17 +853,17 @@ test "codegen: bank_call <label-in-bank> emits mov $bank, mb + call <addr>" {
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
     // 7-byte expansion: 0x10 (movImm16Reg) + imm16($0000) + 0x0C (mb)
-    //                 + 0x80 (call) + addr16
+    //                 + 0xA0 (call) + addr16
     const body = out.imageBody();
     try std.testing.expectEqual(@as(u8, 0x10), body[0]);
     try std.testing.expectEqual(@as(u8, 0x00), body[1]); // bank low
     try std.testing.expectEqual(@as(u8, 0x00), body[2]); // bank high
     try std.testing.expectEqual(@as(u8, 0x0C), body[3]); // mb register
-    try std.testing.expectEqual(@as(u8, 0x80), body[4]); // call opcode
+    try std.testing.expectEqual(@as(u8, 0xA0), body[4]); // call opcode
     // Bytes 5-6 = call target address (bank-window-relative).
 }
 
-test "codegen: bank_jump emits jmp opcode (0x70) instead of call (0x80)" {
+test "codegen: bank_jump emits jmp opcode (0x90) instead of call (0xA0)" {
     var out = try assemble(
         \\main:
         \\  bank_jump greet
@@ -875,7 +875,7 @@ test "codegen: bank_jump emits jmp opcode (0x70) instead of call (0x80)" {
     , .{});
     defer out.deinit();
     try std.testing.expect(!out.cg.hasErrors());
-    try std.testing.expectEqual(@as(u8, 0x70), out.imageBody()[4]);
+    try std.testing.expectEqual(@as(u8, 0x90), out.imageBody()[4]);
 }
 
 test "codegen: bank_call into a higher-numbered bank emits the bank index" {

--- a/tests/asm/opcode_resolver.test.zig
+++ b/tests/asm/opcode_resolver.test.zig
@@ -28,9 +28,9 @@ test "opres: hlt resolves to 0xFF (zero-operand sentinel)" {
     try std.testing.expectEqual(@as(u8, 0xFF), cg.image[16]);
 }
 
-test "opres: cmp reg, label_ref(const) uses imm16 form (0x60)" {
+test "opres: cmp reg, label_ref(const) uses imm16 form (0x80)" {
     // `TARGET` is a const → label_ref resolves to imm16, picking
-    // 0x60 (cmp Reg, Imm16) over a hypothetical addr form.
+    // 0x80 (cmp Reg, Imm16) over a hypothetical addr form.
     const src =
         \\const TARGET = $10
         \\cmp r1, TARGET
@@ -41,10 +41,10 @@ test "opres: cmp reg, label_ref(const) uses imm16 form (0x60)" {
     var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     try std.testing.expect(!cg.hasErrors());
-    try std.testing.expectEqual(@as(u8, 0x60), cg.image[16]);
+    try std.testing.expectEqual(@as(u8, 0x80), cg.image[16]);
 }
 
-test "opres: jmp label_ref(label) uses addr form (0x70)" {
+test "opres: jmp label_ref(label) uses addr form (0x90)" {
     const src =
         \\target:
         \\  hlt
@@ -56,9 +56,9 @@ test "opres: jmp label_ref(label) uses addr form (0x70)" {
     var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     try std.testing.expect(!cg.hasErrors());
-    // image: hlt(0xFF) then jmp(0x70) + addr LE(00 00)
+    // image: hlt(0xFF) then jmp(0x90) + addr LE(00 00)
     try std.testing.expectEqual(@as(u8, 0xFF), cg.image[16]);
-    try std.testing.expectEqual(@as(u8, 0x70), cg.image[17]);
+    try std.testing.expectEqual(@as(u8, 0x90), cg.image[17]);
 }
 
 test "opres: indexed addressing emits 3-byte operand (addr + reg)" {
@@ -79,8 +79,8 @@ test "opres: mov8 indexed emits 5-byte operand (opcode + addr + 2 regs)" {
     var cg = try gero.asm_.assemble(alloc, src, pt, .{ .debug_symbols = false });
     defer cg.deinit();
     try std.testing.expect(!cg.hasErrors());
-    // 0x29 + addr LE (00 30) + idx_reg (r1 = 0x02) + dst_reg (r2 = 0x03)
-    try std.testing.expectEqualSlices(u8, &.{ 0x29, 0x00, 0x30, 0x02, 0x03 }, cg.image[16..]);
+    // 0x25 + addr LE (00 30) + idx_reg (r1 = 0x02) + dst_reg (r2 = 0x03)
+    try std.testing.expectEqualSlices(u8, &.{ 0x25, 0x00, 0x30, 0x02, 0x03 }, cg.image[16..]);
 }
 
 test "opres: imm8 narrowing — mov8 picks Imm8 shape over widening" {

--- a/tests/disasm/printer.test.zig
+++ b/tests/disasm/printer.test.zig
@@ -75,7 +75,7 @@ test "printer: truncated tail comments instead of crashing" {
 test "printer: symbols substitute matching addresses" {
     // jmp &0021 — with a symbol for $0021 named "fib", renders
     // as `jmp fib`.
-    const bytes = [_]u8{ 0x70, 0x21, 0x00 };
+    const bytes = [_]u8{ 0x90, 0x21, 0x00 };
     const entries = [_]gero.disasm.Symbol{.{ .address = 0x0021, .kind = .label, .name = "fib" }};
     const symbols: gero.disasm.Symbols = .{ .entries = &entries };
 
@@ -109,7 +109,7 @@ test "printer: data symbol switches to data-mode rendering" {
 }
 
 test "printer: unmatched address stays as &XXXX" {
-    const bytes = [_]u8{ 0x70, 0x22, 0x00 }; // jmp &0022
+    const bytes = [_]u8{ 0x90, 0x22, 0x00 }; // jmp &0022
     const entries = [_]gero.disasm.Symbol{.{ .address = 0x0021, .kind = .label, .name = "fib" }};
     const symbols: gero.disasm.Symbols = .{ .entries = &entries };
 

--- a/tests/vm/dispatch.test.zig
+++ b/tests/vm/dispatch.test.zig
@@ -92,7 +92,7 @@ test "dispatch: bytes without a handler raise invalid-opcode" {
 
     // Pick bytes that have no handler yet: the invalid-opcode
     // fault should fire on each.
-    inline for ([_]u8{ 0x00, 0x6F, 0x83, 0xA5 }) |op| {
+    inline for ([_]u8{ 0x00, 0x6F, 0xA5, 0xD0 }) |op| {
         vm.regs.write(.ip, 0x1100);
         vm.mmap.writeByte(0x1100, op);
         vm.regs.write(.sp, 0xFFFE);
@@ -170,7 +170,7 @@ test "nested interrupts: cli inside ISR1 lets a second int fire and rti unwinds 
     vm.mmap.writeByte(0x1100, 0xFC);
     vm.mmap.writeByte(0x1101, 0x20);
     // ISR1 at 0x4000: cli; int 0x21; rti.
-    vm.mmap.writeByte(0x4000, 0xA2); // cli
+    vm.mmap.writeByte(0x4000, 0xB2); // cli
     vm.mmap.writeByte(0x4001, 0xFC); // int
     vm.mmap.writeByte(0x4002, 0x21);
     vm.mmap.writeByte(0x4003, 0xFD); // rti
@@ -204,8 +204,8 @@ test "dispatch: step auto-advances ip by instruction size" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
-    // 0x91 nop is 1 byte and has no handler yet → faults. Use a
-    // mov instead: 0x11 mov reg, reg is 3 bytes total.
+    // Use mov reg,reg (0x11, 3 bytes total) so we observe ip
+    // advancing by more than 1 byte after one step.
     vm.regs.write(.ip, 0x1100);
     vm.mmap.writeByte(0x1100, 0x11);
     vm.mmap.writeByte(0x1101, 0x03); // src = r2

--- a/tests/vm/handlers/arith.test.zig
+++ b/tests/vm/handlers/arith.test.zig
@@ -156,7 +156,7 @@ test "mul 0x46 imm16,reg: result fits in 16 bits clears C+V" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x10);
-    loadProgram(&vm, &.{ 0x46, 0x05, 0x00, 0x02 }); // 0x10 * 5 = 0x50
+    loadProgram(&vm, &.{ 0x46, 0x05, 0x00, 0x02 }); // 0x10 * 5 = 0x60
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x50), vm.regs.read(.r1));
     try std.testing.expectEqual(@as(u16, 0x00), vm.regs.read(.acu));
@@ -339,7 +339,7 @@ test "divs 0x4D imm16,reg: quotient outside i16 range faults via vector 0x05" {
 
 // ---------- adc / sbc ----------
 
-test "adc 0x64 imm16,reg: 32-bit add via low + adc high" {
+test "adc 0x50 imm16,reg: 32-bit add via low + adc high" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     // Add 0x0001FFFF + 0x00010002 = 0x00030001. Low halves: 0xFFFF +
@@ -354,23 +354,23 @@ test "adc 0x64 imm16,reg: 32-bit add via low + adc high" {
     try std.testing.expectEqual(@as(u16, 0x0001), vm.regs.read(.r1));
 
     // adc r2, 0x0001 — uses C from above.
-    loadProgram(&vm, &.{ 0x64, 0x01, 0x00, 0x03 });
+    loadProgram(&vm, &.{ 0x50, 0x01, 0x00, 0x03 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0003), vm.regs.read(.r2));
 }
 
-test "adc 0x65 reg,reg with carry-in" {
+test "adc 0x51 reg,reg with carry-in" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x10);
     vm.regs.write(.r2, 0x05);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x65, 0x03, 0x02 }); // adc r2, r1 (src, dst — with C=1)
+    loadProgram(&vm, &.{ 0x51, 0x03, 0x02 }); // adc r2, r1 (src, dst — with C=1)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x16), vm.regs.read(.r1));
 }
 
-test "sbc 0x66 imm16,reg: 32-bit sub via sub low + sbc high" {
+test "sbc 0x52 imm16,reg: 32-bit sub via sub low + sbc high" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     // 0x00030000 - 0x00010001 = 0x0001FFFF. Low: 0x0000 - 0x0001 =
@@ -382,18 +382,18 @@ test "sbc 0x66 imm16,reg: 32-bit sub via sub low + sbc high" {
     try std.testing.expect(flags(&vm).c);
     try std.testing.expectEqual(@as(u16, 0xFFFF), vm.regs.read(.r1));
 
-    loadProgram(&vm, &.{ 0x66, 0x01, 0x00, 0x03 }); // sbc r2, 0x0001 (uses C)
+    loadProgram(&vm, &.{ 0x52, 0x01, 0x00, 0x03 }); // sbc r2, 0x0001 (uses C)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0001), vm.regs.read(.r2));
 }
 
-test "sbc 0x67 reg,reg with borrow-in" {
+test "sbc 0x53 reg,reg with borrow-in" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x10);
     vm.regs.write(.r2, 0x05);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x67, 0x03, 0x02 }); // sbc r2, r1 (src, dst — with C=1)
+    loadProgram(&vm, &.{ 0x53, 0x03, 0x02 }); // sbc r2, r1 (src, dst — with C=1)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0A), vm.regs.read(.r1));
 }

--- a/tests/vm/handlers/bitwise.test.zig
+++ b/tests/vm/handlers/bitwise.test.zig
@@ -20,35 +20,35 @@ fn flags(vm: *VM) struct { z: bool, n: bool, c: bool, v: bool } {
 
 // ---------- and ----------
 
-test "and 0x50 imm16,reg" {
+test "and 0x60 imm16,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFF0F);
-    loadProgram(&vm, &.{ 0x50, 0xF0, 0x00, 0x02 }); // and 0x00F0, r1
+    loadProgram(&vm, &.{ 0x60, 0xF0, 0x00, 0x02 }); // and 0x00F0, r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.r1));
     const f = flags(&vm);
     try std.testing.expect(f.z and !f.n and !f.c and !f.v);
 }
 
-test "and 0x50: high bit set marks N" {
+test "and 0x60: high bit set marks N" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFFFF);
-    loadProgram(&vm, &.{ 0x50, 0x00, 0x80, 0x02 }); // and 0x8000, r1
+    loadProgram(&vm, &.{ 0x60, 0x00, 0x80, 0x02 }); // and 0x8000, r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x8000), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).n);
 }
 
-test "and 0x51 reg,reg clears C+V even if preset" {
+test "and 0x61 reg,reg clears C+V even if preset" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFF00);
     vm.regs.write(.r2, 0xFF0F);
     vm.regs.setFlag(.carry, true);
     vm.regs.setFlag(.overflow, true);
-    loadProgram(&vm, &.{ 0x51, 0x03, 0x02 }); // and r2, r1 → r1 &= r2 (src, dst)
+    loadProgram(&vm, &.{ 0x61, 0x03, 0x02 }); // and r2, r1 → r1 &= r2 (src, dst)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xFF00), vm.regs.read(.r1));
     try std.testing.expect(!flags(&vm).c);
@@ -57,41 +57,41 @@ test "and 0x51 reg,reg clears C+V even if preset" {
 
 // ---------- or ----------
 
-test "or 0x52 imm16,reg" {
+test "or 0x62 imm16,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x000F);
-    loadProgram(&vm, &.{ 0x52, 0xF0, 0x00, 0x02 }); // or 0x00F0, r1
+    loadProgram(&vm, &.{ 0x62, 0xF0, 0x00, 0x02 }); // or 0x00F0, r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x00FF), vm.regs.read(.r1));
 }
 
-test "or 0x53 reg,reg" {
+test "or 0x63 reg,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xF000);
     vm.regs.write(.r2, 0x000F);
-    loadProgram(&vm, &.{ 0x53, 0x03, 0x02 }); // or r2, r1 → r1 |= r2 (src, dst)
+    loadProgram(&vm, &.{ 0x63, 0x03, 0x02 }); // or r2, r1 → r1 |= r2 (src, dst)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xF00F), vm.regs.read(.r1));
 }
 
 // ---------- xor ----------
 
-test "xor 0x54 imm16,reg" {
+test "xor 0x64 imm16,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xAAAA);
-    loadProgram(&vm, &.{ 0x54, 0xFF, 0xFF, 0x02 }); // xor 0xFFFF, r1 (= not)
+    loadProgram(&vm, &.{ 0x64, 0xFF, 0xFF, 0x02 }); // xor 0xFFFF, r1 (= not)
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5555), vm.regs.read(.r1));
 }
 
-test "xor 0x55 reg,reg: self-xor zeroes the register" {
+test "xor 0x65 reg,reg: self-xor zeroes the register" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xCAFE);
-    loadProgram(&vm, &.{ 0x55, 0x02, 0x02 }); // xor r1, r1
+    loadProgram(&vm, &.{ 0x65, 0x02, 0x02 }); // xor r1, r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).z);
@@ -99,125 +99,125 @@ test "xor 0x55 reg,reg: self-xor zeroes the register" {
 
 // ---------- not ----------
 
-test "not 0x56 reg: bitwise complement" {
+test "not 0x66 reg: bitwise complement" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xAAAA);
-    loadProgram(&vm, &.{ 0x56, 0x02 });
+    loadProgram(&vm, &.{ 0x66, 0x02 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5555), vm.regs.read(.r1));
 }
 
 // ---------- shl ----------
 
-test "shl 0x58 reg,imm8: simple left shift, C from last bit out" {
+test "shl 0x70 reg,imm8: simple left shift, C from last bit out" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x4001); // bit 14 set, bit 0 set
-    loadProgram(&vm, &.{ 0x58, 0x02, 0x02 }); // shl r1, 2
+    loadProgram(&vm, &.{ 0x70, 0x02, 0x02 }); // shl r1, 2
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0004), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).c); // last bit out was bit 14 = 1
 }
 
-test "shl 0x58 reg,imm8: count 0 preserves C" {
+test "shl 0x70 reg,imm8: count 0 preserves C" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x1234);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x58, 0x02, 0x00 });
+    loadProgram(&vm, &.{ 0x70, 0x02, 0x00 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x1234), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).c); // unchanged
 }
 
-test "shl 0x58: count >= 16 zeroes the result and clears C" {
+test "shl 0x70: count >= 16 zeroes the result and clears C" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x00FF);
-    loadProgram(&vm, &.{ 0x58, 0x02, 0x14 }); // shl r1, 20
+    loadProgram(&vm, &.{ 0x70, 0x02, 0x14 }); // shl r1, 20
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).z);
     try std.testing.expect(!flags(&vm).c);
 }
 
-test "shl 0x59 reg,reg: count from src" {
+test "shl 0x71 reg,reg: count from src" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0008);
     vm.regs.write(.r2, 0x0003);
-    loadProgram(&vm, &.{ 0x59, 0x02, 0x03 });
+    loadProgram(&vm, &.{ 0x71, 0x02, 0x03 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0040), vm.regs.read(.r1));
 }
 
 // ---------- shr ----------
 
-test "shr 0x5A reg,imm8: logical right shift, zero-fills high bit" {
+test "shr 0x72 reg,imm8: logical right shift, zero-fills high bit" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x8003);
-    loadProgram(&vm, &.{ 0x5A, 0x02, 0x02 }); // shr r1, 2
+    loadProgram(&vm, &.{ 0x72, 0x02, 0x02 }); // shr r1, 2
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).c); // last bit out was bit 1 (set)
 }
 
-test "shr 0x5A: count 0 preserves C" {
+test "shr 0x72: count 0 preserves C" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x1234);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x5A, 0x02, 0x00 });
+    loadProgram(&vm, &.{ 0x72, 0x02, 0x00 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x1234), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).c);
 }
 
-test "shr 0x5B reg,reg: count from src" {
+test "shr 0x73 reg,reg: count from src" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0080);
     vm.regs.write(.r2, 0x0004);
-    loadProgram(&vm, &.{ 0x5B, 0x02, 0x03 });
+    loadProgram(&vm, &.{ 0x73, 0x02, 0x03 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0008), vm.regs.read(.r1));
 }
 
 // ---------- rol ----------
 
-test "rol 0x5C reg,imm8: rotate left through carry, count 1" {
+test "rol 0x76 reg,imm8: rotate left through carry, count 1" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x8001);
     vm.regs.setFlag(.carry, false);
-    loadProgram(&vm, &.{ 0x5C, 0x02, 0x01 }); // rol r1, 1
+    loadProgram(&vm, &.{ 0x76, 0x02, 0x01 }); // rol r1, 1
     _ = gero.vm.step(&vm);
     // bit 15 (1) → C; old C (0) → bit 0 of result; rest shifts left.
     try std.testing.expectEqual(@as(u16, 0x0002), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).c);
 }
 
-test "rol 0x5C: rotation preserves all bits through 17-bit chain" {
+test "rol 0x76: rotation preserves all bits through 17-bit chain" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xABCD);
     vm.regs.setFlag(.carry, false);
     // 17 rotations completes a full cycle → register + C back to start.
-    loadProgram(&vm, &.{ 0x5C, 0x02, 0x11 }); // rol r1, 17
+    loadProgram(&vm, &.{ 0x76, 0x02, 0x11 }); // rol r1, 17
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xABCD), vm.regs.read(.r1));
     try std.testing.expect(!flags(&vm).c);
 }
 
-test "rol 0x5D reg,reg" {
+test "rol 0x77 reg,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x8000);
     vm.regs.write(.r2, 0x0001);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x5D, 0x02, 0x03 });
+    loadProgram(&vm, &.{ 0x77, 0x02, 0x03 });
     _ = gero.vm.step(&vm);
     // bit 15 → C, old C(=1) → bit 0
     try std.testing.expectEqual(@as(u16, 0x0001), vm.regs.read(.r1));
@@ -226,37 +226,37 @@ test "rol 0x5D reg,reg" {
 
 // ---------- ror ----------
 
-test "ror 0x5E reg,imm8: rotate right through carry" {
+test "ror 0x78 reg,imm8: rotate right through carry" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0001);
     vm.regs.setFlag(.carry, false);
-    loadProgram(&vm, &.{ 0x5E, 0x02, 0x01 });
+    loadProgram(&vm, &.{ 0x78, 0x02, 0x01 });
     _ = gero.vm.step(&vm);
     // bit 0 → C; old C (0) → bit 15.
     try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).c);
 }
 
-test "ror 0x5E: carry-in feeds into bit 15" {
+test "ror 0x78: carry-in feeds into bit 15" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0002);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x5E, 0x02, 0x01 });
+    loadProgram(&vm, &.{ 0x78, 0x02, 0x01 });
     _ = gero.vm.step(&vm);
     // bit 0 (0) → C; old C (1) → bit 15.
     try std.testing.expectEqual(@as(u16, 0x8001), vm.regs.read(.r1));
     try std.testing.expect(!flags(&vm).c);
 }
 
-test "ror 0x5F reg,reg: count 17 is a full cycle" {
+test "ror 0x79 reg,reg: count 17 is a full cycle" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xCAFE);
     vm.regs.write(.r2, 0x0011); // 17
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x5F, 0x02, 0x03 });
+    loadProgram(&vm, &.{ 0x79, 0x02, 0x03 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xCAFE), vm.regs.read(.r1));
     try std.testing.expect(flags(&vm).c); // unchanged after full cycle
@@ -269,46 +269,46 @@ test "logical: invalid register raises invalid-register fault" {
     defer vm.deinit();
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
 
-    loadProgram(&vm, &.{ 0x51, 0x02, 0xFF }); // and r1, <out-of-range>
+    loadProgram(&vm, &.{ 0x61, 0x02, 0xFF }); // and r1, <out-of-range>
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
 
-// ---------- asr (0x6B / 0x6C) — arithmetic shift right ----------
+// ---------- asr (0x74 / 0x75) — arithmetic shift right ----------
 
-test "asr 0x6B: negative number preserves sign bit on shift" {
+test "asr 0x74: negative number preserves sign bit on shift" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFF00); // = -256 signed
-    loadProgram(&vm, &.{ 0x6B, 0x02, 0x01 }); // asr r1, $01
+    loadProgram(&vm, &.{ 0x74, 0x02, 0x01 }); // asr r1, $01
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xFF80), vm.regs.read(.r1)); // -128 signed
 }
 
-test "asr 0x6B: positive number behaves like shr" {
+test "asr 0x74: positive number behaves like shr" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0080);
-    loadProgram(&vm, &.{ 0x6B, 0x02, 0x01 });
+    loadProgram(&vm, &.{ 0x74, 0x02, 0x01 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0040), vm.regs.read(.r1));
 }
 
-test "asr 0x6B: shift by large count saturates to sign extension" {
+test "asr 0x74: shift by large count saturates to sign extension" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x8000); // = -32768 signed, MSB set
-    loadProgram(&vm, &.{ 0x6B, 0x02, 0xFF }); // asr r1, 255 — way past 16
+    loadProgram(&vm, &.{ 0x74, 0x02, 0xFF }); // asr r1, 255 — way past 16
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xFFFF), vm.regs.read(.r1)); // all sign-extended
 }
 
-test "asr 0x6C reg,reg: shift count from second register" {
+test "asr 0x75 reg,reg: shift count from second register" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFFFC); // = -4 signed
     vm.regs.write(.r2, 0x0001);
-    loadProgram(&vm, &.{ 0x6C, 0x02, 0x03 }); // asr r1, r2
+    loadProgram(&vm, &.{ 0x75, 0x02, 0x03 }); // asr r1, r2
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.r1)); // -2 signed
 }
@@ -317,7 +317,7 @@ test "asr: shift by zero is a no-op (no C update, value untouched)" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xC0DE);
-    loadProgram(&vm, &.{ 0x6B, 0x02, 0x00 });
+    loadProgram(&vm, &.{ 0x74, 0x02, 0x00 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xC0DE), vm.regs.read(.r1));
 }
@@ -326,7 +326,7 @@ test "asr: invalid register raises invalid-register fault" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
-    loadProgram(&vm, &.{ 0x6B, 0xFF, 0x01 });
+    loadProgram(&vm, &.{ 0x74, 0xFF, 0x01 });
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }

--- a/tests/vm/handlers/cmp.test.zig
+++ b/tests/vm/handlers/cmp.test.zig
@@ -20,11 +20,11 @@ fn flags(vm: *VM) struct { z: bool, n: bool, c: bool, v: bool } {
 
 // ---------- cmp ----------
 
-test "cmp 0x60 reg,imm16: equal → Z=1" {
+test "cmp 0x80 reg,imm16: equal → Z=1" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x1234);
-    loadProgram(&vm, &.{ 0x60, 0x02, 0x34, 0x12 }); // cmp r1, 0x1234
+    loadProgram(&vm, &.{ 0x80, 0x02, 0x34, 0x12 }); // cmp r1, 0x1234
     _ = gero.vm.step(&vm);
     const f = flags(&vm);
     try std.testing.expect(f.z and !f.n and !f.c and !f.v);
@@ -32,31 +32,31 @@ test "cmp 0x60 reg,imm16: equal → Z=1" {
     try std.testing.expectEqual(@as(u16, 0x1234), vm.regs.read(.r1));
 }
 
-test "cmp 0x60 reg,imm16: a < b unsigned sets C" {
+test "cmp 0x80 reg,imm16: a < b unsigned sets C" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0001);
-    loadProgram(&vm, &.{ 0x60, 0x02, 0x02, 0x00 }); // cmp r1, 2
+    loadProgram(&vm, &.{ 0x80, 0x02, 0x02, 0x00 }); // cmp r1, 2
     _ = gero.vm.step(&vm);
     try std.testing.expect(flags(&vm).c); // 1 - 2 borrows
     try std.testing.expect(flags(&vm).n);
 }
 
-test "cmp 0x60 reg,imm16: a > b clears C and Z" {
+test "cmp 0x80 reg,imm16: a > b clears C and Z" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0010);
-    loadProgram(&vm, &.{ 0x60, 0x02, 0x05, 0x00 }); // cmp r1, 5
+    loadProgram(&vm, &.{ 0x80, 0x02, 0x05, 0x00 }); // cmp r1, 5
     _ = gero.vm.step(&vm);
     const f = flags(&vm);
     try std.testing.expect(!f.c and !f.z and !f.n);
 }
 
-test "cmp 0x60: signed comparison via N ≠ V flags i16 max vs -1" {
+test "cmp 0x80: signed comparison via N ≠ V flags i16 max vs -1" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x7FFF); // i16 max
-    loadProgram(&vm, &.{ 0x60, 0x02, 0xFF, 0xFF }); // cmp r1, 0xFFFF (= -1)
+    loadProgram(&vm, &.{ 0x80, 0x02, 0xFF, 0xFF }); // cmp r1, 0xFFFF (= -1)
     _ = gero.vm.step(&vm);
     // 0x7FFF - 0xFFFF = 0x8000 (truncated). Signed: 32767 - (-1) = 32768
     // which overflows i16 → V=1. Result high bit set → N=1.
@@ -65,22 +65,22 @@ test "cmp 0x60: signed comparison via N ≠ V flags i16 max vs -1" {
     // jge takes branch when N == V → 32767 >= -1 is true. ✓
 }
 
-test "cmp 0x61 reg,reg: same registers Z=1" {
+test "cmp 0x81 reg,reg: same registers Z=1" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xABCD);
-    loadProgram(&vm, &.{ 0x61, 0x02, 0x02 }); // cmp r1, r1
+    loadProgram(&vm, &.{ 0x81, 0x02, 0x02 }); // cmp r1, r1
     _ = gero.vm.step(&vm);
     try std.testing.expect(flags(&vm).z);
     try std.testing.expectEqual(@as(u16, 0xABCD), vm.regs.read(.r1));
 }
 
-test "cmp 0x61: different values, signed comparison" {
+test "cmp 0x81: different values, signed comparison" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFFFE); // -2
     vm.regs.write(.r2, 0x0005); // 5
-    loadProgram(&vm, &.{ 0x61, 0x02, 0x03 }); // cmp r1, r2
+    loadProgram(&vm, &.{ 0x81, 0x02, 0x03 }); // cmp r1, r2
     _ = gero.vm.step(&vm);
     // -2 - 5 = -7 (0xFFF9). Negative result → N=1. No signed overflow.
     try std.testing.expect(flags(&vm).n);
@@ -89,45 +89,45 @@ test "cmp 0x61: different values, signed comparison" {
 
 // ---------- tst ----------
 
-test "tst 0x62 reg,imm16: zero mask sets Z" {
+test "tst 0x82 reg,imm16: zero mask sets Z" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xCAFE);
-    loadProgram(&vm, &.{ 0x62, 0x02, 0x00, 0x00 }); // tst r1, 0
+    loadProgram(&vm, &.{ 0x82, 0x02, 0x00, 0x00 }); // tst r1, 0
     _ = gero.vm.step(&vm);
     try std.testing.expect(flags(&vm).z);
     // r1 untouched.
     try std.testing.expectEqual(@as(u16, 0xCAFE), vm.regs.read(.r1));
 }
 
-test "tst 0x62: bit set in both → Z=0" {
+test "tst 0x82: bit set in both → Z=0" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x8001);
-    loadProgram(&vm, &.{ 0x62, 0x02, 0x00, 0x80 }); // tst r1, 0x8000
+    loadProgram(&vm, &.{ 0x82, 0x02, 0x00, 0x80 }); // tst r1, 0x8000
     _ = gero.vm.step(&vm);
     try std.testing.expect(!flags(&vm).z);
     try std.testing.expect(flags(&vm).n); // high bit set in AND result
 }
 
-test "tst 0x62: clears C and V even if preset" {
+test "tst 0x82: clears C and V even if preset" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x00FF);
     vm.regs.setFlag(.carry, true);
     vm.regs.setFlag(.overflow, true);
-    loadProgram(&vm, &.{ 0x62, 0x02, 0x0F, 0x00 });
+    loadProgram(&vm, &.{ 0x82, 0x02, 0x0F, 0x00 });
     _ = gero.vm.step(&vm);
     try std.testing.expect(!flags(&vm).c);
     try std.testing.expect(!flags(&vm).v);
 }
 
-test "tst 0x63 reg,reg" {
+test "tst 0x83 reg,reg" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFF00);
     vm.regs.write(.r2, 0x00FF);
-    loadProgram(&vm, &.{ 0x63, 0x02, 0x03 });
+    loadProgram(&vm, &.{ 0x83, 0x02, 0x03 });
     _ = gero.vm.step(&vm);
     try std.testing.expect(flags(&vm).z); // no overlapping bits
     // Neither register changed.
@@ -142,7 +142,7 @@ test "cmp/tst: invalid register raises invalid-register fault" {
     defer vm.deinit();
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
 
-    loadProgram(&vm, &.{ 0x61, 0x02, 0xFF }); // cmp r1, <out-of-range>
+    loadProgram(&vm, &.{ 0x81, 0x02, 0xFF }); // cmp r1, <out-of-range>
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
@@ -176,11 +176,11 @@ test "bclr 0x69 reg,imm8 — clears the target bit" {
     try std.testing.expectEqual(@as(u16, 0xFEFF), vm.regs.read(.r1));
 }
 
-test "btest 0x6A reg,imm8 — bit set → Z=0, N=1" {
+test "btest 0x67 reg,imm8 — bit set → Z=0, N=1" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0080);
-    loadProgram(&vm, &.{ 0x6A, 0x02, 0x07 }); // btest r1, $07
+    loadProgram(&vm, &.{ 0x67, 0x02, 0x07 }); // btest r1, $07
     _ = gero.vm.step(&vm);
     try std.testing.expect(!flags(&vm).z);
     try std.testing.expect(flags(&vm).n);
@@ -188,11 +188,11 @@ test "btest 0x6A reg,imm8 — bit set → Z=0, N=1" {
     try std.testing.expectEqual(@as(u16, 0x0080), vm.regs.read(.r1));
 }
 
-test "btest 0x6A reg,imm8 — bit clear → Z=1, N=0" {
+test "btest 0x67 reg,imm8 — bit clear → Z=1, N=0" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0080);
-    loadProgram(&vm, &.{ 0x6A, 0x02, 0x06 }); // btest r1, $06 (bit clear)
+    loadProgram(&vm, &.{ 0x67, 0x02, 0x06 }); // btest r1, $06 (bit clear)
     _ = gero.vm.step(&vm);
     try std.testing.expect(flags(&vm).z);
     try std.testing.expect(!flags(&vm).n);

--- a/tests/vm/handlers/jumps.test.zig
+++ b/tests/vm/handlers/jumps.test.zig
@@ -11,39 +11,39 @@ fn loadProgram(vm: *VM, bytes: []const u8) void {
 
 // ---------- unconditional ----------
 
-test "jmp 0x70 addr: always sets ip to target" {
+test "jmp 0x90 addr: always sets ip to target" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
-    loadProgram(&vm, &.{ 0x70, 0x00, 0x20 }); // jmp 0x2000
+    loadProgram(&vm, &.{ 0x90, 0x00, 0x20 }); // jmp 0x2000
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jmp 0x70: jump-to-self does NOT advance past the instruction" {
+test "jmp 0x90: jump-to-self does NOT advance past the instruction" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     // jmp $1100 — should stay parked on this instruction (infinite loop).
-    loadProgram(&vm, &.{ 0x70, 0x00, 0x11 });
+    loadProgram(&vm, &.{ 0x90, 0x00, 0x11 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x1100), vm.regs.read(.ip));
 }
 
-test "jmp 0x71 reg: target read from register" {
+test "jmp 0x91 reg: target read from register" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x3000);
-    loadProgram(&vm, &.{ 0x71, 0x02 }); // jmp r1
+    loadProgram(&vm, &.{ 0x91, 0x02 }); // jmp r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
 }
 
 // ---------- conditional jumps ----------
 
-test "jeq 0x72: Z=1 branches, Z=0 falls through" {
+test "jeq 0x92: Z=1 branches, Z=0 falls through" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.zero, true);
-    loadProgram(&vm, &.{ 0x72, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x92, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 
@@ -51,120 +51,120 @@ test "jeq 0x72: Z=1 branches, Z=0 falls through" {
     var vm2 = VM.init(std.testing.allocator);
     defer vm2.deinit();
     vm2.regs.setFlag(.zero, false);
-    loadProgram(&vm2, &.{ 0x72, 0x00, 0x20 });
+    loadProgram(&vm2, &.{ 0x92, 0x00, 0x20 });
     _ = gero.vm.step(&vm2);
     try std.testing.expectEqual(@as(u16, 0x1103), vm2.regs.read(.ip));
 }
 
-test "jne 0x73: Z=0 branches" {
+test "jne 0x93: Z=0 branches" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.zero, false);
-    loadProgram(&vm, &.{ 0x73, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x93, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jlt 0x74: N ≠ V branches (signed less)" {
+test "jlt 0x94: N ≠ V branches (signed less)" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.negative, true);
     vm.regs.setFlag(.overflow, false);
-    loadProgram(&vm, &.{ 0x74, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x94, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jle 0x75: Z=1 takes the branch" {
+test "jle 0x95: Z=1 takes the branch" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.zero, true);
-    loadProgram(&vm, &.{ 0x75, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x95, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jle 0x75: Z=0 N≠V (signed less) takes the branch" {
+test "jle 0x95: Z=0 N≠V (signed less) takes the branch" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.zero, false);
     vm.regs.setFlag(.negative, false);
     vm.regs.setFlag(.overflow, true);
-    loadProgram(&vm, &.{ 0x75, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x95, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jgt 0x76: Z=0 ∧ N=V branches" {
+test "jgt 0x96: Z=0 ∧ N=V branches" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.zero, false);
     vm.regs.setFlag(.negative, false);
     vm.regs.setFlag(.overflow, false);
-    loadProgram(&vm, &.{ 0x76, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x96, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jge 0x77: N=V branches (includes Z=1)" {
+test "jge 0x97: N=V branches (includes Z=1)" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.zero, true);
     vm.regs.setFlag(.negative, true);
     vm.regs.setFlag(.overflow, true);
-    loadProgram(&vm, &.{ 0x77, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x97, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jcc 0x78: C=0 branches" {
+test "jcc 0x98: C=0 branches" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.carry, false);
-    loadProgram(&vm, &.{ 0x78, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x98, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jcs 0x79: C=1 branches" {
+test "jcs 0x99: C=1 branches" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x79, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x99, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jvc 0x7A: V=0 branches" {
+test "jvc 0x9A: V=0 branches" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.overflow, false);
-    loadProgram(&vm, &.{ 0x7A, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x9A, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jvs 0x7B: V=1 branches" {
+test "jvs 0x9B: V=1 branches" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.overflow, true);
-    loadProgram(&vm, &.{ 0x7B, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x9B, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "jz 0x7C / jnz 0x7D: aliases for jeq / jne" {
+test "jz 0x9C / jnz 0x9D: aliases for jeq / jne" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.zero, true);
-    loadProgram(&vm, &.{ 0x7C, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x9C, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 
     var vm2 = VM.init(std.testing.allocator);
     defer vm2.deinit();
     vm2.regs.setFlag(.zero, false);
-    loadProgram(&vm2, &.{ 0x7D, 0x00, 0x30 });
+    loadProgram(&vm2, &.{ 0x9D, 0x00, 0x30 });
     _ = gero.vm.step(&vm2);
     try std.testing.expectEqual(@as(u16, 0x3000), vm2.regs.read(.ip));
 }
@@ -173,21 +173,21 @@ test "conditional jumps: fall-through matrix when the condition is false" {
     // Flag bits: Z=0, N=1, C=2, V=3 in the `flg` register.
     const Case = struct { opcode: u8, flg: u16, label: []const u8 };
     const cases = [_]Case{
-        .{ .opcode = 0x72, .flg = 0b0000, .label = "jeq with Z=0" },
-        .{ .opcode = 0x73, .flg = 0b0001, .label = "jne with Z=1" },
-        .{ .opcode = 0x74, .flg = 0b0000, .label = "jlt with N=V=0" },
-        .{ .opcode = 0x74, .flg = 0b1010, .label = "jlt with N=V=1" },
-        .{ .opcode = 0x75, .flg = 0b0000, .label = "jle with Z=0, N=V=0" },
-        .{ .opcode = 0x76, .flg = 0b0001, .label = "jgt with Z=1" },
-        .{ .opcode = 0x76, .flg = 0b1000, .label = "jgt with N≠V" },
-        .{ .opcode = 0x77, .flg = 0b0010, .label = "jge with N=1, V=0" },
-        .{ .opcode = 0x77, .flg = 0b1000, .label = "jge with N=0, V=1" },
-        .{ .opcode = 0x78, .flg = 0b0100, .label = "jcc with C=1" },
-        .{ .opcode = 0x79, .flg = 0b0000, .label = "jcs with C=0" },
-        .{ .opcode = 0x7A, .flg = 0b1000, .label = "jvc with V=1" },
-        .{ .opcode = 0x7B, .flg = 0b0000, .label = "jvs with V=0" },
-        .{ .opcode = 0x7C, .flg = 0b0000, .label = "jz with Z=0" },
-        .{ .opcode = 0x7D, .flg = 0b0001, .label = "jnz with Z=1" },
+        .{ .opcode = 0x92, .flg = 0b0000, .label = "jeq with Z=0" },
+        .{ .opcode = 0x93, .flg = 0b0001, .label = "jne with Z=1" },
+        .{ .opcode = 0x94, .flg = 0b0000, .label = "jlt with N=V=0" },
+        .{ .opcode = 0x94, .flg = 0b1010, .label = "jlt with N=V=1" },
+        .{ .opcode = 0x95, .flg = 0b0000, .label = "jle with Z=0, N=V=0" },
+        .{ .opcode = 0x96, .flg = 0b0001, .label = "jgt with Z=1" },
+        .{ .opcode = 0x96, .flg = 0b1000, .label = "jgt with N≠V" },
+        .{ .opcode = 0x97, .flg = 0b0010, .label = "jge with N=1, V=0" },
+        .{ .opcode = 0x97, .flg = 0b1000, .label = "jge with N=0, V=1" },
+        .{ .opcode = 0x98, .flg = 0b0100, .label = "jcc with C=1" },
+        .{ .opcode = 0x99, .flg = 0b0000, .label = "jcs with C=0" },
+        .{ .opcode = 0x9A, .flg = 0b1000, .label = "jvc with V=1" },
+        .{ .opcode = 0x9B, .flg = 0b0000, .label = "jvs with V=0" },
+        .{ .opcode = 0x9C, .flg = 0b0000, .label = "jz with Z=0" },
+        .{ .opcode = 0x9D, .flg = 0b0001, .label = "jnz with Z=1" },
     };
     for (cases) |c| {
         var vm = VM.init(std.testing.allocator);
@@ -205,34 +205,34 @@ test "conditional jumps: fall-through matrix when the condition is false" {
 
 // ---------- djnz ----------
 
-test "djnz 0x7E: decrement and branch while non-zero" {
+test "djnz 0x9E: decrement and branch while non-zero" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0003);
-    loadProgram(&vm, &.{ 0x7E, 0x02, 0x00, 0x20 }); // djnz r1, 0x2000
+    loadProgram(&vm, &.{ 0x9E, 0x02, 0x00, 0x20 }); // djnz r1, 0x2000
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0002), vm.regs.read(.r1));
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
 }
 
-test "djnz 0x7E: fall through when decrement reaches zero" {
+test "djnz 0x9E: fall through when decrement reaches zero" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0001);
-    loadProgram(&vm, &.{ 0x7E, 0x02, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x9E, 0x02, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.r1));
     // Fall-through: ip advances past the 4-byte instruction.
     try std.testing.expectEqual(@as(u16, 0x1104), vm.regs.read(.ip));
 }
 
-test "djnz 0x7E: flags are NOT touched by the decrement" {
+test "djnz 0x9E: flags are NOT touched by the decrement" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0001);
     vm.regs.setFlag(.zero, false);
     vm.regs.setFlag(.carry, true);
-    loadProgram(&vm, &.{ 0x7E, 0x02, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0x9E, 0x02, 0x00, 0x20 });
     _ = gero.vm.step(&vm);
     // r1 just hit 0, but Z stays false (djnz is flag-neutral).
     try std.testing.expect(!vm.regs.flagSet(.zero));
@@ -241,39 +241,39 @@ test "djnz 0x7E: flags are NOT touched by the decrement" {
 
 // ---------- jr ----------
 
-test "jr 0x7F: positive offset, post-instruction relative" {
+test "jr 0x9F: positive offset, post-instruction relative" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
-    loadProgram(&vm, &.{ 0x7F, 0x10 }); // jr +16
+    loadProgram(&vm, &.{ 0x9F, 0x10 }); // jr +16
     _ = gero.vm.step(&vm);
     // target = ip(0x1100) + 2 + 16 = 0x1112
     try std.testing.expectEqual(@as(u16, 0x1112), vm.regs.read(.ip));
 }
 
-test "jr 0x7F: negative offset rolls back" {
+test "jr 0x9F: negative offset rolls back" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
-    loadProgram(&vm, &.{ 0x7F, 0xFE }); // jr -2 (i8 = -2)
+    loadProgram(&vm, &.{ 0x9F, 0xFE }); // jr -2 (i8 = -2)
     _ = gero.vm.step(&vm);
     // target = ip(0x1100) + 2 + (-2) = 0x1100 → loops on itself.
     try std.testing.expectEqual(@as(u16, 0x1100), vm.regs.read(.ip));
 }
 
-test "jr 0x7F: zero offset advances to next instruction" {
+test "jr 0x9F: zero offset advances to next instruction" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
-    loadProgram(&vm, &.{ 0x7F, 0x00 });
+    loadProgram(&vm, &.{ 0x9F, 0x00 });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
 }
 
 // ---------- fault paths ----------
 
-test "jmp 0x71: invalid register raises invalid-register fault" {
+test "jmp 0x91: invalid register raises invalid-register fault" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
-    loadProgram(&vm, &.{ 0x71, 0xFF });
+    loadProgram(&vm, &.{ 0x91, 0xFF });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }

--- a/tests/vm/handlers/mov.test.zig
+++ b/tests/vm/handlers/mov.test.zig
@@ -106,14 +106,14 @@ test "mov 0x17 addr,reg,reg: indexed load (base + offset_reg)" {
     try std.testing.expectEqual(@as(u16, 0x1105), vm.regs.read(.ip));
 }
 
-test "mov8 0x29 addr,reg,reg: indexed BYTE load (base + offset_reg)" {
+test "mov8 0x25 addr,reg,reg: indexed BYTE load (base + offset_reg)" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
     vm.regs.write(.r1, 0x10); // offset
     vm.mmap.writeByte(0x2010, 0x42);
     vm.mmap.writeByte(0x2011, 0xFF); // adjacent byte — must NOT bleed into r2 hi
-    loadProgram(&vm, &.{ 0x29, 0x00, 0x20, 0x02, 0x03 }); // r2 ← mem[0x2000 + r1]
+    loadProgram(&vm, &.{ 0x25, 0x00, 0x20, 0x02, 0x03 }); // r2 ← mem[0x2000 + r1]
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x0042), vm.regs.read(.r2));
     try std.testing.expectEqual(@as(u16, 0x1105), vm.regs.read(.ip));
@@ -215,22 +215,22 @@ test "mov8 0x24 [reg],reg: byte load via pointer zero-extends" {
     try std.testing.expectEqual(@as(u16, 0x0099), vm.regs.read(.r2));
 }
 
-test "movh 0x25 reg,addr: writes the high byte of reg to memory" {
+test "movh 0x26 reg,addr: writes the high byte of reg to memory" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
     vm.regs.write(.r1, 0xAB12);
-    loadProgram(&vm, &.{ 0x25, 0x02, 0x00, 0x20 }); // mem[0x2000] ← r1.hi
+    loadProgram(&vm, &.{ 0x26, 0x02, 0x00, 0x20 }); // mem[0x2000] ← r1.hi
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u8, 0xAB), vm.mmap.readByte(0x2000));
 }
 
-test "movl 0x26 reg,addr: writes the low byte of reg to memory" {
+test "movl 0x27 reg,addr: writes the low byte of reg to memory" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
     vm.regs.write(.r1, 0xAB12);
-    loadProgram(&vm, &.{ 0x26, 0x02, 0x00, 0x20 }); // mem[0x2000] ← r1.lo
+    loadProgram(&vm, &.{ 0x27, 0x02, 0x00, 0x20 }); // mem[0x2000] ← r1.lo
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u8, 0x12), vm.mmap.readByte(0x2000));
 }
@@ -250,7 +250,7 @@ test "mov family: no variant touches flags" {
         &.{ 0x12, 0x02, 0x00, 0x20 }, // mov reg,addr
         &.{ 0x13, 0x00, 0x20, 0x02 }, // mov addr,reg
         &.{ 0x21, 0x42, 0x02 }, // mov8 imm8,reg
-        &.{ 0x25, 0x02, 0x00, 0x21 }, // movh reg,addr
+        &.{ 0x26, 0x02, 0x00, 0x21 }, // movh reg,addr
     }) |bytes| {
         loadProgram(&vm, bytes);
         try expectFlagsUnchanged(&vm);
@@ -272,7 +272,7 @@ test "mov: invalid register index raises invalid-register fault" {
 
 // ---------- block memory ops (bcpy / bset) ----------
 
-test "bcpy 0x27: copies len bytes from src to dst" {
+test "bcpy 0x2c: copies len bytes from src to dst" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
@@ -286,7 +286,7 @@ test "bcpy 0x27: copies len bytes from src to dst" {
     vm.regs.write(.r2, 0x2000); // src
     vm.regs.write(.r3, 0x0004); // len
 
-    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0x04 }); // bcpy r1, r2, r3
+    loadProgram(&vm, &.{ 0x2c, 0x02, 0x03, 0x04 }); // bcpy r1, r2, r3
     _ = gero.vm.step(&vm);
 
     try std.testing.expectEqual(@as(u8, 0xDE), vm.mmap.readByte(0x3000));
@@ -307,7 +307,7 @@ test "bcpy: len = 0 is a no-op" {
     vm.regs.write(.r1, 0x3000);
     vm.regs.write(.r2, 0x2000);
     vm.regs.write(.r3, 0x0000);
-    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0x04 });
+    loadProgram(&vm, &.{ 0x2c, 0x02, 0x03, 0x04 });
     _ = gero.vm.step(&vm);
 
     try std.testing.expectEqual(@as(u8, 0xBB), vm.mmap.readByte(0x3000));
@@ -324,7 +324,7 @@ test "bcpy: address wraps at the 16-bit boundary" {
     vm.regs.write(.r1, 0x4000);
     vm.regs.write(.r2, 0xFFFE);
     vm.regs.write(.r3, 0x0003);
-    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0x04 });
+    loadProgram(&vm, &.{ 0x2c, 0x02, 0x03, 0x04 });
     _ = gero.vm.step(&vm);
 
     try std.testing.expectEqual(@as(u8, 0x11), vm.mmap.readByte(0x4000));
@@ -339,7 +339,7 @@ test "bcpy: doesn't touch flags" {
     vm.regs.write(.r1, 0x3000);
     vm.regs.write(.r2, 0x2000);
     vm.regs.write(.r3, 0x0010);
-    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0x04 });
+    loadProgram(&vm, &.{ 0x2c, 0x02, 0x03, 0x04 });
     try expectFlagsUnchanged(&vm);
 }
 
@@ -349,12 +349,12 @@ test "bcpy: invalid register index raises invalid-register fault" {
 
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
     // bcpy r1, r2, <out-of-range>
-    loadProgram(&vm, &.{ 0x27, 0x02, 0x03, 0xFF });
+    loadProgram(&vm, &.{ 0x2c, 0x02, 0x03, 0xFF });
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
 
-test "bfill 0x28: fills len bytes with the value-register's low byte" {
+test "bfill 0x2d: fills len bytes with the value-register's low byte" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
@@ -362,7 +362,7 @@ test "bfill 0x28: fills len bytes with the value-register's low byte" {
     vm.regs.write(.r2, 0x0008); // len
     vm.regs.write(.r3, 0xDEAD); // value (only 0xAD will be written)
 
-    loadProgram(&vm, &.{ 0x28, 0x02, 0x03, 0x04 }); // bset r1, r2, r3
+    loadProgram(&vm, &.{ 0x2d, 0x02, 0x03, 0x04 }); // bset r1, r2, r3
     _ = gero.vm.step(&vm);
 
     var i: u16 = 0;
@@ -381,7 +381,7 @@ test "bfill: len = 0 is a no-op" {
     vm.regs.write(.r1, 0x3000);
     vm.regs.write(.r2, 0x0000);
     vm.regs.write(.r3, 0xFF);
-    loadProgram(&vm, &.{ 0x28, 0x02, 0x03, 0x04 });
+    loadProgram(&vm, &.{ 0x2d, 0x02, 0x03, 0x04 });
     _ = gero.vm.step(&vm);
 
     try std.testing.expectEqual(@as(u8, 0xCC), vm.mmap.readByte(0x3000));
@@ -394,7 +394,7 @@ test "bfill: address wraps at the 16-bit boundary" {
     vm.regs.write(.r1, 0xFFFE);
     vm.regs.write(.r2, 0x0003);
     vm.regs.write(.r3, 0x5A);
-    loadProgram(&vm, &.{ 0x28, 0x02, 0x03, 0x04 });
+    loadProgram(&vm, &.{ 0x2d, 0x02, 0x03, 0x04 });
     _ = gero.vm.step(&vm);
 
     try std.testing.expectEqual(@as(u8, 0x5A), vm.mmap.readByte(0xFFFE));
@@ -409,7 +409,7 @@ test "bfill: doesn't touch flags" {
     vm.regs.write(.r1, 0x3000);
     vm.regs.write(.r2, 0x0010);
     vm.regs.write(.r3, 0x00);
-    loadProgram(&vm, &.{ 0x28, 0x02, 0x03, 0x04 });
+    loadProgram(&vm, &.{ 0x2d, 0x02, 0x03, 0x04 });
     try expectFlagsUnchanged(&vm);
 }
 
@@ -418,34 +418,34 @@ test "bfill: invalid register index raises invalid-register fault" {
     defer vm.deinit();
 
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
-    loadProgram(&vm, &.{ 0x28, 0x02, 0xFF, 0x04 });
+    loadProgram(&vm, &.{ 0x2d, 0x02, 0xFF, 0x04 });
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
 
-// ---------- sext (0x2E) ----------
+// ---------- sext (0x4F) ----------
 
-test "sext 0x2E: negative low byte (bit 7 set) → reg.hi ← 0xFF" {
+test "sext 0x4F: negative low byte (bit 7 set) → reg.hi ← 0xFF" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x1234); // hi byte garbage
     vm.mmap.writeByte(0x1100, 0x80); // r1.lo will be set to 0x80 first via mov8
     loadProgram(&vm, &.{
         0x21, 0x80, 0x02, // mov8 $80, r1  → r1 = 0x0080
-        0x2E, 0x02, // sext r1            → r1 = 0xFF80
+        0x4F, 0x02, // sext r1            → r1 = 0xFF80
     });
     _ = gero.vm.step(&vm); // mov8
     _ = gero.vm.step(&vm); // sext
     try std.testing.expectEqual(@as(u16, 0xFF80), vm.regs.read(.r1));
 }
 
-test "sext 0x2E: positive low byte (bit 7 clear) → reg.hi ← 0x00" {
+test "sext 0x4F: positive low byte (bit 7 clear) → reg.hi ← 0x00" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xFFFF); // hi byte garbage, will be cleaned
     loadProgram(&vm, &.{
         0x21, 0x7F, 0x02, // mov8 $7F, r1  → r1 = 0x007F
-        0x2E, 0x02, // sext r1            → r1 = 0x007F (no change)
+        0x4F, 0x02, // sext r1            → r1 = 0x007F (no change)
     });
     _ = gero.vm.step(&vm);
     _ = gero.vm.step(&vm);
@@ -456,7 +456,7 @@ test "sext: doesn't touch flags" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x0080); // bit 7 set
-    loadProgram(&vm, &.{ 0x2E, 0x02 });
+    loadProgram(&vm, &.{ 0x4F, 0x02 });
     try expectFlagsUnchanged(&vm);
 }
 
@@ -464,7 +464,7 @@ test "sext: invalid register raises invalid-register fault" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
-    loadProgram(&vm, &.{ 0x2E, 0xFF });
+    loadProgram(&vm, &.{ 0x4F, 0xFF });
     try std.testing.expectEqual(gero.vm.StepResult.branched, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }

--- a/tests/vm/handlers/subroutine.test.zig
+++ b/tests/vm/handlers/subroutine.test.zig
@@ -9,11 +9,11 @@ fn loadProgram(vm: *VM, bytes: []const u8) void {
     }
 }
 
-test "call 0x80 addr: pushes fp + ret-ip, sets fp = sp, jumps" {
+test "call 0xa0 addr: pushes fp + ret-ip, sets fp = sp, jumps" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.fp, 0xDEAD);
-    loadProgram(&vm, &.{ 0x80, 0x00, 0x20 }); // call 0x2000
+    loadProgram(&vm, &.{ 0xa0, 0x00, 0x20 }); // call 0x2000
     _ = gero.vm.step(&vm);
 
     // After call: ip = target.
@@ -28,11 +28,11 @@ test "call 0x80 addr: pushes fp + ret-ip, sets fp = sp, jumps" {
     try std.testing.expectEqual(@as(u16, 0xFFFA), vm.regs.read(.fp));
 }
 
-test "call 0x81 reg: target from register, ret-ip is post-instruction (+2)" {
+test "call 0xa1 reg: target from register, ret-ip is post-instruction (+2)" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x3000);
-    loadProgram(&vm, &.{ 0x81, 0x02 }); // call r1
+    loadProgram(&vm, &.{ 0xa1, 0x02 }); // call r1
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.ip));
     // Ret-ip pushed = ip_before + 2 = 0x1102.
@@ -44,9 +44,9 @@ test "call/ret round-trip: control returns to the instruction after call" {
     defer vm.deinit();
 
     // Caller at 0x1100: `call 0x2000` (3 bytes).
-    loadProgram(&vm, &.{ 0x80, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0xa0, 0x00, 0x20 });
     // Subroutine at 0x2000: a bare `ret`.
-    vm.mmap.writeByte(0x2000, 0x82);
+    vm.mmap.writeByte(0x2000, 0xa2);
 
     _ = gero.vm.step(&vm); // call
     try std.testing.expectEqual(@as(u16, 0x2000), vm.regs.read(.ip));
@@ -64,14 +64,14 @@ test "call/ret nested two levels: outer ret reaches the original caller" {
 
     // 0x1100: call 0x2000
     // 0x1103: hlt-marker (we won't execute it)
-    loadProgram(&vm, &.{ 0x80, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0xa0, 0x00, 0x20 });
     // 0x2000: call 0x2100
     // 0x2003: ret
-    vm.mmap.writeByte(0x2000, 0x80);
+    vm.mmap.writeByte(0x2000, 0xa0);
     vm.mmap.writeWord(0x2001, 0x2100);
-    vm.mmap.writeByte(0x2003, 0x82);
+    vm.mmap.writeByte(0x2003, 0xa2);
     // 0x2100: ret
-    vm.mmap.writeByte(0x2100, 0x82);
+    vm.mmap.writeByte(0x2100, 0xa2);
 
     _ = gero.vm.step(&vm); // outer call → ip=0x2000
     _ = gero.vm.step(&vm); // inner call → ip=0x2100
@@ -85,17 +85,17 @@ test "call/ret nested two levels: outer ret reaches the original caller" {
     try std.testing.expectEqual(@as(u16, 0xFFFE), vm.regs.read(.fp));
 }
 
-test "ret 0x82: unwinds locals that the callee pushed below fp" {
+test "ret 0xa2: unwinds locals that the callee pushed below fp" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
 
     // 0x1100: call 0x2000
-    loadProgram(&vm, &.{ 0x80, 0x00, 0x20 });
+    loadProgram(&vm, &.{ 0xa0, 0x00, 0x20 });
     // 0x2000: push 0xCAFE (3 bytes) — a local on the stack.
     // 0x2003: ret.
     vm.mmap.writeByte(0x2000, 0x30); // push imm16
     vm.mmap.writeWord(0x2001, 0xCAFE);
-    vm.mmap.writeByte(0x2003, 0x82);
+    vm.mmap.writeByte(0x2003, 0xa2);
 
     _ = gero.vm.step(&vm); // call → ip=0x2000, sp moved 4 bytes (fp+ret-ip).
     _ = gero.vm.step(&vm); // push imm16 → sp moves another 2 bytes.
@@ -108,11 +108,11 @@ test "ret 0x82: unwinds locals that the callee pushed below fp" {
     try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
 }
 
-test "call 0x81: invalid register raises invalid-register fault" {
+test "call 0xa1: invalid register raises invalid-register fault" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
-    loadProgram(&vm, &.{ 0x81, 0xFF });
+    loadProgram(&vm, &.{ 0xa1, 0xFF });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }

--- a/tests/vm/handlers/system.test.zig
+++ b/tests/vm/handlers/system.test.zig
@@ -11,34 +11,34 @@ fn loadProgram(vm: *VM, bytes: []const u8) void {
 
 // ---------- misc ----------
 
-test "swap 0x90: registers exchanged, ip advances 3 bytes" {
+test "swap 0xC0: registers exchanged, ip advances 3 bytes" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0x1111);
     vm.regs.write(.r2, 0x2222);
-    loadProgram(&vm, &.{ 0x90, 0x02, 0x03 }); // swap r1, r2
+    loadProgram(&vm, &.{ 0xC0, 0x02, 0x03 }); // swap r1, r2
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x2222), vm.regs.read(.r1));
     try std.testing.expectEqual(@as(u16, 0x1111), vm.regs.read(.r2));
     try std.testing.expectEqual(@as(u16, 0x1103), vm.regs.read(.ip));
 }
 
-test "swap 0x90: invalid register raises fault" {
+test "swap 0xC0: invalid register raises fault" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_register), 0x5000);
-    loadProgram(&vm, &.{ 0x90, 0x02, 0xFF });
+    loadProgram(&vm, &.{ 0xC0, 0x02, 0xFF });
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
 }
 
-test "nop 0x91: nothing changes except ip" {
+test "nop 0xC1: nothing changes except ip" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.r1, 0xCAFE);
     vm.regs.write(.flg, 0xFFFF);
     const flg_before = vm.regs.read(.flg);
-    loadProgram(&vm, &.{0x91});
+    loadProgram(&vm, &.{0xC1});
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u16, 0xCAFE), vm.regs.read(.r1));
     try std.testing.expectEqual(flg_before, vm.regs.read(.flg));
@@ -47,11 +47,11 @@ test "nop 0x91: nothing changes except ip" {
 
 // ---------- flag manipulation ----------
 
-test "clc 0xA0: clears C, leaves other flags intact" {
+test "clc 0xB0: clears C, leaves other flags intact" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.flg, 0xFFFF);
-    loadProgram(&vm, &.{0xA0});
+    loadProgram(&vm, &.{0xB0});
     _ = gero.vm.step(&vm);
     try std.testing.expect(!vm.regs.flagSet(.carry));
     // Other flags untouched.
@@ -61,11 +61,11 @@ test "clc 0xA0: clears C, leaves other flags intact" {
     try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
 }
 
-test "sec 0xA1: sets C only" {
+test "sec 0xB1: sets C only" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.flg, 0);
-    loadProgram(&vm, &.{0xA1});
+    loadProgram(&vm, &.{0xB1});
     _ = gero.vm.step(&vm);
     try std.testing.expect(vm.regs.flagSet(.carry));
     try std.testing.expect(!vm.regs.flagSet(.zero));
@@ -74,24 +74,24 @@ test "sec 0xA1: sets C only" {
     try std.testing.expect(!vm.regs.flagSet(.interrupt_disable));
 }
 
-test "cli 0xA2 / sei 0xA3: toggle interrupt-disable bit" {
+test "cli 0xB2 / sei 0xB3: toggle interrupt-disable bit" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.setFlag(.interrupt_disable, true);
-    loadProgram(&vm, &.{0xA2}); // cli
+    loadProgram(&vm, &.{0xB2}); // cli
     _ = gero.vm.step(&vm);
     try std.testing.expect(!vm.regs.flagSet(.interrupt_disable));
 
-    loadProgram(&vm, &.{0xA3}); // sei
+    loadProgram(&vm, &.{0xB3}); // sei
     _ = gero.vm.step(&vm);
     try std.testing.expect(vm.regs.flagSet(.interrupt_disable));
 }
 
-test "clv 0xA4: clears V only" {
+test "clv 0xB4: clears V only" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.flg, 0xFFFF);
-    loadProgram(&vm, &.{0xA4});
+    loadProgram(&vm, &.{0xB4});
     _ = gero.vm.step(&vm);
     try std.testing.expect(!vm.regs.flagSet(.overflow));
     try std.testing.expect(vm.regs.flagSet(.carry));
@@ -190,7 +190,7 @@ test "hlt 0xFF: returns halted, ip stays on hlt instruction" {
 test "run: exits on hlt" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
-    loadProgram(&vm, &.{ 0x91, 0x91, 0xFF }); // nop, nop, hlt
+    loadProgram(&vm, &.{ 0xC1, 0xC1, 0xFF }); // nop, nop, hlt
     try std.testing.expectEqual(gero.vm.StepResult.halted, gero.vm.run(&vm));
     try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
 }
@@ -198,7 +198,7 @@ test "run: exits on hlt" {
 test "run: exits on brk, but resuming continues to hlt" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
-    loadProgram(&vm, &.{ 0x91, 0xFE, 0xFF }); // nop, brk, hlt
+    loadProgram(&vm, &.{ 0xC1, 0xFE, 0xFF }); // nop, brk, hlt
     try std.testing.expectEqual(gero.vm.StepResult.breakpoint, gero.vm.run(&vm));
     // ip is past the brk.
     try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));

--- a/tests/vm/loader.test.zig
+++ b/tests/vm/loader.test.zig
@@ -169,8 +169,8 @@ test "boot: banked program installs the bank pool" {
 test "boot + run: nop nop hlt program executes and halts" {
     var buf: [16 + 3]u8 = undefined;
     _ = buildGx(buf[0..16], 0x0001, 0, 0x0000, 3, 0, 0);
-    buf[16] = 0x91; // nop
-    buf[17] = 0x91; // nop
+    buf[16] = 0xC1; // nop
+    buf[17] = 0xC1; // nop
     buf[18] = 0xFF; // hlt
     const loaded = try gero.vm.parseGx(&buf);
 
@@ -190,9 +190,9 @@ test "cycles: init starts at 0 and step increments by 1 each call" {
     try std.testing.expectEqual(@as(u64, 0), vm.cycles);
 
     vm.regs.write(.ip, 0x1100);
-    vm.mmap.writeByte(0x1100, 0x91); // nop
-    vm.mmap.writeByte(0x1101, 0x91);
-    vm.mmap.writeByte(0x1102, 0x91);
+    vm.mmap.writeByte(0x1100, 0xC1); // nop
+    vm.mmap.writeByte(0x1101, 0xC1);
+    vm.mmap.writeByte(0x1102, 0xC1);
     _ = gero.vm.step(&vm);
     try std.testing.expectEqual(@as(u64, 1), vm.cycles);
     _ = gero.vm.step(&vm);
@@ -214,7 +214,7 @@ test "cycles: run accumulates one per step including the terminating hlt" {
     var vm = VM.init(std.testing.allocator);
     defer vm.deinit();
     vm.regs.write(.ip, 0x1100);
-    vm.mmap.writeByte(0x1100, 0x91); // nop
+    vm.mmap.writeByte(0x1100, 0xC1); // nop
     vm.mmap.writeByte(0x1101, 0xFF); // hlt
     _ = gero.vm.run(&vm);
     try std.testing.expectEqual(@as(u64, 2), vm.cycles);

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -8,8 +8,11 @@ test "opcodes: operandSize matches encoding widths" {
     try std.testing.expectEqual(@as(u8, 1), gero.vm.operandSize(.reg));
     try std.testing.expectEqual(@as(u8, 1), gero.vm.operandSize(.imm8));
     try std.testing.expectEqual(@as(u8, 1), gero.vm.operandSize(.zp));
+    try std.testing.expectEqual(@as(u8, 1), gero.vm.operandSize(.reg_indirect));
     try std.testing.expectEqual(@as(u8, 2), gero.vm.operandSize(.imm16));
     try std.testing.expectEqual(@as(u8, 2), gero.vm.operandSize(.addr));
+    try std.testing.expectEqual(@as(u8, 2), gero.vm.operandSize(.reg_offset));
+    try std.testing.expectEqual(@as(u8, 3), gero.vm.operandSize(.indexed));
 }
 
 test "opcodes: OpcodeInfo.size sums opcode + operands" {
@@ -25,7 +28,7 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     const movx = OpcodeInfo{ .mnemonic = "mov", .operands = &.{ .imm16, .reg } };
     try std.testing.expectEqual(@as(u8, 4), movx.size());
 
-    const movix = OpcodeInfo{ .mnemonic = "mov", .operands = &.{ .addr, .reg, .reg } };
+    const movix = OpcodeInfo{ .mnemonic = "mov", .operands = &.{ .indexed, .reg } };
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
@@ -34,11 +37,6 @@ test "opcodes: table holds exactly 105 named entries" {
     for (table) |entry| if (entry != null) {
         count += 1;
     };
-    // 97 = 93 base + 4 byte-mov ZP variants (0x2A-0x2D), then 3
-    // single-bit ops at 0x68/0x69/0x6A (bset / bclr / btest),
-    // sext at 0x2E (sign-extension), 2 asr variants at
-    // 0x6B/0x6C (arithmetic shift right), then 2 reg-offset mov
-    // variants at 0x1C/0x1D (frame-relative load + store).
     try std.testing.expectEqual(@as(usize, 105), count);
 }
 
@@ -57,18 +55,20 @@ test "opcodes: table sample — mov family" {
     try std.testing.expectEqualStrings("mov", table[0x10].?.mnemonic);
     try std.testing.expectEqualSlices(Operand, &.{ .imm16, .reg }, table[0x10].?.operands);
     try std.testing.expectEqualStrings("mov", table[0x17].?.mnemonic);
-    try std.testing.expectEqualSlices(Operand, &.{ .addr, .reg, .reg }, table[0x17].?.operands);
+    try std.testing.expectEqualSlices(Operand, &.{ .indexed, .reg }, table[0x17].?.operands);
     try std.testing.expectEqualStrings("mov", table[0x1B].?.mnemonic);
     try std.testing.expectEqualSlices(Operand, &.{ .imm16, .zp }, table[0x1B].?.operands);
+    try std.testing.expectEqualStrings("mov", table[0x1C].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{ .reg_offset, .reg }, table[0x1C].?.operands);
 }
 
-test "opcodes: table sample — control flow" {
-    try std.testing.expectEqualStrings("jmp", table[0x70].?.mnemonic);
-    try std.testing.expectEqualSlices(Operand, &.{.addr}, table[0x70].?.operands);
-    try std.testing.expectEqualStrings("djnz", table[0x7E].?.mnemonic);
-    try std.testing.expectEqualSlices(Operand, &.{ .reg, .addr }, table[0x7E].?.operands);
-    try std.testing.expectEqualStrings("jr", table[0x7F].?.mnemonic);
-    try std.testing.expectEqualSlices(Operand, &.{.imm8}, table[0x7F].?.operands);
+test "opcodes: table sample — branches" {
+    try std.testing.expectEqualStrings("jmp", table[0x90].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{.addr}, table[0x90].?.operands);
+    try std.testing.expectEqualStrings("djnz", table[0x9E].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{ .reg, .addr }, table[0x9E].?.operands);
+    try std.testing.expectEqualStrings("jr", table[0x9F].?.mnemonic);
+    try std.testing.expectEqualSlices(Operand, &.{.imm8}, table[0x9F].?.operands);
 }
 
 test "opcodes: table sample — system" {
@@ -83,27 +83,27 @@ test "opcodes: table sample — system" {
 test "opcodes: instruction sizes span the full 1-5 byte range" {
     // 1 byte — no operands.
     try std.testing.expectEqual(@as(u8, 1), table[0xFF].?.size()); // hlt
-    try std.testing.expectEqual(@as(u8, 1), table[0x91].?.size()); // nop
-    try std.testing.expectEqual(@as(u8, 1), table[0xA0].?.size()); // clc
+    try std.testing.expectEqual(@as(u8, 1), table[0xC1].?.size()); // nop
+    try std.testing.expectEqual(@as(u8, 1), table[0xB0].?.size()); // clc
 
     // 2 bytes — 1 single-byte operand.
     try std.testing.expectEqual(@as(u8, 2), table[0x31].?.size()); // push reg
-    try std.testing.expectEqual(@as(u8, 2), table[0x7F].?.size()); // jr imm8
+    try std.testing.expectEqual(@as(u8, 2), table[0x9F].?.size()); // jr imm8
     try std.testing.expectEqual(@as(u8, 2), table[0xFC].?.size()); // int imm8
 
     // 3 bytes — combinations summing to 2 operand bytes.
-    try std.testing.expectEqual(@as(u8, 3), table[0x70].?.size()); // jmp addr
+    try std.testing.expectEqual(@as(u8, 3), table[0x90].?.size()); // jmp addr
     try std.testing.expectEqual(@as(u8, 3), table[0x11].?.size()); // mov reg,reg
     try std.testing.expectEqual(@as(u8, 3), table[0x30].?.size()); // push imm16
 
     // 4 bytes — most binary ops.
     try std.testing.expectEqual(@as(u8, 4), table[0x10].?.size()); // mov imm16,reg
     try std.testing.expectEqual(@as(u8, 4), table[0x40].?.size()); // add imm16,reg
-    try std.testing.expectEqual(@as(u8, 4), table[0x7E].?.size()); // djnz reg,addr
+    try std.testing.expectEqual(@as(u8, 4), table[0x9E].?.size()); // djnz reg,addr
 
     // 5 bytes — indexed mov (word) + indexed mov8 (byte).
-    try std.testing.expectEqual(@as(u8, 5), table[0x17].?.size()); // mov addr,reg,reg
-    try std.testing.expectEqual(@as(u8, 5), table[0x29].?.size()); // mov8 addr,reg,reg
+    try std.testing.expectEqual(@as(u8, 5), table[0x17].?.size()); // mov indexed,reg
+    try std.testing.expectEqual(@as(u8, 5), table[0x25].?.size()); // mov8 indexed,reg
 }
 
 test "opcodes: unused byte values are null" {
@@ -111,10 +111,11 @@ test "opcodes: unused byte values are null" {
     try std.testing.expect(table[0x00] == null);
     try std.testing.expect(table[0x0F] == null);
     try std.testing.expect(table[0x33] == null);
-    try std.testing.expect(table[0x57] == null);
-    try std.testing.expect(table[0x6F] == null);
-    try std.testing.expect(table[0xB0] == null);
-    try std.testing.expect(table[0xFB] == null);
+    try std.testing.expect(table[0x54] == null); // 0x5X arith-carry gap
+    try std.testing.expect(table[0x6A] == null); // 0x6X bitwise gap
+    try std.testing.expect(table[0x7A] == null); // 0x7X shifts gap
+    try std.testing.expect(table[0xD0] == null); // reserved page
+    try std.testing.expect(table[0xFB] == null); // pre-system gap
 }
 
 test "opcodes: schema sizes never overflow a u8 instruction" {


### PR DESCRIPTION
## Summary

Renumber every non-`mov`, non-stack, non-primary-arithmetic opcode onto a dedicated 16-slot page so the high nibble tells you the family at a glance. Adds `Operand.reg_indirect` and `Operand.indexed` so the VM operand enum matches the resolver's `Kind` enum — disassembly stops special-casing by opcode byte.

Closes nothing on its own — pre-1.0 housekeeping that pairs with #186 (already merged). Editor submodules bumped to v0.3.0 in the same PR.

## New page topology

| Page  | Role                                              |
|-------|---------------------------------------------------|
| 0x1X  | `mov` word                                        |
| 0x2X  | `mov` byte                                        |
| 0x3X  | stack (`push` / `pop`)                            |
| 0x4X  | arith primary (`add` / `sub` / `mul` / `div` / …) — `sext` lands at `0x4F` |
| 0x5X  | arith carry-propagating (`adc` / `sbc`)           |
| 0x6X  | bitwise (`and` / `or` / `xor` / `not` / `btest` / `bset` / `bclr`) |
| 0x7X  | shifts (`shl` / `shr` / `asr` / `rol` / `ror`)    |
| 0x8X  | `cmp` / `tst`                                     |
| 0x9X  | branches (`jmp` / `jeq` / `jne` / `jlt` / `jgt` / `jle` / `jge` / …) |
| 0xAX  | subroutines (`call` / `ret` / `bank_call` / `bank_jump`) |
| 0xBX  | flag control (`clc` / `sec` / `cli` / `sei` / `clv`) |
| 0xCX  | misc (`swap` / `bcpy` / `bfill` / `nop`)          |
| 0xD0–0xEF | reserved                                      |
| 0xFX  | system (`int` / `rti` / `brk` / `hlt`)            |

105 opcodes laid out across mathematically-tight pages. Arithmetic needs two pages (`0x4X` + `0x5X`) because 20 ops don't fit in 16 slots; carry-propagating variants get the second page rather than spilling into bitwise.

## Why now

Pre-1.0 is the only moment we can renumber without a deprecation horizon. Every consumer that hard-codes opcode bytes will need to re-encode, but:

- the mnemonic surface is unchanged
- the operand grammar is unchanged
- the assembler/disassembler/VM all read from the same `opcodes.zig` table

so re-encoding a `.gx` is `gero asm` → done.

## Operand enum schema fix

The asm `opcode_resolver` already carried `reg_indirect` / `indexed` / `reg_offset` in its `Kind` enum, but the VM `Operand` enum only knew `reg` / `imm8` / `imm16` / `addr` / `zp` / `reg_offset`. Disassembly papered over the gap by special-casing the two opcodes that take `[reg]` or `[addr + reg]`. This PR adds:

- `Operand.reg_indirect` — 1 byte, `[reg]`
- `Operand.indexed` — 3 bytes, `[addr + reg]`

so the VM table is self-describing and `disasm` walks the operand list uniformly. Resolver unchanged.

## Editor submodules — v0.3.0

| Submodule | Bump  | Coverage |
|-----------|-------|----------|
| `tree-sitter-gero-asm` | v0.2.1 → v0.3.0 | `sext` / `asr` / `btest` / `bclr` / `bfill` added to mnemonic alternation; `bset` kept (the resolver disambiguates by operand shape); new corpus `v0_3_features.txt` pins `[reg + imm]` stack-frame addressing |
| `vscode-gero`          | v0.2.1 → v0.3.0 | Same five mnemonics added to their natural TextMate categories (`sext` → arith, `asr` → bitwise, `btest`/`bclr` → test, `bfill` → data movement) |

The repagination itself has zero editor-surface impact — bytes change, mnemonics + grammar don't. The v0.3.0 bumps exist for #186's mnemonics; they're shipped here because the same downstream consumer cycle (Neovim users, VS Code users) will install both at once.

## Changeset

Marked `major` — every embedded `.gx` blob needs re-encoding, and downstream tools that switch on opcode bytes (none in-tree, but plausibly downstream) need to be retabled.

## Test plan

- [x] `zig build ci` → green (488/488 steps, 2484/2484 tests across Debug/ReleaseSafe/ReleaseFast/ReleaseSmall × 5 targets)
- [x] `tree-sitter test` → 21/21 corpus parses (new `v0_3_features.txt` covers bit ops, sext/asr, bfill, `[reg + imm]`)
- [x] `gero check docs/examples/*.gas` → all 5 examples + 2 include-only files pass
- [x] Docs (`docs/isa.md` §5) restructured into 13 sub-sections, one role per heading; before/after pagination overview at top of §5
- [x] `disasm` no longer special-cases by opcode byte (operand enum self-describes)