### PR TITLE
chore(meta): pre-release prep for v0.2.0

### DIFF
--- a/.changeset/isa-repagination.md
+++ b/.changeset/isa-repagination.md
@@ -1,5 +1,6 @@
 ---
-bump: major
+bump: minor
+breaking: true
 ---
 
 ISA repagination: one 16-slot page per role. All opcode bytes outside the `mov`,

--- a/build.zig
+++ b/build.zig
@@ -24,6 +24,17 @@ pub fn build(b: *std.Build) void {
     });
     gero_mod.addImport("knit", knit_mod);
 
+    // The library carries its own build_options so consumers picking up
+    // `gero` as a dependency see VERSION without needing to wire options
+    // themselves. The extra `is_lib` marker forces `addOptions` to emit a
+    // distinct content-addressed file from `cli_options` — without it,
+    // both objects hash to the same path and the CLI binary fails to
+    // build with a "file in two modules" error.
+    const lib_options = b.addOptions();
+    lib_options.addOption([]const u8, "version", package_version);
+    lib_options.addOption(bool, "is_lib", true);
+    gero_mod.addOptions("build_options", lib_options);
+
     const lib = b.addLibrary(.{
         .name = "gero",
         .root_module = gero_mod,

--- a/src/gero.zig
+++ b/src/gero.zig
@@ -1,6 +1,8 @@
 /// Gero — 16-bit virtual machine + assembler + Lua-style language
 /// ecosystem in Zig. Public barrel.
-pub const VERSION = "0.0.0";
+/// Package version — sourced from `build.zig.zon` via `build_options`
+/// so library consumers don't need a second site to bump.
+pub const VERSION: []const u8 = @import("build_options").version;
 
 /// VM kernel — register file, memory, and the composing `VM` type.
 pub const vm = @import("vm/vm.zig");

--- a/tests/gero.test.zig
+++ b/tests/gero.test.zig
@@ -1,6 +1,14 @@
 const std = @import("std");
 const gero = @import("gero");
 
-test "gero exposes VERSION" {
-    try std.testing.expectEqualStrings("0.0.0", gero.VERSION);
+test "gero exposes VERSION sourced from build.zig.zon" {
+    // The exact version moves on every release; pin the shape (X.Y.Z)
+    // so the smoke test stays valid across bumps.
+    var it = std.mem.splitScalar(u8, gero.VERSION, '.');
+    var parts: usize = 0;
+    while (it.next()) |part| : (parts += 1) {
+        try std.testing.expect(part.len > 0);
+        for (part) |c| try std.testing.expect(c >= '0' and c <= '9');
+    }
+    try std.testing.expectEqual(@as(usize, 3), parts);
 }


### PR DESCRIPTION
## Summary

Two pre-flight fixups before cutting v0.2.0:

1. **Downgrade `isa-repagination.md` bump major → minor + breaking** — `scripts/changeset-version.sh` is mechanical; a major bump from `0.1.2` produces `1.0.0`, not `v0.2.0`. Pre-1.0 convention is breaking → minor with the `breaking: true` marker, leaving the actual major bump reserved for the v1.0 cut.
2. **Wire `gero.VERSION` through `build_options`** — was a permanent `"0.0.0"` sentinel pinned by a smoke test. The CLI already sources from `build.zig.zon`; the library now does too. Library and CLI carry separate options objects (lib side has an `is_lib` marker) so both can coexist in the same module graph without Zig's content-addressed `addOptions` collapsing them onto the same file.

## Test plan

- [x] `zig build ci` green
- [x] `zig build test-modes` green (Debug/ReleaseSafe/ReleaseFast/ReleaseSmall)
- [x] `gero --version` still prints `gero 0.1.2`
- [x] `gero.VERSION` smoke test now asserts shape (X.Y.Z, digits only) instead of pinning a literal

Merge → `zig build version` will compute `v0.2.0` from the highest remaining bump (minor).