### PR TITLE
feat(lang): parser core — AST, recursive descent, Pratt precedence

### DIFF
--- a/.changeset/lang-parser.md
+++ b/.changeset/lang-parser.md
@@ -4,7 +4,13 @@ bump: minor
 
 `gero.lang.parse` lands — the recursive-descent parser that
 consumes the lexer's `TokenStream` and emits an `ast.Program`.
-Covers every statement and expression form in gero-lang §3-§6:
+Covers every statement and expression form in gero-lang §3-§6.
+
+The same PR locks down the **gero-lang v1 spec** in
+`docs/gero-lang.md` so the language shape is final before the
+typechecker and codegen land on top.
+
+**Parser surface:**
 
 - Declarations: `let` / `const` / `def` / `lambda` / `class` /
   `struct` / `enum` / `use` (whole-module, aliased, selective,
@@ -13,7 +19,7 @@ Covers every statement and expression form in gero-lang §3-§6:
   expr when guard` shape), `while` (with `while let`), `for-in`
   with optional `step`, `match` with patterns + guards, `do…end`
   as both statement and expression, `return` / `break` /
-  `continue` / `print`
+  `continue` / `print` / `defer`
 - Patterns: wildcard, ident binding, literal, or-pattern,
   range-pattern, tuple, struct (with shorthand), enum variant
 - Type annotations: primitives, `T?` nullable, `[T; N]` arrays,
@@ -21,31 +27,63 @@ Covers every statement and expression form in gero-lang §3-§6:
 - Assignment forms: plain `=`, every compound `+=` / `-=` /
   `*=` / `/=` / `%=` / `&=` / `|=` / `^=` / `<<=` / `>>=`,
   statement-only `++` / `--`, `_ = expr` discard
-- Pratt-precedence expression parser per §3.3: range < `or` <
-  `and` < cmp < `|` < `^` < `&` < shift < add/sub < mul/div <
-  `is` < unary < postfix
-- Annotation attachment: `@bank N` / `@interrupt N` / `@final` /
-  `@inline` / `@override` / `@private` / `@static` / `@abstract`
-  / `@noreturn` / `@test` / `@bench` / `@zero_page` / `@addr` —
+- Pratt-precedence expression parser per §4.2.1, including the
+  `as` cast operator and `is` variant test
+- Annotation attachment: every annotation in §3.7 — `@bank N`,
+  `@interrupt N`, `@final`, `@inline`, `@override`, `@private`,
+  `@static`, `@abstract`, `@noreturn`, `@test`, `@bench`,
+  `@zero_page`, `@addr`, `@volatile`, `@align(N)`, `@cold` —
   paren'd or bare-arg form, multi-annotation stacks, attaches to
   the following `def` / `class` / `struct` / `enum` / `let` /
   `const` / class field / class method
+- `@asm("...")` emits a dedicated `asm_stmt` AST node at
+  statement position; `@abstract def` declares a method without
+  a body.
 
-Lexer extended with:
+**Lexer additions:**
 
-- Compound-assign tokens (`+=`, `-=`, …, `<<=`, `>>=`) — §4.2
-- Fixed-point literals (`1.5`, `0.125`, …) — §3.3, pre-encoded as
-  Q8.8 (`1.5` → `0x0180`)
-- `$1234` hex literals — §3.7.1, sibling to `0x1234`
+- Compound-assign tokens (`+=`, `-=`, …, `<<=`, `>>=`)
+- Fixed-point literals (`1.5`, `0.125`, …) pre-encoded as Q8.8
+- `$1234` hex literals
+- `defer` keyword
 
-Diagnostics flow through `core.ParseError` for consistency with the
-asm side.
+**Spec lockdown (`docs/gero-lang.md`):**
 
-Annotation attachment landed for every spec target (§3.7): `def`,
-`class`, `struct`, `enum`, class fields + methods, and module-level
-`let` / `const` (so `@bank N`, `@zero_page`, `@addr $1234` reach
-codegen). `@asm("…")` emits a dedicated `asm_stmt` AST node at
-statement position. `@abstract def` declares a method without a
-body.
+- §1 — `let`-mutable-by-default flagged as intentional
+- §2.4 — Hex literals are `$...` only; `0x` removed for retro
+  consistency
+- §2.6 — Adds `asm` and `bake` keywords
+- §3.4.4 — New section: References `&T` for pass-by-reference
+  without copies, with `&x` prefix and `mem.addr_of(x)` for raw
+  `u16` addresses
+- §3.5.1 — Type casts (`x as T`) with full conversion table
+- §3.7.1 — Adds `@volatile` and `@align(N)`
+- §3.7.2 — `@inline` capped at 32 bytecode instructions
+  post-lowering; `@cold` lays cold functions after non-cold ones
+  deterministically; new `@no_capture` annotation
+- §3.7.7 — Reclassifies `@asm("…")` as the builtin `asm`
+  statement (§4.11), not an annotation
+- §3.8 — New section: `bake` compile-time evaluation for lookup
+  tables, palette ramps, RNG seeds
+- §4.2 — Adds overflow-explicit operators `+%` / `-%` / `*%`
+  (wrap) and `+|` / `-|` / `*|` (saturate); plain `+` / `-` /
+  `*` trap on overflow in debug builds, wrap in release builds.
+  MMIO assignment via `@addr @volatile` bindings.
+- §4.4 — Removes `then` after `if` / `elif` heads
+- §4.5 — Removes `do` after `while` / `for` heads
+- §4.5.4 — New: labeled `break :label` and `continue :label`
+- §4.6.1 — Tail-call optimization on direct `return self_or_sibling(args)`
+- §4.6.2 — User-defined variadic parameters (`args: ...`)
+- §4.7.1 — Short lambda form `|x| x*2` (Rust-style)
+- §4.8 — Match arm separator switched from `then` to `=>`
+- §4.10 — Defer bytecode-cost section added
+- §4.11 — New section: inline `asm "..."` statement
+- §5.3.1 — Typed `mem.read_u8 / read_u16 / read_i8 / read_i16 /
+  write_*` + `mem.addr_of` builtin; `debug_assert` distinct from
+  `assert`
+- §6 — `super.<field>` allowed; class-fields-default-public
+  documented as intentional
+- §9 — Adds explicit out-of-scope notes for raw pointers,
+  borrow checker, and the `then` / `do` removal
 
 Public re-exports through `gero.lang`: `ast`, `ParseTree`, `parse`.

--- a/.changeset/lang-parser.md
+++ b/.changeset/lang-parser.md
@@ -1,0 +1,39 @@
+---
+bump: minor
+---
+
+`gero.lang.parse` lands — the recursive-descent parser that
+consumes the lexer's `TokenStream` and emits an `ast.Program`.
+Covers every statement and expression form in gero-lang §4:
+
+- Declarations: `let` / `const` / `def` / `lambda` / `class` /
+  `struct` / `enum` / `use` (whole-module, aliased, selective,
+  quoted-path), plus `local` visibility shim
+- Control flow: `if` / `elif` / `else` (with `if let pat =
+  expr when guard` shape), `while` (with `while let`), `for-in`
+  with optional `step`, `match` with patterns + guards, `do…end`
+  as both statement and expression, `return` / `break` /
+  `continue` / `print`
+- Patterns: wildcard, ident binding, literal, or-pattern,
+  range-pattern, tuple, struct (with shorthand), enum variant
+- Type annotations: primitives, `T?` nullable, `[T; N]` arrays,
+  `Vec(T)`, tuples, `fn(args) -> ret`
+- Assignment forms: plain `=`, every compound `+=` / `-=` /
+  `*=` / `/=` / `%=` / `&=` / `|=` / `^=` / `<<=` / `>>=`,
+  statement-only `++` / `--`, `_ = expr` discard
+- Pratt-precedence expression parser per §3.3: range < `or` <
+  `and` < cmp < `|` < `^` < `&` < shift < add/sub < mul/div <
+  `is` < unary < postfix
+- Annotation attachment: `@bank N` / `@interrupt N` / `@final` /
+  `@inline` / `@override` / `@private` / `@static` / `@abstract`
+  / `@noreturn` / `@test` / `@bench` / `@zero_page` / `@addr` —
+  paren'd or bare-arg form, multi-annotation stacks, attaches to
+  the following `def` / `class` / `struct` / `enum` / `let` /
+  `const` / class field / class method
+
+Lexer extended with compound-assign tokens (`+=`, `-=`, …,
+`<<=`, `>>=`) needed by the parser. Diagnostics flow through
+`core.ParseError` for consistency with the asm side.
+
+Public re-exports through `gero.lang`: `ast`, `ParseTree`,
+`parse`.

--- a/.changeset/lang-parser.md
+++ b/.changeset/lang-parser.md
@@ -4,7 +4,7 @@ bump: minor
 
 `gero.lang.parse` lands — the recursive-descent parser that
 consumes the lexer's `TokenStream` and emits an `ast.Program`.
-Covers every statement and expression form in gero-lang §4:
+Covers every statement and expression form in gero-lang §3-§6:
 
 - Declarations: `let` / `const` / `def` / `lambda` / `class` /
   `struct` / `enum` / `use` (whole-module, aliased, selective,
@@ -31,9 +31,21 @@ Covers every statement and expression form in gero-lang §4:
   the following `def` / `class` / `struct` / `enum` / `let` /
   `const` / class field / class method
 
-Lexer extended with compound-assign tokens (`+=`, `-=`, …,
-`<<=`, `>>=`) needed by the parser. Diagnostics flow through
-`core.ParseError` for consistency with the asm side.
+Lexer extended with:
 
-Public re-exports through `gero.lang`: `ast`, `ParseTree`,
-`parse`.
+- Compound-assign tokens (`+=`, `-=`, …, `<<=`, `>>=`) — §4.2
+- Fixed-point literals (`1.5`, `0.125`, …) — §3.3, pre-encoded as
+  Q8.8 (`1.5` → `0x0180`)
+- `$1234` hex literals — §3.7.1, sibling to `0x1234`
+
+Diagnostics flow through `core.ParseError` for consistency with the
+asm side.
+
+Annotation attachment landed for every spec target (§3.7): `def`,
+`class`, `struct`, `enum`, class fields + methods, and module-level
+`let` / `const` (so `@bank N`, `@zero_page`, `@addr $1234` reach
+codegen). `@asm("…")` emits a dedicated `asm_stmt` AST node at
+statement position. `@abstract def` declares a method without a
+body.
+
+Public re-exports through `gero.lang`: `ast`, `ParseTree`, `parse`.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -12,10 +12,18 @@ for J-RPG-class games and similar carts; see §1 for the philosophy.
 
 ## 1. Philosophy
 
-- **Reads like Lua / BASIC** — `let`, `do … end`, `if … then … end`,
+- **Reads like Lua / BASIC** — `let`, `do … end`, `if … end`,
   `print`. Familiar to anyone who's touched a teaching language.
+- **No block keywords mid-statement** — no `then` after `if`, no `do`
+  after `while` / `for`. The newline ends the head; the body starts
+  on the next line. Less noise, fewer cumulative `end`s to read past.
 - **No semicolons** — statement boundaries are newlines. Cheap to
   type, less visual noise. (Modern Lua, Go, Python convention.)
+- **Mutable `let` by default** — `let x = 0` is mutable, `const X = 0`
+  is immutable. Style follows Lua / JS / BASIC, not Rust / Swift.
+  This is a deliberate choice for the teaching-language audience the
+  syntax targets; the cost is a small friction for devs arriving from
+  Rust/Swift where `let` means immutable.
 - **Typed at the variable / function boundary** — every `let` /
   parameter / return type gets an annotation OR is inferred from
   context. Once compiled, types are erased — runtime is fully
@@ -57,7 +65,7 @@ continuation (`a +\n  b`) is **not** a line-continuation rule.
 
 The one exception lives outside the bracket families: a `.` at the
 start of the next line continues the postfix chain on the previous
-expression (§4.6.1). That's the only newline-significant carve-out
+expression (§4.6.3). That's the only newline-significant carve-out
 in the otherwise strict newline-terminated grammar.
 
 ### 2.2 Comments
@@ -85,12 +93,16 @@ The compiler doesn't enforce — convention only.
 | Form | Example | Type |
 |------|---------|------|
 | Decimal | `42`, `1000` | `int` (= `i16`) by default |
-| Hex | `0xFF`, `0xABCD` | `int` |
+| Hex | `$FF`, `$ABCD` | `int`. `$` prefix only — retro 6502/Z80 style. |
 | Binary | `0b1010_0101` | `int`. Underscores allowed for readability. |
 | Negative | `-1` | `int` (unary minus operator) |
 
 No floating-point literals — gero VM is integer-only. For fractions
 use the `fixed` type (8.8 fixed-point — see §3.3).
+
+The lexer disambiguates `$FE40` (hex literal) from `$(expr)` (string
+interpolation, §3.2.2) by lookahead: digit / hex-letter after `$` →
+literal; `(` after `$` → interpolation marker.
 
 ### 2.5 String literals
 
@@ -113,13 +125,15 @@ literal is undefined (it lives in ROM at runtime).
 Single-quoted single-byte literals are sugar for their ASCII value:
 
 ```
-let c: u8 = 'A'              -- 0x41
-let nl: u8 = '\n'            -- 0x0A
-if s.at(0) == 'A' then ...   -- byte compare reads naturally
+let c: u8 = 'A'              -- $41
+let nl: u8 = '\n'            -- $0A
+if s.at(0) == 'A'            -- byte compare reads naturally
+  ...
+end
 ```
 
 The token's type is `u8`. Same escape table as strings (`\n` `\t`
-`\r` `\0` `\\` `\'` `\xHH`). `'A'` and `0x41` compile to identical
+`\r` `\0` `\\` `\'` `\xHH`). `'A'` and `$41` compile to identical
 bytecode — char literals exist purely for source readability. Mirrors
 the asm spec's `'A'` (asm §1.4) so byte literals look the same across
 both languages.
@@ -128,8 +142,8 @@ both languages.
 
 ```
 let const def lambda return
-if then else end
-while do for in step
+if else end
+while for in step
 match case when
 class extends self super
 enum is
@@ -138,7 +152,16 @@ true false nil
 and or not
 break continue defer
 print
+asm bake
 ```
+
+`then` after `if`/`elif` and `do` after `while`/`for` are **not**
+keywords. The head expression ends at the newline; the body starts
+on the next line. Writing `if cond then …` is a syntax error.
+
+`asm` is a builtin statement (§4.11) for one-instruction inline
+assembly. `bake` marks a `def` or `do`-block for compile-time
+evaluation (§3.8).
 
 `and`, `or`, `not` are the boolean operators (short-circuit). The
 bitwise counterparts use symbolic operators `&` `|` `^` `<<` `>>`
@@ -186,7 +209,7 @@ Mutable byte buffers are `[u8; N]` (fixed size).
 |------|---------|------------|
 | `a + b`           | `str` (concatenation) | **Yes** — new buffer in `state.allocator` |
 | `s.len`           | `u16` (byte count, excluding `\0`) | No |
-| `s.at(i)`         | `u8` (byte at index `i`) | No. Bounds-check at runtime; out-of-bounds → fault vector `0x02`. |
+| `s.at(i)`         | `u8` (byte at index `i`) | No. Bounds-check at runtime; out-of-bounds → fault vector `$02`. |
 | `s == other`      | `bool` (lexicographic equality, byte-wise) | No |
 | `s != other`      | `bool` | No |
 | `s < other` etc.  | `bool` (lex ordering) | No |
@@ -264,8 +287,8 @@ same spec language, runtime-evaluated. Allocates the result.
 fraction). Range ±127.99…, precision 1/256.
 
 ```
-let v: fixed = 1.5    -- compiles to 0x0180
-let dx: fixed = 0.125 -- compiles to 0x0020
+let v: fixed = 1.5    -- compiles to $0180
+let dx: fixed = 0.125 -- compiles to $0020
 ```
 
 Standard arithmetic operators work transparently:
@@ -296,9 +319,10 @@ PICO-8, Sonic, early Doom used.
 | Dynamic array | `Vec(i16)` | Growable buffer with `push` / `pop` / `len` / `at`. See §3.4.3. |
 | Tuple | `(i16, str)` | Anonymous heterogeneous pair / triple / etc. Max 4 elements (5+ → use a struct). Destructurable in `let` and `match`. Field access via `.0`, `.1`, …. |
 | Optional | `T?` | Nullable pointer type — see §3.4.1. |
+| Reference | `&T` | Borrowed reference, no arithmetic. See §3.4.4. |
 | Function | `fn(i16, i16) -> i16` | First-class — assignable, passable. |
 | Struct | `struct Foo a: i16, b: u8 end` | C-style POD. Fields contiguous in memory, no methods. See §3.4.2. Literal: `Foo { a: 1, b: 2 }`. |
-| Class | `class Foo { … }` | Vtable + fields, methods, single inheritance. See §6. |
+| Class | `class Foo … end` | Vtable + fields, methods, single inheritance. See §6. |
 
 #### 3.4.1 Nullable types `T?`
 
@@ -316,18 +340,18 @@ let n: i16     = 0            -- not nullable; use a sentinel for "absent"
 const NOT_FOUND: i16 = -1     -- conventional sentinel for absent index
 ```
 
-**Layout** = `sizeof(T)`. The value `0x0000` is the canonical `nil`
-representation (since pointer types use `0x0000` as their natural
+**Layout** = `sizeof(T)`. The value `$0000` is the canonical `nil`
+representation (since pointer types use `$0000` as their natural
 null), so no tag byte is needed.
 
 **Testing for nil:**
 
 ```
-if p != nil then
+if p != nil
   p.greet()           -- safe — flow analysis carries non-nil through
 end
 
-if p == nil then
+if p == nil
   return
 end
 p.greet()             -- safe here too
@@ -335,7 +359,7 @@ p.greet()             -- safe here too
 
 **Dereferencing a nullable.** Direct method/field access on a `T?`
 value compiles with a runtime nil-check that faults via vector
-`0x02` if the value is `nil`. The compiler **statically requires
+`$02` if the value is `nil`. The compiler **statically requires
 a nil-check** in obvious cases — uncheck-then-deref in straight-line
 code is a compile error:
 
@@ -353,17 +377,46 @@ just `nil` and explicit checks. Old-school authentic.
 
 ```
 def parse_int(s: str) -> (i16, str?)
-  if s.len == 0 then return (0, "empty input") end
+  if s.len == 0
+    return (0, "empty input")
+  end
   -- ...
   return (value, nil)
 end
 
 let (n, err) = parse_int(input)
-if err != nil then handle(err) end
+if err != nil
+  log(err)
+  return
+end
+use(n)        -- compiler tracks: on this path err was nil,
+              -- so n came from the success arm and is valid
 ```
 
 The `str?` second slot is the error message when present, `nil` on
 success. Idiomatic in Lua, Go, and most pre-Rust runtimes.
+
+**Flow analysis.** The compiler tracks the relationship between a
+multi-return tuple's slots so that the success path doesn't pessimize
+into the error path. Specifically, when the source has the shape
+
+```
+let (value, err) = produces_value_or_error()
+if err != nil
+  -- bail path (return / break / continue / @noreturn call)
+end
+-- here: err is statically nil, value came from the success arm
+```
+
+the compiler treats `value` as definitely valid after the bail
+branch — no second check needed. The same applies to `if err ==
+nil then …` (truthy branch sees the success path) and to `match`
+with explicit `nil` / non-`nil` arms.
+
+The analysis works on the **most-recent assignment** of `err`: if
+the user reassigns `err` between the check and the use, the
+guarantee evaporates. This is intentional — same shape as Go's
+or Lua's idiom; no implicit linear typing.
 
 #### 3.4.2 `struct` vs `class` — when to use which
 
@@ -456,7 +509,7 @@ let xs: Vec(i16)   = Vec.from([1, 2, 3])   -- pre-filled from a fixed array
 | `v.pop()`          | `T?` | Remove + return the last element. `nil` when empty. |
 | `v.len()`          | `u16` | Current element count. |
 | `v.cap()`          | `u16` | Current backing capacity. |
-| `v.at(i)`          | `T` | Bounds-checked. Out-of-range → fault vector `0x02`. |
+| `v.at(i)`          | `T` | Bounds-checked. Out-of-range → fault vector `$02`. |
 | `v.get(i)`         | `T?` | Safe variant — `nil` instead of fault. |
 | `v.set(i, x)`      | `nil` | Bounds-checked write. |
 | `v[i]` / `v[i] = x` | `T` / `nil` | Sugar for `at` / `set`. |
@@ -466,7 +519,7 @@ let xs: Vec(i16)   = Vec.from([1, 2, 3])   -- pre-filled from a fixed array
 `Vec(T)` participates in `for-in`:
 
 ```
-for item in inv do
+for item in inv
   use(item)
 end
 ```
@@ -479,6 +532,82 @@ and writes on a moved-from `Vec` are undefined.
 as `Range` and `[T; N]`) — there are no user-defined generic types
 or functions. If you need a typed container beyond `Vec`, build a
 class around `[T; N]` or `Vec(T)` with the right operations.
+
+#### 3.4.4 References `&T`
+
+A reference is a 16-bit address bound to a typed slot. References
+exist for two reasons on a 16-bit cart target:
+
+1. **Avoid copying compound values** at function-call boundaries.
+   Passing a `Stats` struct (6 bytes) by value copies 6 bytes on every
+   call. Passing `&Stats` copies 2 bytes (the address) and the callee
+   mutates in place.
+2. **Compose with the asm escape hatch and MMIO setup** — getting the
+   address of a stack-local buffer to pass to a DMA register or an
+   `asm "..."` block.
+
+**Syntax.**
+
+```
+def apply_damage(stats: &Stats, dmg: i16)
+  stats.hp = stats.hp - dmg     -- mutates the referenced struct
+end
+
+let s = Stats { hp: 100, mp: 50, atk: 10, def: 5 }
+apply_damage(&s, 20)             -- prefix `&` to take a reference
+print s.hp                       -- 80 (mutation visible)
+```
+
+The `&` prefix produces a reference; the callee's parameter type is
+`&T`. References auto-deref for field access and method calls
+(`stats.hp`, `stats.method()`) — no explicit `*` deref operator.
+
+**Mutability.** A reference is always mutating through the binding.
+There is no `&const T` / `&mut T` distinction (no borrow checker in
+gero-lang). To document "read-only", pass by value (with the copy
+cost) or follow a naming convention. The trade-off is intentional:
+the borrow checker adds compile-time complexity that the target
+audience doesn't need and the cart target doesn't reward.
+
+**Lifetime.** A reference is valid as long as the binding it points
+at is in scope. Returning `&local` from a function (where `local` is
+a stack binding) is a compile error — the compiler tracks
+stack-vs-static origin to reject the obvious cases:
+
+```
+def bad() -> &Stats
+  let s = Stats { hp: 0, mp: 0, atk: 0, def: 0 }
+  return &s          -- COMPILE ERROR: returns ref to stack-local
+end
+
+let static_s = Stats { ... }
+def ok() -> &Stats
+  return &static_s   -- OK: static binding outlives any caller
+end
+```
+
+The compiler does **not** track cross-call lifetimes (no full borrow
+checker). Storing a reference inside a class field and outliving the
+referent is undefined behavior — discipline at the source level.
+
+**Restrictions.**
+
+- No reference arithmetic (`&x + 1` is a compile error).
+- No `&&T` (reference-to-reference).
+- No reference to a temporary (`&(a + b)` is a compile error — there
+  is no addressable storage for the temporary).
+- A reference parameter cannot be `nil` — use `&T` for "always
+  present, mutate this", or use `T?` (nullable pointer) for "may be
+  absent".
+
+**Layout.** 2 bytes (a 16-bit pointer). Same runtime cost as a class
+instance reference.
+
+For raw byte-level address arithmetic (the rare cases where you
+genuinely want a `u16` address value — DMA setup, manual MMIO setup,
+`asm "..."` bridge), use `mem.addr_of(x) -> u16` (§5.3). That returns
+the address as a plain integer; it's the explicit "I want bytes,
+not a typed reference" escape hatch.
 
 ### 3.5 Inference
 
@@ -526,7 +655,7 @@ crossing the integer / `fixed` boundary — use `as` to force the
 conversion:
 
 ```
-let small: u8 = (raw & 0xFF) as u8
+let small: u8 = (raw & $FF) as u8
 let wide:  i16 = byte_count as i16
 let pixel: u8 = palette[i] as u8
 let dx:    fixed = velocity as fixed     -- top byte = velocity, frac = 0
@@ -594,7 +723,9 @@ documented per program.
 Use `is` for variant-tag tests (binding-free):
 
 ```
-if item is Item.Sword then equip_basic() end
+if item is Item.Sword
+  equip_basic()
+end
 ```
 
 For payload extraction, use `match` (§4.8).
@@ -612,7 +743,7 @@ Multiple annotations stack. Order matters only when explicitly noted.
 | Annotation | Applies to | Effect |
 |------------|------------|--------|
 | `@bank N` | `def`, `let`, `const`, **file** | Place compiled output in bank `N` (compiler emits cross-bank trampolines for calls — §7.3). See precedence note below. |
-| `@zero_page` | `let` | Place this global in the zero-page region (`0x0000..0x00FF`) — 1-byte addressing mode, faster + smaller code. Slot pressure is high (256 bytes shared); compiler errors on overflow. |
+| `@zero_page` | `let` | Place this global in the zero-page region (`$0000..$00FF`) — 1-byte addressing mode, faster + smaller code. Slot pressure is high (256 bytes shared); compiler errors on overflow. |
 | `@addr $1234` | `let` | Pin this global at the given absolute address. Use for binding to memory-mapped IO registers or fixed-position state. The compiler reserves no other RAM at that address. |
 | `@volatile` | `let` | Treat every read of this binding as a real memory load (never cached in a register). Pair with `@addr` for memory-mapped IO registers whose value changes outside the compiler's view (vblank flag, input port, RNG tap). |
 | `@align(N)` | `let`, `const`, `struct` | Force `N`-byte alignment of the placement. `N` must be a power of two (1, 2, 4, 8, 16, …). Necessary when the hardware demands aligned data — sprite sheets at 16-byte boundaries, tile maps at page boundaries (256), audio buffers at 4 bytes. |
@@ -627,7 +758,7 @@ Per-declaration `@bank` always wins over the file-level default. A
 declaration inside a file with `@bank 5` at the top can opt out
 back to the base image with `@bank 0`. Declarations that appear
 without any `@bank` annotation (and no file-level default) land
-in the base image (bank-less area before `0xC000`).
+in the base image (bank-less area before `$C000`).
 
 ```
 @zero_page
@@ -651,14 +782,19 @@ end
 
 | Annotation | Applies to | Effect |
 |------------|------------|--------|
-| `@inline` | `def` | Always inline at call sites. Compiler errors if the function is recursive or its body is too large. |
-| `@cold` | `def` | Mark the function as unlikely-called. The compiler is free to place it far from the hot path (separate code page, late in the section) so adjacent hot code stays in cache / prefetch range. Useful for error helpers, panic paths, debug-only dumps. |
+| `@inline` | `def` | Always inline at call sites. Compile error if the function is recursive or its lowered body exceeds **32 bytecode instructions**. |
+| `@cold` | `def` | Mark the function as unlikely-called. Codegen emits all `@cold` functions of a module **after** every non-cold function, in source-declaration order. Bytecode placement is deterministic and reproducible across compiler versions. |
+| `@no_capture` | `def` | Forbid this function from defining any closure that captures-and-mutates a binding from its lexical scope. See §4.7.2 (closures auto-promote to heap when they mutate captures; `@no_capture` forces a compile error instead so cycle-critical functions can't pay that cost by accident). |
 
 ```
 @inline
 def fast_clamp(x: i16, min: i16, max: i16) -> i16
-  if x < min then return min end
-  if x > max then return max end
+  if x < min
+    return min
+  end
+  if x > max
+    return max
+  end
   return x
 end
 
@@ -667,17 +803,38 @@ def panic_oob(addr: u16) -> noreturn
   print "PANIC: out-of-bounds @ ", addr
   hlt
 end
+
+@no_capture
+def hot_render_loop(state: &GameState)
+  for sprite in state.sprites
+    let draw = |s| blit(s)        -- read-only capture: OK
+    draw(sprite)
+  end
+end
 ```
 
 `@inline` attaches to named `def`s only. Lambdas already inline
 when they don't escape (their body folds into the caller); when
 they do escape they become first-class values and inlining would
 defeat that — there's no useful middle ground to expose via
-annotation.
+annotation. The 32-instruction limit is on the function body **after
+lowering** (post-typecheck, pre-codegen). The limit is fixed across
+compiler versions so source that compiles today keeps compiling.
 
-`@cold` is a *hint*, not a guarantee — the compiler decides
-placement. A `@cold` function on the hot path (called from a tight
-loop) still compiles correctly, just sub-optimally.
+`@cold` placement is deterministic: each module's compiled output is
+laid out as `[hot fn 1, hot fn 2, …, cold fn A, cold fn B, …]`. The
+relative order of hot functions matches source order; the relative
+order of cold functions matches source order. Same input source →
+same byte layout, every time, every compiler version. The cost is one
+extra branch on the rare hot-to-cold call; the win is a denser hot
+path.
+
+`@no_capture` is a compile-time-only check. A function annotated with
+it can still **define** closures, and those closures can still
+capture read-only — the only thing rejected is capture-and-mutate
+(which is what triggers the heap promotion). The check runs after
+typechecking, before codegen. Useful on per-frame game loops and ISR
+helpers where a hidden alloc is unacceptable.
 
 #### 3.7.3 Diverging functions
 
@@ -694,8 +851,8 @@ end
 
 def use_potion(item: Action)
   match item
-    case Action.Heal(n) then heal(n)
-    case _              then panic("not a healing item")
+    case Action.Heal(n) => heal(n)
+    case _              => panic("not a healing item")
   end
 end
 ```
@@ -713,15 +870,15 @@ Module-level visibility is controlled by the `local` keyword
 
 | Annotation | Applies to | Effect |
 |------------|------------|--------|
-| `@interrupt N` | `def` | Bind this function as the handler for vector `N` (gero ISA §6.1). The compiler emits the `rti` epilogue automatically and writes the function address into `mem[0x1000 + 2 * N]` at boot. The function body must take no parameters and return nothing. |
+| `@interrupt N` | `def` | Bind this function as the handler for vector `N` (gero ISA §6.1). The compiler emits the `rti` epilogue automatically and writes the function address into `mem[$1000 + 2 * N]` at boot. The function body must take no parameters and return nothing. |
 
 ```
-@interrupt 0x06              -- vblank
+@interrupt $06              -- vblank
 def on_vblank()
   frame_count += 1
 end
 
-@interrupt 0x21              -- save-flush convention
+@interrupt $21              -- save-flush convention
 def on_save_request()
   flush_save_state()
 end
@@ -819,19 +976,92 @@ The compiler enforces:
 
 #### 3.7.7 Inline assembly
 
-| Annotation | Applies to | Effect |
-|------------|------------|--------|
-| `@asm("...")` | statement-level | Embed a single asm instruction. Operands can reference gero-lang locals via `{name}` substitution. |
+Inline asm is not an annotation — see §4.11 for the `asm "..."`
+statement form.
+
+### 3.8 Compile-time evaluation (`bake`)
+
+`bake` marks a `def` or `do`-block for **compile-time evaluation**.
+The compiler runs the marked code at compile time and bakes the
+result into static data — no runtime cost, no runtime code emitted
+for the baked computation itself.
+
+This is the canonical way to generate lookup tables (sin/cos,
+palette ramps, RNG seeds, mip levels) without hand-encoding the
+bytes, and without a separate build script that emits `.gr` files.
 
 ```
-def fast_swap(a: u16, b: u16)
-  @asm("swap {a}, {b}")
+bake def make_sin_table() -> [i16; 256]
+  let t: [i16; 256] = [0; 256]
+  for i in 0..256
+    t[i] = fixed_sin(i * 360 / 256)
+  end
+  return t
+end
+
+const SIN_TABLE = make_sin_table()
+-- 512 bytes of static data; no runtime cost
+```
+
+`bake do` is the same idea inline, without a named function:
+
+```
+const PALETTE = bake do
+  let p: [u8; 16] = [0; 16]
+  for i in 0..16
+    p[i] = ramp_to_palette(i)
+  end
+  p
 end
 ```
 
-The asm escape hatch is the **last resort** — if you find yourself
-using it more than 2-3 times in a project, the compiler is missing a
-codegen optimization and you should file an issue.
+**Restrictions on bake bodies.** The bake interpreter is a strict
+subset of the runtime:
+
+- **No MMIO access.** Reading or writing a binding annotated `@addr`
+  is a compile error inside `bake` code. The hardware doesn't exist
+  at compile time.
+- **No `asm "..."` statements.** Same reason — no VM at compile time.
+- **No `@interrupt` handlers triggered.** Bake runs in a pure
+  evaluator with no scheduler.
+- **No calls to non-`bake` functions** except a curated set of pure
+  stdlib helpers (`math.*` arithmetic + fixed-point routines). The
+  compiler errors on calls to functions it can't prove
+  side-effect-free. Other `bake` functions can call each other freely.
+- **No `mem.*` raw memory access** — `read_*`, `write_*`, `memcpy`,
+  `memset`, `peek`, `poke`, `addr_of` all have no compile-time
+  meaning. Bake code operates on language-level values only.
+- **No `defer`, no `@volatile`.** Both are runtime-only concepts.
+- **`const` references and literals** are readable freely.
+
+The bake interpreter is finite: it has an instruction budget
+(default: 100 million micro-steps) to prevent infinite loops at
+compile time. Exceeding the budget is a compile error with a
+diagnostic pointing at the source.
+
+**Output types.** Any value that has a constant runtime
+representation can be baked: `[T; N]`, tuples, structs containing
+only bakeable fields, primitive integers, `bool`, `str` (interned in
+static data). Classes are **not** bakeable — vtable pointers can't
+be resolved until link time. `Vec(T)` is not bakeable either (heap
+allocation has no compile-time meaning); use `[T; N]` instead.
+
+**Lifetime.** A baked value is in static data, just like a string
+literal. It lives in ROM at runtime and cannot be mutated. Assigning
+to a `let` initialized from a `bake` result copies the bytes into a
+mutable location:
+
+```
+const READONLY_TABLE = bake make_sin_table()      -- in ROM
+let scratch_table = bake make_sin_table()         -- copied to mutable slot
+
+READONLY_TABLE[0] = 1   -- COMPILE ERROR: bake result is const
+scratch_table[0] = 1    -- OK
+```
+
+The `bake` keyword cannot be combined with `@cold`, `@inline`,
+`@interrupt`, `@bank`, or `@no_capture` — those describe runtime
+codegen and have no meaning for compile-time evaluation.
 
 ---
 
@@ -862,7 +1092,7 @@ Same model as JavaScript / TypeScript `const`. Old-school BASIC's
 matters and the compiler can help catch reassignment bugs.
 
 ```
-const PI_FIXED = 0x0324       -- comptime, inlined
+const PI_FIXED = $0324       -- comptime, inlined
 const player_name = read_input()  -- runtime, but read-only
 player_name = "x"             -- compile error: cannot reassign const
 ```
@@ -888,8 +1118,8 @@ out if the shape doesn't match), use `match` with an early-return:
 
 ```
 match item
-  case Item.Potion(n) then heal(n)
-  case _              then return
+  case Item.Potion(n) => heal(n)
+  case _              => return
 end
 ```
 
@@ -912,6 +1142,23 @@ x++         -- statement only — sugar for x += 1
 x--         -- statement only — sugar for x -= 1
 ```
 
+**MMIO writes** — when `x` is a global annotated `@addr` (and
+typically `@volatile`), assignment compiles to a real store at the
+pinned address. No special syntax needed:
+
+```
+@addr $FE40
+@volatile
+let DISPCTL: u8 = 0
+
+DISPCTL = $42        -- writes byte $42 to address $FE40
+DISPCTL |= $80       -- read-modify-write through the pin
+```
+
+The `@volatile` annotation (§3.7.1) guarantees both reads and writes
+are real memory operations (never cached in a register, never elided
+by dead-store optimization).
+
 `++` and `--` are **statements**, not expressions. They cannot be
 nested inside another expression:
 
@@ -933,32 +1180,54 @@ no value produced". Go uses the same rule.
 
 | Category | Operators | Notes |
 |----------|-----------|-------|
-| Arithmetic | `+` `-` `*` `/` `%` | `/` and `%` on signed → truncated toward zero |
+| Arithmetic | `+` `-` `*` `/` `%` | `/` and `%` on signed → truncated toward zero. Overflow: trap in debug, wrap in release (see below). |
+| Arithmetic (explicit wrap) | `+%` `-%` `*%` | Always wrap on overflow, in any build mode. Use when wrap is intentional (RNG step, hash mixing). |
+| Arithmetic (saturate) | `+\|` `-\|` `*\|` | Clamp to the type's min/max on overflow, in any build mode. Use when saturation is the correct semantics (HP after damage, audio mix levels). |
 | Comparison | `==` `!=` `<` `<=` `>` `>=` | All return `bool` |
 | Logical | `and` `or` `not` | Short-circuit evaluation. `not` is unary. |
 | Bitwise | `&` `\|` `^` `<<` `>>` `~` | Map directly to ISA `and` / `or` / `xor` / `shl` / `shr` / `not`. `~` is unary bitwise NOT. |
+| Reference | `&` (prefix) | `&x` takes a typed reference to `x`. See §3.4.4. |
 | Range | `..` `..=` | See §4.5. Produce range values (built-in special type). |
 | Type test | `is` | `value is EnumVariant` — see §3.6. |
+| Type cast | `as` | `value as T` converts between numeric types — see §3.5.1. |
+
+**Overflow on plain arithmetic** (`+`, `-`, `*`):
+
+- **Debug builds** (`gero build`, default): the compiler emits an
+  overflow check. On overflow, the program traps via fault vector
+  `$02` with a diagnostic pointing at the source location.
+- **Release builds** (`gero build --release`): the check is elided
+  and the operation wraps two's-complement. Use `+%` / `+|` to make
+  the wrap or saturate intent explicit when the choice matters.
+
+Saturating `+|` on signed types clamps to `[T::MIN, T::MAX]` of the
+result type; on unsigned, clamps to `[0, T::MAX]`. The intermediate
+computation uses one bit of extra width to detect the overflow cheaply
+on the gero VM's add-with-carry.
 
 **Precedence (highest to lowest):**
 
-1. Unary: `-` `not` `~`
-2. `*` `/` `%`
-3. `+` `-`
-4. `<<` `>>`
-5. `&`
-6. `^`
-7. `\|`
-8. Comparison: `==` `!=` `<` `<=` `>` `>=`
-9. `and`
-10. `or`
-11. `..` `..=`
-12. Assignment (`=`, `+=`, etc. — right-associative)
+1. Unary prefix: `-` `not` `~` `&`
+2. `as` (cast)
+3. `*` `/` `%` `*%` `*|`
+4. `+` `-` `+%` `-%` `+|` `-|`
+5. `<<` `>>`
+6. `&` (bitwise AND — context disambiguates from prefix `&`)
+7. `^`
+8. `\|`
+9. Comparison: `==` `!=` `<` `<=` `>` `>=`
+10. `is`
+11. `and`
+12. `or`
+13. `..` `..=`
+14. Assignment (`=`, `+=`, etc. — right-associative)
+
+Wrapping (`+%`) and saturating (`+|`) operators share their plain
+counterpart's precedence — they're not "promoted" relative to `+`.
 
 Same precedence as C / Rust for bitwise vs comparison (low) and
 shifts vs arithmetic (low). Use parens when in doubt — `if (flags &
-MASK) == TARGET then` reads better than relying on precedence
-memory.
+MASK) == TARGET` reads better than relying on precedence memory.
 
 #### 4.2.2 Discarding a value
 
@@ -1011,69 +1280,73 @@ returns; `return` propagates to the enclosing function.
 ### 4.4 Conditionals
 
 ```
-if cond then
+if cond
   body
 end
 
-if cond then
+if cond
   body
 else
   other
 end
 
-if cond then
+if cond
   body
-else if cond2 then
+else if cond2
   other
 else
   default
 end
 ```
 
-No parentheses around conditions. Lua-style.
+No parentheses around conditions, no `then` keyword. The condition
+expression ends at the newline; the body starts on the next line.
 
 #### 4.4.1 `if let`
 
 Pattern-match in conditional position. Bindings introduced by the
-pattern are in scope inside the `then` branch (and only there):
+pattern are in scope inside the truthy branch (and only there):
 
 ```
-if let Item.Potion(n) = item then
+if let Item.Potion(n) = item
   drink(n)
 end
 
-if let Event.MouseClick(x, y) = e when x < 128 then
+if let Event.MouseClick(x, y) = e when x < 128
   hit_left(x, y)
 end
 ```
 
 Pattern syntax = §4.8.1; `when` guards are accepted (§4.8.2). When
-the pattern doesn't match, the `then` branch is skipped (and `else`
+the pattern doesn't match, the truthy branch is skipped (and `else`
 runs if present).
 
 ### 4.5 Loops
 
 ```
-while cond do
+while cond
   body
 end
 
-for i in 0..=10 do          -- inclusive 0..10
+for i in 0..=10              -- inclusive 0..10
   body
 end
 
-for i in 0..10 do           -- exclusive (0..9)
+for i in 0..10               -- exclusive (0..9)
   body
 end
 
-for i in 0..=100 step 5 do  -- explicit step
+for i in 0..=100 step 5      -- explicit step
   body
 end
 
-for item in collection do
+for item in collection
   body
 end
 ```
+
+No `do` keyword after the head — the condition / range expression
+ends at the newline, body starts on the next line.
 
 `break` and `continue` work in any loop.
 
@@ -1099,8 +1372,8 @@ checked to match. Runtime slot: 4 × `sizeof(T)` + 1 byte for the
 inclusive flag (padded to the next 2-byte boundary).
 
 ```
-for byte_val in 0u8..=255u8 do            -- iterate every byte
-for tile_id in 0i16..=tile_count do
+for byte_val in 0u8..=255u8              -- iterate every byte
+for tile_id in 0i16..=tile_count
 ```
 
 Methods:
@@ -1111,7 +1384,7 @@ Methods:
 | `r.empty()` | `bool` | True if no elements would be produced (e.g. `5..=2`). |
 | `r.len()` | `u16` | Number of elements that would be visited. |
 
-`for x in r do` is special-cased by the compiler — no allocation,
+`for x in r` is special-cased by the compiler — no allocation,
 no iterator object. User-defined iterables ship via the iterator
 protocol; see §4.5.3.
 
@@ -1121,11 +1394,11 @@ Loop while a pattern keeps matching. The bindings refresh each
 iteration:
 
 ```
-while let Event.KeyDown(k) = poll_event() do
+while let Event.KeyDown(k) = poll_event()
   handle_key(k)
 end
 
-while let Item.Potion(n) = inventory.next() when n > 0 do
+while let Item.Potion(n) = inventory.next() when n > 0
   drink(n)
 end
 ```
@@ -1133,9 +1406,9 @@ end
 Equivalent rewrite (longer) for the keydown loop:
 
 ```
-while true do
+while true
   let evt = poll_event()
-  if let Event.KeyDown(k) = evt then
+  if let Event.KeyDown(k) = evt
     handle_key(k)
   else
     break
@@ -1160,7 +1433,9 @@ class Inventory
   let cursor: u16 = 0
 
   def next(self) -> Item?
-    if self.cursor >= self.count then return nil end
+    if self.cursor >= self.count
+      return nil
+    end
     let item = self.items[self.cursor]
     self.cursor += 1
     return item
@@ -1168,32 +1443,81 @@ class Inventory
 end
 
 let inv = Inventory.new()
-for item in inv do
+for item in inv
   use(item)
 end                  -- terminates when inv.next() returns nil
 ```
 
-**Desugaring.** `for x in expr do body end` compiles to:
+**Desugaring.** `for x in expr <body> end` compiles to:
 
 ```
 let __it = expr
-while true do
+while true
   let __v = __it.next()
-  if __v == nil then break end
+  if __v == nil
+    break
+  end
   let x = __v
-  body
+  <body>
 end
 ```
 
 The iterator value is the expression itself — there's no separate
-"iterator object". Iteration is destructive (the instance's own
-cursor advances). To iterate the same data twice, instantiate
-twice or expose a `reset()` method on your class.
+"iterator object". **Iteration is destructive**: the instance's own
+cursor advances during the loop. After `for item in inv … end`, `inv`
+is at its end; a second loop produces nothing until `inv` is reset.
+To iterate the same data twice, instantiate twice or expose a
+`reset()` method on your class:
+
+```
+for item in inv             -- first pass: iterates 0..count
+  use(item)
+end
+for item in inv             -- second pass: empty! cursor already at count
+  use(item)
+end
+
+inv.cursor = 0              -- manual reset
+for item in inv             -- now this works again
+  use(item)
+end
+```
+
+This is intentional — `next(self) -> T?` is the simplest possible
+iterator protocol on a 16-bit target. The user is responsible for
+reset semantics if reuse is needed.
 
 **Built-ins** (`Range`, `[T; N]`, `str`, `Vec(T)`) are special-cased
 by the compiler — `for-in` over them emits direct memory access
 with no `next()` call. The user-visible model is identical to a
 custom iterator; the special-case is invisible.
+
+#### 4.5.4 Labeled loops
+
+A loop may carry a `:label` after its head; `break :label` and
+`continue :label` target the labeled loop instead of the innermost:
+
+```
+for y in 0..height :rows
+  for x in 0..width
+    if hit_wall(x, y)
+      break :rows               -- exits the outer loop
+    end
+    if skip_column(x)
+      continue :rows             -- next y, not next x
+    end
+  end
+end
+```
+
+The label is a lowercase identifier. Unlabeled `break` / `continue`
+keep targeting the innermost loop. A `break :unknown` referencing a
+non-existent label is a compile error. Labels do not leak into the
+expression namespace — they're a loop-local annotation.
+
+`while` and `for-in` both accept labels; the syntax is `<head>
+:label` (the label trails after the iterable / condition, before the
+newline).
 
 ### 4.6 Functions
 
@@ -1210,7 +1534,9 @@ end
 
 -- recursion: name is in scope inside its own body
 def fib(n: i16) -> i16
-  if n < 2 then return n end
+  if n < 2
+    return n
+  end
   return fib(n - 1) + fib(n - 2)
 end
 ```
@@ -1236,7 +1562,84 @@ let r = apply(add, 3, 4)   -- 7
 The function-pointer type is spelled `fn(args) -> ret` in
 annotations. At runtime it's a 16-bit code address.
 
-#### 4.6.1 Method calls and chaining
+#### 4.6.1 Tail-call optimization
+
+When a function's last action before returning is `return f(args)`
+where `f` is either the current function (self) or another function
+of the same parameter shape (sibling), the compiler reuses the
+current stack frame instead of pushing a new one. This is **the
+only** tail-call shape optimized — full Scheme-style TCO across all
+call positions is out of scope.
+
+```
+def count_down(n: i16)
+  if n == 0
+    return
+  end
+  print n
+  return count_down(n - 1)        -- TCO: reuses frame, no stack growth
+end
+
+def alt_a(n: i16) -> i16
+  if n == 0
+    return 0
+  end
+  return alt_b(n - 1)             -- sibling TCO: same param shape
+end
+def alt_b(n: i16) -> i16
+  if n == 0
+    return 1
+  end
+  return alt_a(n - 1)
+end
+```
+
+TCO does **not** apply to:
+
+- `return f(args) + 1` — there is work after the call.
+- `return f(args)` where `f` has a different parameter shape — the
+  frame layout differs.
+- Function-pointer calls (`return op(x)` where `op` is a variable) —
+  the target isn't known at compile time.
+
+Use `gero check --verbose` to confirm a tail call was optimized.
+Non-tail recursion (`fib`-style) is unaffected — each call still
+pushes a frame. Deep non-tail recursion will overflow the gero VM
+stack (typically `$0100..$0FFF`, 4 KB); rewrite as a loop when
+depth is unbounded.
+
+#### 4.6.2 Variadic parameters
+
+The last parameter of a `def` may be variadic, spelled `args: ...`:
+
+```
+def log(level: u8, fmt: str, args: ...)
+  print level, " ", format(fmt, args)
+end
+
+log(1, "player at $(d:3d), $(d:3d)", x, y)
+```
+
+Inside the body, `args` is a **tuple** containing the supplied
+arguments. There is no runtime length field — the compiler knows
+the arity at each call site and emits a per-call specialization
+sharing the function body. The arity must be ≥ 0 (zero variadic
+args is allowed).
+
+The format-spec language (§3.2.2) understands varargs: `format(fmt,
+args)` forwards a varargs tuple positionally. User-defined helpers
+follow the same convention.
+
+Restrictions:
+
+- Only the **last** parameter may be variadic.
+- A variadic parameter has **no default value** — caller supplies
+  zero or more positional args of the expected type.
+- All variadic args must be **the same statically-known type** (or
+  satisfy a common annotation). Mixed-type varargs aren't supported;
+  for heterogeneous data, pass a tuple or struct explicitly.
+
+#### 4.6.3 Method calls and chaining
 
 Methods on classes (and stdlib helpers spelled as methods) call with
 dot notation:
@@ -1275,7 +1678,51 @@ Lambdas are first-class function values (same as named `def`s) —
 assign, pass, return, store. They differ from `def` only in being
 unnamed and inline.
 
-#### 4.7.1 Static lexical scope (closures)
+#### 4.7.1 Short lambda form
+
+For single-expression lambdas (the common case in `map`, `filter`,
+`fold`), gero-lang accepts a Rust-style short form:
+
+```
+|x| x * 2                           -- one param, expression body
+|x, y| x + y                        -- multiple params
+|| read_input()                     -- zero params
+|x: i16| -> i16  x * 2              -- explicit types (rare; usually inferred)
+```
+
+The body is a **single expression**, not a block — there is no
+`return` keyword, no `end` terminator. The expression's value is the
+lambda's return value.
+
+```
+let doubled = xs.map(|x| x * 2)
+let evens   = xs.filter(|x| x % 2 == 0)
+let total   = xs.fold(0, |acc, x| acc + x)
+```
+
+For multi-statement bodies, drop back to the long form:
+
+```
+let summary = items.map(lambda (item: Item) -> str
+  let n = format_count(item.count)
+  let name = item.display_name()
+  return name + " x" + n
+end)
+```
+
+Or wrap the work in a `do … end` expression so the short form still
+applies:
+
+```
+let labels = items.map(|item| do
+  let n = format_count(item.count)
+  item.display_name() + " x" + n
+end)
+```
+
+Both lambda forms have identical capture semantics (see §4.7.2).
+
+#### 4.7.2 Static lexical scope (closures)
 
 All functions — `def` and `lambda` alike — close over the lexical
 scope they were defined in. Free variables in the body resolve to the
@@ -1309,7 +1756,7 @@ The promotion decision is automatic — the programmer doesn't
 annotate. To inspect the choice, `gero check --verbose` reports
 which `let` bindings were promoted.
 
-#### 4.7.2 Inline scoped computation: use `do … end`
+#### 4.7.3 Inline scoped computation: use `do … end`
 
 Older lang traditions use Immediately Invoked Lambda Expressions
 (IILEs) for "compute a value with some scratch state". gero-lang
@@ -1325,7 +1772,7 @@ end
 
 let board = do
   let b: [u8; 64] = [0; 64]
-  for i in 0..8 do
+  for i in 0..8
     b[i * 8 + i] = 1   -- diagonal
   end
   b
@@ -1365,17 +1812,17 @@ patterns, and compile-time exhaustiveness checking.
 
 ```
 match item
-  case Item.Potion(n) when n > 50 then
+  case Item.Potion(n) when n > 50 =>
     print "big potion"
-  case Item.Potion(_) then
+  case Item.Potion(_) =>
     print "small potion"
-  case _ then
+  case _ =>
     print "not a potion"
 end
 ```
 
 The guard runs only after the pattern matches; failure falls through
-to the next arm.
+to the next arm. The arm separator is `=>` (fat arrow), not `then`.
 
 #### 4.8.3 Exhaustiveness
 
@@ -1384,13 +1831,13 @@ unhandled and there's no wildcard arm:
 
 ```
 match item
-  case Item.Sword then ...
-  case Item.Potion(_) then ...
+  case Item.Sword => ...
+  case Item.Potion(_) => ...
   -- ERROR: missing case for Item.Key
 end
 ```
 
-Add a `case _ then ...` to discharge the warning, OR list every
+Add a `case _ => ...` to discharge the warning, OR list every
 variant explicitly. For non-enum scrutinees (integers, strings),
 exhaustiveness can't be checked — the compiler requires a wildcard
 arm or warns.
@@ -1407,19 +1854,19 @@ end
 
 def handle(e: Event)
   match e
-    case Event.Quit then
+    case Event.Quit =>
       cleanup()
-    case Event.KeyDown(k) when k == 0x1B then       -- ESC
+    case Event.KeyDown(k) when k == $1B =>       -- ESC
       cleanup()
-    case Event.KeyDown(_) then
+    case Event.KeyDown(_) =>
       -- ignore other keys
-    case Event.MouseClick(x, y) when x < 128 then
+    case Event.MouseClick(x, y) when x < 128 =>
       hit_left_pane(x, y)
-    case Event.MouseClick(x, y) then
+    case Event.MouseClick(x, y) =>
       hit_right_pane(x, y)
-    case Event.Tick(f) when f % 60 == 0 then
+    case Event.Tick(f) when f % 60 == 0 =>
       one_second_tick()
-    case Event.Tick(_) then
+    case Event.Tick(_) =>
       -- frame tick, no per-second action
   end
 end
@@ -1431,7 +1878,7 @@ end
   tag byte
 - **With payloads**: dispatch on tag, then bind locals from payload
   bytes, then evaluate guard if present
-- **Or patterns**: expanded to `case A then X case B then X`
+- **Or patterns**: expanded to `case A => X case B => X`
   (compiler dedupes the body if it can)
 - **Range patterns**: emit `cmp` + bounded jumps
 
@@ -1445,7 +1892,7 @@ end
 | Want to handle the no-match case inline (else branch) | `if let` |
 | Pattern is in a loop draining a stream | `while let` |
 | Want guards with multiple cases | `match` (single-case guards work in `if let` too) |
-| Single pattern but failure should bail (return / break) | `match` with `case _ then return` (or @noreturn helper) |
+| Single pattern but failure should bail (return / break) | `match` with `case _ => return` (or @noreturn helper) |
 
 In short: `match` is the dispatcher; `if let` / `while let` / `let
 else` are sugar for the single-pattern shapes. Reach for `match`
@@ -1468,7 +1915,7 @@ without imports, parens, or `io.print(…)` ceremony — exactly the
 shape a 12-year-old learning to code on the gtx-16 should hit on
 day one. The trade-off is intentional.
 
-Compiles to a host-provided syscall (`int 0x10`). The host's printer
+Compiles to a host-provided syscall (`int $10`). The host's printer
 implementation defines the output channel (gtx-16 prints to a debug
 console; CLI tools print to stdout).
 
@@ -1502,10 +1949,12 @@ body, `match`-arm body, `lambda` body). The deferred statement runs
 when that block exits, not when the function returns.
 
 ```
-while cond do
+while cond
   let frame = acquire()
   defer release(frame)      -- runs at the bottom of every iteration
-  if early then break end   -- release still runs before the break
+  if early
+    break                   -- release still runs before the break
+  end
   process(frame)
 end
 ```
@@ -1524,7 +1973,7 @@ defer c()
 via an early `return` that's nested in deeper blocks below the
 defer — every exit path through this block fires the cleanup.
 
-**Exit paths NOT covered.** Hardware faults (gero's `int 0x02`-style
+**Exit paths NOT covered.** Hardware faults (gero's `int $02`-style
 traps — out-of-bounds, nil-deref, div-by-zero). Defers do **not**
 run on fault. Faults are terminal in gero; no user-level recovery
 path runs.
@@ -1544,6 +1993,70 @@ it routes the jump through a generated cleanup label so the same
 emission code is shared. Zero runtime overhead on the common
 no-defer path.
 
+**Bytecode cost.** A block with `N` defers and `M` distinct exit
+paths emits one shared cleanup tail (`N` instructions on average) and
+`M` jumps routed through it — total ≈ `N + M` bytecode instructions
+per block on top of the bare block, regardless of how often the
+exits are taken at runtime. The cleanup tail is reached by the
+jumps via the cleanup label; each `return` / `break` / `continue`
+becomes one branch. The runtime cost per exit is the LIFO-walk of
+the cleanup tail itself (`N` calls + the original control transfer).
+For typical use (1-2 defers, 1-3 exits), the cost is small enough
+to be invisible at the per-frame scale; for hot loops that defer
+inside the loop body, the defer cost runs **once per iteration** —
+budget accordingly.
+
+### 4.11 Inline assembly (`asm`)
+
+`asm "<instruction>"` is a builtin statement that emits a single
+bytecode instruction directly. It's the escape hatch into the
+gero ISA for cases the compiler can't express: ISR atomic
+windows, hand-tuned hot loops, cycle-counted timing tricks, or
+direct manipulation of the VM's register / flag state.
+
+```
+def fast_swap(a: u16, b: u16)
+  asm "swap {a}, {b}"
+end
+
+def fence()
+  asm "memfence"
+end
+```
+
+**Substitution.** Operands inside `{name}` braces resolve to the
+gero-lang local with that name. The compiler validates that the
+local exists and emits the appropriate register / addressing
+reference at the asm slot.
+
+**Constraints.**
+
+- **One instruction per `asm` statement.** Multi-instruction asm
+  blocks are not supported; chain multiple `asm "..."` statements
+  in source order if needed.
+- **Substituted operands must be of a type the instruction accepts**
+  — the assembler validates this at lowering time. Type mismatch
+  is a compile error pointing at the gero-lang local, not the asm
+  string.
+- **No control-flow into / out of an `asm` statement.** The asm
+  instruction must complete normally; no embedded branches, no
+  jumps to labels outside the asm. (The asm statement itself can
+  still affect the VM PC if the instruction is a branch — `asm
+  "ret"` returns from the enclosing function, like any `return`
+  statement would — but the compiler does not analyze this and the
+  user is responsible for the resulting control flow.)
+
+**When to reach for it.** The asm escape hatch is the **last
+resort**. If you find yourself using it more than 2-3 times in a
+real project, the compiler is missing a codegen optimization and
+the right move is to surface the missing feature in the language
+or stdlib. The lifeline is real but it shouldn't carry weight.
+
+For longer cycle-counted routines, write the whole function in
+gero asm (`.gx` source) and link it via the standard linker rules
+— inline `asm` is for the one-instruction sliver of a high-level
+function, not for whole subroutines.
+
 ---
 
 ## 5. Modules
@@ -1557,10 +2070,12 @@ prefix with `local` to keep private.
 ```
 -- file: math.gr
 
-const PI_FIXED = 0x0324      -- π ≈ 3.14159 in 8.8 fixed
+const PI_FIXED = $0324      -- π ≈ 3.14159 in 8.8 fixed
 
 def abs(x: i16) -> i16
-  if x < 0 then return -x end
+  if x < 0
+    return -x
+  end
   return x
 end
 
@@ -1593,22 +2108,59 @@ solves one concrete need:
 | Module | What |
 |--------|------|
 | `math` | `abs`, `min`, `max`, `clamp`, `sqrt_fixed`, fixed-point helpers, `rng()` |
-| `mem`  | `memcpy`, `memset`, `peek`, `poke` (raw VM-level memory ops) |
-| `str`  | `len`, `at`, `cmp`, `concat` (allocated) |
+| `mem`  | typed peek / poke / memcpy / memset / `addr_of` — see §5.3.1 |
+| `str`  | `len`, `at`, `cmp`, `concat` (allocated), `format(fmt, args)` |
 | `bank` | `switch_to(N)`, `current()` — bank manipulation |
-| `test` | `assert(cond, msg?)`, `assert_eq(a, b)` — for `@test` functions |
+| `test` | `assert_eq(a, b)`, `assert_ne(a, b)` — used in `@test` functions |
 
-`assert` is **always in scope** without import — it's a built-in
-pseudo-function that compiles to a conditional `int 0x02`-style
-trap (Invalid-state fault, vector `0x02`) when the condition is
-false. The optional message is included in the diagnostic. Outside
-of `@test` functions, prefer explicit error handling — `assert` is
-for invariants that **should never** fail.
+`assert` and `debug_assert` are **always in scope** without import —
+both are built-in pseudo-functions:
+
+- `assert(cond, msg?)` — always evaluated, in every build mode. On
+  `false`, traps via fault vector `$02` with the optional message
+  in the diagnostic. Use for invariants that **must never fail**
+  in production code.
+- `debug_assert(cond, msg?)` — evaluated in debug builds only.
+  Elided entirely (zero bytecode emitted) under `gero build
+  --release`. Use for pedagogical / development-time checks that
+  shouldn't carry shipping cost.
 
 ```
-assert(self.hp >= 0, "hp went negative")
-assert_eq(items.len(), 4)
+assert(self.hp >= 0, "hp went negative")        -- always live
+debug_assert(items.len() < 1000)                -- debug-only
 ```
+
+#### 5.3.1 `mem` stdlib
+
+```
+mem.read_u8(addr: u16) -> u8
+mem.read_u16(addr: u16) -> u16
+mem.read_i8(addr: u16) -> i8
+mem.read_i16(addr: u16) -> i16
+mem.write_u8(addr: u16, v: u8)
+mem.write_u16(addr: u16, v: u16)
+mem.write_i8(addr: u16, v: i8)
+mem.write_i16(addr: u16, v: i16)
+
+mem.memcpy(dst: u16, src: u16, n: u16)
+mem.memset(dst: u16, v: u8, n: u16)
+
+mem.addr_of(x) -> u16
+mem.peek(addr: u16) -> u8           -- alias for read_u8
+mem.poke(addr: u16, v: u8)          -- alias for write_u8
+```
+
+`mem.read_u16` / `mem.write_u16` follow the gero VM convention:
+little-endian, low byte at `addr`, high byte at `addr + 1`. Signed
+variants (`read_i16`, `write_i16`) use the same byte order with
+two's-complement interpretation.
+
+`mem.addr_of(x)` returns the runtime address of `x` as a plain `u16`.
+For typed reference passing, use `&T` (§3.4.4) — `addr_of` is the raw
+escape for the cases where the bytes themselves matter (DMA setup,
+asm bridge, manual MMIO layout). Calling `addr_of` on a `let` local
+returns its stack-slot address, valid until the enclosing scope ends;
+calling on a `const` returns its static-data address (always valid).
 
 Host-specific modules (`input`, `display`, `audio` for gtx-16) live
 outside the gero stdlib — gtx-16 ships its own header modules.
@@ -1636,7 +2188,7 @@ class Player
 
   def take_damage(self, amount: i16)
     self.hp = self.hp - amount
-    if self.hp <= 0 then
+    if self.hp <= 0
       self.die()
     end
   end
@@ -1672,6 +2224,40 @@ Single inheritance only. Method resolution: walks the chain bottom
 up, first hit wins. `super.method(args)` calls the parent's version
 explicitly.
 
+**Field shadowing and `super.<field>`.** A subclass may declare a
+field with the same name as a parent field — the subclass field
+shadows the parent's for unqualified access (`self.value`). The
+shadowed parent field remains addressable via `super.<field>`:
+
+```
+class Parent
+  let value: i16 = 10
+end
+
+class Child extends Parent
+  let value: i16 = 20    -- shadows Parent.value
+
+  def report(self)
+    print self.value      -- 20 (own field)
+    print super.value     -- 10 (parent field, still in memory)
+  end
+end
+```
+
+`super.<field>` follows the same chain-walking resolution as
+`super.<method>` — first ancestor that declares the named field
+wins. Layout-wise, both fields occupy distinct slots in the instance
+memory (Child instances have one `value` for the parent layout +
+one for the subclass).
+
+**Visibility default.** Class members (fields and methods) are
+**public by default** — no `@public` annotation needed. This is
+intentional: on a 16-bit target the cycle cost of enforcing
+encapsulation is paid in code size and call indirection, and the
+target audience (game logic, not library API design) gets more value
+from terse direct access than from contract-enforcement. Mark
+members `@private` (§3.7.6) when the encapsulation actively matters.
+
 OOP compiles to:
 - A vtable in static data per class (function pointers indexed by
   method ID)
@@ -1700,22 +2286,22 @@ Old-school enough — same model NES games used for actor systems.
 ### 7.2 Memory layout of a compiled program
 
 ```
-0x0000..0x00FF  zero page (stdlib uses for fast globals)
-0x0100..0x0FFF  conventional stack range
-0x1000..0x10FF  IVT (compiler emits handlers if program declares them)
-0x1100..       compiled code
+$0000..$00FF  zero page (stdlib uses for fast globals)
+$0100..$0FFF  conventional stack range
+$1000..$10FF  IVT (compiler emits handlers if program declares them)
+$1100..       compiled code
               ↓
               user state (allocated globals, mutable data)
               ↓
-0x7FFF (or wherever code ends)
+$7FFF (or wherever code ends)
 
-0x8000..0xBFFF  Mapped region A (plain RAM; on gtx-16, carts
+$8000..$BFFF  Mapped region A (plain RAM; on gtx-16, carts
                                   typically store sprite sheets here)
-0xC000..0xFEFF  bank window (compiler emits per-bank if program
+$C000..$FEFF  bank window (compiler emits per-bank if program
                               uses banked modules)
-0xFE40..0xFEFF  gtx-16 IO surface (display, drawing, audio,
+$FE40..$FEFF  gtx-16 IO surface (display, drawing, audio,
                                     input — see gtx-16 §14)
-0xFF00..0xFFFF  IO page tail (RNG, timing, KV store, mouse)
+$FF00..$FFFF  IO page tail (RNG, timing, KV store, mouse)
 ```
 
 ### 7.3 Banked modules
@@ -1772,7 +2358,9 @@ print "Hello, world!"
 
 ```
 def fib(n: i16) -> i16
-  if n < 2 then return n end
+  if n < 2
+    return n
+  end
   return fib(n - 1) + fib(n - 2)
 end
 
@@ -1794,7 +2382,7 @@ class GameState
   let bag: [u8; 64]
 
   def init(self)
-    if save.exists() then
+    if save.exists()
       save.load(self)
     else
       self.player_x = 128
@@ -1804,10 +2392,18 @@ class GameState
   end
 
   def update(self)
-    if input.up()    then self.player_y = self.player_y - 1 end
-    if input.down()  then self.player_y = self.player_y + 1 end
-    if input.left()  then self.player_x = self.player_x - 1 end
-    if input.right() then self.player_x = self.player_x + 1 end
+    if input.up()
+      self.player_y -= 1
+    end
+    if input.down()
+      self.player_y += 1
+    end
+    if input.left()
+      self.player_x -= 1
+    end
+    if input.right()
+      self.player_x += 1
+    end
   end
 
   def draw(self)
@@ -1819,7 +2415,7 @@ end
 
 let state = GameState()
 
-while true do
+while true
   state.update()
   state.draw()
 end
@@ -1855,3 +2451,16 @@ and the compiler simple; the absence isn't a missing feature.
   checks.
 - **`++` / `--` as expressions.** They're statements only (§4.2);
   no `let y = x++` ambiguity.
+- **Raw pointers `*T` with arithmetic.** References (`&T`, §3.4.4)
+  cover the "pass without copy" use case without arithmetic. For
+  raw `u16` addresses (asm bridge, DMA setup), `mem.addr_of(x)` and
+  `mem.read_*` / `mem.write_*` (§5.3.1) are the explicit escape;
+  there is no `*T + 1` syntax.
+- **Borrow checker.** References don't track exclusive vs shared
+  borrows; lifetime checking is limited to "no return ref to stack
+  local" (§3.4.4). The cart audience doesn't need Rust-grade memory
+  safety on top of what `T?` and explicit checks already provide.
+- **`then` / `do` after block heads.** Removed for source noise
+  reduction; the parser is recursive-descent and doesn't need them.
+  See §4.4 / §4.5. (Lua keeps them for LR-parser reasons that don't
+  apply here.)

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -609,6 +609,49 @@ genuinely want a `u16` address value — DMA setup, manual MMIO setup,
 the address as a plain integer; it's the explicit "I want bytes,
 not a typed reference" escape hatch.
 
+#### 3.4.5 Memory access patterns — when to use which
+
+gero-lang gives you four ways to touch memory at different
+abstraction levels. Picking the right one is mostly about the
+question you're answering:
+
+| Tool | Reach for it when |
+|------|-------------------|
+| **Value type** (`Stats`, `[u8; 64]`, `u16`) | Default. Copy semantics, no aliasing. The type system tracks everything. |
+| **`&T` reference** (§3.4.4) | "Pass this compound value without paying the copy cost; the callee will mutate it." Typed, auto-deref, lifetime-limited. |
+| **`@addr $XXXX` binding** (§3.7.1) | "There's a hardware register or fixed-position state at this address; give it a name and a type." Pair with `@volatile` for MMIO. |
+| **`mem.read_*` / `mem.write_*`** (§5.3.1) | "I have a `u16` address (computed at runtime, or coming from a DMA setup) and I want to peek/poke specific bytes there." |
+| **`mem.addr_of(x) -> u16`** (§5.3) | "I need the raw integer address of `x` to feed an asm bridge or DMA register." Escape from the typed world. |
+
+**Decision tree.**
+
+```
+Do you have a name for the location?
+├─ yes, and it's a hardware register
+│    → @addr + @volatile binding (read/write like a normal var)
+├─ yes, and it's a regular variable
+│    → use the variable directly; the type system handles it
+│
+└─ no, you have a runtime u16 address
+     → mem.read_* / mem.write_* (typed peek/poke)
+
+Do you need to pass a compound value to a function?
+├─ small (<= 4 bytes), purely consumed → pass by value
+├─ large or mutated by callee → pass &T reference
+└─ needs to outlive the call frame → store in a class field
+                                     or static binding
+
+Do you need to bridge a value into asm "..." or DMA setup?
+├─ typed pointer is fine → &x (and the asm reads it as a u16)
+└─ raw u16 is what the hardware expects → mem.addr_of(x)
+```
+
+**What NOT to do.** Don't reach for `mem.read_u8($1234)` when you
+could write a `@addr $1234 let foo: u8` binding — the binding is
+named, typed, and respects `@volatile`. Don't take `mem.addr_of(x)`
+when `&x` would work — references carry the type and let the
+compiler check field access for you.
+
 ### 3.5 Inference
 
 Type annotations are **optional everywhere** the compiler can deduce
@@ -686,6 +729,22 @@ let vx:    i16 = (player.vx_fixed) as i16  -- truncate frac toward zero
 unary prefix. `x + y as u8` parses as `x + (y as u8)`. `x as u8 + 1`
 parses as `(x as u8) + 1`. Use parentheses when in doubt — the spec
 won't get less surprising the longer you stare at it.
+
+**Three ways to inspect a value's type — when to use which.**
+
+gero-lang separates *converting* a value, *testing* a value's tag,
+and *destructuring* it. Same value, three distinct questions:
+
+| Form | Question | Returns |
+|------|----------|---------|
+| `value as T` | "Re-interpret these bytes as `T`." (cast / convert) | The converted value. |
+| `value is Variant` | "Is this enum value the `Variant` tag?" (test, no bind) | `bool`. |
+| `match value` arms | "Which variant is it, and what's the payload?" (test + bind + dispatch) | The arm's body value. |
+
+Don't mix them: `if x as Item.Sword` is a compile error (you can't
+cast to an enum variant); use `if x is Item.Sword`. `let y = x is
+Player` is rarely what you want — if you need to act on the test, use
+`if let Player { ... } = x` or `match`.
 
 ### 3.6 Enums (tagged unions)
 
@@ -1181,8 +1240,6 @@ no value produced". Go uses the same rule.
 | Category | Operators | Notes |
 |----------|-----------|-------|
 | Arithmetic | `+` `-` `*` `/` `%` | `/` and `%` on signed → truncated toward zero. Overflow: trap in debug, wrap in release (see below). |
-| Arithmetic (explicit wrap) | `+%` `-%` `*%` | Always wrap on overflow, in any build mode. Use when wrap is intentional (RNG step, hash mixing). |
-| Arithmetic (saturate) | `+\|` `-\|` `*\|` | Clamp to the type's min/max on overflow, in any build mode. Use when saturation is the correct semantics (HP after damage, audio mix levels). |
 | Comparison | `==` `!=` `<` `<=` `>` `>=` | All return `bool` |
 | Logical | `and` `or` `not` | Short-circuit evaluation. `not` is unary. |
 | Bitwise | `&` `\|` `^` `<<` `>>` `~` | Map directly to ISA `and` / `or` / `xor` / `shl` / `shr` / `not`. `~` is unary bitwise NOT. |
@@ -1191,26 +1248,29 @@ no value produced". Go uses the same rule.
 | Type test | `is` | `value is EnumVariant` — see §3.6. |
 | Type cast | `as` | `value as T` converts between numeric types — see §3.5.1. |
 
-**Overflow on plain arithmetic** (`+`, `-`, `*`):
+**Overflow on arithmetic** (`+`, `-`, `*`):
 
 - **Debug builds** (`gero build`, default): the compiler emits an
   overflow check. On overflow, the program traps via fault vector
   `$02` with a diagnostic pointing at the source location.
 - **Release builds** (`gero build --release`): the check is elided
-  and the operation wraps two's-complement. Use `+%` / `+|` to make
-  the wrap or saturate intent explicit when the choice matters.
+  and the operation wraps two's-complement.
 
-Saturating `+|` on signed types clamps to `[T::MIN, T::MAX]` of the
-result type; on unsigned, clamps to `[0, T::MAX]`. The intermediate
-computation uses one bit of extra width to detect the overflow cheaply
-on the gero VM's add-with-carry.
+This is the Rust model — one set of operators, build mode decides
+the policy. No `+%` / `+|` operator variants: if you genuinely need
+wrap or saturate as the semantic (RNG step, HP-after-damage clamp),
+use the `math` stdlib helpers (`math.wrap_add`, `math.sat_add`, …)
+or drop to `asm "..."` for the one-instruction case. Keeping the
+operator surface narrow is intentional — explicit wrap is a rare
+need, and binding `+` to its build-mode policy lets the same
+source read the same way regardless of context.
 
 **Precedence (highest to lowest):**
 
 1. Unary prefix: `-` `not` `~` `&`
 2. `as` (cast)
-3. `*` `/` `%` `*%` `*|`
-4. `+` `-` `+%` `-%` `+|` `-|`
+3. `*` `/` `%`
+4. `+` `-`
 5. `<<` `>>`
 6. `&` (bitwise AND — context disambiguates from prefix `&`)
 7. `^`
@@ -1221,9 +1281,6 @@ on the gero VM's add-with-carry.
 12. `or`
 13. `..` `..=`
 14. Assignment (`=`, `+=`, etc. — right-associative)
-
-Wrapping (`+%`) and saturating (`+|`) operators share their plain
-counterpart's precedence — they're not "promoted" relative to `+`.
 
 Same precedence as C / Rust for bitwise vs comparison (low) and
 shifts vs arithmetic (low). Use parens when in doubt — `if (flags &

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -519,6 +519,45 @@ Style convention: annotate functions in stdlib, public modules, and
 anywhere the type's intent matters more than terseness. Skip in
 private helpers and obvious cases.
 
+#### 3.5.1 Type casts
+
+When inference can't bridge a type gap — narrowing, widening, or
+crossing the integer / `fixed` boundary — use `as` to force the
+conversion:
+
+```
+let small: u8 = (raw & 0xFF) as u8
+let wide:  i16 = byte_count as i16
+let pixel: u8 = palette[i] as u8
+let dx:    fixed = velocity as fixed     -- top byte = velocity, frac = 0
+let vx:    i16 = (player.vx_fixed) as i16  -- truncate frac toward zero
+```
+
+**Conversion rules:**
+
+| From → To | Behavior |
+|-----------|----------|
+| Narrower integer (`i16` → `u8`) | Two's-complement truncation — keep the low byte. |
+| Signed wider (`i8` → `i16`) | Sign extension. |
+| Unsigned wider (`u8` → `u16`) | Zero extension. |
+| `bool` → integer | `false=0`, `true=1`. |
+| Integer → `bool` | `0 → false`, anything-else → `true`. |
+| `fixed` → integer | Round toward zero — truncate the fractional byte. |
+| Integer → `fixed` | Top byte = integer value, fraction byte = 0. |
+| `u8` ↔ char | No-op — same byte, just the type changes. |
+
+**Not supported** (no syntax to express, compile error):
+
+- Reference-type casts (`str` ↔ class, `Vec(i16)` ↔ `Vec(u16)`).
+- Class ↔ class downcasts. Use `match` with the enum / class
+  tag instead.
+- Function-pointer reinterpret. Function types are opaque.
+
+**Precedence** (§3.3): `as` binds tighter than `is` but looser than
+unary prefix. `x + y as u8` parses as `x + (y as u8)`. `x as u8 + 1`
+parses as `(x as u8) + 1`. Use parentheses when in doubt — the spec
+won't get less surprising the longer you stare at it.
+
 ### 3.6 Enums (tagged unions)
 
 Sum types — a value is exactly one of N variants, each variant

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -39,14 +39,26 @@ goal.
 Spaces and tabs are insignificant within a line. **Newlines terminate
 statements** (no semicolons). Blank lines are allowed anywhere.
 
-To continue a long expression onto the next line, use parentheses or
-break inside a binary operator:
+To continue a long expression onto the next line, wrap it in
+parentheses:
 
 ```
-let total =
+let total = (
   player.hp +
   player.mp
+)
 ```
+
+Inside any open `( … )`, `[ … ]`, or `{ … }` group, newlines are
+ignored — so multi-line argument lists, array / struct / tuple
+literals, and parameter declarations wrap naturally. Outside those
+groups, a newline ends the current statement; trailing-operator
+continuation (`a +\n  b`) is **not** a line-continuation rule.
+
+The one exception lives outside the bracket families: a `.` at the
+start of the next line continues the postfix chain on the previous
+expression (§4.6.1). That's the only newline-significant carve-out
+in the otherwise strict newline-terminated grammar.
 
 ### 2.2 Comments
 
@@ -593,7 +605,7 @@ end
 
 | Annotation | Applies to | Effect |
 |------------|------------|--------|
-| `@inline` | `def`, `lambda` | Always inline at call sites. Compiler errors if the function is recursive or its body is too large. |
+| `@inline` | `def` | Always inline at call sites. Compiler errors if the function is recursive or its body is too large. |
 
 ```
 @inline
@@ -604,11 +616,17 @@ def fast_clamp(x: i16, min: i16, max: i16) -> i16
 end
 ```
 
+`@inline` attaches to named `def`s only. Lambdas already inline
+when they don't escape (their body folds into the caller); when
+they do escape they become first-class values and inlining would
+defeat that — there's no useful middle ground to expose via
+annotation.
+
 #### 3.7.3 Diverging functions
 
 | Annotation | Applies to | Effect |
 |------------|------------|--------|
-| `@noreturn` | `def`, `lambda` | Asserts the function never returns normally (it must `hlt`, infinite-loop, or call another `@noreturn`). The compiler treats calls as diverging — usable in `match` bail arms with otherwise non-exhaustive shape. The return type, if specified, must be `noreturn`. |
+| `@noreturn` | `def` | Asserts the function never returns normally (it must `hlt`, infinite-loop, or call another `@noreturn`). The compiler treats calls as diverging — usable in `match` bail arms with otherwise non-exhaustive shape. The return type, if specified, must be `noreturn`. |
 
 ```
 @noreturn

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -575,6 +575,8 @@ Multiple annotations stack. Order matters only when explicitly noted.
 | `@bank N` | `def`, `let`, `const`, **file** | Place compiled output in bank `N` (compiler emits cross-bank trampolines for calls — §7.3). See precedence note below. |
 | `@zero_page` | `let` | Place this global in the zero-page region (`0x0000..0x00FF`) — 1-byte addressing mode, faster + smaller code. Slot pressure is high (256 bytes shared); compiler errors on overflow. |
 | `@addr $1234` | `let` | Pin this global at the given absolute address. Use for binding to memory-mapped IO registers or fixed-position state. The compiler reserves no other RAM at that address. |
+| `@volatile` | `let` | Treat every read of this binding as a real memory load (never cached in a register). Pair with `@addr` for memory-mapped IO registers whose value changes outside the compiler's view (vblank flag, input port, RNG tap). |
+| `@align(N)` | `let`, `const`, `struct` | Force `N`-byte alignment of the placement. `N` must be a power of two (1, 2, 4, 8, 16, …). Necessary when the hardware demands aligned data — sprite sheets at 16-byte boundaries, tile maps at page boundaries (256), audio buffers at 4 bytes. |
 
 **`@bank` precedence.** `@bank N` may appear at either:
 - **File scope** — the first non-comment token in a `.gr` file.
@@ -593,7 +595,12 @@ in the base image (bank-less area before `0xC000`).
 let cursor_pos: u16 = 0      -- fast access, e.g. updated 60×/sec
 
 @addr $FE40
+@volatile
 let DISPCTL: u8 = 0          -- bound to gtx-16 display-control IO register
+
+@align(16)
+@addr $C000
+let sprite_sheet: [u8; 2048] -- aligned tile data, banked window
 
 @bank 5
 def town_intro_dialog() -> str
@@ -606,6 +613,7 @@ end
 | Annotation | Applies to | Effect |
 |------------|------------|--------|
 | `@inline` | `def` | Always inline at call sites. Compiler errors if the function is recursive or its body is too large. |
+| `@cold` | `def` | Mark the function as unlikely-called. The compiler is free to place it far from the hot path (separate code page, late in the section) so adjacent hot code stays in cache / prefetch range. Useful for error helpers, panic paths, debug-only dumps. |
 
 ```
 @inline
@@ -614,6 +622,12 @@ def fast_clamp(x: i16, min: i16, max: i16) -> i16
   if x > max then return max end
   return x
 end
+
+@cold
+def panic_oob(addr: u16) -> noreturn
+  print "PANIC: out-of-bounds @ ", addr
+  hlt
+end
 ```
 
 `@inline` attaches to named `def`s only. Lambdas already inline
@@ -621,6 +635,10 @@ when they don't escape (their body folds into the caller); when
 they do escape they become first-class values and inlining would
 defeat that — there's no useful middle ground to expose via
 annotation.
+
+`@cold` is a *hint*, not a guarantee — the compiler decides
+placement. A `@cold` function on the hot path (called from a tight
+loop) still compiles correctly, just sub-optimally.
 
 #### 3.7.3 Diverging functions
 

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -136,7 +136,7 @@ enum is
 use from as local
 true false nil
 and or not
-break continue
+break continue defer
 print
 ```
 
@@ -1471,6 +1471,78 @@ day one. The trade-off is intentional.
 Compiles to a host-provided syscall (`int 0x10`). The host's printer
 implementation defines the output channel (gtx-16 prints to a debug
 console; CLI tools print to stdout).
+
+### 4.10 Defer
+
+`defer <stmt>` schedules a statement to run when the enclosing block
+exits. Useful for hardware-state save / restore, IRQ-mask windows,
+and any cleanup that has to fire on **every** exit path including
+`return` / `break` / `continue`:
+
+```
+def render_with_palette(new_pal: u8)
+  let old = read_palette()
+  defer set_palette(old)        -- restoration guaranteed
+  set_palette(new_pal)
+  render_frame()
+  -- if render_frame returns early, the palette still restores
+end
+
+def safe_update()
+  let mask = read_irq_mask()
+  defer set_irq_mask(mask)
+  set_irq_mask(0)
+  -- critical section: any return / break / continue still restores
+end
+```
+
+**Scope.** Block-scoped — the defer attaches to the nearest
+enclosing block (`do`, `if`-arm, `while` / `for` body, function
+body, `match`-arm body, `lambda` body). The deferred statement runs
+when that block exits, not when the function returns.
+
+```
+while cond do
+  let frame = acquire()
+  defer release(frame)      -- runs at the bottom of every iteration
+  if early then break end   -- release still runs before the break
+  process(frame)
+end
+```
+
+**Order.** Multiple defers in the same block run in **LIFO** order:
+
+```
+defer a()
+defer b()
+defer c()
+-- on exit: c, then b, then a
+```
+
+**Exit paths covered.** Normal end-of-block, `return`, `break`,
+`continue`. The deferred statement also runs when the block exits
+via an early `return` that's nested in deeper blocks below the
+defer — every exit path through this block fires the cleanup.
+
+**Exit paths NOT covered.** Hardware faults (gero's `int 0x02`-style
+traps — out-of-bounds, nil-deref, div-by-zero). Defers do **not**
+run on fault. Faults are terminal in gero; no user-level recovery
+path runs.
+
+**Restrictions.** The deferred statement is parsed as a regular
+statement, but the codegen / typechecker rejects:
+
+- `defer return …`, `defer break`, `defer continue` — cleanup
+  blocks can't redirect control flow. Wrap with `do … end` if you
+  need a multi-line body that doesn't contain those forms.
+- `defer defer …` — pointless, doesn't compose.
+
+**Compilation.** The compiler walks the block accumulating defers
+into a per-block list. At each scope-exit point it emits the
+cleanup code in reverse order; for `return` / `break` / `continue`
+it routes the jump through a generated cleanup label so the same
+emission code is shared. Zero runtime overhead on the common
+no-defer path.
 
 ---
 

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -5,6 +5,8 @@
 /// Per [gero-lang spec](../docs/gero-lang.md).
 const std = @import("std");
 const lexer_mod = @import("lang/lexer.zig");
+const ast_mod = @import("lang/ast.zig");
+const parser_mod = @import("lang/parser.zig");
 
 /// Re-export: lexer token.
 pub const Token = lexer_mod.Token;
@@ -12,3 +14,10 @@ pub const Token = lexer_mod.Token;
 pub const TokenStream = lexer_mod.TokenStream;
 /// Re-export: `.gr` tokenizer.
 pub const tokenize = lexer_mod.tokenize;
+
+/// Re-export: AST node types.
+pub const ast = ast_mod;
+/// Re-export: parser output (program + diagnostics).
+pub const ParseTree = parser_mod.ParseTree;
+/// Re-export: parse a tokenized source into an `ast.Program`.
+pub const parse = parser_mod.parse;

--- a/src/lang/annotation.zig
+++ b/src/lang/annotation.zig
@@ -1,0 +1,71 @@
+/// Annotation parser — `@name` / `@name(args...)` markers that
+/// the parser accumulates into a pending buffer and attaches to
+/// the following decl. Both the paren form (`@bank(5)`) and the
+/// bare-arg sugar (`@bank 5` — single inline arg on the same line)
+/// are recognized. §3.7.
+///
+/// Imports `Parser` + `ParserError` from `parser.zig`; calls
+/// `expr.parseExpression` to capture arg expressions.
+const std = @import("std");
+const ast = @import("ast.zig");
+const lexer = @import("lexer.zig");
+const parser_mod = @import("parser.zig");
+const expr_mod = @import("expr.zig");
+
+const Parser = parser_mod.Parser;
+const ParserError = parser_mod.ParserError;
+const Kind = lexer.Token.Kind;
+
+/// Parse a single `@name[(args...)]` annotation. The lexer emits
+/// the `@`+identifier as one `.annotation` token whose span covers
+/// both bytes.
+pub fn parseAnnotation(p: *Parser) ParserError!ast.Annotation {
+    const at_tok = p.peek();
+    p.pos += 1;
+
+    const name_span: ast.Span = .{
+        .start = at_tok.start + 1,
+        .end = at_tok.end,
+    };
+
+    var args: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (args.items) |a| ast.freeExpr(p.allocator, a);
+        args.deinit(p.allocator);
+    }
+
+    var end: u32 = at_tok.end;
+
+    if (p.accept(.lparen)) |_| {
+        if (!p.check(.rparen)) {
+            while (true) {
+                const arg = try expr_mod.parseExpression(p, 0);
+                try args.append(p.allocator, arg);
+                if (p.accept(.comma) == null) break;
+            }
+        }
+        const close = try p.expect(.rparen, ")");
+        end = close.end;
+    } else if (canStartParenlessAnnotationArg(p.peek().kind)) {
+        // Sugar: `@bank 5`, `@interrupt 0x06`, `@addr $FE40`. Stops
+        // at the line boundary (newline) — only one expression
+        // captured.
+        const arg = try expr_mod.parseExpression(p, 0);
+        const arg_span = arg.span();
+        try args.append(p.allocator, arg);
+        end = arg_span.end;
+    }
+
+    return .{
+        .name = name_span,
+        .args = try args.toOwnedSlice(p.allocator),
+        .span = .{ .start = at_tok.start, .end = end },
+    };
+}
+
+fn canStartParenlessAnnotationArg(k: Kind) bool {
+    return switch (k) {
+        .int_lit, .ident, .str_start, .kw_true, .kw_false, .kw_nil => true,
+        else => false,
+    };
+}

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -729,6 +729,10 @@ pub const Statement = union(enum) {
     local_decl: LocalDecl,
     /// `@asm("...")` — single inline-asm escape hatch line.
     asm_stmt: AsmStmt,
+    /// `defer <stmt>` — schedule `stmt` to run when the enclosing
+    /// block exits (§4.10). LIFO across multiple defers in the same
+    /// block. Codegen owns the cleanup-label management.
+    defer_stmt: DeferStmt,
     /// Catch-all for unrecognized lines. Carries a span so consumers
     /// can skip cleanly.
     unknown: UnknownStmt,
@@ -757,6 +761,7 @@ pub const Statement = union(enum) {
             .use_decl => |s| s.span,
             .local_decl => |s| s.span,
             .asm_stmt => |s| s.span,
+            .defer_stmt => |s| s.span,
             .unknown => |s| s.span,
         };
     }
@@ -1049,6 +1054,15 @@ pub const AsmStmt = struct {
     span: Span,
 };
 
+/// `defer <stmt>` — schedule a statement to run when the enclosing
+/// block exits (§4.10). The body is held as a single `*Statement`;
+/// wrap in `do … end` for multi-statement cleanups. LIFO order
+/// across multiple defers in the same block.
+pub const DeferStmt = struct {
+    body: *Statement,
+    span: Span,
+};
+
 /// Catch-all for unrecognized statement-position input. The span
 /// covers the recovered source range; consumers usually just emit a
 /// diagnostic and skip.
@@ -1158,6 +1172,10 @@ pub fn freeStatement(allocator: std.mem.Allocator, s: *Statement) void {
             allocator.free(ed.variants);
         },
         .use_decl => |ud| allocator.free(ud.items),
+        .defer_stmt => |d| {
+            freeStatement(allocator, d.body);
+            allocator.destroy(d.body);
+        },
         .local_decl, .asm_stmt, .unknown => {},
     }
 }

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -1,0 +1,1284 @@
+/// Gero-lang AST — what the parser emits, what the typechecker
+/// and codegen consume. Every node carries a `Span` so diagnostics
+/// can resolve back to `(file, line, col)` against the original
+/// source text.
+///
+/// Mirrors the shape of `src/asm/ast.zig`: discriminated unions
+/// for `Statement`, `Expr`, `Pattern`, `TypeAnn`; allocated child
+/// trees are owned by the program allocator and released via
+/// `Program.deinit`.
+///
+/// Per gero-lang spec (see `docs/gero-lang.md`).
+const std = @import("std");
+const lexer = @import("lexer.zig");
+
+/// Byte range in the source buffer. Used by every AST node so a
+/// downstream pass (typechecker, codegen, formatter) can locate
+/// the original token sequence.
+pub const Span = struct {
+    start: u32,
+    end: u32,
+
+    /// Span covering exactly one token.
+    pub fn fromToken(t: lexer.Token) Span {
+        return .{ .start = t.start, .end = t.end };
+    }
+
+    /// Smallest span covering both `a` and `b`.
+    pub fn join(a: Span, b: Span) Span {
+        return .{
+            .start = @min(a.start, b.start),
+            .end = @max(a.end, b.end),
+        };
+    }
+};
+
+// =====================================================================
+// Annotations — `@name` / `@name(arg)` markers attached to a decl.
+// =====================================================================
+
+/// One `@name(...)` annotation. Bound to the following decl by the
+/// parser. The argument list is captured verbatim as expressions so
+/// each annotation's semantics (e.g. `@bank 5`, `@interrupt 0x06`,
+/// `@addr $FE40`, `@asm("swap {a}, {b}")`) stay decoupled from the
+/// parser shape. The downstream typechecker / codegen interprets
+/// the args per the annotation's contract.
+pub const Annotation = struct {
+    /// Span of the annotation name (without the `@` prefix). Lexeme
+    /// bytes recover via `source[name.start..name.end]`.
+    name: Span,
+    /// Args in source order. Empty for marker annotations (`@final`,
+    /// `@inline`, `@override`, `@noreturn`, `@private`, `@static`,
+    /// `@abstract`, `@test`, `@bench`, `@zero_page`).
+    args: []*Expr,
+    /// Span covering `@name` plus any `(...)`. End-to-end.
+    span: Span,
+};
+
+// =====================================================================
+// Type annotations — appear after `:` in `let x: T = ...`, after
+// `->` in `def name(...) -> T`, and in `fn(T1, T2) -> T3` types.
+// =====================================================================
+
+/// Type expression — parses the surface syntax of `docs/gero-lang.md`
+/// §3.1 (primitives), §3.2 (`str`), §3.3 (`fixed`), §3.4 (compound
+/// types), §3.4.1 (nullable suffix `?`), §3.4.3 (`Vec(T)`).
+pub const TypeAnn = union(enum) {
+    /// `i16`, `u8`, `bool`, `str`, `fixed`, a class name, an enum
+    /// name, etc. The typechecker resolves the lexeme to a primitive
+    /// or a user-defined declaration.
+    named: NamedType,
+    /// `T?` — nullable suffix. Per §3.4.1, restricted to pointer-like
+    /// inner types; the typechecker enforces that, the parser
+    /// accepts the syntax uniformly.
+    nullable: NullableType,
+    /// `[T; N]` — fixed-size array. `N` is a compile-time integer
+    /// expression (typically a literal).
+    array: ArrayType,
+    /// `Vec(T)` — compiler-known dynamic array. The inner type is
+    /// the element type.
+    vec: VecType,
+    /// `(T1, T2, ...)` — tuple. Per §3.4 max 4 elements; the parser
+    /// accepts more and the typechecker rejects oversize tuples.
+    tuple: TupleType,
+    /// `fn(args...) -> ret` — function pointer type. `ret` is
+    /// optional (defaults to `nil`).
+    fn_type: FnType,
+
+    /// Smallest `Span` covering the whole type annotation.
+    pub fn span(self: TypeAnn) Span {
+        return switch (self) {
+            .named => |n| n.span,
+            .nullable => |n| n.span,
+            .array => |a| a.span,
+            .vec => |v| v.span,
+            .tuple => |t| t.span,
+            .fn_type => |f| f.span,
+        };
+    }
+};
+
+/// `i16`, `MyClass`, `Foo.Bar`, etc. — a single named type.
+pub const NamedType = struct {
+    /// Span of the type name (and any `.qualified.path` segments
+    /// joined dot-separated).
+    name: Span,
+    span: Span,
+};
+
+/// `T?` — wraps an inner type, marks the binding nullable.
+pub const NullableType = struct {
+    inner: *TypeAnn,
+    span: Span,
+};
+
+/// `[T; N]` — fixed-size array. `len_expr` is a comptime integer.
+pub const ArrayType = struct {
+    elem: *TypeAnn,
+    /// Compile-time length expression. Typically an int literal.
+    len_expr: *Expr,
+    span: Span,
+};
+
+/// `Vec(T)` — compiler-known dynamic array. `elem` is the element
+/// type.
+pub const VecType = struct {
+    elem: *TypeAnn,
+    span: Span,
+};
+
+/// `(T1, T2, ...)` — anonymous tuple type.
+pub const TupleType = struct {
+    elems: []*TypeAnn,
+    span: Span,
+};
+
+/// `fn(T1, T2, ...) -> R` — function-pointer type.
+pub const FnType = struct {
+    params: []*TypeAnn,
+    /// `null` when the arrow is omitted — the parser canonicalizes
+    /// "no return type" to `nil`. Provided here so the printer can
+    /// round-trip the source shape.
+    ret: ?*TypeAnn,
+    span: Span,
+};
+
+// =====================================================================
+// Patterns — appear in `let` destructuring (§4.1.1), `if let`
+// (§4.4.1), `while let` (§4.5.2), `match` arms (§4.8.1).
+// =====================================================================
+
+/// One pattern node. The parser builds these for every binding
+/// shape the spec lists in §4.8.1.
+pub const Pattern = union(enum) {
+    /// `_` — matches anything, binds nothing.
+    wildcard: SpanOnly,
+    /// `ident` — matches anything, binds the value to `ident`.
+    ident: IdentPattern,
+    /// `42` / `0xFF` / `-1` — integer literal.
+    int_lit: IntLitPattern,
+    /// `"hello"` — string literal (compares byte-wise).
+    str_lit: SpanOnly,
+    /// `'A'` — char literal.
+    char_lit: CharLitPattern,
+    /// `true` / `false`.
+    bool_lit: BoolLitPattern,
+    /// `nil`.
+    nil_lit: SpanOnly,
+    /// `A | B | C` — or-pattern; any sub-pattern matches.
+    or_pattern: OrPattern,
+    /// `0..=15` / `0..16` — range pattern.
+    range_pattern: RangePattern,
+    /// `(p1, p2, ...)` — tuple pattern; binds element-wise.
+    tuple_pattern: TuplePattern,
+    /// `Enum.Variant(p1, p2, ...)` — enum variant; `args` is empty
+    /// for nullary variants like `Item.Sword`. The parser captures
+    /// the variant path as a span; the typechecker resolves it.
+    variant_pattern: VariantPattern,
+    /// `Type { field, field: pat, ... }` — struct pattern; missing
+    /// binders shorthand to `field: field`.
+    struct_pattern: StructPattern,
+
+    /// Smallest `Span` covering the whole pattern.
+    pub fn span(self: Pattern) Span {
+        return switch (self) {
+            .wildcard, .str_lit, .nil_lit => |p| p.span,
+            .ident => |p| p.span,
+            .int_lit => |p| p.span,
+            .char_lit => |p| p.span,
+            .bool_lit => |p| p.span,
+            .or_pattern => |p| p.span,
+            .range_pattern => |p| p.span,
+            .tuple_pattern => |p| p.span,
+            .variant_pattern => |p| p.span,
+            .struct_pattern => |p| p.span,
+        };
+    }
+};
+
+/// Shared payload for span-only AST variants (`wildcard`,
+/// `nil_lit`, `str_lit` pattern, etc.).
+pub const SpanOnly = struct {
+    span: Span,
+};
+
+/// `x` — binding-style pattern: matches anything, captures the
+/// value under `name`.
+pub const IdentPattern = struct {
+    /// Span of the bound identifier.
+    name: Span,
+    span: Span,
+};
+
+/// `42` — integer-literal pattern.
+pub const IntLitPattern = struct {
+    value: i32,
+    span: Span,
+};
+
+/// `'A'` — char-literal pattern.
+pub const CharLitPattern = struct {
+    /// ASCII byte value the char literal compiled to.
+    value: u8,
+    span: Span,
+};
+
+/// `true` / `false` — bool-literal pattern.
+pub const BoolLitPattern = struct {
+    value: bool,
+    span: Span,
+};
+
+/// `A | B | C` — or-pattern. `alts` is non-empty.
+pub const OrPattern = struct {
+    alts: []*Pattern,
+    span: Span,
+};
+
+/// `0..10` / `0..=15` — range pattern (matches values inside the
+/// range).
+pub const RangePattern = struct {
+    start: *Expr,
+    end: *Expr,
+    /// `true` for `..=`, `false` for `..`.
+    inclusive: bool,
+    span: Span,
+};
+
+/// `(p1, p2, ...)` — tuple destructuring.
+pub const TuplePattern = struct {
+    elems: []*Pattern,
+    span: Span,
+};
+
+/// `Enum.Variant(p1, p2, ...)` — enum-variant pattern (with
+/// optional payload binders).
+pub const VariantPattern = struct {
+    /// Variant path like `Item.Sword` or `Item.Potion`. The
+    /// typechecker resolves the head to an enum decl and the tail
+    /// to a variant.
+    path: Span,
+    /// Sub-patterns for the variant's payload, in declaration order.
+    /// Empty for nullary variants.
+    args: []*Pattern,
+    span: Span,
+};
+
+/// `Type { field, field: pat, ... }` — struct-destructuring
+/// pattern.
+pub const StructPattern = struct {
+    /// Type name (`Player`, etc.).
+    type_name: Span,
+    fields: []StructPatternField,
+    span: Span,
+};
+
+/// One field of a struct pattern: `name` plus a nested pattern.
+pub const StructPatternField = struct {
+    /// Field name as it appears in the type definition.
+    name: Span,
+    /// Sub-pattern matching the field's value. Shorthand
+    /// `Player { hp, mp }` desugars at parse time to `{ hp: hp,
+    /// mp: mp }` — the parser allocates an `IdentPattern` with the
+    /// same name + span.
+    sub: *Pattern,
+    span: Span,
+};
+
+// =====================================================================
+// Expressions — every value-producing form. Pratt precedence per
+// `docs/gero-lang.md` §3.3.
+// =====================================================================
+
+/// Every value-producing form in the language. Each variant
+/// carries its own struct payload (or `SpanOnly` for the keyword
+/// literals); operator precedence is enforced by the parser when
+/// it builds these nodes.
+pub const Expr = union(enum) {
+    int_lit: IntLitExpr,
+    bool_lit: BoolLitExpr,
+    nil_lit: SpanOnly,
+    char_lit: CharLitExpr,
+    /// Full string literal (possibly with interpolation parts). The
+    /// parser flattens the lexer's `str_start`/`str_part`/
+    /// `str_expr_start`/`str_expr_end`/`str_end` stream into a
+    /// linear `parts` list of byte runs + interpolated subexprs.
+    str_lit: StrLitExpr,
+    /// Bare identifier — variable reference.
+    ident: IdentExpr,
+    /// `self` keyword inside a class method.
+    self_expr: SpanOnly,
+    /// `super` keyword inside a class method body.
+    super_expr: SpanOnly,
+    /// `( inner )` — explicit grouping. Kept in the AST for span
+    /// integrity and so the printer can round-trip user parens.
+    paren: ParenExpr,
+    /// `-x` / `not x` / `~x` — unary prefix.
+    unary: UnaryExpr,
+    /// `lhs op rhs` — every infix operator. The `op` field carries
+    /// the operator kind; precedence is encoded at parse time by
+    /// the Pratt loop.
+    binary: BinaryExpr,
+    /// `start .. end` / `start ..= end` (with optional `step` —
+    /// `step` arrives via the `for` header, not as an inline part
+    /// of a `..` expression; this node just carries `start`/`end`/
+    /// `inclusive`).
+    range: RangeExpr,
+    /// `callee(args...)`. The callee is any expression that
+    /// evaluates to a function (ident, lambda, field access, etc.).
+    call: CallExpr,
+    /// `obj.method(args...)` — sugar for a regular call where the
+    /// receiver is bound to the first parameter.
+    method_call: MethodCallExpr,
+    /// `obj.field` — direct field access, no parentheses.
+    field: FieldExpr,
+    /// `obj[index]` — bracket-index access. For `Vec(T)` and arrays
+    /// codegen emits the `at`/`get` opcode; for strings it's byte
+    /// access.
+    index: IndexExpr,
+    /// `do ... end` as an expression — evaluates to the last
+    /// expression of the body. §4.3.
+    do_expr: DoExpr,
+    /// `if cond then a else b` as an expression (§4.4 — the bodies
+    /// are blocks; the value is the last expression of the taken
+    /// branch). Optional in the spec — `if` is primarily a
+    /// statement; the parser produces this form when an `if` is
+    /// found in expression position.
+    if_expr: IfExpr,
+    /// `lambda (args) -> ret body end` — anonymous function literal.
+    lambda: LambdaExpr,
+    /// `[expr, expr, ...]` — array literal. Used for `[T; N]` init
+    /// and `Vec.from([...])` arg.
+    list_lit: ListLit,
+    /// `Type { field: expr, ... }` — struct literal.
+    struct_lit: StructLit,
+    /// `(a, b, ...)` — tuple literal (at least 2 elements; singletons
+    /// are paren expressions).
+    tuple_lit: TupleLit,
+    /// `value is Enum.Variant` — variant-tag test. Rhs is a span over
+    /// the qualified variant path.
+    is_test: IsTestExpr,
+
+    /// Smallest `Span` covering the whole expression.
+    pub fn span(self: Expr) Span {
+        return switch (self) {
+            .int_lit => |e| e.span,
+            .bool_lit => |e| e.span,
+            .nil_lit, .self_expr, .super_expr => |e| e.span,
+            .char_lit => |e| e.span,
+            .str_lit => |e| e.span,
+            .ident => |e| e.span,
+            .paren => |e| e.span,
+            .unary => |e| e.span,
+            .binary => |e| e.span,
+            .range => |e| e.span,
+            .call => |e| e.span,
+            .method_call => |e| e.span,
+            .field => |e| e.span,
+            .index => |e| e.span,
+            .do_expr => |e| e.span,
+            .if_expr => |e| e.span,
+            .lambda => |e| e.span,
+            .list_lit => |e| e.span,
+            .struct_lit => |e| e.span,
+            .tuple_lit => |e| e.span,
+            .is_test => |e| e.span,
+        };
+    }
+};
+
+/// Integer literal (decimal / hex / binary; the lexer normalizes
+/// all three into a single `int_lit` token).
+pub const IntLitExpr = struct {
+    value: i32,
+    span: Span,
+};
+
+/// `true` / `false` — bool literal.
+pub const BoolLitExpr = struct {
+    value: bool,
+    span: Span,
+};
+
+/// `'A'` — single-byte char literal.
+pub const CharLitExpr = struct {
+    /// Single-byte char-literal value (the lexer already decoded
+    /// escape sequences).
+    value: u8,
+    span: Span,
+};
+
+/// String literal — possibly interpolated. `parts` runs in source
+/// order; for `"hello, $(name)!"` the list is
+/// `[ .lit("hello, "), .interp(<name expr>), .lit("!") ]`. Adjacent
+/// interpolations are still separated by an empty `.lit("")` part so
+/// downstream consumers can rely on a uniform "literal between every
+/// pair of interps" shape.
+pub const StrLitExpr = struct {
+    parts: []StrPart,
+    span: Span,
+};
+
+/// One chunk in a possibly-interpolated string literal.
+pub const StrPart = union(enum) {
+    /// Raw byte run inside the string. Span covers the bytes
+    /// between the surrounding delimiters/interps. Escape sequences
+    /// are not yet decoded — codegen reads `source[span.start..span.end]`
+    /// and resolves escapes there.
+    lit: StrLitPart,
+    /// `$(expr)` substitution. The optional format spec lives in
+    /// `format_spec` and is rendered by the runtime formatter.
+    interp: StrInterpPart,
+};
+
+/// Plain byte-run part of a string literal.
+pub const StrLitPart = struct {
+    span: Span,
+};
+
+/// `$(expr[:fmt])` part of a string literal.
+pub const StrInterpPart = struct {
+    expr: *Expr,
+    /// `null` when no `:fmt` spec is present. Span covers the bytes
+    /// after `:` and up to the closing `)`. Same minimal subset of
+    /// Python's spec language as §3.2.2 describes.
+    format_spec: ?Span,
+    span: Span,
+};
+
+/// Bare identifier reference in expression position.
+pub const IdentExpr = struct {
+    /// Span of the identifier token. Lexeme bytes recover via
+    /// `source[span.start..span.end]`.
+    span: Span,
+};
+
+/// `( inner )` — explicit grouping wrapper.
+pub const ParenExpr = struct {
+    inner: *Expr,
+    span: Span,
+};
+
+/// `op operand` — unary prefix expression.
+pub const UnaryExpr = struct {
+    op: UnaryOp,
+    operand: *Expr,
+    span: Span,
+};
+
+/// Unary prefix operators per §4.2.1.
+pub const UnaryOp = enum {
+    /// `-x` — two's-complement negation.
+    neg,
+    /// `not x` — logical NOT. Boolean-valued.
+    log_not,
+    /// `~x` — bitwise NOT.
+    bit_not,
+};
+
+/// `lhs op rhs` — binary infix expression.
+pub const BinaryExpr = struct {
+    op: BinaryOp,
+    lhs: *Expr,
+    rhs: *Expr,
+    span: Span,
+};
+
+/// Binary operators per §4.2.1. Precedence is encoded by the
+/// Pratt loop in `parser.zig`; this enum just names every operator
+/// the parser recognizes.
+pub const BinaryOp = enum {
+    // arithmetic
+    add, // +
+    sub, // -
+    mul, // *
+    div, // /
+    mod, // %
+
+    // shift
+    shl, // <<
+    shr, // >>
+
+    // bitwise
+    bit_and, // &
+    bit_or, // |
+    bit_xor, // ^
+
+    // comparison
+    eq, // ==
+    neq, // !=
+    lt, // <
+    lte, // <=
+    gt, // >
+    gte, // >=
+
+    // logical
+    log_and, // and
+    log_or, // or
+};
+
+/// `start..end` / `start..=end` — range expression.
+pub const RangeExpr = struct {
+    start: *Expr,
+    end: *Expr,
+    /// `true` for `..=`, `false` for `..`.
+    inclusive: bool,
+    span: Span,
+};
+
+/// `callee(args...)` — function call.
+pub const CallExpr = struct {
+    callee: *Expr,
+    args: []*Expr,
+    span: Span,
+};
+
+/// `receiver.method(args...)` — method-call sugar.
+pub const MethodCallExpr = struct {
+    receiver: *Expr,
+    /// Method name span.
+    method: Span,
+    args: []*Expr,
+    span: Span,
+};
+
+/// `receiver.field` — field access (no parens).
+pub const FieldExpr = struct {
+    receiver: *Expr,
+    /// Field name span.
+    field: Span,
+    span: Span,
+};
+
+/// `receiver[index]` — bracket-index access.
+pub const IndexExpr = struct {
+    receiver: *Expr,
+    index: *Expr,
+    span: Span,
+};
+
+/// `do ... end` used as an expression.
+pub const DoExpr = struct {
+    body: []Statement,
+    span: Span,
+};
+
+/// `if cond then ... [else ...] end` used as an expression.
+pub const IfExpr = struct {
+    /// `cond / then-body` pairs in source order. The first arm is
+    /// the `if`; subsequent arms are `else if` / `elif`.
+    arms: []IfArm,
+    /// `else` body, `null` when omitted.
+    else_body: ?[]Statement,
+    span: Span,
+};
+
+/// One `cond / body` arm of an if / elif chain. The arm is either
+/// the plain shape (`cond` set, let_* null) or the `if let pat =
+/// expr [when guard]` shape (cond null, let_* set). §4.4 / §4.4.1.
+pub const IfArm = struct {
+    cond: ?*Expr,
+    let_pattern: ?*Pattern,
+    let_expr: ?*Expr,
+    let_guard: ?*Expr,
+    body: []Statement,
+    span: Span,
+};
+
+/// `lambda (args) [-> ret] body end` — anonymous function value.
+pub const LambdaExpr = struct {
+    params: []Param,
+    /// Optional return-type annotation. `null` when the source
+    /// omits the `-> T` part.
+    ret_type: ?*TypeAnn,
+    body: []Statement,
+    span: Span,
+};
+
+/// `[a, b, c, ...]` — array / list literal.
+pub const ListLit = struct {
+    elems: []*Expr,
+    span: Span,
+};
+
+/// `Type { field: expr, ... }` — struct literal.
+pub const StructLit = struct {
+    /// Type name (`Player`, `Stats`, etc.).
+    type_name: Span,
+    fields: []StructLitField,
+    span: Span,
+};
+
+/// One field of a struct literal.
+pub const StructLitField = struct {
+    name: Span,
+    value: *Expr,
+    span: Span,
+};
+
+/// `(a, b, ...)` — tuple literal.
+pub const TupleLit = struct {
+    elems: []*Expr,
+    span: Span,
+};
+
+/// `lhs is Enum.Variant` — variant-tag test.
+pub const IsTestExpr = struct {
+    lhs: *Expr,
+    /// Variant path span — typically `EnumType.Variant`.
+    variant_path: Span,
+    span: Span,
+};
+
+// =====================================================================
+// Function parameters — shared between `def`, `lambda`, and class
+// methods.
+// =====================================================================
+
+/// One parameter of a `def` / `lambda` / class method.
+pub const Param = struct {
+    name: Span,
+    /// `null` when the parameter has no explicit type — inference
+    /// will pin it from call-site usage (§3.5).
+    type_ann: ?*TypeAnn,
+    span: Span,
+};
+
+// =====================================================================
+// Statements — the top-level units of a program.
+// =====================================================================
+
+/// Top-level statement node. The parser unwraps `local` shims into
+/// the inner decl's `is_local: true`, so `local_decl` itself only
+/// appears for malformed inputs.
+pub const Statement = union(enum) {
+    /// `let pattern[: T] = expr` / `let name: T` (uninit form).
+    let_decl: LetDecl,
+    /// `const NAME = expr`. The parser captures the RHS verbatim;
+    /// comptime-folding happens in the codegen pass.
+    const_decl: ConstDecl,
+    /// `target = expr` and the compound-assign family.
+    assign: AssignStmt,
+    /// `x++` / `x--`.
+    inc_dec: IncDecStmt,
+    /// `_ = expr` — explicit discard. Per §4.2.2.
+    discard: DiscardStmt,
+    /// Bare expression as a statement — function/method call whose
+    /// return value is discarded implicitly (`nil`-typed calls).
+    expr_stmt: ExprStmt,
+    /// `do ... end` at statement position.
+    block: BlockStmt,
+    /// `if cond then ... [elif ...] [else ...] end`.
+    if_stmt: IfStmt,
+    /// `while cond do ... end`.
+    while_stmt: WhileStmt,
+    /// `for binding in iter [step expr] do ... end`.
+    for_stmt: ForStmt,
+    /// `match scrutinee case pat [when guard] then body ... end`.
+    match_stmt: MatchStmt,
+    /// `return [expr]`.
+    return_stmt: ReturnStmt,
+    /// `break`.
+    break_stmt: SpanOnly,
+    /// `continue`.
+    continue_stmt: SpanOnly,
+    /// `print expr1, expr2, ...`.
+    print_stmt: PrintStmt,
+    /// `def name(params) [-> T] body end`.
+    def_decl: DefDecl,
+    /// `class Name [extends Parent] { ... }`.
+    class_decl: ClassDecl,
+    /// `struct Name field: T, ... end`.
+    struct_decl: StructDecl,
+    /// `enum Name case Variant[(payload)] ... end`.
+    enum_decl: EnumDecl,
+    /// `use module [as alias]` and `use sym from module`.
+    use_decl: UseDecl,
+    /// `local <decl>` — visibility modifier wrapping a let/const/def/
+    /// class/struct/enum/use decl. The parser flattens this by
+    /// setting the inner decl's `is_local` field rather than
+    /// nesting; this variant remains here for unrecognized shapes.
+    local_decl: LocalDecl,
+    /// `@asm("...")` — single inline-asm escape hatch line.
+    asm_stmt: AsmStmt,
+    /// Catch-all for unrecognized lines. Carries a span so consumers
+    /// can skip cleanly.
+    unknown: UnknownStmt,
+
+    /// Smallest `Span` covering the whole statement.
+    pub fn span(self: Statement) Span {
+        return switch (self) {
+            .let_decl => |s| s.span,
+            .const_decl => |s| s.span,
+            .assign => |s| s.span,
+            .inc_dec => |s| s.span,
+            .discard => |s| s.span,
+            .expr_stmt => |s| s.span,
+            .block => |s| s.span,
+            .if_stmt => |s| s.span,
+            .while_stmt => |s| s.span,
+            .for_stmt => |s| s.span,
+            .match_stmt => |s| s.span,
+            .return_stmt => |s| s.span,
+            .break_stmt, .continue_stmt => |s| s.span,
+            .print_stmt => |s| s.span,
+            .def_decl => |s| s.span,
+            .class_decl => |s| s.span,
+            .struct_decl => |s| s.span,
+            .enum_decl => |s| s.span,
+            .use_decl => |s| s.span,
+            .local_decl => |s| s.span,
+            .asm_stmt => |s| s.span,
+            .unknown => |s| s.span,
+        };
+    }
+};
+
+/// `let pattern[: T][ = expr]` — variable binding.
+pub const LetDecl = struct {
+    /// Pattern bound by the `let`. For the canonical single-name
+    /// case it's `Pattern.ident`; destructuring (§4.1.1) uses other
+    /// pattern shapes.
+    pattern: *Pattern,
+    /// `null` when no `: T` annotation is given.
+    type_ann: ?*TypeAnn,
+    /// `null` when the form is `let name: T` (declared but
+    /// uninitialized; the typechecker requires the annotation in
+    /// that case).
+    init: ?*Expr,
+    /// Set by `local let ...` — the visibility shim.
+    is_local: bool,
+    span: Span,
+};
+
+/// `const NAME[: T] = expr` — immutable binding.
+pub const ConstDecl = struct {
+    /// Span of the identifier being bound.
+    name: Span,
+    /// `null` when the form omits the type annotation (typical for
+    /// `const`).
+    type_ann: ?*TypeAnn,
+    init: *Expr,
+    is_local: bool,
+    span: Span,
+};
+
+/// `target op= value` (or plain `=`) — assignment statement.
+pub const AssignStmt = struct {
+    /// L-value (`x`, `obj.field`, `arr[i]`, etc.). The parser does
+    /// not enforce assignability here — that's a typechecker pass.
+    target: *Expr,
+    op: AssignOp,
+    value: *Expr,
+    span: Span,
+};
+
+/// Assignment operator kinds per §4.2.
+pub const AssignOp = enum {
+    /// Plain `=`.
+    set,
+    /// `+=` / `-=` / `*=` / `/=` / `%=`
+    add_set,
+    sub_set,
+    mul_set,
+    div_set,
+    mod_set,
+    /// `&=` / `|=` / `^=`
+    bit_and_set,
+    bit_or_set,
+    bit_xor_set,
+    /// `<<=` / `>>=`
+    shl_set,
+    shr_set,
+};
+
+/// `target++` / `target--` — statement-level increment / decrement.
+pub const IncDecStmt = struct {
+    /// L-value being mutated.
+    target: *Expr,
+    /// `true` for `++`, `false` for `--`.
+    inc: bool,
+    span: Span,
+};
+
+/// `_ = expr` — explicit value discard.
+pub const DiscardStmt = struct {
+    /// Expression whose value is evaluated then dropped.
+    expr: *Expr,
+    span: Span,
+};
+
+/// Bare expression statement (typically a call whose return value
+/// is `nil`).
+pub const ExprStmt = struct {
+    expr: *Expr,
+    span: Span,
+};
+
+/// `do ... end` at statement position.
+pub const BlockStmt = struct {
+    body: []Statement,
+    span: Span,
+};
+
+/// `if cond then ... [elif ...] [else ...] end` — statement form.
+pub const IfStmt = struct {
+    /// `cond / then-body` pairs in source order; the first arm is
+    /// the `if`, the rest are `else if` / `elif`.
+    arms: []IfArm,
+    else_body: ?[]Statement,
+    span: Span,
+};
+
+/// `while cond do ... end` (or the `while let` variant).
+pub const WhileStmt = struct {
+    /// For `while let pat = expr do ... end`, `cond` is null and
+    /// `let_pattern` / `let_expr` carry the binding shape.
+    cond: ?*Expr,
+    let_pattern: ?*Pattern,
+    let_expr: ?*Expr,
+    /// Optional `when guard` clause on the `while let` form.
+    let_guard: ?*Expr,
+    body: []Statement,
+    span: Span,
+};
+
+/// `for x in iter [step N] do ... end`.
+pub const ForStmt = struct {
+    /// Binding name (typical `for x in xs` form). Tuple destructuring
+    /// can be added later by upgrading to a `Pattern`; today the
+    /// parser accepts a single identifier per spec §4.5 examples.
+    binding: Span,
+    /// Iterable / range expression.
+    iter: *Expr,
+    /// `null` unless the source explicitly carried `step N`.
+    step: ?*Expr,
+    body: []Statement,
+    span: Span,
+};
+
+/// `match expr case pat ... end` — pattern dispatch.
+pub const MatchStmt = struct {
+    scrutinee: *Expr,
+    arms: []MatchArm,
+    span: Span,
+};
+
+/// One `case pat [when guard] then body` arm of a `match`.
+pub const MatchArm = struct {
+    pattern: *Pattern,
+    /// Optional `when` guard following the pattern.
+    guard: ?*Expr,
+    body: []Statement,
+    span: Span,
+};
+
+/// `return [expr]` statement.
+pub const ReturnStmt = struct {
+    /// `null` for bare `return`.
+    value: ?*Expr,
+    span: Span,
+};
+
+/// `print expr, expr, ...` statement.
+pub const PrintStmt = struct {
+    /// Comma-separated argument list. Per §4.9, items are space-
+    /// separated in output and a newline is appended.
+    args: []*Expr,
+    span: Span,
+};
+
+/// `def name(params) [-> T] body end` — function declaration.
+pub const DefDecl = struct {
+    annotations: []Annotation,
+    /// Function name span. Lexeme via `source[name.start..name.end]`.
+    name: Span,
+    params: []Param,
+    ret_type: ?*TypeAnn,
+    body: []Statement,
+    is_local: bool,
+    span: Span,
+};
+
+/// `class Name [extends Parent] { ... }` — class declaration.
+pub const ClassDecl = struct {
+    annotations: []Annotation,
+    /// Class name span.
+    name: Span,
+    /// Span of the parent class name when `extends Foo` is present;
+    /// `null` otherwise.
+    extends: ?Span,
+    /// Field declarations (`let name: T` lines inside the class
+    /// body).
+    fields: []ClassField,
+    /// Method declarations.
+    methods: []DefDecl,
+    is_local: bool,
+    span: Span,
+};
+
+/// `let name: T [= init]` inside a class body.
+pub const ClassField = struct {
+    annotations: []Annotation,
+    name: Span,
+    type_ann: ?*TypeAnn,
+    /// `null` when no default value is specified.
+    init: ?*Expr,
+    span: Span,
+};
+
+/// `struct Name field: T ... end` — struct declaration (POD).
+pub const StructDecl = struct {
+    annotations: []Annotation,
+    name: Span,
+    fields: []StructField,
+    is_local: bool,
+    span: Span,
+};
+
+/// One field of a `struct` declaration.
+pub const StructField = struct {
+    name: Span,
+    type_ann: *TypeAnn,
+    span: Span,
+};
+
+/// `enum Name case Variant ... end` — sum-type declaration.
+pub const EnumDecl = struct {
+    annotations: []Annotation,
+    name: Span,
+    variants: []EnumVariant,
+    is_local: bool,
+    span: Span,
+};
+
+/// One `case` arm of an `enum` declaration.
+pub const EnumVariant = struct {
+    name: Span,
+    /// Per-payload-field type annotations. Empty for nullary
+    /// variants. Each entry carries an optional binding name; the
+    /// `Item.Key(name: str, count: u8)` form has names, the
+    /// `Item.Potion(i16)` form has anonymous payloads (name span is
+    /// zero-width).
+    payload: []EnumPayloadField,
+    span: Span,
+};
+
+/// One payload slot inside an `enum` variant.
+pub const EnumPayloadField = struct {
+    /// Zero-width span when the payload is anonymous (`(i16)`);
+    /// otherwise the field's binding name.
+    name: Span,
+    type_ann: *TypeAnn,
+    span: Span,
+};
+
+/// `use module [as alias]` / `use a, b from module` — import.
+pub const UseDecl = struct {
+    /// Module path span — either a bare ident (`math`) or a quoted
+    /// path (`"./physics"`). The parser captures the span as-is;
+    /// resolution semantics are the linker's job.
+    module: Span,
+    /// `true` when the module spec was a quoted-path form.
+    quoted_path: bool,
+    /// Optional selective-import list (`use abs, sqrt from math`).
+    /// Empty for a whole-module import.
+    items: []UseItem,
+    /// Optional whole-module alias (`use math as m`).
+    alias: ?Span,
+    is_local: bool,
+    span: Span,
+};
+
+/// One name in a selective-import list (`use a, b from m`).
+pub const UseItem = struct {
+    name: Span,
+    /// Optional per-item alias (`use abs as absolute from math`).
+    alias: ?Span,
+    span: Span,
+};
+
+/// `local <decl>` shim with a non-decl payload — produced only on
+/// malformed inputs (real `local` decls flatten into the inner
+/// decl's `is_local: true`).
+pub const LocalDecl = struct {
+    /// Unparsed body span when the `local` keyword was followed by
+    /// a non-decl shape. Kept here for diagnostics.
+    span: Span,
+};
+
+/// `@asm("...")` — inline-assembly escape hatch (§3.7.7).
+pub const AsmStmt = struct {
+    /// Span covering the string literal (including the surrounding
+    /// quotes). Codegen reads the bytes and performs `{name}`
+    /// substitution against the enclosing scope.
+    body: Span,
+    span: Span,
+};
+
+/// Catch-all for unrecognized statement-position input. The span
+/// covers the recovered source range; consumers usually just emit a
+/// diagnostic and skip.
+pub const UnknownStmt = struct {
+    span: Span,
+};
+
+// =====================================================================
+// Program — output of `parse`. Owns every allocated child node.
+// =====================================================================
+
+/// Top-level parse output. Owns the statement list and every child
+/// node hanging off it (expressions, patterns, type annotations).
+pub const Program = struct {
+    statements: []Statement,
+    allocator: std.mem.Allocator,
+
+    /// Release the owned statement list and every allocated child
+    /// node hanging off it.
+    pub fn deinit(self: *Program) void {
+        for (self.statements) |*s| freeStatement(self.allocator, s);
+        self.allocator.free(self.statements);
+    }
+};
+
+// =====================================================================
+// Tree-recursive free helpers. The parser allocates child nodes via
+// `allocator.create(...)`; these mirror that traversal exactly.
+// =====================================================================
+
+/// Release every child allocation hanging off `s`. Used by
+/// `Program.deinit` and by the parser's recovery paths.
+pub fn freeStatement(allocator: std.mem.Allocator, s: *Statement) void {
+    switch (s.*) {
+        .let_decl => |ld| {
+            freePattern(allocator, ld.pattern);
+            if (ld.type_ann) |t| freeTypeAnn(allocator, t);
+            if (ld.init) |e| freeExpr(allocator, e);
+        },
+        .const_decl => |cd| {
+            if (cd.type_ann) |t| freeTypeAnn(allocator, t);
+            freeExpr(allocator, cd.init);
+        },
+        .assign => |as_| {
+            freeExpr(allocator, as_.target);
+            freeExpr(allocator, as_.value);
+        },
+        .inc_dec => |id| freeExpr(allocator, id.target),
+        .discard => |d| freeExpr(allocator, d.expr),
+        .expr_stmt => |es| freeExpr(allocator, es.expr),
+        .block => |b| freeStatementList(allocator, b.body),
+        .if_stmt => |is_| freeIfArmsAndElse(allocator, is_.arms, is_.else_body),
+        .while_stmt => |ws| {
+            if (ws.cond) |c| freeExpr(allocator, c);
+            if (ws.let_pattern) |p| freePattern(allocator, p);
+            if (ws.let_expr) |e| freeExpr(allocator, e);
+            if (ws.let_guard) |g| freeExpr(allocator, g);
+            freeStatementList(allocator, ws.body);
+        },
+        .for_stmt => |fs| {
+            freeExpr(allocator, fs.iter);
+            if (fs.step) |s_| freeExpr(allocator, s_);
+            freeStatementList(allocator, fs.body);
+        },
+        .match_stmt => |ms| {
+            freeExpr(allocator, ms.scrutinee);
+            for (ms.arms) |arm| {
+                freePattern(allocator, arm.pattern);
+                if (arm.guard) |g| freeExpr(allocator, g);
+                freeStatementList(allocator, arm.body);
+            }
+            allocator.free(ms.arms);
+        },
+        .return_stmt => |rs| {
+            if (rs.value) |v| freeExpr(allocator, v);
+        },
+        .break_stmt, .continue_stmt => {},
+        .print_stmt => |ps| {
+            for (ps.args) |a| freeExpr(allocator, a);
+            allocator.free(ps.args);
+        },
+        .def_decl => |dd| freeDefDecl(allocator, dd),
+        .class_decl => |cd| {
+            freeAnnotations(allocator, cd.annotations);
+            for (cd.fields) |f| {
+                freeAnnotations(allocator, f.annotations);
+                if (f.type_ann) |t| freeTypeAnn(allocator, t);
+                if (f.init) |e| freeExpr(allocator, e);
+            }
+            allocator.free(cd.fields);
+            for (cd.methods) |m| freeDefDecl(allocator, m);
+            allocator.free(cd.methods);
+        },
+        .struct_decl => |sd| {
+            freeAnnotations(allocator, sd.annotations);
+            for (sd.fields) |f| freeTypeAnn(allocator, f.type_ann);
+            allocator.free(sd.fields);
+        },
+        .enum_decl => |ed| {
+            freeAnnotations(allocator, ed.annotations);
+            for (ed.variants) |v| {
+                for (v.payload) |p| freeTypeAnn(allocator, p.type_ann);
+                allocator.free(v.payload);
+            }
+            allocator.free(ed.variants);
+        },
+        .use_decl => |ud| allocator.free(ud.items),
+        .local_decl, .asm_stmt, .unknown => {},
+    }
+}
+
+fn freeDefDecl(allocator: std.mem.Allocator, d: DefDecl) void {
+    freeAnnotations(allocator, d.annotations);
+    for (d.params) |p| if (p.type_ann) |t| freeTypeAnn(allocator, t);
+    allocator.free(d.params);
+    if (d.ret_type) |r| freeTypeAnn(allocator, r);
+    freeStatementList(allocator, d.body);
+}
+
+fn freeStatementList(allocator: std.mem.Allocator, list: []Statement) void {
+    for (list) |*s| freeStatement(allocator, s);
+    allocator.free(list);
+}
+
+fn freeIfArmsAndElse(
+    allocator: std.mem.Allocator,
+    arms: []IfArm,
+    else_body: ?[]Statement,
+) void {
+    for (arms) |arm| {
+        if (arm.cond) |c| freeExpr(allocator, c);
+        if (arm.let_pattern) |p| freePattern(allocator, p);
+        if (arm.let_expr) |e| freeExpr(allocator, e);
+        if (arm.let_guard) |g| freeExpr(allocator, g);
+        freeStatementList(allocator, arm.body);
+    }
+    allocator.free(arms);
+    if (else_body) |body| freeStatementList(allocator, body);
+}
+
+fn freeAnnotations(allocator: std.mem.Allocator, anns: []Annotation) void {
+    for (anns) |a| {
+        for (a.args) |arg| freeExpr(allocator, arg);
+        allocator.free(a.args);
+    }
+    allocator.free(anns);
+}
+
+/// Recursively release an expression tree owned by `allocator`.
+pub fn freeExpr(allocator: std.mem.Allocator, e: *Expr) void {
+    switch (e.*) {
+        .int_lit, .bool_lit, .nil_lit, .char_lit, .ident, .self_expr, .super_expr => {},
+        .str_lit => |s| {
+            for (s.parts) |p| switch (p) {
+                .lit => {},
+                .interp => |ip| freeExpr(allocator, ip.expr),
+            };
+            allocator.free(s.parts);
+        },
+        .paren => |p| freeExpr(allocator, p.inner),
+        .unary => |u| freeExpr(allocator, u.operand),
+        .binary => |b| {
+            freeExpr(allocator, b.lhs);
+            freeExpr(allocator, b.rhs);
+        },
+        .range => |r| {
+            freeExpr(allocator, r.start);
+            freeExpr(allocator, r.end);
+        },
+        .call => |c| {
+            freeExpr(allocator, c.callee);
+            for (c.args) |a| freeExpr(allocator, a);
+            allocator.free(c.args);
+        },
+        .method_call => |m| {
+            freeExpr(allocator, m.receiver);
+            for (m.args) |a| freeExpr(allocator, a);
+            allocator.free(m.args);
+        },
+        .field => |f| freeExpr(allocator, f.receiver),
+        .index => |i| {
+            freeExpr(allocator, i.receiver);
+            freeExpr(allocator, i.index);
+        },
+        .do_expr => |d| freeStatementList(allocator, d.body),
+        .if_expr => |ie| freeIfArmsAndElse(allocator, ie.arms, ie.else_body),
+        .lambda => |l| {
+            for (l.params) |p| if (p.type_ann) |t| freeTypeAnn(allocator, t);
+            allocator.free(l.params);
+            if (l.ret_type) |r| freeTypeAnn(allocator, r);
+            freeStatementList(allocator, l.body);
+        },
+        .list_lit => |ll| {
+            for (ll.elems) |x| freeExpr(allocator, x);
+            allocator.free(ll.elems);
+        },
+        .struct_lit => |sl| {
+            for (sl.fields) |f| freeExpr(allocator, f.value);
+            allocator.free(sl.fields);
+        },
+        .tuple_lit => |tl| {
+            for (tl.elems) |x| freeExpr(allocator, x);
+            allocator.free(tl.elems);
+        },
+        .is_test => |it| freeExpr(allocator, it.lhs),
+    }
+    allocator.destroy(e);
+}
+
+/// Recursively release a pattern tree owned by `allocator`.
+pub fn freePattern(allocator: std.mem.Allocator, p: *Pattern) void {
+    switch (p.*) {
+        .wildcard,
+        .ident,
+        .int_lit,
+        .str_lit,
+        .char_lit,
+        .bool_lit,
+        .nil_lit,
+        => {},
+        .or_pattern => |op| {
+            for (op.alts) |a| freePattern(allocator, a);
+            allocator.free(op.alts);
+        },
+        .range_pattern => |rp| {
+            freeExpr(allocator, rp.start);
+            freeExpr(allocator, rp.end);
+        },
+        .tuple_pattern => |tp| {
+            for (tp.elems) |e| freePattern(allocator, e);
+            allocator.free(tp.elems);
+        },
+        .variant_pattern => |vp| {
+            for (vp.args) |a| freePattern(allocator, a);
+            allocator.free(vp.args);
+        },
+        .struct_pattern => |sp| {
+            for (sp.fields) |f| freePattern(allocator, f.sub);
+            allocator.free(sp.fields);
+        },
+    }
+    allocator.destroy(p);
+}
+
+/// Recursively release a type-annotation tree owned by `allocator`.
+pub fn freeTypeAnn(allocator: std.mem.Allocator, t: *TypeAnn) void {
+    switch (t.*) {
+        .named => {},
+        .nullable => |n| freeTypeAnn(allocator, n.inner),
+        .array => |a| {
+            freeTypeAnn(allocator, a.elem);
+            freeExpr(allocator, a.len_expr);
+        },
+        .vec => |v| freeTypeAnn(allocator, v.elem),
+        .tuple => |tu| {
+            for (tu.elems) |e| freeTypeAnn(allocator, e);
+            allocator.free(tu.elems);
+        },
+        .fn_type => |fn_t| {
+            for (fn_t.params) |p| freeTypeAnn(allocator, p);
+            allocator.free(fn_t.params);
+            if (fn_t.ret) |r| freeTypeAnn(allocator, r);
+        },
+    }
+    allocator.destroy(t);
+}

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -296,6 +296,10 @@ pub const StructPatternField = struct {
 /// it builds these nodes.
 pub const Expr = union(enum) {
     int_lit: IntLitExpr,
+    /// Fixed-point literal — `1.5`, `0.125`, etc. The lexer
+    /// pre-encodes the value as Q8.8 (top byte integer, bottom byte
+    /// `round(frac * 256)`).
+    fixed_lit: FixedLitExpr,
     bool_lit: BoolLitExpr,
     nil_lit: SpanOnly,
     char_lit: CharLitExpr,
@@ -363,6 +367,7 @@ pub const Expr = union(enum) {
     pub fn span(self: Expr) Span {
         return switch (self) {
             .int_lit => |e| e.span,
+            .fixed_lit => |e| e.span,
             .bool_lit => |e| e.span,
             .nil_lit, .self_expr, .super_expr => |e| e.span,
             .char_lit => |e| e.span,
@@ -390,6 +395,16 @@ pub const Expr = union(enum) {
 /// Integer literal (decimal / hex / binary; the lexer normalizes
 /// all three into a single `int_lit` token).
 pub const IntLitExpr = struct {
+    value: i32,
+    span: Span,
+};
+
+/// Fixed-point literal — `1.5`, `0.125`, etc. `value` is the
+/// pre-encoded Q8.8 (top byte integer part, bottom byte
+/// `round(frac * 256)`). Sign carried in the 16-bit two's-complement
+/// pattern; the lexer applies negation when the literal is preceded
+/// by `-` in operand position.
+pub const FixedLitExpr = struct {
     value: i32,
     span: Span,
 };
@@ -1174,7 +1189,7 @@ fn freeAnnotations(allocator: std.mem.Allocator, anns: []Annotation) void {
 /// Recursively release an expression tree owned by `allocator`.
 pub fn freeExpr(allocator: std.mem.Allocator, e: *Expr) void {
     switch (e.*) {
-        .int_lit, .bool_lit, .nil_lit, .char_lit, .ident, .self_expr, .super_expr => {},
+        .int_lit, .fixed_lit, .bool_lit, .nil_lit, .char_lit, .ident, .self_expr, .super_expr => {},
         .str_lit => |s| {
             for (s.parts) |p| switch (p) {
                 .lit => {},

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -362,6 +362,11 @@ pub const Expr = union(enum) {
     /// `value is Enum.Variant` — variant-tag test. Rhs is a span over
     /// the qualified variant path.
     is_test: IsTestExpr,
+    /// `value as T` — explicit type conversion (§3.8). The runtime
+    /// shape depends on the source / target types (truncation,
+    /// sign / zero extension, fixed↔int rounding); the parser just
+    /// captures the inner expression + target type annotation.
+    cast: CastExpr,
 
     /// Smallest `Span` covering the whole expression.
     pub fn span(self: Expr) Span {
@@ -388,6 +393,7 @@ pub const Expr = union(enum) {
             .struct_lit => |e| e.span,
             .tuple_lit => |e| e.span,
             .is_test => |e| e.span,
+            .cast => |e| e.span,
         };
     }
 };
@@ -642,6 +648,13 @@ pub const IsTestExpr = struct {
     lhs: *Expr,
     /// Variant path span — typically `EnumType.Variant`.
     variant_path: Span,
+    span: Span,
+};
+
+/// `inner as T` — explicit type conversion.
+pub const CastExpr = struct {
+    inner: *Expr,
+    target_type: *TypeAnn,
     span: Span,
 };
 
@@ -1243,6 +1256,10 @@ pub fn freeExpr(allocator: std.mem.Allocator, e: *Expr) void {
             allocator.free(tl.elems);
         },
         .is_test => |it| freeExpr(allocator, it.lhs),
+        .cast => |c| {
+            freeExpr(allocator, c.inner);
+            freeTypeAnn(allocator, c.target_type);
+        },
     }
     allocator.destroy(e);
 }

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -736,6 +736,9 @@ pub const Statement = union(enum) {
 
 /// `let pattern[: T][ = expr]` — variable binding.
 pub const LetDecl = struct {
+    /// `@bank N` / `@zero_page` / `@addr $1234` attach here at
+    /// module scope (§3.7.1). Empty for nested `let`s.
+    annotations: []Annotation,
     /// Pattern bound by the `let`. For the canonical single-name
     /// case it's `Pattern.ident`; destructuring (§4.1.1) uses other
     /// pattern shapes.
@@ -753,6 +756,8 @@ pub const LetDecl = struct {
 
 /// `const NAME[: T] = expr` — immutable binding.
 pub const ConstDecl = struct {
+    /// `@bank N` attaches here at module scope (§3.7.1).
+    annotations: []Annotation,
     /// Span of the identifier being bound.
     name: Span,
     /// `null` when the form omits the type annotation (typical for
@@ -1051,11 +1056,13 @@ pub const Program = struct {
 pub fn freeStatement(allocator: std.mem.Allocator, s: *Statement) void {
     switch (s.*) {
         .let_decl => |ld| {
+            freeAnnotations(allocator, ld.annotations);
             freePattern(allocator, ld.pattern);
             if (ld.type_ann) |t| freeTypeAnn(allocator, t);
             if (ld.init) |e| freeExpr(allocator, e);
         },
         .const_decl => |cd| {
+            freeAnnotations(allocator, cd.annotations);
             if (cd.type_ann) |t| freeTypeAnn(allocator, t);
             freeExpr(allocator, cd.init);
         },

--- a/src/lang/decl.zig
+++ b/src/lang/decl.zig
@@ -26,6 +26,9 @@ pub fn parseLetDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     p.pos += 1;
     const start = let_tok.start;
 
+    const annotations = try parser_mod.takePendingAnnotations(p);
+    errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
+
     const pattern = try pattern_mod.parsePattern(p);
 
     var type_ann: ?*ast.TypeAnn = null;
@@ -46,6 +49,7 @@ pub fn parseLetDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     const end = if (init) |e| e.span().end else if (type_ann) |t| t.span().end else pattern.span().end;
     try p.requireStatementBoundary();
     return .{ .let_decl = .{
+        .annotations = annotations,
         .pattern = pattern,
         .type_ann = type_ann,
         .init = init,
@@ -59,6 +63,9 @@ pub fn parseConstDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     const const_tok = p.peek();
     p.pos += 1;
     const start = const_tok.start;
+
+    const annotations = try parser_mod.takePendingAnnotations(p);
+    errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
 
     const name_tok = try p.expect(.ident, "identifier");
     const name_span = ast.Span.fromToken(name_tok);
@@ -74,6 +81,7 @@ pub fn parseConstDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     try p.requireStatementBoundary();
 
     return .{ .const_decl = .{
+        .annotations = annotations,
         .name = name_span,
         .type_ann = type_ann,
         .init = init,

--- a/src/lang/decl.zig
+++ b/src/lang/decl.zig
@@ -189,7 +189,10 @@ pub fn freeParams(allocator: std.mem.Allocator, params: []ast.Param) void {
 
 // ---------- class ----------
 
-/// `class Name [extends Parent] { ... }`.
+/// `class Name [extends Parent] ... end`. The body starts after
+/// the optional `extends` clause; fields and methods alternate
+/// freely; `end` closes the class. Consistent with `struct`, `def`,
+/// and `if` / `while` block delimiters (§6, §3.7.6).
 pub fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     const class_tok = p.peek();
     p.pos += 1;
@@ -207,7 +210,6 @@ pub fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
         extends = ast.Span.fromToken(parent_tok);
     }
 
-    _ = try p.expect(.lbrace, "{");
     p.skipNewlines();
 
     var fields: std.ArrayList(ast.ClassField) = .empty;
@@ -215,7 +217,7 @@ pub fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     var methods: std.ArrayList(ast.DefDecl) = .empty;
     errdefer cleanupMethods(p.allocator, &methods);
 
-    while (!p.atEnd() and !p.check(.rbrace)) {
+    while (!p.atEnd() and !p.check(.kw_end)) {
         // Accumulate annotations inside the class body, same as
         // file-level. They attach to the next field or method.
         while (p.check(.annotation)) {
@@ -233,7 +235,7 @@ pub fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
                 const m = try parseDefDeclInner(p, false);
                 try methods.append(p.allocator, m);
             },
-            .rbrace => break,
+            .kw_end => break,
             else => {
                 try p.recordError(
                     "expected field (`let`) or method (`def`) in class body",
@@ -245,7 +247,7 @@ pub fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
         p.skipNewlines();
     }
 
-    const close_tok = try p.expect(.rbrace, "}");
+    const close_tok = try p.expect(.kw_end, "end");
     try p.requireStatementBoundary();
 
     return .{ .class_decl = .{

--- a/src/lang/decl.zig
+++ b/src/lang/decl.zig
@@ -158,7 +158,9 @@ fn hasAnnotationNamed(
 }
 
 /// Parameter list following the opening `(`. Consumes the closing
-/// `)`. Both `def` and `lambda` use this.
+/// `)`. Both `def` and `lambda` use this. Newlines are tolerated
+/// after `(`, after each `,`, and before `)` so long parameter
+/// lists can wrap across lines.
 pub fn parseParamList(p: *Parser) ParserError![]ast.Param {
     var params: std.ArrayList(ast.Param) = .empty;
     errdefer {
@@ -166,6 +168,7 @@ pub fn parseParamList(p: *Parser) ParserError![]ast.Param {
         params.deinit(p.allocator);
     }
 
+    p.skipNewlines();
     if (p.check(.rparen)) {
         _ = p.accept(.rparen);
         return try params.toOwnedSlice(p.allocator);
@@ -197,8 +200,11 @@ pub fn parseParamList(p: *Parser) ParserError![]ast.Param {
         });
 
         if (p.accept(.comma) == null) break;
+        p.skipNewlines();
+        if (p.check(.rparen)) break; // trailing comma
     }
 
+    p.skipNewlines();
     _ = try p.expect(.rparen, ")");
     return try params.toOwnedSlice(p.allocator);
 }

--- a/src/lang/decl.zig
+++ b/src/lang/decl.zig
@@ -1,0 +1,620 @@
+/// Declaration parsers — `let`, `const`, `def`, `class`, `struct`,
+/// `enum`, `use`, plus the shared `parseParamList` (used by both
+/// `def` and `lambda`). Annotations land here too via
+/// `takePendingAnnotations` from `parser.zig`.
+///
+/// Imports `Parser` + `ParserError` from `parser.zig`; delegates
+/// to `expr`, `pattern`, `type_ann`, `annotation` for sub-shapes,
+/// and to `parser_mod.parseStatement` for function bodies.
+const std = @import("std");
+const ast = @import("ast.zig");
+const lexer = @import("lexer.zig");
+const parser_mod = @import("parser.zig");
+const expr_mod = @import("expr.zig");
+const pattern_mod = @import("pattern.zig");
+const type_mod = @import("type_ann.zig");
+const annotation_mod = @import("annotation.zig");
+
+const Parser = parser_mod.Parser;
+const ParserError = parser_mod.ParserError;
+
+// ---------- let / const ----------
+
+/// `let pattern[: T] = expr` / `let name: T` (uninit form).
+pub fn parseLetDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const let_tok = p.peek();
+    p.pos += 1;
+    const start = let_tok.start;
+
+    const pattern = try pattern_mod.parsePattern(p);
+
+    var type_ann: ?*ast.TypeAnn = null;
+    if (p.accept(.colon)) |_| {
+        type_ann = try type_mod.parseTypeAnn(p);
+    }
+
+    var init: ?*ast.Expr = null;
+    if (p.accept(.equals)) |_| {
+        init = try expr_mod.parseExpression(p, 0);
+    } else if (type_ann == null) {
+        try p.recordError(
+            "expected `=` or `: T` after `let` binding",
+            "= or : T",
+        );
+    }
+
+    const end = if (init) |e| e.span().end else if (type_ann) |t| t.span().end else pattern.span().end;
+    try p.requireStatementBoundary();
+    return .{ .let_decl = .{
+        .pattern = pattern,
+        .type_ann = type_ann,
+        .init = init,
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+/// `const NAME[: T] = expr`.
+pub fn parseConstDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const const_tok = p.peek();
+    p.pos += 1;
+    const start = const_tok.start;
+
+    const name_tok = try p.expect(.ident, "identifier");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    var type_ann: ?*ast.TypeAnn = null;
+    if (p.accept(.colon)) |_| {
+        type_ann = try type_mod.parseTypeAnn(p);
+    }
+    _ = try p.expect(.equals, "=");
+
+    const init = try expr_mod.parseExpression(p, 0);
+    const end = init.span().end;
+    try p.requireStatementBoundary();
+
+    return .{ .const_decl = .{
+        .name = name_span,
+        .type_ann = type_ann,
+        .init = init,
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+// ---------- def ----------
+
+/// `def name(params) [-> T] body end` — top-level wrapper.
+pub fn parseDefDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const decl = try parseDefDeclInner(p, is_local);
+    return .{ .def_decl = decl };
+}
+
+/// Inner form used directly by class-method parsing.
+pub fn parseDefDeclInner(p: *Parser, is_local: bool) ParserError!ast.DefDecl {
+    const def_tok = p.peek();
+    p.pos += 1;
+    const start = def_tok.start;
+
+    const annotations = try parser_mod.takePendingAnnotations(p);
+    errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "function name");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    _ = try p.expect(.lparen, "(");
+    const params = try parseParamList(p);
+    errdefer freeParams(p.allocator, params);
+
+    var ret_type: ?*ast.TypeAnn = null;
+    if (p.accept(.arrow)) |_| {
+        ret_type = try type_mod.parseTypeAnn(p);
+    }
+    errdefer if (ret_type) |r| ast.freeTypeAnn(p.allocator, r);
+
+    p.skipNewlines();
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parser_mod.parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{
+        .annotations = annotations,
+        .name = name_span,
+        .params = params,
+        .ret_type = ret_type,
+        .body = try body.toOwnedSlice(p.allocator),
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end_tok.end },
+    };
+}
+
+/// Parameter list following the opening `(`. Consumes the closing
+/// `)`. Both `def` and `lambda` use this.
+pub fn parseParamList(p: *Parser) ParserError![]ast.Param {
+    var params: std.ArrayList(ast.Param) = .empty;
+    errdefer {
+        freeParams(p.allocator, params.items);
+        params.deinit(p.allocator);
+    }
+
+    if (p.check(.rparen)) {
+        _ = p.accept(.rparen);
+        return try params.toOwnedSlice(p.allocator);
+    }
+
+    while (true) {
+        const tok = p.peek();
+        const name_span: ast.Span = switch (tok.kind) {
+            .ident, .kw_self => blk: {
+                p.pos += 1;
+                break :blk .{ .start = tok.start, .end = tok.end };
+            },
+            else => {
+                try p.recordError("expected parameter name", "identifier");
+                return error.ParseFailed;
+            },
+        };
+
+        var type_ann: ?*ast.TypeAnn = null;
+        if (p.accept(.colon)) |_| {
+            type_ann = try type_mod.parseTypeAnn(p);
+        }
+
+        const param_end: u32 = if (type_ann) |t| t.span().end else name_span.end;
+        try params.append(p.allocator, .{
+            .name = name_span,
+            .type_ann = type_ann,
+            .span = .{ .start = name_span.start, .end = param_end },
+        });
+
+        if (p.accept(.comma) == null) break;
+    }
+
+    _ = try p.expect(.rparen, ")");
+    return try params.toOwnedSlice(p.allocator);
+}
+
+/// Release a parameter slice (handles the nested type-annotation
+/// allocations).
+pub fn freeParams(allocator: std.mem.Allocator, params: []ast.Param) void {
+    for (params) |p| if (p.type_ann) |t| ast.freeTypeAnn(allocator, t);
+    allocator.free(params);
+}
+
+// ---------- class ----------
+
+/// `class Name [extends Parent] { ... }`.
+pub fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const class_tok = p.peek();
+    p.pos += 1;
+    const start = class_tok.start;
+
+    const annotations = try parser_mod.takePendingAnnotations(p);
+    errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "class name");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    var extends: ?ast.Span = null;
+    if (p.accept(.kw_extends)) |_| {
+        const parent_tok = try p.expect(.ident, "parent class name");
+        extends = ast.Span.fromToken(parent_tok);
+    }
+
+    _ = try p.expect(.lbrace, "{");
+    p.skipNewlines();
+
+    var fields: std.ArrayList(ast.ClassField) = .empty;
+    errdefer cleanupClassFields(p.allocator, &fields);
+    var methods: std.ArrayList(ast.DefDecl) = .empty;
+    errdefer cleanupMethods(p.allocator, &methods);
+
+    while (!p.atEnd() and !p.check(.rbrace)) {
+        // Accumulate annotations inside the class body, same as
+        // file-level. They attach to the next field or method.
+        while (p.check(.annotation)) {
+            const ann = try annotation_mod.parseAnnotation(p);
+            try p.pending_annotations.append(p.allocator, ann);
+            p.skipNewlines();
+        }
+
+        switch (p.peek().kind) {
+            .kw_let => {
+                const field = try parseClassField(p);
+                try fields.append(p.allocator, field);
+            },
+            .kw_def => {
+                const m = try parseDefDeclInner(p, false);
+                try methods.append(p.allocator, m);
+            },
+            .rbrace => break,
+            else => {
+                try p.recordError(
+                    "expected field (`let`) or method (`def`) in class body",
+                    "let or def",
+                );
+                try p.recoverToNewline();
+            },
+        }
+        p.skipNewlines();
+    }
+
+    const close_tok = try p.expect(.rbrace, "}");
+    try p.requireStatementBoundary();
+
+    return .{ .class_decl = .{
+        .annotations = annotations,
+        .name = name_span,
+        .extends = extends,
+        .fields = try fields.toOwnedSlice(p.allocator),
+        .methods = try methods.toOwnedSlice(p.allocator),
+        .is_local = is_local,
+        .span = .{ .start = start, .end = close_tok.end },
+    } };
+}
+
+fn parseClassField(p: *Parser) ParserError!ast.ClassField {
+    const let_tok = p.peek();
+    p.pos += 1;
+
+    const annotations = try parser_mod.takePendingAnnotations(p);
+    errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "field name");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    var type_ann: ?*ast.TypeAnn = null;
+    if (p.accept(.colon)) |_| {
+        type_ann = try type_mod.parseTypeAnn(p);
+    }
+
+    var init: ?*ast.Expr = null;
+    var end_idx: u32 = if (type_ann) |t| t.span().end else name_span.end;
+    if (p.accept(.equals)) |_| {
+        const e = try expr_mod.parseExpression(p, 0);
+        end_idx = e.span().end;
+        init = e;
+    }
+
+    try p.requireStatementBoundary();
+    return .{
+        .annotations = annotations,
+        .name = name_span,
+        .type_ann = type_ann,
+        .init = init,
+        .span = .{ .start = let_tok.start, .end = end_idx },
+    };
+}
+
+fn cleanupClassFields(
+    allocator: std.mem.Allocator,
+    fields: *std.ArrayList(ast.ClassField),
+) void {
+    for (fields.items) |f| {
+        parser_mod.freeAnnSlice(allocator, f.annotations);
+        if (f.type_ann) |t| ast.freeTypeAnn(allocator, t);
+        if (f.init) |e| ast.freeExpr(allocator, e);
+    }
+    fields.deinit(allocator);
+}
+
+fn cleanupMethods(
+    allocator: std.mem.Allocator,
+    methods: *std.ArrayList(ast.DefDecl),
+) void {
+    for (methods.items) |m| {
+        parser_mod.freeAnnSlice(allocator, m.annotations);
+        freeParams(allocator, m.params);
+        if (m.ret_type) |r| ast.freeTypeAnn(allocator, r);
+        for (m.body) |*s| ast.freeStatement(allocator, s);
+        allocator.free(m.body);
+    }
+    methods.deinit(allocator);
+}
+
+// ---------- struct ----------
+
+/// `struct Name field: T ... end` — POD declaration.
+pub fn parseStructDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const struct_tok = p.peek();
+    p.pos += 1;
+    const start = struct_tok.start;
+
+    const annotations = try parser_mod.takePendingAnnotations(p);
+    errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "struct name");
+    const name_span = ast.Span.fromToken(name_tok);
+    p.skipNewlines();
+
+    var fields: std.ArrayList(ast.StructField) = .empty;
+    errdefer {
+        for (fields.items) |f| ast.freeTypeAnn(p.allocator, f.type_ann);
+        fields.deinit(p.allocator);
+    }
+
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        const fname_tok = try p.expect(.ident, "field name");
+        _ = try p.expect(.colon, ":");
+        const ftype = try type_mod.parseTypeAnn(p);
+        const fend = ftype.span().end;
+        try fields.append(p.allocator, .{
+            .name = ast.Span.fromToken(fname_tok),
+            .type_ann = ftype,
+            .span = .{ .start = fname_tok.start, .end = fend },
+        });
+        _ = p.accept(.comma);
+        p.skipNewlines();
+    }
+
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .struct_decl = .{
+        .annotations = annotations,
+        .name = name_span,
+        .fields = try fields.toOwnedSlice(p.allocator),
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+// ---------- enum ----------
+
+/// `enum Name case Variant[(payload)] ... end`.
+pub fn parseEnumDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const enum_tok = p.peek();
+    p.pos += 1;
+    const start = enum_tok.start;
+
+    const annotations = try parser_mod.takePendingAnnotations(p);
+    errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "enum name");
+    const name_span = ast.Span.fromToken(name_tok);
+    p.skipNewlines();
+
+    var variants: std.ArrayList(ast.EnumVariant) = .empty;
+    errdefer cleanupEnumVariants(p.allocator, &variants);
+
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        _ = try p.expect(.kw_case, "case");
+        const v_name_tok = try p.expect(.ident, "variant name");
+        const v_name_span = ast.Span.fromToken(v_name_tok);
+
+        var payload: std.ArrayList(ast.EnumPayloadField) = .empty;
+        errdefer {
+            for (payload.items) |pf| ast.freeTypeAnn(p.allocator, pf.type_ann);
+            payload.deinit(p.allocator);
+        }
+
+        var v_end: u32 = v_name_tok.end;
+        if (p.accept(.lparen)) |_| {
+            if (!p.check(.rparen)) {
+                while (true) {
+                    const tok0 = p.peek();
+                    const tok1 = p.peekAt(1);
+                    if (tok0.kind == .ident and tok1.kind == .colon) {
+                        const fname_tok = p.peek();
+                        p.pos += 2;
+                        const ftype = try type_mod.parseTypeAnn(p);
+                        try payload.append(p.allocator, .{
+                            .name = ast.Span.fromToken(fname_tok),
+                            .type_ann = ftype,
+                            .span = .{ .start = fname_tok.start, .end = ftype.span().end },
+                        });
+                    } else {
+                        const ftype = try type_mod.parseTypeAnn(p);
+                        const ts = ftype.span();
+                        try payload.append(p.allocator, .{
+                            .name = .{ .start = ts.start, .end = ts.start },
+                            .type_ann = ftype,
+                            .span = ts,
+                        });
+                    }
+                    if (p.accept(.comma) == null) break;
+                }
+            }
+            const close = try p.expect(.rparen, ")");
+            v_end = close.end;
+        }
+
+        try variants.append(p.allocator, .{
+            .name = v_name_span,
+            .payload = try payload.toOwnedSlice(p.allocator),
+            .span = .{ .start = v_name_span.start, .end = v_end },
+        });
+
+        p.skipNewlines();
+    }
+
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .enum_decl = .{
+        .annotations = annotations,
+        .name = name_span,
+        .variants = try variants.toOwnedSlice(p.allocator),
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+fn cleanupEnumVariants(
+    allocator: std.mem.Allocator,
+    variants: *std.ArrayList(ast.EnumVariant),
+) void {
+    for (variants.items) |v| {
+        for (v.payload) |pf| ast.freeTypeAnn(allocator, pf.type_ann);
+        allocator.free(v.payload);
+    }
+    variants.deinit(allocator);
+}
+
+// ---------- use ----------
+
+/// `use module [as alias]`, `use a, b from module`,
+/// `use "./path"`.
+pub fn parseUseDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const use_tok = p.peek();
+    p.pos += 1;
+    const start = use_tok.start;
+
+    var items: std.ArrayList(ast.UseItem) = .empty;
+    errdefer items.deinit(p.allocator);
+
+    var module_span: ast.Span = undefined;
+    var quoted_path = false;
+    var alias: ?ast.Span = null;
+
+    const start_pos = p.pos;
+    if (try lookaheadHasFromClause(p)) {
+        while (true) {
+            const n_tok = try p.expect(.ident, "import name");
+            var item_alias: ?ast.Span = null;
+            var item_end = n_tok.end;
+            if (p.accept(.kw_as)) |_| {
+                const a_tok = try p.expect(.ident, "alias");
+                item_alias = ast.Span.fromToken(a_tok);
+                item_end = a_tok.end;
+            }
+            try items.append(p.allocator, .{
+                .name = ast.Span.fromToken(n_tok),
+                .alias = item_alias,
+                .span = .{ .start = n_tok.start, .end = item_end },
+            });
+            if (p.accept(.comma) == null) break;
+        }
+        _ = try p.expect(.kw_from, "from");
+        module_span = try parseUseModuleSpec(p, &quoted_path);
+    } else {
+        p.pos = start_pos;
+        module_span = try parseUseModuleSpec(p, &quoted_path);
+        if (p.accept(.kw_as)) |_| {
+            const a_tok = try p.expect(.ident, "alias");
+            alias = ast.Span.fromToken(a_tok);
+        }
+    }
+
+    const end: u32 = if (alias) |a| a.end else module_span.end;
+    try p.requireStatementBoundary();
+
+    return .{ .use_decl = .{
+        .module = module_span,
+        .quoted_path = quoted_path,
+        .items = try items.toOwnedSlice(p.allocator),
+        .alias = alias,
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+fn parseUseModuleSpec(p: *Parser, quoted: *bool) ParserError!ast.Span {
+    if (p.check(.str_start)) return try parseQuotedPath(p, quoted);
+    quoted.* = false;
+    const tok = try p.expect(.ident, "module name");
+    return ast.Span.fromToken(tok);
+}
+
+fn parseQuotedPath(p: *Parser, quoted: *bool) ParserError!ast.Span {
+    quoted.* = true;
+    const start_tok = try p.expect(.str_start, "\"");
+    var end_idx: u32 = start_tok.end;
+    while (true) {
+        const t = p.peek();
+        switch (t.kind) {
+            .str_part => {
+                p.pos += 1;
+                end_idx = t.end;
+            },
+            .str_end => {
+                p.pos += 1;
+                end_idx = t.end;
+                break;
+            },
+            .str_expr_start => {
+                try p.recordError(
+                    "string interpolation not allowed in `use` path",
+                    "literal path",
+                );
+                return error.ParseFailed;
+            },
+            else => return error.ParseFailed,
+        }
+    }
+    return .{ .start = start_tok.start, .end = end_idx };
+}
+
+fn lookaheadHasFromClause(p: *Parser) ParserError!bool {
+    var i = p.pos;
+    if (i >= p.tokens.len) return false;
+    if (p.tokens[i].kind != .ident) return false;
+    while (true) {
+        if (i >= p.tokens.len or p.tokens[i].kind != .ident) return false;
+        i += 1;
+        if (i < p.tokens.len and p.tokens[i].kind == .kw_as) {
+            i += 1;
+            if (i >= p.tokens.len or p.tokens[i].kind != .ident) return false;
+            i += 1;
+        }
+        if (i < p.tokens.len and p.tokens[i].kind == .comma) {
+            i += 1;
+            continue;
+        }
+        break;
+    }
+    return i < p.tokens.len and p.tokens[i].kind == .kw_from;
+}
+
+// ---------- local <decl> ----------
+
+/// `local <decl>` — visibility shim. Sets `is_local: true` on the
+/// inner decl rather than nesting a wrapper variant.
+pub fn parseLocalDecl(
+    p: *Parser,
+    statements: *std.ArrayList(ast.Statement),
+) !void {
+    const local_tok = p.peek();
+    p.pos += 1;
+    const start = local_tok.start;
+
+    switch (p.peek().kind) {
+        .kw_let => try statements.append(p.allocator, try parseLetDecl(p, true)),
+        .kw_const => try statements.append(p.allocator, try parseConstDecl(p, true)),
+        .kw_def => try statements.append(p.allocator, try parseDefDecl(p, true)),
+        .kw_class => try statements.append(p.allocator, try parseClassDecl(p, true)),
+        .kw_enum => try statements.append(p.allocator, try parseEnumDecl(p, true)),
+        .kw_use => try statements.append(p.allocator, try parseUseDecl(p, true)),
+        .ident => {
+            const lex = p.source[p.peek().start..p.peek().end];
+            if (std.mem.eql(u8, lex, "struct")) {
+                try statements.append(p.allocator, try parseStructDecl(p, true));
+                return;
+            }
+            try p.recordError(
+                "expected declaration after `local`",
+                "let / const / def / class / struct / enum / use",
+            );
+            try p.recoverToNewline();
+            try statements.append(p.allocator, .{ .local_decl = .{
+                .span = .{ .start = start, .end = p.peek().start },
+            } });
+        },
+        else => {
+            try p.recordError(
+                "expected declaration after `local`",
+                "let / const / def / class / struct / enum / use",
+            );
+            try p.recoverToNewline();
+            try statements.append(p.allocator, .{ .local_decl = .{
+                .span = .{ .start = start, .end = p.peek().start },
+            } });
+        },
+    }
+}

--- a/src/lang/decl.zig
+++ b/src/lang/decl.zig
@@ -112,15 +112,24 @@ pub fn parseDefDeclInner(p: *Parser, is_local: bool) ParserError!ast.DefDecl {
     }
     errdefer if (ret_type) |r| ast.freeTypeAnn(p.allocator, r);
 
-    p.skipNewlines();
+    // `@abstract` on a method (§3.7.6) declares the signature
+    // without a body — subclasses must implement it. Skip the body
+    // parse + `end` expectation in that case.
+    const is_abstract = hasAnnotationNamed(p, annotations, "abstract");
+
     var body: std.ArrayList(ast.Statement) = .empty;
     errdefer parser_mod.cleanupStatements(p.allocator, &body);
+    var end_byte: u32 = if (ret_type) |r| r.span().end else p.peek().start;
 
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        try parser_mod.parseStatement(p, &body);
+    if (!is_abstract) {
         p.skipNewlines();
+        while (!p.atEnd() and !p.check(.kw_end)) {
+            try parser_mod.parseStatement(p, &body);
+            p.skipNewlines();
+        }
+        const end_tok = try p.expect(.kw_end, "end");
+        end_byte = end_tok.end;
     }
-    const end_tok = try p.expect(.kw_end, "end");
     try p.requireStatementBoundary();
 
     return .{
@@ -130,8 +139,22 @@ pub fn parseDefDeclInner(p: *Parser, is_local: bool) ParserError!ast.DefDecl {
         .ret_type = ret_type,
         .body = try body.toOwnedSlice(p.allocator),
         .is_local = is_local,
-        .span = .{ .start = start, .end = end_tok.end },
+        .span = .{ .start = start, .end = end_byte },
     };
+}
+
+/// True when `annotations` contains an entry whose name matches
+/// `name` exactly. Used by `parseDefDeclInner` for `@abstract`.
+fn hasAnnotationNamed(
+    p: *const Parser,
+    annotations: []const ast.Annotation,
+    name: []const u8,
+) bool {
+    for (annotations) |a| {
+        const lex = p.source[a.name.start..a.name.end];
+        if (std.mem.eql(u8, lex, name)) return true;
+    }
+    return false;
 }
 
 /// Parameter list following the opening `(`. Consumes the closing

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -1,0 +1,562 @@
+/// Expression parser — Pratt loop over the precedence hierarchy
+/// from `docs/gero-lang.md` §3.3. Primaries cover every literal
+/// + ident + paren + tuple + list + struct literal + `do…end` /
+/// `if…end` / `lambda…end` expression form.
+///
+/// The Pratt loop in `parseExpression(min_prec)` consumes operators
+/// whose precedence is ≥ `min_prec`, recursing on RHS at one tier
+/// higher. Unary prefix and postfix call/index/field are folded
+/// into the leaf path (`parseUnary` → `parseCallChain` →
+/// `parsePrimary`).
+const std = @import("std");
+const ast = @import("ast.zig");
+const lexer = @import("lexer.zig");
+const parser_mod = @import("parser.zig");
+const decl_mod = @import("decl.zig");
+
+const Parser = parser_mod.Parser;
+const ParserError = parser_mod.ParserError;
+const Kind = lexer.Token.Kind;
+
+/// Precedence levels — higher binds tighter. Used by the Pratt
+/// loop to encode `docs/gero-lang.md` §3.3.
+pub const Prec = struct {
+    /// Initial level passed by callers that want the full expression.
+    pub const lowest: u8 = 0;
+    /// `..` / `..=` — produce range values; bind loosest.
+    pub const range: u8 = 1;
+    /// `or` — logical OR, short-circuits.
+    pub const log_or: u8 = 2;
+    /// `and` — logical AND, short-circuits.
+    pub const log_and: u8 = 3;
+    /// `==` / `!=` / `<` / `<=` / `>` / `>=`.
+    pub const compare: u8 = 4;
+    /// `|` — bitwise OR.
+    pub const bit_or: u8 = 5;
+    /// `^` — bitwise XOR.
+    pub const bit_xor: u8 = 6;
+    /// `&` — bitwise AND.
+    pub const bit_and: u8 = 7;
+    /// `<<` / `>>` — bit shifts.
+    pub const shift: u8 = 8;
+    /// `+` / `-` — additive arithmetic.
+    pub const add: u8 = 9;
+    /// `*` / `/` / `%` — multiplicative arithmetic.
+    pub const mul: u8 = 10;
+    /// `is` — variant-tag test. Binds tighter than arithmetic.
+    pub const is_test: u8 = 11;
+    /// Unary prefix: `-x` / `not x` / `~x`.
+    pub const unary: u8 = 12;
+    /// Postfix: call `( )`, index `[ ]`, field `.`.
+    pub const call: u8 = 13;
+};
+
+/// Parse an expression with the Pratt loop. `min_prec` is the
+/// minimum operator precedence the loop will consume — call sites
+/// pass `0` for "full expression".
+pub fn parseExpression(p: *Parser, min_prec: u8) ParserError!*ast.Expr {
+    var lhs = try parseUnary(p);
+    errdefer ast.freeExpr(p.allocator, lhs);
+
+    while (true) {
+        const k = p.peek().kind;
+
+        if (k == .dot_dot or k == .dot_dot_eq) {
+            const prec = Prec.range;
+            if (prec < min_prec) break;
+            const inclusive = k == .dot_dot_eq;
+            p.pos += 1;
+            const rhs = try parseExpression(p, prec + 1);
+            const new_node = try p.allocExpr(.{ .range = .{
+                .start = lhs,
+                .end = rhs,
+                .inclusive = inclusive,
+                .span = .{ .start = lhs.span().start, .end = rhs.span().end },
+            } });
+            lhs = new_node;
+            continue;
+        }
+
+        if (k == .kw_is) {
+            const prec = Prec.is_test;
+            if (prec < min_prec) break;
+            p.pos += 1;
+            const head_tok = try p.expect(.ident, "enum name");
+            _ = try p.expect(.dot, ".");
+            const var_tok = try p.expect(.ident, "variant name");
+            const path: ast.Span = .{ .start = head_tok.start, .end = var_tok.end };
+            const new_node = try p.allocExpr(.{ .is_test = .{
+                .lhs = lhs,
+                .variant_path = path,
+                .span = .{ .start = lhs.span().start, .end = var_tok.end },
+            } });
+            lhs = new_node;
+            continue;
+        }
+
+        if (binaryOpOf(k)) |info| {
+            if (info.prec < min_prec) break;
+            p.pos += 1;
+            const rhs = try parseExpression(p, info.prec + 1);
+            const new_node = try p.allocExpr(.{ .binary = .{
+                .op = info.op,
+                .lhs = lhs,
+                .rhs = rhs,
+                .span = .{ .start = lhs.span().start, .end = rhs.span().end },
+            } });
+            lhs = new_node;
+            continue;
+        }
+
+        break;
+    }
+    return lhs;
+}
+
+const BinaryInfo = struct {
+    op: ast.BinaryOp,
+    prec: u8,
+};
+
+fn binaryOpOf(k: Kind) ?BinaryInfo {
+    return switch (k) {
+        .kw_or => .{ .op = .log_or, .prec = Prec.log_or },
+        .kw_and => .{ .op = .log_and, .prec = Prec.log_and },
+        .eq_eq => .{ .op = .eq, .prec = Prec.compare },
+        .bang_eq => .{ .op = .neq, .prec = Prec.compare },
+        .lt => .{ .op = .lt, .prec = Prec.compare },
+        .lt_eq => .{ .op = .lte, .prec = Prec.compare },
+        .gt => .{ .op = .gt, .prec = Prec.compare },
+        .gt_eq => .{ .op = .gte, .prec = Prec.compare },
+        .pipe => .{ .op = .bit_or, .prec = Prec.bit_or },
+        .caret => .{ .op = .bit_xor, .prec = Prec.bit_xor },
+        .amp => .{ .op = .bit_and, .prec = Prec.bit_and },
+        .shl => .{ .op = .shl, .prec = Prec.shift },
+        .shr => .{ .op = .shr, .prec = Prec.shift },
+        .plus => .{ .op = .add, .prec = Prec.add },
+        .minus => .{ .op = .sub, .prec = Prec.add },
+        .star => .{ .op = .mul, .prec = Prec.mul },
+        .slash => .{ .op = .div, .prec = Prec.mul },
+        .percent => .{ .op = .mod, .prec = Prec.mul },
+        else => null,
+    };
+}
+
+fn parseUnary(p: *Parser) ParserError!*ast.Expr {
+    const tok = p.peek();
+    switch (tok.kind) {
+        .minus => {
+            p.pos += 1;
+            const operand = try parseUnary(p);
+            return try p.allocExpr(.{ .unary = .{
+                .op = .neg,
+                .operand = operand,
+                .span = .{ .start = tok.start, .end = operand.span().end },
+            } });
+        },
+        .kw_not => {
+            p.pos += 1;
+            const operand = try parseUnary(p);
+            return try p.allocExpr(.{ .unary = .{
+                .op = .log_not,
+                .operand = operand,
+                .span = .{ .start = tok.start, .end = operand.span().end },
+            } });
+        },
+        .tilde => {
+            p.pos += 1;
+            const operand = try parseUnary(p);
+            return try p.allocExpr(.{ .unary = .{
+                .op = .bit_not,
+                .operand = operand,
+                .span = .{ .start = tok.start, .end = operand.span().end },
+            } });
+        },
+        else => return try parseCallChain(p),
+    }
+}
+
+fn parseCallChain(p: *Parser) ParserError!*ast.Expr {
+    var e = try parsePrimary(p);
+    errdefer ast.freeExpr(p.allocator, e);
+
+    while (true) {
+        switch (p.peek().kind) {
+            .lparen => e = try parseCallArgs(p, e),
+            .lbracket => e = try parseIndexAccess(p, e),
+            .dot => e = try parseFieldOrMethod(p, e),
+            else => break,
+        }
+    }
+    return e;
+}
+
+fn parseCallArgs(p: *Parser, callee: *ast.Expr) ParserError!*ast.Expr {
+    p.pos += 1;
+    var args: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (args.items) |a| ast.freeExpr(p.allocator, a);
+        args.deinit(p.allocator);
+    }
+    if (!p.check(.rparen)) {
+        while (true) {
+            const a = try parseExpression(p, 0);
+            try args.append(p.allocator, a);
+            if (p.accept(.comma) == null) break;
+        }
+    }
+    const rp = try p.expect(.rparen, ")");
+    return try p.allocExpr(.{ .call = .{
+        .callee = callee,
+        .args = try args.toOwnedSlice(p.allocator),
+        .span = .{ .start = callee.span().start, .end = rp.end },
+    } });
+}
+
+fn parseIndexAccess(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
+    p.pos += 1;
+    const idx = try parseExpression(p, 0);
+    const rb = try p.expect(.rbracket, "]");
+    return try p.allocExpr(.{ .index = .{
+        .receiver = receiver,
+        .index = idx,
+        .span = .{ .start = receiver.span().start, .end = rb.end },
+    } });
+}
+
+fn parseFieldOrMethod(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
+    p.pos += 1;
+    const name_tok = try p.expect(.ident, "field or method name");
+    if (p.check(.lparen)) {
+        p.pos += 1;
+        var args: std.ArrayList(*ast.Expr) = .empty;
+        errdefer {
+            for (args.items) |a| ast.freeExpr(p.allocator, a);
+            args.deinit(p.allocator);
+        }
+        if (!p.check(.rparen)) {
+            while (true) {
+                const a = try parseExpression(p, 0);
+                try args.append(p.allocator, a);
+                if (p.accept(.comma) == null) break;
+            }
+        }
+        const rp = try p.expect(.rparen, ")");
+        return try p.allocExpr(.{ .method_call = .{
+            .receiver = receiver,
+            .method = ast.Span.fromToken(name_tok),
+            .args = try args.toOwnedSlice(p.allocator),
+            .span = .{ .start = receiver.span().start, .end = rp.end },
+        } });
+    }
+    return try p.allocExpr(.{ .field = .{
+        .receiver = receiver,
+        .field = ast.Span.fromToken(name_tok),
+        .span = .{ .start = receiver.span().start, .end = name_tok.end },
+    } });
+}
+
+fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
+    const tok = p.peek();
+    switch (tok.kind) {
+        .int_lit => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .int_lit = .{
+                .value = tok.value,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_true => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .bool_lit = .{
+                .value = true,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_false => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .bool_lit = .{
+                .value = false,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_nil => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .nil_lit = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_self => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .self_expr = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_super => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .super_expr = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .ident => {
+            const next = p.peekAt(1).kind;
+            if (next == .lbrace and looksLikeStructLit(p)) {
+                return try parseStructLit(p);
+            }
+            p.pos += 1;
+            return try p.allocExpr(.{ .ident = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .str_start => return try parseStringLit(p),
+        .lparen => return try parseParenOrTupleExpr(p),
+        .lbracket => return try parseListLit(p),
+        .kw_do => return try parseDoExpr(p),
+        .kw_if => return try parseIfExpr(p),
+        .kw_lambda => return try parseLambda(p),
+        else => {
+            try p.recordError("expected expression", "expression");
+            return error.ParseFailed;
+        },
+    }
+}
+
+/// Heuristic: `TypeName { ... }` in expression position is a struct
+/// literal. We use ASCII uppercase as the marker — same convention
+/// the lang docs use for type names.
+fn looksLikeStructLit(p: *const Parser) bool {
+    const tok = p.peek();
+    if (tok.start >= p.source.len) return false;
+    const b = p.source[tok.start];
+    return b >= 'A' and b <= 'Z';
+}
+
+fn parseStructLit(p: *Parser) ParserError!*ast.Expr {
+    const name_tok = p.peek();
+    p.pos += 1;
+    _ = try p.expect(.lbrace, "{");
+    p.skipNewlines();
+
+    var fields: std.ArrayList(ast.StructLitField) = .empty;
+    errdefer {
+        for (fields.items) |f| ast.freeExpr(p.allocator, f.value);
+        fields.deinit(p.allocator);
+    }
+
+    if (!p.check(.rbrace)) {
+        while (true) {
+            p.skipNewlines();
+            if (p.check(.rbrace)) break;
+            const fname_tok = try p.expect(.ident, "field name");
+            _ = try p.expect(.colon, ":");
+            const value = try parseExpression(p, 0);
+            try fields.append(p.allocator, .{
+                .name = ast.Span.fromToken(fname_tok),
+                .value = value,
+                .span = .{ .start = fname_tok.start, .end = value.span().end },
+            });
+            if (p.accept(.comma) == null) break;
+            p.skipNewlines();
+        }
+    }
+    p.skipNewlines();
+    const rb = try p.expect(.rbrace, "}");
+    return try p.allocExpr(.{ .struct_lit = .{
+        .type_name = ast.Span.fromToken(name_tok),
+        .fields = try fields.toOwnedSlice(p.allocator),
+        .span = .{ .start = name_tok.start, .end = rb.end },
+    } });
+}
+
+fn parseStringLit(p: *Parser) ParserError!*ast.Expr {
+    const start_tok = p.peek();
+    p.pos += 1;
+    var parts: std.ArrayList(ast.StrPart) = .empty;
+    errdefer cleanupStrParts(p.allocator, &parts);
+
+    var end_idx: u32 = start_tok.end;
+    while (true) {
+        const t = p.peek();
+        switch (t.kind) {
+            .str_part => {
+                p.pos += 1;
+                try parts.append(p.allocator, .{ .lit = .{
+                    .span = .{ .start = t.start, .end = t.end },
+                } });
+                end_idx = t.end;
+            },
+            .str_expr_start => {
+                p.pos += 1;
+                const inner = try parseExpression(p, 0);
+                // Optional `:fmt` spec — captured verbatim as a byte
+                // span; the runtime formatter parses it per
+                // `docs/gero-lang.md` §3.2.2.
+                var fmt_span: ?ast.Span = null;
+                if (p.accept(.colon)) |colon_tok| {
+                    const fmt_start = colon_tok.end;
+                    var depth: u32 = 0;
+                    while (true) {
+                        const nt = p.peek();
+                        if (nt.kind == .str_expr_end and depth == 0) break;
+                        if (nt.kind == .lparen) depth += 1;
+                        if (nt.kind == .rparen and depth > 0) depth -= 1;
+                        if (nt.kind == .eof) break;
+                        p.pos += 1;
+                    }
+                    const fmt_end = p.peek().start;
+                    fmt_span = .{ .start = fmt_start, .end = fmt_end };
+                }
+                const close = try p.expect(.str_expr_end, ")");
+                try parts.append(p.allocator, .{ .interp = .{
+                    .expr = inner,
+                    .format_spec = fmt_span,
+                    .span = .{ .start = t.start, .end = close.end },
+                } });
+                end_idx = close.end;
+            },
+            .str_end => {
+                p.pos += 1;
+                end_idx = t.end;
+                break;
+            },
+            else => {
+                try p.recordError("malformed string literal", "string part");
+                return error.ParseFailed;
+            },
+        }
+    }
+    return try p.allocExpr(.{ .str_lit = .{
+        .parts = try parts.toOwnedSlice(p.allocator),
+        .span = .{ .start = start_tok.start, .end = end_idx },
+    } });
+}
+
+fn cleanupStrParts(
+    allocator: std.mem.Allocator,
+    parts: *std.ArrayList(ast.StrPart),
+) void {
+    for (parts.items) |part| switch (part) {
+        .lit => {},
+        .interp => |ip| ast.freeExpr(allocator, ip.expr),
+    };
+    parts.deinit(allocator);
+}
+
+fn parseParenOrTupleExpr(p: *Parser) ParserError!*ast.Expr {
+    const lp = p.peek();
+    p.pos += 1;
+    p.skipNewlines();
+    const first = try parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, first);
+
+    if (p.accept(.rparen)) |rp| {
+        return try p.allocExpr(.{ .paren = .{
+            .inner = first,
+            .span = .{ .start = lp.start, .end = rp.end },
+        } });
+    }
+
+    var elems: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (elems.items) |e| ast.freeExpr(p.allocator, e);
+        elems.deinit(p.allocator);
+    }
+    try elems.append(p.allocator, first);
+    while (p.accept(.comma)) |_| {
+        p.skipNewlines();
+        if (p.check(.rparen)) break; // trailing comma
+        const e = try parseExpression(p, 0);
+        try elems.append(p.allocator, e);
+    }
+    const rp = try p.expect(.rparen, ")");
+    return try p.allocExpr(.{ .tuple_lit = .{
+        .elems = try elems.toOwnedSlice(p.allocator),
+        .span = .{ .start = lp.start, .end = rp.end },
+    } });
+}
+
+fn parseListLit(p: *Parser) ParserError!*ast.Expr {
+    const lb = p.peek();
+    p.pos += 1;
+    p.skipNewlines();
+    var elems: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (elems.items) |e| ast.freeExpr(p.allocator, e);
+        elems.deinit(p.allocator);
+    }
+    if (!p.check(.rbracket)) {
+        while (true) {
+            p.skipNewlines();
+            const e = try parseExpression(p, 0);
+            try elems.append(p.allocator, e);
+            if (p.accept(.comma) == null) break;
+            p.skipNewlines();
+            if (p.check(.rbracket)) break;
+        }
+    }
+    p.skipNewlines();
+    const rb = try p.expect(.rbracket, "]");
+    return try p.allocExpr(.{ .list_lit = .{
+        .elems = try elems.toOwnedSlice(p.allocator),
+        .span = .{ .start = lb.start, .end = rb.end },
+    } });
+}
+
+fn parseDoExpr(p: *Parser) ParserError!*ast.Expr {
+    const do_tok = p.peek();
+    p.pos += 1;
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parser_mod.parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    return try p.allocExpr(.{ .do_expr = .{
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = do_tok.start, .end = end_tok.end },
+    } });
+}
+
+fn parseIfExpr(p: *Parser) ParserError!*ast.Expr {
+    const start_tok = p.peek();
+    const stmt_mod = @import("stmt.zig");
+    const result = try stmt_mod.parseIfChain(p);
+    return try p.allocExpr(.{ .if_expr = .{
+        .arms = result.arms,
+        .else_body = result.else_body,
+        .span = .{ .start = start_tok.start, .end = result.end },
+    } });
+}
+
+fn parseLambda(p: *Parser) ParserError!*ast.Expr {
+    const lambda_tok = p.peek();
+    p.pos += 1;
+    _ = try p.expect(.lparen, "(");
+    const params = try decl_mod.parseParamList(p);
+    errdefer decl_mod.freeParams(p.allocator, params);
+
+    var ret_type: ?*ast.TypeAnn = null;
+    if (p.accept(.arrow)) |_| {
+        const type_mod = @import("type_ann.zig");
+        ret_type = try type_mod.parseTypeAnn(p);
+    }
+    errdefer if (ret_type) |r| ast.freeTypeAnn(p.allocator, r);
+
+    p.skipNewlines();
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parser_mod.parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    return try p.allocExpr(.{ .lambda = .{
+        .params = params,
+        .ret_type = ret_type,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = lambda_tok.start, .end = end_tok.end },
+    } });
+}

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -282,6 +282,13 @@ fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
                 .span = .{ .start = tok.start, .end = tok.end },
             } });
         },
+        .fixed_lit => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .fixed_lit = .{
+                .value = tok.value,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
         .kw_true => {
             p.pos += 1;
             return try p.allocExpr(.{ .bool_lit = .{

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -201,6 +201,7 @@ fn parseCallChain(p: *Parser) ParserError!*ast.Expr {
 
 fn parseCallArgs(p: *Parser, callee: *ast.Expr) ParserError!*ast.Expr {
     p.pos += 1;
+    p.skipNewlines();
     var args: std.ArrayList(*ast.Expr) = .empty;
     errdefer {
         for (args.items) |a| ast.freeExpr(p.allocator, a);
@@ -211,8 +212,11 @@ fn parseCallArgs(p: *Parser, callee: *ast.Expr) ParserError!*ast.Expr {
             const a = try parseExpression(p, 0);
             try args.append(p.allocator, a);
             if (p.accept(.comma) == null) break;
+            p.skipNewlines();
+            if (p.check(.rparen)) break; // trailing comma
         }
     }
+    p.skipNewlines();
     const rp = try p.expect(.rparen, ")");
     return try p.allocExpr(.{ .call = .{
         .callee = callee,
@@ -237,6 +241,7 @@ fn parseFieldOrMethod(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
     const name_tok = try p.expect(.ident, "field or method name");
     if (p.check(.lparen)) {
         p.pos += 1;
+        p.skipNewlines();
         var args: std.ArrayList(*ast.Expr) = .empty;
         errdefer {
             for (args.items) |a| ast.freeExpr(p.allocator, a);
@@ -247,8 +252,11 @@ fn parseFieldOrMethod(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
                 const a = try parseExpression(p, 0);
                 try args.append(p.allocator, a);
                 if (p.accept(.comma) == null) break;
+                p.skipNewlines();
+                if (p.check(.rparen)) break; // trailing comma
             }
         }
+        p.skipNewlines();
         const rp = try p.expect(.rparen, ")");
         return try p.allocExpr(.{ .method_call = .{
             .receiver = receiver,

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -181,6 +181,14 @@ fn parseCallChain(p: *Parser) ParserError!*ast.Expr {
     errdefer ast.freeExpr(p.allocator, e);
 
     while (true) {
+        // Leading-dot line continuation (§4.6.1): a `.` at the
+        // start of the next line continues the postfix chain.
+        // `xs\n  .filter(p)\n  .map(f)` reads as a single chained
+        // expression. Only the dot triggers — bare newlines still
+        // terminate the expression for binary ops.
+        if (p.check(.newline) and p.peekAt(1).kind == .dot) {
+            p.pos += 1;
+        }
         switch (p.peek().kind) {
             .lparen => e = try parseCallArgs(p, e),
             .lbracket => e = try parseIndexAccess(p, e),

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -45,10 +45,13 @@ pub const Prec = struct {
     pub const mul: u8 = 10;
     /// `is` — variant-tag test. Binds tighter than arithmetic.
     pub const is_test: u8 = 11;
+    /// `as` — explicit type cast. Binds tighter than `is` so
+    /// `x as u8 is Foo.A` reads as `(x as u8) is Foo.A`.
+    pub const as_cast: u8 = 12;
     /// Unary prefix: `-x` / `not x` / `~x`.
-    pub const unary: u8 = 12;
+    pub const unary: u8 = 13;
     /// Postfix: call `( )`, index `[ ]`, field `.`.
-    pub const call: u8 = 13;
+    pub const call: u8 = 14;
 };
 
 /// Parse an expression with the Pratt loop. `min_prec` is the
@@ -89,6 +92,24 @@ pub fn parseExpression(p: *Parser, min_prec: u8) ParserError!*ast.Expr {
                 .lhs = lhs,
                 .variant_path = path,
                 .span = .{ .start = lhs.span().start, .end = var_tok.end },
+            } });
+            lhs = new_node;
+            continue;
+        }
+
+        // `x as T` — explicit type conversion (§3.8). RHS is a type
+        // annotation, not an expression; uses the same parser as
+        // `let x: T` / `-> T`.
+        if (k == .kw_as) {
+            const prec = Prec.as_cast;
+            if (prec < min_prec) break;
+            p.pos += 1;
+            const type_mod = @import("type_ann.zig");
+            const target_type = try type_mod.parseTypeAnn(p);
+            const new_node = try p.allocExpr(.{ .cast = .{
+                .inner = lhs,
+                .target_type = target_type,
+                .span = .{ .start = lhs.span().start, .end = target_type.span().end },
             } });
             lhs = new_node;
             continue;

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -729,6 +729,24 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
             continue;
         }
 
+        // `$FFFF` — asm-style hex literal, accepted in lang for
+        // ergonomics with memory-mapped IO addresses (§3.7.1
+        // `@addr $FE40`). Only valid outside string-body mode; the
+        // `$(…)` interpolation form short-circuits earlier.
+        if (b == '$' and state.index + 1 < source.len and isHexDigit(source[state.index + 1])) {
+            const start = state.index;
+            state.index += 1;
+            var value: i32 = 0;
+            while (state.index < source.len) : (state.index += 1) {
+                const c = source[state.index];
+                if (c == '_') continue;
+                if (!isHexDigit(c)) break;
+                value = value * 16 + hexValue(c);
+            }
+            try pushToken(&state, .int_lit, start, state.index, value);
+            continue;
+        }
+
         // Integer literal — bare digit, or `-` followed by a
         // digit at an operand position.
         if (isDigit(b)) {

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -107,6 +107,9 @@ pub const Token = struct {
         kw_break,
         kw_continue,
         kw_print,
+        /// `defer` — schedule a statement to run when the enclosing
+        /// block exits (§4.10). LIFO order across multiple defers.
+        kw_defer,
 
         // -- punctuation --------------------------------------
         newline,
@@ -253,6 +256,7 @@ const keyword_table = [_]KeywordEntry{
     .{ .lex = "break", .kind = .kw_break },
     .{ .lex = "continue", .kind = .kw_continue },
     .{ .lex = "print", .kind = .kw_print },
+    .{ .lex = "defer", .kind = .kw_defer },
 };
 
 /// Lookup `name` (already lowercase per the identifier rule) in

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -118,6 +118,26 @@ pub const Token = struct {
 
         // -- assignment ---------------------------------------
         equals,
+        /// `+=` — compound add-assign.
+        plus_eq,
+        /// `-=` — compound sub-assign.
+        minus_eq,
+        /// `*=` — compound mul-assign.
+        star_eq,
+        /// `/=` — compound div-assign.
+        slash_eq,
+        /// `%=` — compound mod-assign.
+        percent_eq,
+        /// `&=` — compound bitwise-AND-assign.
+        amp_eq,
+        /// `|=` — compound bitwise-OR-assign.
+        pipe_eq,
+        /// `^=` — compound bitwise-XOR-assign.
+        caret_eq,
+        /// `<<=` — compound shift-left-assign.
+        shl_eq,
+        /// `>>=` — compound shift-right-assign.
+        shr_eq,
 
         // -- arithmetic ---------------------------------------
         plus,
@@ -753,6 +773,24 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
             try pushToken(&state, .gt_eq, start, state.index, 0);
             continue;
         }
+        // `<<=` / `>>=` — compound shift-assign. Longest match wins,
+        // so check the 3-byte form before `<<` / `>>` / `<=` / `>=`.
+        if (b == '<' and state.index + 2 < source.len and
+            source[state.index + 1] == '<' and source[state.index + 2] == '=')
+        {
+            const start = state.index;
+            state.index += 3;
+            try pushToken(&state, .shl_eq, start, state.index, 0);
+            continue;
+        }
+        if (b == '>' and state.index + 2 < source.len and
+            source[state.index + 1] == '>' and source[state.index + 2] == '=')
+        {
+            const start = state.index;
+            state.index += 3;
+            try pushToken(&state, .shr_eq, start, state.index, 0);
+            continue;
+        }
         if (b == '<' and state.index + 1 < source.len and source[state.index + 1] == '<') {
             const start = state.index;
             state.index += 2;
@@ -764,6 +802,30 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
             state.index += 2;
             try pushToken(&state, .shr, start, state.index, 0);
             continue;
+        }
+        // Compound-assign forms `<op>=` — single-char op followed
+        // by `=`. The `++` / `--` / `==` / `!=` / `<=` / `>=` /
+        // `<<` / `>>` cases above already short-circuit out, so by
+        // the time we reach here the `=` must be a compound-assign
+        // for one of the arithmetic / bitwise ops.
+        if (state.index + 1 < source.len and source[state.index + 1] == '=') {
+            const ck: ?Token.Kind = switch (b) {
+                '+' => .plus_eq,
+                '-' => .minus_eq,
+                '*' => .star_eq,
+                '/' => .slash_eq,
+                '%' => .percent_eq,
+                '&' => .amp_eq,
+                '|' => .pipe_eq,
+                '^' => .caret_eq,
+                else => null,
+            };
+            if (ck) |k| {
+                const start = state.index;
+                state.index += 2;
+                try pushToken(&state, k, start, state.index, 0);
+                continue;
+            }
         }
         if (b == '+' and state.index + 1 < source.len and source[state.index + 1] == '+') {
             const start = state.index;

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -35,6 +35,13 @@ pub const Token = struct {
         /// operand position (see `is_operand_position` in the
         /// implementation); otherwise emitted as `.minus`.
         int_lit,
+        /// Fixed-point literal — decimal with fractional part
+        /// (`1.5`, `0.125`, `3.14159`). Pre-encoded as Q8.8 in the
+        /// `value` field: top byte is the integer part, bottom byte
+        /// is `round(frac * 256)`. `1.5` → `0x0180`, `0.125` →
+        /// `0x0020`. Negative form via the unary minus operator,
+        /// not the literal itself.
+        fixed_lit,
         /// `@`-prefixed annotation marker. `start` covers the
         /// `@`; `end` covers the trailing identifier. The parser
         /// reads the identifier from the lexeme.
@@ -307,6 +314,7 @@ fn isOperandEnd(kind: Token.Kind) bool {
     return switch (kind) {
         .ident,
         .int_lit,
+        .fixed_lit,
         .rparen,
         .rbrace,
         .rbracket,
@@ -460,6 +468,41 @@ fn lexInteger(state: *State, negative: bool) !void {
             if (!isDigit(b)) break;
             // @as: widen u8 digit → i32 to keep the multiply-add signed.
             value = value * 10 + @as(i32, b - '0');
+        }
+
+        // Fractional part — `1.5`, `0.125`, etc. Only triggered
+        // when a digit follows the `.`; `1.foo()` stays as
+        // `int_lit(1)` + `.dot` + `ident(foo)`. The fraction is
+        // converted to Q8.8 by `frac_digits * 256 / 10^N` with a
+        // round-nearest add of `10^N / 2`.
+        const has_fraction = state.index + 1 < state.source.len and
+            state.source[state.index] == '.' and
+            isDigit(state.source[state.index + 1]);
+        if (has_fraction) {
+            state.index += 1; // consume `.`
+            var frac_digits: i64 = 0;
+            var divisor: i64 = 1;
+            while (state.index < state.source.len) : (state.index += 1) {
+                const b = state.source[state.index];
+                if (b == '_') continue;
+                if (!isDigit(b)) break;
+                // @as: widen u8 digit (0..9) → i64 so the running fraction stays wide.
+                frac_digits = frac_digits * 10 + @as(i64, b - '0');
+                divisor *= 10;
+            }
+            const frac_byte: i64 = @divTrunc(frac_digits * 256 + @divTrunc(divisor, 2), divisor);
+            // @as: narrow i64 → i32 for the Q8.8 byte; `& 0xFF` bounds it to 0..255.
+            const encoded: i32 = (value << 8) | @as(i32, @intCast(frac_byte & 0xFF));
+            if (negative) {
+                // Two's-complement Q8.8 negation: flip then add 1.
+                // For positive Q8.8 the encoded value fits in u16;
+                // store the negated 16-bit pattern as signed i32.
+                const neg: i32 = -encoded;
+                try pushToken(state, .fixed_lit, start, state.index, neg);
+            } else {
+                try pushToken(state, .fixed_lit, start, state.index, encoded);
+            }
+            return;
         }
     }
 

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -1,40 +1,37 @@
-/// Gero-lang parser — consumes the `TokenStream` produced by
-/// `lexer.tokenize` and emits an `ast.Program`. Token-stream-based
-/// (not knit byte-combinators — those operate on raw bytes; the
-/// lang side runs the lexer first then walks tokens).
+/// Gero-lang parser — driver. Consumes the lexer's `TokenStream`,
+/// runs a hand-rolled statement-kind dispatch, and hands off to
+/// sibling modules for each language sub-surface:
 ///
-/// Architecture:
+///   - `expr.zig`       — Pratt expressions + primaries
+///   - `pattern.zig`    — `match` / `let` destructuring patterns
+///   - `type_ann.zig`   — type annotations
+///   - `annotation.zig` — `@name(...)` decorators
+///   - `decl.zig`       — `let` / `const` / `def` / `class` /
+///                        `struct` / `enum` / `use`
+///   - `stmt.zig`       — `if` / `while` / `for` / `match` /
+///                        `do` / `return` / `print` / expr-stmts
 ///
-/// - Statement-level dispatch is hand-rolled — a switch on the
-///   current token's kind plus a handful of look-ahead checks.
-/// - Expression parsing is Pratt-style: `parseExpression(min_prec)`
-///   loops, eating binary operators whose precedence is at least
-///   `min_prec`, recursing for the RHS at one tier higher. Unary
-///   prefix, function-call postfix, field/index postfix all live in
-///   the leaf path. Precedence table sourced from
-///   `docs/gero-lang.md` §3.3.
-/// - Errors append to `errors` but never abort parsing — the parser
-///   skips to the next statement boundary (a `.newline` token) and
-///   resumes. A single drive surfaces every problem at once.
+/// Errors append to `errors` but never abort parsing — the parser
+/// recovers to the next newline so one drive surfaces every problem.
 ///
-/// Annotation attachment: the parser keeps a pending-annotation
-/// buffer. When it parses `@name(args)`, it pushes to the buffer.
-/// When it parses a decl that accepts annotations (`def`, `let`,
-/// `const`, `class`, `struct`, `enum`, class-level field/method),
-/// it drains the buffer into the decl's `annotations` slice.
-/// Annotations followed by non-decl statements are reported as a
-/// diagnostic and discarded.
+/// `Parser`, `ParserError`, and the helpers below are `pub` so the
+/// sibling modules can compose against them. They aren't part of
+/// the `gero.lang` public API surface (`src/lang.zig` re-exports
+/// only `parse`, `ParseTree`, and the `ast` barrel).
 const std = @import("std");
 const knit = @import("knit");
 const core = knit.core;
 const lexer = @import("lexer.zig");
 const ast = @import("ast.zig");
+const annotation_mod = @import("annotation.zig");
+const decl_mod = @import("decl.zig");
+const stmt_mod = @import("stmt.zig");
 
 const Kind = lexer.Token.Kind;
 
 /// Output of `parse` — the program AST plus diagnostics. Errors
 /// don't abort parsing; the parser recovers to the next statement
-/// boundary so a single run drains every problem at once.
+/// boundary so a single run drains every problem.
 pub const ParseTree = struct {
     program: ast.Program,
     errors: []core.ParseError,
@@ -60,7 +57,7 @@ pub fn parse(
     stream: lexer.TokenStream,
 ) !ParseTree {
     var statements: std.ArrayList(ast.Statement) = .empty;
-    errdefer cleanupStatements(allocator, &statements);
+    errdefer cleanupStatementList(allocator, &statements);
 
     var errors: std.ArrayList(core.ParseError) = .empty;
     errdefer errors.deinit(allocator);
@@ -99,7 +96,7 @@ pub fn parse(
 
     // Any unattached pending annotations at EOF — emit one diagnostic
     // and free their inner allocations. The buffer itself (capacity)
-    // is released by the `defer pending_annotations.deinit` above.
+    // is released by the `defer` above.
     if (pending_annotations.items.len > 0) {
         try errors.append(allocator, core.parseError(
             "lang_parser",
@@ -124,8 +121,16 @@ pub fn parse(
     };
 }
 
-/// Cleanup partial state when an OOM path triggers `errdefer`.
-fn cleanupStatements(
+/// Cleanup helper used by `parse`'s `errdefer` and by sibling
+/// modules for body lists (`do`/`if`/`match` arms, function bodies).
+pub fn cleanupStatements(
+    allocator: std.mem.Allocator,
+    statements: *std.ArrayList(ast.Statement),
+) void {
+    cleanupStatementList(allocator, statements);
+}
+
+fn cleanupStatementList(
     allocator: std.mem.Allocator,
     statements: *std.ArrayList(ast.Statement),
 ) void {
@@ -133,22 +138,33 @@ fn cleanupStatements(
     statements.deinit(allocator);
 }
 
-fn cleanupAnnotations(
-    allocator: std.mem.Allocator,
-    anns: *std.ArrayList(ast.Annotation),
-) void {
-    for (anns.items) |a| {
+/// Release an annotation slice (and the expression args owned by
+/// each entry). Shared between `decl.zig` and the cleanup helpers
+/// here.
+pub fn freeAnnSlice(allocator: std.mem.Allocator, anns: []ast.Annotation) void {
+    for (anns) |a| {
         for (a.args) |arg| ast.freeExpr(allocator, arg);
         allocator.free(a.args);
     }
-    anns.deinit(allocator);
+    allocator.free(anns);
+}
+
+/// Drain pending annotations into a fresh owned slice. The buffer
+/// is reset so subsequent decls don't inherit stale entries.
+pub fn takePendingAnnotations(p: *Parser) ![]ast.Annotation {
+    const slice = try p.allocator.dupe(ast.Annotation, p.pending_annotations.items);
+    p.pending_annotations.clearRetainingCapacity();
+    return slice;
 }
 
 // =====================================================================
 // Parser state + cursor helpers.
 // =====================================================================
 
-const Parser = struct {
+/// Working state of a single `parse` invocation. `pos` cursors
+/// `tokens`; sibling modules call the methods below to advance it
+/// and accumulate diagnostics.
+pub const Parser = struct {
     source: []const u8,
     tokens: []const lexer.Token,
     pos: usize,
@@ -158,52 +174,45 @@ const Parser = struct {
 
     /// Current token. Always defined — the lexer guarantees a
     /// trailing `.eof` token.
-    fn peek(self: *const Parser) lexer.Token {
+    pub fn peek(self: *const Parser) lexer.Token {
         return self.tokens[self.pos];
     }
 
     /// Token `n` positions ahead. Safe past EOF: returns the EOF
     /// token (the lexer guarantees one trailing).
-    fn peekAt(self: *const Parser, n: usize) lexer.Token {
+    pub fn peekAt(self: *const Parser, n: usize) lexer.Token {
         const idx = @min(self.pos + n, self.tokens.len - 1);
         return self.tokens[idx];
     }
 
-    fn atEnd(self: *const Parser) bool {
+    /// True when the current token is `.eof`.
+    pub fn atEnd(self: *const Parser) bool {
         return self.peek().kind == .eof;
     }
 
     /// True when the current token matches `kind`.
-    fn check(self: *const Parser, kind: Kind) bool {
+    pub fn check(self: *const Parser, kind: Kind) bool {
         return self.peek().kind == kind;
-    }
-
-    /// Same as `check` but for a span of allowed kinds.
-    fn checkAny(self: *const Parser, kinds: []const Kind) bool {
-        const k = self.peek().kind;
-        for (kinds) |c| if (k == c) return true;
-        return false;
     }
 
     /// Consume the current token if it matches `kind`. Returns the
     /// consumed token on hit, `null` on miss.
-    fn accept(self: *Parser, kind: Kind) ?lexer.Token {
+    pub fn accept(self: *Parser, kind: Kind) ?lexer.Token {
         if (!self.check(kind)) return null;
         const t = self.peek();
         self.pos += 1;
         return t;
     }
 
-    /// Skip newline tokens; they don't carry semantics outside the
-    /// statement-boundary role.
-    fn skipNewlines(self: *Parser) void {
+    /// Skip newline tokens; they're only meaningful as statement
+    /// boundaries.
+    pub fn skipNewlines(self: *Parser) void {
         while (self.check(.newline)) self.pos += 1;
     }
 
-    /// Skip newlines, return whether we consumed at least one or
-    /// reached EOF. Used after a statement is parsed to assert the
-    /// caller didn't trail garbage before the next statement.
-    fn requireStatementBoundary(self: *Parser) !void {
+    /// Assert the next token is a statement boundary (`.newline`
+    /// or EOF); otherwise emit a diagnostic and recover.
+    pub fn requireStatementBoundary(self: *Parser) !void {
         if (self.atEnd() or self.check(.newline)) {
             self.skipNewlines();
             return;
@@ -215,15 +224,10 @@ const Parser = struct {
         try self.recoverToNewline();
     }
 
-    fn currentSpan(self: *const Parser) ast.Span {
-        const t = self.peek();
-        return .{ .start = t.start, .end = t.end };
-    }
-
-    /// Append a diagnostic anchored at the current token. The lexeme
-    /// of the actual token is recorded as `actual` so consumers see
-    /// what the parser tripped on.
-    fn recordError(
+    /// Append a diagnostic anchored at the current token. Records
+    /// the actual lexeme so the consumer sees what tripped the
+    /// parser.
+    pub fn recordError(
         self: *Parser,
         message: []const u8,
         expected: []const u8,
@@ -241,66 +245,54 @@ const Parser = struct {
         ));
     }
 
-    /// Append a diagnostic at the given token index without
-    /// consuming.
-    fn recordErrorAt(
-        self: *Parser,
-        index: u32,
-        message: []const u8,
-        expected: []const u8,
-    ) !void {
-        try self.errors.append(self.allocator, core.parseError(
-            "lang_parser",
-            index,
-            message,
-            .{ .expected = expected, .kind = .syntactic },
-        ));
-    }
-
     /// Advance until the next newline (or EOF). Used for
     /// statement-level error recovery.
-    fn recoverToNewline(self: *Parser) !void {
+    pub fn recoverToNewline(self: *Parser) !void {
         while (!self.atEnd() and !self.check(.newline)) self.pos += 1;
         self.skipNewlines();
     }
 
-    /// Expect a specific token kind; emit a diagnostic and bail out
-    /// of the current production via `error.ParseFailed` if missing.
-    /// Successful match returns the consumed token.
-    fn expect(self: *Parser, kind: Kind, what: []const u8) ParserError!lexer.Token {
+    /// Expect a specific token kind. Returns the consumed token on
+    /// hit; on miss, emits a diagnostic and bails with
+    /// `error.ParseFailed` (caller recovers to the next newline).
+    pub fn expect(self: *Parser, kind: Kind, what: []const u8) ParserError!lexer.Token {
         if (self.accept(kind)) |t| return t;
         try self.recordError("expected token", what);
         return error.ParseFailed;
     }
 
-    /// Allocate and initialize an `*Expr`.
-    fn allocExpr(self: *Parser, value: ast.Expr) !*ast.Expr {
+    /// Allocate + initialize an `*Expr`.
+    pub fn allocExpr(self: *Parser, value: ast.Expr) !*ast.Expr {
         const node = try self.allocator.create(ast.Expr);
         node.* = value;
         return node;
     }
 
-    fn allocPattern(self: *Parser, value: ast.Pattern) !*ast.Pattern {
+    /// Allocate + initialize a `*Pattern`.
+    pub fn allocPattern(self: *Parser, value: ast.Pattern) !*ast.Pattern {
         const node = try self.allocator.create(ast.Pattern);
         node.* = value;
         return node;
     }
 
-    fn allocTypeAnn(self: *Parser, value: ast.TypeAnn) !*ast.TypeAnn {
+    /// Allocate + initialize a `*TypeAnn`.
+    pub fn allocTypeAnn(self: *Parser, value: ast.TypeAnn) !*ast.TypeAnn {
         const node = try self.allocator.create(ast.TypeAnn);
         node.* = value;
         return node;
     }
 
-    fn lexeme(self: *const Parser, span: ast.Span) []const u8 {
+    /// Borrow the source bytes covered by `span`.
+    pub fn lexeme(self: *const Parser, span: ast.Span) []const u8 {
         return self.source[span.start..span.end];
     }
 };
 
 /// Local error set for productions that may bail to the nearest
-/// statement-recovery point. `OutOfMemory` propagates to the caller;
-/// `ParseFailed` triggers `recoverToNewline` at the statement level.
-const ParserError = error{ OutOfMemory, ParseFailed };
+/// statement-recovery point. `OutOfMemory` propagates to the
+/// caller; `ParseFailed` triggers `recoverToNewline` at the
+/// statement level.
+pub const ParserError = error{ OutOfMemory, ParseFailed };
 
 // =====================================================================
 // Top-level dispatch.
@@ -312,7 +304,7 @@ fn parseTopLevel(
 ) !void {
     // Accumulate annotations into the parser's pending buffer.
     while (p.check(.annotation)) {
-        const ann = parseAnnotation(p) catch |err| switch (err) {
+        const ann = annotation_mod.parseAnnotation(p) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.ParseFailed => {
                 try p.recoverToNewline();
@@ -329,79 +321,40 @@ fn parseTopLevel(
     };
 }
 
-fn parseStatement(
+/// Dispatch on the leading token kind. Public so sibling modules
+/// (`expr.zig` for `do`/`if`/`lambda` bodies, `stmt.zig` for `if`/
+/// `while`/`for`/`match` bodies) can recurse back through the same
+/// statement-kind switch.
+pub fn parseStatement(
     p: *Parser,
     statements: *std.ArrayList(ast.Statement),
 ) ParserError!void {
-    const start = p.peek().start;
-    const k = p.peek().kind;
-
-    switch (k) {
-        .kw_let => {
-            const stmt = try parseLetDecl(p, false);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_const => {
-            const stmt = try parseConstDecl(p, false);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_def => {
-            const stmt = try parseDefDecl(p, false);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_class => {
-            const stmt = try parseClassDecl(p, false);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_enum => {
-            const stmt = try parseEnumDecl(p, false);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_local => {
-            try parseLocalDecl(p, statements);
-        },
-        .kw_use => {
-            const stmt = try parseUseDecl(p, false);
-            try statements.append(p.allocator, stmt);
-        },
+    switch (p.peek().kind) {
+        .kw_let => try statements.append(p.allocator, try decl_mod.parseLetDecl(p, false)),
+        .kw_const => try statements.append(p.allocator, try decl_mod.parseConstDecl(p, false)),
+        .kw_def => try statements.append(p.allocator, try decl_mod.parseDefDecl(p, false)),
+        .kw_class => try statements.append(p.allocator, try decl_mod.parseClassDecl(p, false)),
+        .kw_enum => try statements.append(p.allocator, try decl_mod.parseEnumDecl(p, false)),
+        .kw_local => try decl_mod.parseLocalDecl(p, statements),
+        .kw_use => try statements.append(p.allocator, try decl_mod.parseUseDecl(p, false)),
         .ident => {
-            // `struct Foo ... end` uses a bare identifier — `struct`
-            // is not a reserved keyword in the lexer so type-name
-            // lookups like `let Stats = ...` stay unambiguous. Look
-            // ahead for the dispatch shape.
+            // `struct Foo ... end` uses a bare identifier (not a
+            // reserved keyword), so type-name lookups like
+            // `let Stats = ...` stay unambiguous. Look ahead for
+            // the dispatch shape.
             const lex = p.source[p.peek().start..p.peek().end];
             if (std.mem.eql(u8, lex, "struct")) {
-                const stmt = try parseStructDecl(p, false);
-                try statements.append(p.allocator, stmt);
+                try statements.append(p.allocator, try decl_mod.parseStructDecl(p, false));
                 return;
             }
-            // Otherwise fall through to expression-or-assignment.
-            try parseExprOrAssignStatement(p, statements);
+            try stmt_mod.parseExprOrAssignStatement(p, statements);
         },
-        .kw_if => {
-            const stmt = try parseIfStatement(p);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_while => {
-            const stmt = try parseWhileStatement(p);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_for => {
-            const stmt = try parseForStatement(p);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_match => {
-            const stmt = try parseMatchStatement(p);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_do => {
-            const stmt = try parseBlockStatement(p);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_return => {
-            const stmt = try parseReturnStatement(p);
-            try statements.append(p.allocator, stmt);
-        },
+        .kw_if => try statements.append(p.allocator, try stmt_mod.parseIfStatement(p)),
+        .kw_while => try statements.append(p.allocator, try stmt_mod.parseWhileStatement(p)),
+        .kw_for => try statements.append(p.allocator, try stmt_mod.parseForStatement(p)),
+        .kw_match => try statements.append(p.allocator, try stmt_mod.parseMatchStatement(p)),
+        .kw_do => try statements.append(p.allocator, try stmt_mod.parseBlockStatement(p)),
+        .kw_return => try statements.append(p.allocator, try stmt_mod.parseReturnStatement(p)),
         .kw_break => {
             const t = p.peek();
             p.pos += 1;
@@ -418,2197 +371,8 @@ fn parseStatement(
             } });
             try p.requireStatementBoundary();
         },
-        .kw_print => {
-            const stmt = try parsePrintStatement(p);
-            try statements.append(p.allocator, stmt);
-        },
+        .kw_print => try statements.append(p.allocator, try stmt_mod.parsePrintStatement(p)),
         .eof => return,
-        else => {
-            // `_ = expr` discard — `_` is a bare identifier in the
-            // lexer; the `kw_let`-style match above doesn't catch
-            // it. `.ident` branch handles the general case too;
-            // this fallthrough handles anything else that can
-            // start an expression (literals, parens, etc.).
-            try parseExprOrAssignStatement(p, statements);
-        },
+        else => try stmt_mod.parseExprOrAssignStatement(p, statements),
     }
-
-    _ = start;
-}
-
-/// `local <decl>` — visibility shim. The keyword must be followed
-/// by a `let` / `const` / `def` / `class` / `struct` / `enum` /
-/// `use` decl. The parser sets the inner decl's `is_local` field.
-fn parseLocalDecl(
-    p: *Parser,
-    statements: *std.ArrayList(ast.Statement),
-) !void {
-    const local_tok = p.peek();
-    p.pos += 1; // consume `local`
-    const start = local_tok.start;
-
-    const k = p.peek().kind;
-    switch (k) {
-        .kw_let => {
-            const stmt = try parseLetDecl(p, true);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_const => {
-            const stmt = try parseConstDecl(p, true);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_def => {
-            const stmt = try parseDefDecl(p, true);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_class => {
-            const stmt = try parseClassDecl(p, true);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_enum => {
-            const stmt = try parseEnumDecl(p, true);
-            try statements.append(p.allocator, stmt);
-        },
-        .kw_use => {
-            const stmt = try parseUseDecl(p, true);
-            try statements.append(p.allocator, stmt);
-        },
-        .ident => {
-            const lex = p.source[p.peek().start..p.peek().end];
-            if (std.mem.eql(u8, lex, "struct")) {
-                const stmt = try parseStructDecl(p, true);
-                try statements.append(p.allocator, stmt);
-                return;
-            }
-            try p.recordError(
-                "expected declaration after `local`",
-                "let / const / def / class / struct / enum / use",
-            );
-            try p.recoverToNewline();
-            try statements.append(p.allocator, .{ .local_decl = .{
-                .span = .{ .start = start, .end = p.peek().start },
-            } });
-        },
-        else => {
-            try p.recordError(
-                "expected declaration after `local`",
-                "let / const / def / class / struct / enum / use",
-            );
-            try p.recoverToNewline();
-            try statements.append(p.allocator, .{ .local_decl = .{
-                .span = .{ .start = start, .end = p.peek().start },
-            } });
-        },
-    }
-}
-
-// =====================================================================
-// Annotations.
-// =====================================================================
-
-/// Parse `@name` or `@name(args...)`. The leading `@` is a single
-/// `.annotation` token covering both the `@` and the trailing
-/// identifier (see `lexer.zig`).
-fn parseAnnotation(p: *Parser) ParserError!ast.Annotation {
-    const at_tok = p.peek();
-    p.pos += 1;
-
-    // The lexer emits `.annotation` as a single token whose span
-    // covers `@name` end-to-end. The leading `@` is one byte.
-    const name_span: ast.Span = .{
-        .start = at_tok.start + 1,
-        .end = at_tok.end,
-    };
-
-    var args: std.ArrayList(*ast.Expr) = .empty;
-    errdefer {
-        for (args.items) |a| ast.freeExpr(p.allocator, a);
-        args.deinit(p.allocator);
-    }
-
-    var end: u32 = at_tok.end;
-
-    // `(arg, arg, ...)` is optional. `@bank N` is the rare arg-
-    // without-parens form spec §3.7.1 documents — accept a single
-    // following expression of "literal-or-ident" shape on the same
-    // line as a sugar.
-    if (p.accept(.lparen)) |_| {
-        if (!p.check(.rparen)) {
-            while (true) {
-                const arg = try parseExpression(p, 0);
-                try args.append(p.allocator, arg);
-                if (p.accept(.comma) == null) break;
-            }
-        }
-        const close = try p.expect(.rparen, ")");
-        end = close.end;
-    } else if (canStartParenlessAnnotationArg(p.peek().kind)) {
-        // Sugar: `@bank 5`, `@interrupt 0x06`, `@addr $FE40`. Stops
-        // at the line boundary (newline) — only one expression
-        // captured.
-        const arg = try parseExpression(p, 0);
-        const arg_span = arg.span();
-        try args.append(p.allocator, arg);
-        end = arg_span.end;
-    }
-
-    return .{
-        .name = name_span,
-        .args = try args.toOwnedSlice(p.allocator),
-        .span = .{ .start = at_tok.start, .end = end },
-    };
-}
-
-fn canStartParenlessAnnotationArg(k: Kind) bool {
-    return switch (k) {
-        .int_lit, .ident, .str_start, .kw_true, .kw_false, .kw_nil => true,
-        else => false,
-    };
-}
-
-/// Drain pending annotations into a fresh owned slice. The buffer
-/// is reset so subsequent decls don't inherit stale entries.
-fn takePendingAnnotations(p: *Parser) ![]ast.Annotation {
-    const slice = try p.allocator.dupe(ast.Annotation, p.pending_annotations.items);
-    p.pending_annotations.clearRetainingCapacity();
-    return slice;
-}
-
-// =====================================================================
-// `let` / `const` declarations.
-// =====================================================================
-
-fn parseLetDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
-    const let_tok = p.peek();
-    p.pos += 1; // consume `let`
-
-    const start = let_tok.start;
-
-    // The bound shape can be a single ident OR a destructuring
-    // pattern. The pattern parser handles both uniformly.
-    const pattern = try parsePattern(p);
-
-    var type_ann: ?*ast.TypeAnn = null;
-    if (p.accept(.colon)) |_| {
-        type_ann = try parseTypeAnn(p);
-    }
-
-    var init: ?*ast.Expr = null;
-    if (p.accept(.equals)) |_| {
-        init = try parseExpression(p, 0);
-    } else if (type_ann == null) {
-        // `let x` with no type and no init is invalid.
-        try p.recordError(
-            "expected `=` or `: T` after `let` binding",
-            "= or : T",
-        );
-    }
-
-    const end = if (init) |e| e.span().end else if (type_ann) |t| t.span().end else pattern.span().end;
-    try p.requireStatementBoundary();
-    return .{ .let_decl = .{
-        .pattern = pattern,
-        .type_ann = type_ann,
-        .init = init,
-        .is_local = is_local,
-        .span = .{ .start = start, .end = end },
-    } };
-}
-
-fn parseConstDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
-    const const_tok = p.peek();
-    p.pos += 1;
-    const start = const_tok.start;
-
-    const name_tok = try p.expect(.ident, "identifier");
-    const name_span = ast.Span.fromToken(name_tok);
-
-    var type_ann: ?*ast.TypeAnn = null;
-    if (p.accept(.colon)) |_| {
-        type_ann = try parseTypeAnn(p);
-    }
-
-    _ = try p.expect(.equals, "=");
-
-    const init = try parseExpression(p, 0);
-    const end = init.span().end;
-    try p.requireStatementBoundary();
-
-    return .{ .const_decl = .{
-        .name = name_span,
-        .type_ann = type_ann,
-        .init = init,
-        .is_local = is_local,
-        .span = .{ .start = start, .end = end },
-    } };
-}
-
-// =====================================================================
-// `def` — function declaration.
-// =====================================================================
-
-fn parseDefDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
-    const decl = try parseDefDeclInner(p, is_local);
-    return .{ .def_decl = decl };
-}
-
-fn parseDefDeclInner(p: *Parser, is_local: bool) ParserError!ast.DefDecl {
-    const def_tok = p.peek();
-    p.pos += 1; // consume `def`
-    const start = def_tok.start;
-
-    const annotations = try takePendingAnnotations(p);
-    errdefer freeAnnSlice(p.allocator, annotations);
-
-    const name_tok = try p.expect(.ident, "function name");
-    const name_span = ast.Span.fromToken(name_tok);
-
-    _ = try p.expect(.lparen, "(");
-    const params = try parseParamList(p);
-    errdefer freeParams(p.allocator, params);
-
-    var ret_type: ?*ast.TypeAnn = null;
-    if (p.accept(.arrow)) |_| {
-        ret_type = try parseTypeAnn(p);
-    }
-    errdefer if (ret_type) |r| ast.freeTypeAnn(p.allocator, r);
-
-    p.skipNewlines();
-    var body: std.ArrayList(ast.Statement) = .empty;
-    errdefer cleanupStatements(p.allocator, &body);
-
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        try parseStatement(p, &body);
-        p.skipNewlines();
-    }
-
-    const end_tok = try p.expect(.kw_end, "end");
-    try p.requireStatementBoundary();
-
-    return .{
-        .annotations = annotations,
-        .name = name_span,
-        .params = params,
-        .ret_type = ret_type,
-        .body = try body.toOwnedSlice(p.allocator),
-        .is_local = is_local,
-        .span = .{ .start = start, .end = end_tok.end },
-    };
-}
-
-fn freeAnnSlice(allocator: std.mem.Allocator, anns: []ast.Annotation) void {
-    for (anns) |a| {
-        for (a.args) |arg| ast.freeExpr(allocator, arg);
-        allocator.free(a.args);
-    }
-    allocator.free(anns);
-}
-
-fn freeParams(allocator: std.mem.Allocator, params: []ast.Param) void {
-    for (params) |p| if (p.type_ann) |t| ast.freeTypeAnn(allocator, t);
-    allocator.free(params);
-}
-
-fn parseParamList(p: *Parser) ParserError![]ast.Param {
-    var params: std.ArrayList(ast.Param) = .empty;
-    errdefer {
-        freeParams(p.allocator, params.items);
-        params.deinit(p.allocator);
-    }
-
-    if (p.check(.rparen)) {
-        _ = p.accept(.rparen);
-        return try params.toOwnedSlice(p.allocator);
-    }
-
-    while (true) {
-        // `self` is a parameter shape too — it gets a `kw_self`
-        // token, not an ident, but the parser treats it as a named
-        // param so methods can be written `def m(self, ...)`.
-        const tok = p.peek();
-        const name_span: ast.Span = switch (tok.kind) {
-            .ident, .kw_self => blk: {
-                p.pos += 1;
-                break :blk .{ .start = tok.start, .end = tok.end };
-            },
-            else => {
-                try p.recordError("expected parameter name", "identifier");
-                return error.ParseFailed;
-            },
-        };
-
-        var type_ann: ?*ast.TypeAnn = null;
-        if (p.accept(.colon)) |_| {
-            type_ann = try parseTypeAnn(p);
-        }
-
-        const param_end: u32 = if (type_ann) |t| t.span().end else name_span.end;
-        try params.append(p.allocator, .{
-            .name = name_span,
-            .type_ann = type_ann,
-            .span = .{ .start = name_span.start, .end = param_end },
-        });
-
-        if (p.accept(.comma) == null) break;
-    }
-
-    _ = try p.expect(.rparen, ")");
-    return try params.toOwnedSlice(p.allocator);
-}
-
-// =====================================================================
-// `class` declaration.
-// =====================================================================
-
-fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
-    const class_tok = p.peek();
-    p.pos += 1;
-    const start = class_tok.start;
-
-    const annotations = try takePendingAnnotations(p);
-    errdefer freeAnnSlice(p.allocator, annotations);
-
-    const name_tok = try p.expect(.ident, "class name");
-    const name_span = ast.Span.fromToken(name_tok);
-
-    var extends: ?ast.Span = null;
-    if (p.accept(.kw_extends)) |_| {
-        const parent_tok = try p.expect(.ident, "parent class name");
-        extends = ast.Span.fromToken(parent_tok);
-    }
-
-    // Body delimiter: spec §6 examples use `{ ... }` for class body.
-    _ = try p.expect(.lbrace, "{");
-    p.skipNewlines();
-
-    var fields: std.ArrayList(ast.ClassField) = .empty;
-    errdefer cleanupClassFields(p.allocator, &fields);
-    var methods: std.ArrayList(ast.DefDecl) = .empty;
-    errdefer cleanupMethods(p.allocator, &methods);
-
-    while (!p.atEnd() and !p.check(.rbrace)) {
-        // Accumulate annotations inside the class body, same as
-        // file-level. They attach to the next field or method.
-        while (p.check(.annotation)) {
-            const ann = try parseAnnotation(p);
-            try p.pending_annotations.append(p.allocator, ann);
-            p.skipNewlines();
-        }
-
-        switch (p.peek().kind) {
-            .kw_let => {
-                const field = try parseClassField(p);
-                try fields.append(p.allocator, field);
-            },
-            .kw_def => {
-                const m = try parseDefDeclInner(p, false);
-                try methods.append(p.allocator, m);
-            },
-            .rbrace => break,
-            else => {
-                try p.recordError(
-                    "expected field (`let`) or method (`def`) in class body",
-                    "let or def",
-                );
-                try p.recoverToNewline();
-            },
-        }
-        p.skipNewlines();
-    }
-
-    const close_tok = try p.expect(.rbrace, "}");
-    try p.requireStatementBoundary();
-
-    return .{ .class_decl = .{
-        .annotations = annotations,
-        .name = name_span,
-        .extends = extends,
-        .fields = try fields.toOwnedSlice(p.allocator),
-        .methods = try methods.toOwnedSlice(p.allocator),
-        .is_local = is_local,
-        .span = .{ .start = start, .end = close_tok.end },
-    } };
-}
-
-fn parseClassField(p: *Parser) ParserError!ast.ClassField {
-    // `let name: T [= init]` — annotations were accumulated before
-    // entering here.
-    const let_tok = p.peek();
-    p.pos += 1;
-
-    const annotations = try takePendingAnnotations(p);
-    errdefer freeAnnSlice(p.allocator, annotations);
-
-    const name_tok = try p.expect(.ident, "field name");
-    const name_span = ast.Span.fromToken(name_tok);
-
-    var type_ann: ?*ast.TypeAnn = null;
-    if (p.accept(.colon)) |_| {
-        type_ann = try parseTypeAnn(p);
-    }
-
-    var init: ?*ast.Expr = null;
-    var end_idx: u32 = if (type_ann) |t| t.span().end else name_span.end;
-    if (p.accept(.equals)) |_| {
-        const e = try parseExpression(p, 0);
-        end_idx = e.span().end;
-        init = e;
-    }
-
-    try p.requireStatementBoundary();
-    return .{
-        .annotations = annotations,
-        .name = name_span,
-        .type_ann = type_ann,
-        .init = init,
-        .span = .{ .start = let_tok.start, .end = end_idx },
-    };
-}
-
-fn cleanupClassFields(
-    allocator: std.mem.Allocator,
-    fields: *std.ArrayList(ast.ClassField),
-) void {
-    for (fields.items) |f| {
-        freeAnnSlice(allocator, f.annotations);
-        if (f.type_ann) |t| ast.freeTypeAnn(allocator, t);
-        if (f.init) |e| ast.freeExpr(allocator, e);
-    }
-    fields.deinit(allocator);
-}
-
-fn cleanupMethods(
-    allocator: std.mem.Allocator,
-    methods: *std.ArrayList(ast.DefDecl),
-) void {
-    for (methods.items) |m| {
-        freeAnnSlice(allocator, m.annotations);
-        freeParams(allocator, m.params);
-        if (m.ret_type) |r| ast.freeTypeAnn(allocator, r);
-        for (m.body) |*s| ast.freeStatement(allocator, s);
-        allocator.free(m.body);
-    }
-    methods.deinit(allocator);
-}
-
-// =====================================================================
-// `struct` declaration.
-// =====================================================================
-
-fn parseStructDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
-    const struct_tok = p.peek();
-    p.pos += 1; // consume `struct` (it's an ident token, not a kw)
-    const start = struct_tok.start;
-
-    const annotations = try takePendingAnnotations(p);
-    errdefer freeAnnSlice(p.allocator, annotations);
-
-    const name_tok = try p.expect(.ident, "struct name");
-    const name_span = ast.Span.fromToken(name_tok);
-
-    p.skipNewlines();
-
-    var fields: std.ArrayList(ast.StructField) = .empty;
-    errdefer {
-        for (fields.items) |f| ast.freeTypeAnn(p.allocator, f.type_ann);
-        fields.deinit(p.allocator);
-    }
-
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        const fname_tok = try p.expect(.ident, "field name");
-        _ = try p.expect(.colon, ":");
-        const ftype = try parseTypeAnn(p);
-        const fend = ftype.span().end;
-        try fields.append(p.allocator, .{
-            .name = ast.Span.fromToken(fname_tok),
-            .type_ann = ftype,
-            .span = .{ .start = fname_tok.start, .end = fend },
-        });
-        // Comma between fields is optional (matches spec examples).
-        _ = p.accept(.comma);
-        p.skipNewlines();
-    }
-
-    const end_tok = try p.expect(.kw_end, "end");
-    try p.requireStatementBoundary();
-
-    return .{ .struct_decl = .{
-        .annotations = annotations,
-        .name = name_span,
-        .fields = try fields.toOwnedSlice(p.allocator),
-        .is_local = is_local,
-        .span = .{ .start = start, .end = end_tok.end },
-    } };
-}
-
-// =====================================================================
-// `enum` declaration.
-// =====================================================================
-
-fn parseEnumDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
-    const enum_tok = p.peek();
-    p.pos += 1;
-    const start = enum_tok.start;
-
-    const annotations = try takePendingAnnotations(p);
-    errdefer freeAnnSlice(p.allocator, annotations);
-
-    const name_tok = try p.expect(.ident, "enum name");
-    const name_span = ast.Span.fromToken(name_tok);
-
-    p.skipNewlines();
-
-    var variants: std.ArrayList(ast.EnumVariant) = .empty;
-    errdefer cleanupEnumVariants(p.allocator, &variants);
-
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        _ = try p.expect(.kw_case, "case");
-        const v_name_tok = try p.expect(.ident, "variant name");
-        const v_name_span = ast.Span.fromToken(v_name_tok);
-
-        var payload: std.ArrayList(ast.EnumPayloadField) = .empty;
-        errdefer {
-            for (payload.items) |pf| ast.freeTypeAnn(p.allocator, pf.type_ann);
-            payload.deinit(p.allocator);
-        }
-
-        var v_end: u32 = v_name_tok.end;
-        if (p.accept(.lparen)) |_| {
-            if (!p.check(.rparen)) {
-                while (true) {
-                    // Two shapes:
-                    //   - `name: type` — named payload field
-                    //   - `type`       — anonymous (zero-width name span)
-                    const tok0 = p.peek();
-                    const tok1 = p.peekAt(1);
-                    if (tok0.kind == .ident and tok1.kind == .colon) {
-                        const fname_tok = p.peek();
-                        p.pos += 2; // consume name + colon
-                        const ftype = try parseTypeAnn(p);
-                        try payload.append(p.allocator, .{
-                            .name = ast.Span.fromToken(fname_tok),
-                            .type_ann = ftype,
-                            .span = .{ .start = fname_tok.start, .end = ftype.span().end },
-                        });
-                    } else {
-                        const ftype = try parseTypeAnn(p);
-                        const ts = ftype.span();
-                        try payload.append(p.allocator, .{
-                            .name = .{ .start = ts.start, .end = ts.start },
-                            .type_ann = ftype,
-                            .span = ts,
-                        });
-                    }
-                    if (p.accept(.comma) == null) break;
-                }
-            }
-            const close = try p.expect(.rparen, ")");
-            v_end = close.end;
-        }
-
-        try variants.append(p.allocator, .{
-            .name = v_name_span,
-            .payload = try payload.toOwnedSlice(p.allocator),
-            .span = .{ .start = v_name_span.start, .end = v_end },
-        });
-
-        p.skipNewlines();
-    }
-
-    const end_tok = try p.expect(.kw_end, "end");
-    try p.requireStatementBoundary();
-
-    return .{ .enum_decl = .{
-        .annotations = annotations,
-        .name = name_span,
-        .variants = try variants.toOwnedSlice(p.allocator),
-        .is_local = is_local,
-        .span = .{ .start = start, .end = end_tok.end },
-    } };
-}
-
-fn cleanupEnumVariants(
-    allocator: std.mem.Allocator,
-    variants: *std.ArrayList(ast.EnumVariant),
-) void {
-    for (variants.items) |v| {
-        for (v.payload) |pf| ast.freeTypeAnn(allocator, pf.type_ann);
-        allocator.free(v.payload);
-    }
-    variants.deinit(allocator);
-}
-
-// =====================================================================
-// `use` declaration.
-// =====================================================================
-
-fn parseUseDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
-    const use_tok = p.peek();
-    p.pos += 1;
-    const start = use_tok.start;
-
-    // Forms (spec §5.2):
-    //   use math
-    //   use "./physics"
-    //   use abs from math
-    //   use abs as absolute from math
-    //   use abs, sqrt from math
-    //   use math as m
-    var items: std.ArrayList(ast.UseItem) = .empty;
-    errdefer items.deinit(p.allocator);
-
-    var module_span: ast.Span = undefined;
-    var quoted_path = false;
-    var alias: ?ast.Span = null;
-
-    // Snapshot for restart: distinguish `use math` from `use abs from math`.
-    // We peek the first identifier; if `from` follows (after possibly more
-    // identifiers), parse the selective shape; else parse the whole-module
-    // form.
-    const start_pos = p.pos;
-    if (try lookaheadHasFromClause(p)) {
-        // Selective: `use name [as alias] (, name [as alias])* from module`
-        while (true) {
-            const n_tok = try p.expect(.ident, "import name");
-            var item_alias: ?ast.Span = null;
-            var item_end = n_tok.end;
-            if (p.accept(.kw_as)) |_| {
-                const a_tok = try p.expect(.ident, "alias");
-                item_alias = ast.Span.fromToken(a_tok);
-                item_end = a_tok.end;
-            }
-            try items.append(p.allocator, .{
-                .name = ast.Span.fromToken(n_tok),
-                .alias = item_alias,
-                .span = .{ .start = n_tok.start, .end = item_end },
-            });
-            if (p.accept(.comma) == null) break;
-        }
-        _ = try p.expect(.kw_from, "from");
-        module_span = try parseUseModuleSpec(p, &quoted_path);
-    } else {
-        // Whole-module: `use module [as alias]`.
-        p.pos = start_pos;
-        module_span = try parseUseModuleSpec(p, &quoted_path);
-        if (p.accept(.kw_as)) |_| {
-            const a_tok = try p.expect(.ident, "alias");
-            alias = ast.Span.fromToken(a_tok);
-        }
-    }
-
-    const end: u32 = if (alias) |a| a.end else module_span.end;
-    try p.requireStatementBoundary();
-
-    return .{ .use_decl = .{
-        .module = module_span,
-        .quoted_path = quoted_path,
-        .items = try items.toOwnedSlice(p.allocator),
-        .alias = alias,
-        .is_local = is_local,
-        .span = .{ .start = start, .end = end },
-    } };
-}
-
-/// Module spec is either a bare ident or a quoted-path string literal.
-fn parseUseModuleSpec(p: *Parser, quoted: *bool) ParserError!ast.Span {
-    if (p.check(.str_start)) {
-        return try parseQuotedPath(p, quoted);
-    }
-    quoted.* = false;
-    const tok = try p.expect(.ident, "module name");
-    return ast.Span.fromToken(tok);
-}
-
-fn parseQuotedPath(p: *Parser, quoted: *bool) ParserError!ast.Span {
-    quoted.* = true;
-    const start_tok = try p.expect(.str_start, "\"");
-    // Eat the body parts until str_end.
-    var end_idx: u32 = start_tok.end;
-    while (true) {
-        const t = p.peek();
-        switch (t.kind) {
-            .str_part => {
-                p.pos += 1;
-                end_idx = t.end;
-            },
-            .str_end => {
-                p.pos += 1;
-                end_idx = t.end;
-                break;
-            },
-            .str_expr_start => {
-                // Interpolation inside an import path isn't useful;
-                // record + recover.
-                try p.recordError(
-                    "string interpolation not allowed in `use` path",
-                    "literal path",
-                );
-                return error.ParseFailed;
-            },
-            else => return error.ParseFailed,
-        }
-    }
-    return .{ .start = start_tok.start, .end = end_idx };
-}
-
-fn lookaheadHasFromClause(p: *Parser) ParserError!bool {
-    // Save position; walk through `ident [as ident] (, ident [as ident])*`
-    // and check whether the next token after that prefix is `kw_from`.
-    var i = p.pos;
-    if (i >= p.tokens.len) return false;
-    if (p.tokens[i].kind != .ident) return false;
-    while (true) {
-        if (i >= p.tokens.len or p.tokens[i].kind != .ident) return false;
-        i += 1;
-        if (i < p.tokens.len and p.tokens[i].kind == .kw_as) {
-            i += 1;
-            if (i >= p.tokens.len or p.tokens[i].kind != .ident) return false;
-            i += 1;
-        }
-        if (i < p.tokens.len and p.tokens[i].kind == .comma) {
-            i += 1;
-            continue;
-        }
-        break;
-    }
-    return i < p.tokens.len and p.tokens[i].kind == .kw_from;
-}
-
-// =====================================================================
-// Control flow.
-// =====================================================================
-
-fn parseIfStatement(p: *Parser) ParserError!ast.Statement {
-    const start_tok = p.peek();
-    const result = try parseIfChain(p);
-    try p.requireStatementBoundary();
-    return .{ .if_stmt = .{
-        .arms = result.arms,
-        .else_body = result.else_body,
-        .span = .{ .start = start_tok.start, .end = result.end },
-    } };
-}
-
-const IfChain = struct {
-    arms: []ast.IfArm,
-    else_body: ?[]ast.Statement,
-    end: u32,
-};
-
-fn parseIfChain(p: *Parser) ParserError!IfChain {
-    _ = try p.expect(.kw_if, "if");
-
-    var arms: std.ArrayList(ast.IfArm) = .empty;
-    errdefer cleanupIfArms(p.allocator, &arms);
-    var else_body: ?[]ast.Statement = null;
-    errdefer if (else_body) |b| {
-        for (b) |*s| ast.freeStatement(p.allocator, s);
-        p.allocator.free(b);
-    };
-
-    try parseIfArm(p, &arms);
-    var end: u32 = 0;
-
-    while (true) {
-        if (p.accept(.kw_elif)) |_| {
-            try parseIfArm(p, &arms);
-            continue;
-        }
-        if (p.accept(.kw_else)) |else_tok| {
-            // `else if cond then ...` flattens into another arm; the
-            // spec lists both `elif` and `else if` (§4.4).
-            if (p.check(.kw_if)) {
-                p.pos += 1;
-                try parseIfArm(p, &arms);
-                continue;
-            }
-            // Plain `else` body.
-            p.skipNewlines();
-            var body: std.ArrayList(ast.Statement) = .empty;
-            errdefer cleanupStatements(p.allocator, &body);
-            while (!p.atEnd() and !p.check(.kw_end)) {
-                try parseStatement(p, &body);
-                p.skipNewlines();
-            }
-            else_body = try body.toOwnedSlice(p.allocator);
-            _ = else_tok;
-            break;
-        }
-        break;
-    }
-
-    const end_tok = try p.expect(.kw_end, "end");
-    end = end_tok.end;
-    return .{
-        .arms = try arms.toOwnedSlice(p.allocator),
-        .else_body = else_body,
-        .end = end,
-    };
-}
-
-fn parseIfArm(
-    p: *Parser,
-    arms: *std.ArrayList(ast.IfArm),
-) ParserError!void {
-    const arm_start = p.peek().start;
-
-    var cond: ?*ast.Expr = null;
-    var let_pattern: ?*ast.Pattern = null;
-    var let_expr: ?*ast.Expr = null;
-    var let_guard: ?*ast.Expr = null;
-    errdefer if (cond) |c| ast.freeExpr(p.allocator, c);
-    errdefer if (let_pattern) |pp| ast.freePattern(p.allocator, pp);
-    errdefer if (let_expr) |e| ast.freeExpr(p.allocator, e);
-    errdefer if (let_guard) |g| ast.freeExpr(p.allocator, g);
-
-    // `if let pat = expr [when guard] then ...` — §4.4.1.
-    if (p.accept(.kw_let)) |_| {
-        let_pattern = try parsePattern(p);
-        _ = try p.expect(.equals, "=");
-        let_expr = try parseExpression(p, 0);
-        if (p.accept(.kw_when)) |_| {
-            let_guard = try parseExpression(p, 0);
-        }
-    } else {
-        cond = try parseExpression(p, 0);
-    }
-    _ = try p.expect(.kw_then, "then");
-    p.skipNewlines();
-
-    var body: std.ArrayList(ast.Statement) = .empty;
-    errdefer cleanupStatements(p.allocator, &body);
-
-    while (!p.atEnd() and !p.check(.kw_end) and !p.check(.kw_else) and !p.check(.kw_elif)) {
-        try parseStatement(p, &body);
-        p.skipNewlines();
-    }
-    const arm_end = p.peek().start;
-    try arms.append(p.allocator, .{
-        .cond = cond,
-        .let_pattern = let_pattern,
-        .let_expr = let_expr,
-        .let_guard = let_guard,
-        .body = try body.toOwnedSlice(p.allocator),
-        .span = .{ .start = arm_start, .end = arm_end },
-    });
-}
-
-fn cleanupIfArms(
-    allocator: std.mem.Allocator,
-    arms: *std.ArrayList(ast.IfArm),
-) void {
-    for (arms.items) |arm| {
-        if (arm.cond) |c| ast.freeExpr(allocator, c);
-        if (arm.let_pattern) |pp| ast.freePattern(allocator, pp);
-        if (arm.let_expr) |e| ast.freeExpr(allocator, e);
-        if (arm.let_guard) |g| ast.freeExpr(allocator, g);
-        for (arm.body) |*s| ast.freeStatement(allocator, s);
-        allocator.free(arm.body);
-    }
-    arms.deinit(allocator);
-}
-
-fn parseWhileStatement(p: *Parser) ParserError!ast.Statement {
-    const while_tok = p.peek();
-    p.pos += 1;
-    const start = while_tok.start;
-
-    var cond: ?*ast.Expr = null;
-    var let_pattern: ?*ast.Pattern = null;
-    var let_expr: ?*ast.Expr = null;
-    var let_guard: ?*ast.Expr = null;
-
-    // `while let pat = expr [when guard] do ... end`
-    if (p.accept(.kw_let)) |_| {
-        let_pattern = try parsePattern(p);
-        _ = try p.expect(.equals, "=");
-        let_expr = try parseExpression(p, 0);
-        if (p.accept(.kw_when)) |_| {
-            let_guard = try parseExpression(p, 0);
-        }
-    } else {
-        cond = try parseExpression(p, 0);
-    }
-
-    _ = try p.expect(.kw_do, "do");
-    p.skipNewlines();
-
-    var body: std.ArrayList(ast.Statement) = .empty;
-    errdefer cleanupStatements(p.allocator, &body);
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        try parseStatement(p, &body);
-        p.skipNewlines();
-    }
-    const end_tok = try p.expect(.kw_end, "end");
-    try p.requireStatementBoundary();
-
-    return .{ .while_stmt = .{
-        .cond = cond,
-        .let_pattern = let_pattern,
-        .let_expr = let_expr,
-        .let_guard = let_guard,
-        .body = try body.toOwnedSlice(p.allocator),
-        .span = .{ .start = start, .end = end_tok.end },
-    } };
-}
-
-fn parseForStatement(p: *Parser) ParserError!ast.Statement {
-    const for_tok = p.peek();
-    p.pos += 1;
-    const start = for_tok.start;
-
-    const binding_tok = try p.expect(.ident, "loop variable name");
-    _ = try p.expect(.kw_in, "in");
-
-    const iter = try parseExpression(p, 0);
-    errdefer ast.freeExpr(p.allocator, iter);
-
-    var step: ?*ast.Expr = null;
-    if (p.accept(.kw_step)) |_| {
-        step = try parseExpression(p, 0);
-    }
-    errdefer if (step) |s| ast.freeExpr(p.allocator, s);
-
-    _ = try p.expect(.kw_do, "do");
-    p.skipNewlines();
-
-    var body: std.ArrayList(ast.Statement) = .empty;
-    errdefer cleanupStatements(p.allocator, &body);
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        try parseStatement(p, &body);
-        p.skipNewlines();
-    }
-    const end_tok = try p.expect(.kw_end, "end");
-    try p.requireStatementBoundary();
-
-    return .{ .for_stmt = .{
-        .binding = ast.Span.fromToken(binding_tok),
-        .iter = iter,
-        .step = step,
-        .body = try body.toOwnedSlice(p.allocator),
-        .span = .{ .start = start, .end = end_tok.end },
-    } };
-}
-
-fn parseMatchStatement(p: *Parser) ParserError!ast.Statement {
-    const match_tok = p.peek();
-    p.pos += 1;
-    const start = match_tok.start;
-
-    const scrutinee = try parseExpression(p, 0);
-    errdefer ast.freeExpr(p.allocator, scrutinee);
-    p.skipNewlines();
-
-    var arms: std.ArrayList(ast.MatchArm) = .empty;
-    errdefer cleanupMatchArms(p.allocator, &arms);
-
-    while (p.accept(.kw_case)) |case_tok| {
-        const arm_start = case_tok.start;
-        const pattern = try parsePattern(p);
-        errdefer ast.freePattern(p.allocator, pattern);
-
-        var guard: ?*ast.Expr = null;
-        if (p.accept(.kw_when)) |_| {
-            guard = try parseExpression(p, 0);
-        }
-        errdefer if (guard) |g| ast.freeExpr(p.allocator, g);
-
-        _ = try p.expect(.kw_then, "then");
-        p.skipNewlines();
-
-        var body: std.ArrayList(ast.Statement) = .empty;
-        errdefer cleanupStatements(p.allocator, &body);
-        while (!p.atEnd() and !p.check(.kw_case) and !p.check(.kw_end)) {
-            try parseStatement(p, &body);
-            p.skipNewlines();
-        }
-        const arm_end = p.peek().start;
-        try arms.append(p.allocator, .{
-            .pattern = pattern,
-            .guard = guard,
-            .body = try body.toOwnedSlice(p.allocator),
-            .span = .{ .start = arm_start, .end = arm_end },
-        });
-    }
-    const end_tok = try p.expect(.kw_end, "end");
-    try p.requireStatementBoundary();
-
-    return .{ .match_stmt = .{
-        .scrutinee = scrutinee,
-        .arms = try arms.toOwnedSlice(p.allocator),
-        .span = .{ .start = start, .end = end_tok.end },
-    } };
-}
-
-fn cleanupMatchArms(
-    allocator: std.mem.Allocator,
-    arms: *std.ArrayList(ast.MatchArm),
-) void {
-    for (arms.items) |arm| {
-        ast.freePattern(allocator, arm.pattern);
-        if (arm.guard) |g| ast.freeExpr(allocator, g);
-        for (arm.body) |*s| ast.freeStatement(allocator, s);
-        allocator.free(arm.body);
-    }
-    arms.deinit(allocator);
-}
-
-fn parseBlockStatement(p: *Parser) ParserError!ast.Statement {
-    const do_tok = p.peek();
-    p.pos += 1;
-    const start = do_tok.start;
-    p.skipNewlines();
-
-    var body: std.ArrayList(ast.Statement) = .empty;
-    errdefer cleanupStatements(p.allocator, &body);
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        try parseStatement(p, &body);
-        p.skipNewlines();
-    }
-    const end_tok = try p.expect(.kw_end, "end");
-    try p.requireStatementBoundary();
-
-    return .{ .block = .{
-        .body = try body.toOwnedSlice(p.allocator),
-        .span = .{ .start = start, .end = end_tok.end },
-    } };
-}
-
-fn parseReturnStatement(p: *Parser) ParserError!ast.Statement {
-    const ret_tok = p.peek();
-    p.pos += 1;
-    const start = ret_tok.start;
-
-    var value: ?*ast.Expr = null;
-    var end: u32 = ret_tok.end;
-    if (!p.check(.newline) and !p.atEnd() and !p.check(.kw_end)) {
-        const v = try parseExpression(p, 0);
-        end = v.span().end;
-        value = v;
-    }
-    try p.requireStatementBoundary();
-
-    return .{ .return_stmt = .{
-        .value = value,
-        .span = .{ .start = start, .end = end },
-    } };
-}
-
-fn parsePrintStatement(p: *Parser) ParserError!ast.Statement {
-    const print_tok = p.peek();
-    p.pos += 1;
-    const start = print_tok.start;
-
-    var args: std.ArrayList(*ast.Expr) = .empty;
-    errdefer {
-        for (args.items) |a| ast.freeExpr(p.allocator, a);
-        args.deinit(p.allocator);
-    }
-
-    // `print` with no following expression on the same line is
-    // valid (prints just the newline). The lexer significant
-    // newlines make this unambiguous.
-    if (!p.check(.newline) and !p.atEnd()) {
-        while (true) {
-            const a = try parseExpression(p, 0);
-            try args.append(p.allocator, a);
-            if (p.accept(.comma) == null) break;
-        }
-    }
-    const end: u32 = if (args.items.len > 0) args.items[args.items.len - 1].span().end else print_tok.end;
-    try p.requireStatementBoundary();
-
-    return .{ .print_stmt = .{
-        .args = try args.toOwnedSlice(p.allocator),
-        .span = .{ .start = start, .end = end },
-    } };
-}
-
-// =====================================================================
-// Expression-or-assignment statement.
-//
-// In statement position, an expression can be:
-//   - bare expression (function call, etc.)
-//   - assignment: `target = expr` / `target += expr` / ...
-//   - increment / decrement: `target++` / `target--`
-//   - discard: `_ = expr`
-// =====================================================================
-
-fn parseExprOrAssignStatement(
-    p: *Parser,
-    statements: *std.ArrayList(ast.Statement),
-) ParserError!void {
-    const start = p.peek().start;
-    const first = try parseExpression(p, 0);
-    errdefer ast.freeExpr(p.allocator, first);
-
-    // Compound-assign / plain-assign / inc-dec / discard / bare expr
-    // are all distinguished by the next token.
-    if (matchAssignOp(p.peek().kind)) |op| {
-        p.pos += 1;
-        // Discard form: `_ = expr` — desugars to `.discard`.
-        if (op == .set and isUnderscore(p, first)) {
-            const value = try parseExpression(p, 0);
-            ast.freeExpr(p.allocator, first);
-            try p.requireStatementBoundary();
-            try statements.append(p.allocator, .{ .discard = .{
-                .expr = value,
-                .span = .{ .start = start, .end = value.span().end },
-            } });
-            return;
-        }
-        const value = try parseExpression(p, 0);
-        try p.requireStatementBoundary();
-        try statements.append(p.allocator, .{ .assign = .{
-            .target = first,
-            .op = op,
-            .value = value,
-            .span = .{ .start = start, .end = value.span().end },
-        } });
-        return;
-    }
-
-    if (p.accept(.plus_plus)) |t| {
-        try p.requireStatementBoundary();
-        try statements.append(p.allocator, .{ .inc_dec = .{
-            .target = first,
-            .inc = true,
-            .span = .{ .start = start, .end = t.end },
-        } });
-        return;
-    }
-    if (p.accept(.minus_minus)) |t| {
-        try p.requireStatementBoundary();
-        try statements.append(p.allocator, .{ .inc_dec = .{
-            .target = first,
-            .inc = false,
-            .span = .{ .start = start, .end = t.end },
-        } });
-        return;
-    }
-
-    try p.requireStatementBoundary();
-    try statements.append(p.allocator, .{ .expr_stmt = .{
-        .expr = first,
-        .span = .{ .start = start, .end = first.span().end },
-    } });
-}
-
-fn isUnderscore(p: *const Parser, e: *const ast.Expr) bool {
-    return switch (e.*) {
-        .ident => |i| std.mem.eql(u8, p.source[i.span.start..i.span.end], "_"),
-        else => false,
-    };
-}
-
-fn matchAssignOp(k: Kind) ?ast.AssignOp {
-    return switch (k) {
-        .equals => .set,
-        .plus_eq => .add_set,
-        .minus_eq => .sub_set,
-        .star_eq => .mul_set,
-        .slash_eq => .div_set,
-        .percent_eq => .mod_set,
-        .amp_eq => .bit_and_set,
-        .pipe_eq => .bit_or_set,
-        .caret_eq => .bit_xor_set,
-        .shl_eq => .shl_set,
-        .shr_eq => .shr_set,
-        else => null,
-    };
-}
-
-// =====================================================================
-// Type-annotation parser.
-// =====================================================================
-
-fn parseTypeAnn(p: *Parser) ParserError!*ast.TypeAnn {
-    var base = try parseTypeBase(p);
-    errdefer ast.freeTypeAnn(p.allocator, base);
-
-    // Postfix `?` — nullable suffix. Loops so `T??` would parse,
-    // though that's unusual; typechecker can flag.
-    while (p.accept(.question)) |q| {
-        const wrapped = try p.allocTypeAnn(.{ .nullable = .{
-            .inner = base,
-            .span = .{ .start = base.span().start, .end = q.end },
-        } });
-        base = wrapped;
-    }
-    return base;
-}
-
-fn parseTypeBase(p: *Parser) ParserError!*ast.TypeAnn {
-    const tok = p.peek();
-    switch (tok.kind) {
-        .lbracket => return try parseArrayType(p),
-        .lparen => return try parseTupleOrParenType(p),
-        .ident => return try parseNamedOrVecType(p),
-        else => {
-            // `fn` type — the spec spells `fn(args) -> ret`. `fn` is
-            // not a keyword in the lexer; it arrives as a bare
-            // ident. The `.ident` branch above handles it through
-            // the regular path (since it has a `(` after `fn`, that
-            // looks like a generic application — handle here).
-            try p.recordError("expected type annotation", "type");
-            return error.ParseFailed;
-        },
-    }
-}
-
-/// `[T; N]`.
-fn parseArrayType(p: *Parser) ParserError!*ast.TypeAnn {
-    const lb_tok = p.peek();
-    p.pos += 1;
-
-    const elem = try parseTypeAnn(p);
-    errdefer ast.freeTypeAnn(p.allocator, elem);
-
-    _ = try p.expect(.semicolon, ";");
-    const len_expr = try parseExpression(p, 0);
-    errdefer ast.freeExpr(p.allocator, len_expr);
-
-    const rb_tok = try p.expect(.rbracket, "]");
-    return try p.allocTypeAnn(.{ .array = .{
-        .elem = elem,
-        .len_expr = len_expr,
-        .span = .{ .start = lb_tok.start, .end = rb_tok.end },
-    } });
-}
-
-/// `(T)` → just T; `(T1, T2, ...)` → tuple.
-fn parseTupleOrParenType(p: *Parser) ParserError!*ast.TypeAnn {
-    const lp_tok = p.peek();
-    p.pos += 1;
-    const first = try parseTypeAnn(p);
-    errdefer ast.freeTypeAnn(p.allocator, first);
-
-    if (p.accept(.rparen)) |rp| {
-        // Single-element grouping isn't reflected in the AST (no
-        // `paren` wrapper for types) — return the inner directly,
-        // span-extended to cover the parens.
-        first.* = switch (first.*) {
-            .named => |n| .{ .named = .{ .name = n.name, .span = .{ .start = lp_tok.start, .end = rp.end } } },
-            .nullable => |n| .{ .nullable = .{ .inner = n.inner, .span = .{ .start = lp_tok.start, .end = rp.end } } },
-            .array => |a| .{ .array = .{ .elem = a.elem, .len_expr = a.len_expr, .span = .{ .start = lp_tok.start, .end = rp.end } } },
-            .vec => |v| .{ .vec = .{ .elem = v.elem, .span = .{ .start = lp_tok.start, .end = rp.end } } },
-            .tuple => |t| .{ .tuple = .{ .elems = t.elems, .span = .{ .start = lp_tok.start, .end = rp.end } } },
-            .fn_type => |f| .{ .fn_type = .{ .params = f.params, .ret = f.ret, .span = .{ .start = lp_tok.start, .end = rp.end } } },
-        };
-        return first;
-    }
-
-    // Tuple shape.
-    var elems: std.ArrayList(*ast.TypeAnn) = .empty;
-    errdefer {
-        for (elems.items) |t| ast.freeTypeAnn(p.allocator, t);
-        elems.deinit(p.allocator);
-    }
-    try elems.append(p.allocator, first);
-
-    _ = try p.expect(.comma, ",");
-    while (true) {
-        const t = try parseTypeAnn(p);
-        try elems.append(p.allocator, t);
-        if (p.accept(.comma) == null) break;
-    }
-    const rp = try p.expect(.rparen, ")");
-    return try p.allocTypeAnn(.{ .tuple = .{
-        .elems = try elems.toOwnedSlice(p.allocator),
-        .span = .{ .start = lp_tok.start, .end = rp.end },
-    } });
-}
-
-/// Named type, `Vec(T)`, or `fn(args) -> ret`.
-fn parseNamedOrVecType(p: *Parser) ParserError!*ast.TypeAnn {
-    const name_tok = p.peek();
-    p.pos += 1;
-    const name_lex = p.source[name_tok.start..name_tok.end];
-
-    if (std.mem.eql(u8, name_lex, "Vec") and p.check(.lparen)) {
-        p.pos += 1;
-        const elem = try parseTypeAnn(p);
-        errdefer ast.freeTypeAnn(p.allocator, elem);
-        const rp = try p.expect(.rparen, ")");
-        return try p.allocTypeAnn(.{ .vec = .{
-            .elem = elem,
-            .span = .{ .start = name_tok.start, .end = rp.end },
-        } });
-    }
-
-    if (std.mem.eql(u8, name_lex, "fn") and p.check(.lparen)) {
-        p.pos += 1;
-        var params: std.ArrayList(*ast.TypeAnn) = .empty;
-        errdefer {
-            for (params.items) |t| ast.freeTypeAnn(p.allocator, t);
-            params.deinit(p.allocator);
-        }
-        if (!p.check(.rparen)) {
-            while (true) {
-                const t = try parseTypeAnn(p);
-                try params.append(p.allocator, t);
-                if (p.accept(.comma) == null) break;
-            }
-        }
-        const rp_tok = try p.expect(.rparen, ")");
-        var ret: ?*ast.TypeAnn = null;
-        var end: u32 = rp_tok.end;
-        if (p.accept(.arrow)) |_| {
-            const r = try parseTypeAnn(p);
-            end = r.span().end;
-            ret = r;
-        }
-        return try p.allocTypeAnn(.{ .fn_type = .{
-            .params = try params.toOwnedSlice(p.allocator),
-            .ret = ret,
-            .span = .{ .start = name_tok.start, .end = end },
-        } });
-    }
-
-    // Plain named type — accumulate `.qualified.path` segments via
-    // dot tokens. The AST captures the joined source span; the
-    // typechecker re-tokenizes against the lexeme.
-    var end_idx: u32 = name_tok.end;
-    while (p.check(.dot) and p.peekAt(1).kind == .ident) {
-        p.pos += 1; // dot
-        const seg = p.peek();
-        p.pos += 1;
-        end_idx = seg.end;
-    }
-
-    return try p.allocTypeAnn(.{ .named = .{
-        .name = .{ .start = name_tok.start, .end = end_idx },
-        .span = .{ .start = name_tok.start, .end = end_idx },
-    } });
-}
-
-// =====================================================================
-// Pattern parser.
-// =====================================================================
-
-fn parsePattern(p: *Parser) ParserError!*ast.Pattern {
-    var first = try parseAtomicPattern(p);
-    errdefer ast.freePattern(p.allocator, first);
-
-    // Or-pattern: `A | B | C`.
-    if (!p.check(.pipe)) return first;
-
-    var alts: std.ArrayList(*ast.Pattern) = .empty;
-    errdefer {
-        for (alts.items) |a| ast.freePattern(p.allocator, a);
-        alts.deinit(p.allocator);
-    }
-    try alts.append(p.allocator, first);
-    var end_span = first.span();
-
-    while (p.accept(.pipe)) |_| {
-        const next = try parseAtomicPattern(p);
-        end_span = next.span();
-        try alts.append(p.allocator, next);
-    }
-    const start = alts.items[0].span().start;
-    return try p.allocPattern(.{ .or_pattern = .{
-        .alts = try alts.toOwnedSlice(p.allocator),
-        .span = .{ .start = start, .end = end_span.end },
-    } });
-}
-
-fn parseAtomicPattern(p: *Parser) ParserError!*ast.Pattern {
-    const tok = p.peek();
-    switch (tok.kind) {
-        .int_lit => {
-            p.pos += 1;
-            // Range pattern: `lo .. hi` or `lo ..= hi`.
-            if (p.check(.dot_dot) or p.check(.dot_dot_eq)) {
-                return try parseRangePatternFrom(p, intLitExpr(tok), tok.start);
-            }
-            return try p.allocPattern(.{ .int_lit = .{
-                .value = tok.value,
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .kw_true => {
-            p.pos += 1;
-            return try p.allocPattern(.{ .bool_lit = .{
-                .value = true,
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .kw_false => {
-            p.pos += 1;
-            return try p.allocPattern(.{ .bool_lit = .{
-                .value = false,
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .kw_nil => {
-            p.pos += 1;
-            return try p.allocPattern(.{ .nil_lit = .{
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .str_start => {
-            return try parseStringLitPattern(p);
-        },
-        .ident => {
-            // Wildcard `_`, plain binding, struct pattern, or enum-variant pattern.
-            const lex = p.source[tok.start..tok.end];
-            if (std.mem.eql(u8, lex, "_")) {
-                p.pos += 1;
-                return try p.allocPattern(.{ .wildcard = .{
-                    .span = .{ .start = tok.start, .end = tok.end },
-                } });
-            }
-
-            // Lookahead: `Ident { ... }` → struct pattern.
-            //            `Ident.Ident(...)` / `Ident.Ident` → variant pattern.
-            //            else → plain identifier binding.
-            const next = p.peekAt(1).kind;
-            if (next == .lbrace) {
-                return try parseStructPattern(p);
-            }
-            if (next == .dot) {
-                return try parseVariantPattern(p);
-            }
-            p.pos += 1;
-            return try p.allocPattern(.{ .ident = .{
-                .name = .{ .start = tok.start, .end = tok.end },
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .lparen => {
-            return try parseTuplePattern(p);
-        },
-        else => {
-            try p.recordError("expected pattern", "pattern");
-            return error.ParseFailed;
-        },
-    }
-}
-
-fn intLitExpr(t: lexer.Token) ast.Expr {
-    return .{ .int_lit = .{
-        .value = t.value,
-        .span = .{ .start = t.start, .end = t.end },
-    } };
-}
-
-fn parseRangePatternFrom(
-    p: *Parser,
-    lo_expr_val: ast.Expr,
-    start: u32,
-) ParserError!*ast.Pattern {
-    const inclusive = p.check(.dot_dot_eq);
-    p.pos += 1; // consume `..` or `..=`
-
-    const lo = try p.allocExpr(lo_expr_val);
-    errdefer ast.freeExpr(p.allocator, lo);
-
-    const hi = try parseExpression(p, 0);
-
-    return try p.allocPattern(.{ .range_pattern = .{
-        .start = lo,
-        .end = hi,
-        .inclusive = inclusive,
-        .span = .{ .start = start, .end = hi.span().end },
-    } });
-}
-
-fn parseStringLitPattern(p: *Parser) ParserError!*ast.Pattern {
-    // The lexer emits str_start | str_part | str_end for an
-    // un-interpolated literal. Patterns reject interpolation —
-    // they're literals only.
-    const start_tok = try p.expect(.str_start, "\"");
-    var end_idx: u32 = start_tok.end;
-    while (true) {
-        const t = p.peek();
-        switch (t.kind) {
-            .str_part => {
-                p.pos += 1;
-                end_idx = t.end;
-            },
-            .str_end => {
-                p.pos += 1;
-                end_idx = t.end;
-                break;
-            },
-            .str_expr_start => {
-                try p.recordError(
-                    "interpolation not allowed in pattern position",
-                    "literal string",
-                );
-                return error.ParseFailed;
-            },
-            else => return error.ParseFailed,
-        }
-    }
-    return try p.allocPattern(.{ .str_lit = .{
-        .span = .{ .start = start_tok.start, .end = end_idx },
-    } });
-}
-
-fn parseStructPattern(p: *Parser) ParserError!*ast.Pattern {
-    const name_tok = p.peek();
-    p.pos += 1;
-    _ = try p.expect(.lbrace, "{");
-
-    var fields: std.ArrayList(ast.StructPatternField) = .empty;
-    errdefer {
-        for (fields.items) |f| ast.freePattern(p.allocator, f.sub);
-        fields.deinit(p.allocator);
-    }
-
-    if (!p.check(.rbrace)) {
-        while (true) {
-            const fname_tok = try p.expect(.ident, "field name");
-            const fname_span = ast.Span.fromToken(fname_tok);
-            var sub: *ast.Pattern = undefined;
-            if (p.accept(.colon)) |_| {
-                sub = try parsePattern(p);
-            } else {
-                // Shorthand: `Foo { hp, mp }` → `hp: hp, mp: mp`.
-                sub = try p.allocPattern(.{ .ident = .{
-                    .name = fname_span,
-                    .span = fname_span,
-                } });
-            }
-            try fields.append(p.allocator, .{
-                .name = fname_span,
-                .sub = sub,
-                .span = .{ .start = fname_span.start, .end = sub.span().end },
-            });
-            if (p.accept(.comma) == null) break;
-        }
-    }
-    const rb = try p.expect(.rbrace, "}");
-    return try p.allocPattern(.{ .struct_pattern = .{
-        .type_name = ast.Span.fromToken(name_tok),
-        .fields = try fields.toOwnedSlice(p.allocator),
-        .span = .{ .start = name_tok.start, .end = rb.end },
-    } });
-}
-
-fn parseVariantPattern(p: *Parser) ParserError!*ast.Pattern {
-    const head_tok = p.peek();
-    p.pos += 1;
-    _ = try p.expect(.dot, ".");
-    const variant_tok = try p.expect(.ident, "variant name");
-    var end_idx: u32 = variant_tok.end;
-
-    var args: std.ArrayList(*ast.Pattern) = .empty;
-    errdefer {
-        for (args.items) |a| ast.freePattern(p.allocator, a);
-        args.deinit(p.allocator);
-    }
-
-    if (p.accept(.lparen)) |_| {
-        if (!p.check(.rparen)) {
-            while (true) {
-                const a = try parsePattern(p);
-                try args.append(p.allocator, a);
-                if (p.accept(.comma) == null) break;
-            }
-        }
-        const rp = try p.expect(.rparen, ")");
-        end_idx = rp.end;
-    }
-    return try p.allocPattern(.{ .variant_pattern = .{
-        .path = .{ .start = head_tok.start, .end = variant_tok.end },
-        .args = try args.toOwnedSlice(p.allocator),
-        .span = .{ .start = head_tok.start, .end = end_idx },
-    } });
-}
-
-fn parseTuplePattern(p: *Parser) ParserError!*ast.Pattern {
-    const lp = p.peek();
-    p.pos += 1;
-    var elems: std.ArrayList(*ast.Pattern) = .empty;
-    errdefer {
-        for (elems.items) |e| ast.freePattern(p.allocator, e);
-        elems.deinit(p.allocator);
-    }
-
-    if (!p.check(.rparen)) {
-        while (true) {
-            const e = try parsePattern(p);
-            try elems.append(p.allocator, e);
-            if (p.accept(.comma) == null) break;
-        }
-    }
-    const rp = try p.expect(.rparen, ")");
-    return try p.allocPattern(.{ .tuple_pattern = .{
-        .elems = try elems.toOwnedSlice(p.allocator),
-        .span = .{ .start = lp.start, .end = rp.end },
-    } });
-}
-
-// =====================================================================
-// Expression parser — Pratt precedence per §3.3.
-// =====================================================================
-
-/// Precedence levels — higher binds tighter. Used by the Pratt loop
-/// to encode the `docs/gero-lang.md` §3.3 hierarchy. Values are
-/// reserved to allow inserting new levels between existing ones
-/// without renumbering call sites.
-const Prec = struct {
-    /// Initial level passed by callers that want the full expression.
-    pub const lowest: u8 = 0;
-    /// `..` / `..=` — produce range values; bind loosest.
-    pub const range: u8 = 1;
-    /// `or` — logical OR, short-circuits.
-    pub const log_or: u8 = 2;
-    /// `and` — logical AND, short-circuits.
-    pub const log_and: u8 = 3;
-    /// `==` / `!=` / `<` / `<=` / `>` / `>=`.
-    pub const compare: u8 = 4;
-    /// `|` — bitwise OR.
-    pub const bit_or: u8 = 5;
-    /// `^` — bitwise XOR.
-    pub const bit_xor: u8 = 6;
-    /// `&` — bitwise AND.
-    pub const bit_and: u8 = 7;
-    /// `<<` / `>>` — bit shifts.
-    pub const shift: u8 = 8;
-    /// `+` / `-` — additive arithmetic.
-    pub const add: u8 = 9;
-    /// `*` / `/` / `%` — multiplicative arithmetic.
-    pub const mul: u8 = 10;
-    /// `is` — variant-tag test. Binds tighter than arithmetic.
-    pub const is_test: u8 = 11;
-    /// Unary prefix: `-x` / `not x` / `~x`.
-    pub const unary: u8 = 12;
-    /// Postfix: call `( )`, index `[ ]`, field `.`.
-    pub const call: u8 = 13;
-};
-
-fn parseExpression(p: *Parser, min_prec: u8) ParserError!*ast.Expr {
-    var lhs = try parseUnary(p);
-    errdefer ast.freeExpr(p.allocator, lhs);
-
-    while (true) {
-        const k = p.peek().kind;
-
-        // Range operator — bind tightest at the lowest level so
-        // `0..10 + 1` parses as `0 .. (10 + 1)`. §3.3 lists range
-        // below assignment.
-        if (k == .dot_dot or k == .dot_dot_eq) {
-            const prec = Prec.range;
-            if (prec < min_prec) break;
-            const inclusive = k == .dot_dot_eq;
-            p.pos += 1;
-            const rhs = try parseExpression(p, prec + 1);
-            const new_node = try p.allocExpr(.{ .range = .{
-                .start = lhs,
-                .end = rhs,
-                .inclusive = inclusive,
-                .span = .{ .start = lhs.span().start, .end = rhs.span().end },
-            } });
-            lhs = new_node;
-            continue;
-        }
-
-        // `is` — variant-tag test (§3.6). Right side is a qualified
-        // variant path like `Item.Sword`.
-        if (k == .kw_is) {
-            const prec = Prec.is_test;
-            if (prec < min_prec) break;
-            p.pos += 1;
-            const head_tok = try p.expect(.ident, "enum name");
-            _ = try p.expect(.dot, ".");
-            const var_tok = try p.expect(.ident, "variant name");
-            const path: ast.Span = .{ .start = head_tok.start, .end = var_tok.end };
-            const new_node = try p.allocExpr(.{ .is_test = .{
-                .lhs = lhs,
-                .variant_path = path,
-                .span = .{ .start = lhs.span().start, .end = var_tok.end },
-            } });
-            lhs = new_node;
-            continue;
-        }
-
-        // Generic binary operators driven by a precedence table.
-        if (binaryOpOf(k)) |info| {
-            if (info.prec < min_prec) break;
-            p.pos += 1;
-            const rhs = try parseExpression(p, info.prec + 1);
-            const new_node = try p.allocExpr(.{ .binary = .{
-                .op = info.op,
-                .lhs = lhs,
-                .rhs = rhs,
-                .span = .{ .start = lhs.span().start, .end = rhs.span().end },
-            } });
-            lhs = new_node;
-            continue;
-        }
-
-        break;
-    }
-    return lhs;
-}
-
-const BinaryInfo = struct {
-    op: ast.BinaryOp,
-    prec: u8,
-};
-
-fn binaryOpOf(k: Kind) ?BinaryInfo {
-    return switch (k) {
-        .kw_or => .{ .op = .log_or, .prec = Prec.log_or },
-        .kw_and => .{ .op = .log_and, .prec = Prec.log_and },
-        .eq_eq => .{ .op = .eq, .prec = Prec.compare },
-        .bang_eq => .{ .op = .neq, .prec = Prec.compare },
-        .lt => .{ .op = .lt, .prec = Prec.compare },
-        .lt_eq => .{ .op = .lte, .prec = Prec.compare },
-        .gt => .{ .op = .gt, .prec = Prec.compare },
-        .gt_eq => .{ .op = .gte, .prec = Prec.compare },
-        .pipe => .{ .op = .bit_or, .prec = Prec.bit_or },
-        .caret => .{ .op = .bit_xor, .prec = Prec.bit_xor },
-        .amp => .{ .op = .bit_and, .prec = Prec.bit_and },
-        .shl => .{ .op = .shl, .prec = Prec.shift },
-        .shr => .{ .op = .shr, .prec = Prec.shift },
-        .plus => .{ .op = .add, .prec = Prec.add },
-        .minus => .{ .op = .sub, .prec = Prec.add },
-        .star => .{ .op = .mul, .prec = Prec.mul },
-        .slash => .{ .op = .div, .prec = Prec.mul },
-        .percent => .{ .op = .mod, .prec = Prec.mul },
-        else => null,
-    };
-}
-
-fn parseUnary(p: *Parser) ParserError!*ast.Expr {
-    const tok = p.peek();
-    switch (tok.kind) {
-        .minus => {
-            p.pos += 1;
-            const operand = try parseUnary(p);
-            return try p.allocExpr(.{ .unary = .{
-                .op = .neg,
-                .operand = operand,
-                .span = .{ .start = tok.start, .end = operand.span().end },
-            } });
-        },
-        .kw_not => {
-            p.pos += 1;
-            const operand = try parseUnary(p);
-            return try p.allocExpr(.{ .unary = .{
-                .op = .log_not,
-                .operand = operand,
-                .span = .{ .start = tok.start, .end = operand.span().end },
-            } });
-        },
-        .tilde => {
-            p.pos += 1;
-            const operand = try parseUnary(p);
-            return try p.allocExpr(.{ .unary = .{
-                .op = .bit_not,
-                .operand = operand,
-                .span = .{ .start = tok.start, .end = operand.span().end },
-            } });
-        },
-        else => return try parseCallChain(p),
-    }
-}
-
-fn parseCallChain(p: *Parser) ParserError!*ast.Expr {
-    var e = try parsePrimary(p);
-    errdefer ast.freeExpr(p.allocator, e);
-
-    while (true) {
-        const k = p.peek().kind;
-        switch (k) {
-            .lparen => {
-                e = try parseCallArgs(p, e);
-            },
-            .lbracket => {
-                e = try parseIndexAccess(p, e);
-            },
-            .dot => {
-                e = try parseFieldOrMethod(p, e);
-            },
-            else => break,
-        }
-    }
-    return e;
-}
-
-fn parseCallArgs(p: *Parser, callee: *ast.Expr) ParserError!*ast.Expr {
-    p.pos += 1; // consume `(`
-    var args: std.ArrayList(*ast.Expr) = .empty;
-    errdefer {
-        for (args.items) |a| ast.freeExpr(p.allocator, a);
-        args.deinit(p.allocator);
-    }
-    if (!p.check(.rparen)) {
-        while (true) {
-            const a = try parseExpression(p, 0);
-            try args.append(p.allocator, a);
-            if (p.accept(.comma) == null) break;
-        }
-    }
-    const rp = try p.expect(.rparen, ")");
-    return try p.allocExpr(.{ .call = .{
-        .callee = callee,
-        .args = try args.toOwnedSlice(p.allocator),
-        .span = .{ .start = callee.span().start, .end = rp.end },
-    } });
-}
-
-fn parseIndexAccess(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
-    p.pos += 1; // consume `[`
-    const idx = try parseExpression(p, 0);
-    const rb = try p.expect(.rbracket, "]");
-    return try p.allocExpr(.{ .index = .{
-        .receiver = receiver,
-        .index = idx,
-        .span = .{ .start = receiver.span().start, .end = rb.end },
-    } });
-}
-
-fn parseFieldOrMethod(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
-    p.pos += 1; // consume `.`
-    const name_tok = try p.expect(.ident, "field or method name");
-    if (p.check(.lparen)) {
-        p.pos += 1;
-        var args: std.ArrayList(*ast.Expr) = .empty;
-        errdefer {
-            for (args.items) |a| ast.freeExpr(p.allocator, a);
-            args.deinit(p.allocator);
-        }
-        if (!p.check(.rparen)) {
-            while (true) {
-                const a = try parseExpression(p, 0);
-                try args.append(p.allocator, a);
-                if (p.accept(.comma) == null) break;
-            }
-        }
-        const rp = try p.expect(.rparen, ")");
-        return try p.allocExpr(.{ .method_call = .{
-            .receiver = receiver,
-            .method = ast.Span.fromToken(name_tok),
-            .args = try args.toOwnedSlice(p.allocator),
-            .span = .{ .start = receiver.span().start, .end = rp.end },
-        } });
-    }
-    return try p.allocExpr(.{ .field = .{
-        .receiver = receiver,
-        .field = ast.Span.fromToken(name_tok),
-        .span = .{ .start = receiver.span().start, .end = name_tok.end },
-    } });
-}
-
-fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
-    const tok = p.peek();
-    switch (tok.kind) {
-        .int_lit => {
-            p.pos += 1;
-            return try p.allocExpr(.{ .int_lit = .{
-                .value = tok.value,
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .kw_true => {
-            p.pos += 1;
-            return try p.allocExpr(.{ .bool_lit = .{
-                .value = true,
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .kw_false => {
-            p.pos += 1;
-            return try p.allocExpr(.{ .bool_lit = .{
-                .value = false,
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .kw_nil => {
-            p.pos += 1;
-            return try p.allocExpr(.{ .nil_lit = .{
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .kw_self => {
-            p.pos += 1;
-            return try p.allocExpr(.{ .self_expr = .{
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .kw_super => {
-            p.pos += 1;
-            return try p.allocExpr(.{ .super_expr = .{
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .ident => {
-            // The lang has no separate char-literal token; the lexer
-            // doesn't distinguish 'x' at the token level either —
-            // chars come through as int_lit with the decoded value
-            // attached. So the only ident-driven primaries are
-            // variable refs and capitalized-type struct-literal
-            // shapes (`Foo { ... }`).
-            const next = p.peekAt(1).kind;
-            if (next == .lbrace and looksLikeStructLit(p)) {
-                return try parseStructLit(p);
-            }
-            p.pos += 1;
-            return try p.allocExpr(.{ .ident = .{
-                .span = .{ .start = tok.start, .end = tok.end },
-            } });
-        },
-        .str_start => return try parseStringLit(p),
-        .lparen => return try parseParenOrTupleExpr(p),
-        .lbracket => return try parseListLit(p),
-        .kw_do => return try parseDoExpr(p),
-        .kw_if => return try parseIfExpr(p),
-        .kw_lambda => return try parseLambda(p),
-        else => {
-            try p.recordError("expected expression", "expression");
-            return error.ParseFailed;
-        },
-    }
-}
-
-/// Conservative heuristic: a struct literal in expression position
-/// looks like `TypeName { ... }`. We don't have an unambiguous way
-/// to tell `if x { ... }` from a struct lit without keyword
-/// disambiguation; the lang uses `then`/`do` to fence those, so
-/// `Ident {` in expression position is always a struct literal.
-fn looksLikeStructLit(p: *const Parser) bool {
-    // First char of the ident must be uppercase OR it must be a
-    // known compiler-built-in (`Vec`). The simplest test is "does
-    // the ident's first byte look like an ASCII uppercase?"
-    const tok = p.peek();
-    if (tok.start >= p.source.len) return false;
-    const b = p.source[tok.start];
-    return b >= 'A' and b <= 'Z';
-}
-
-fn parseStructLit(p: *Parser) ParserError!*ast.Expr {
-    const name_tok = p.peek();
-    p.pos += 1;
-    _ = try p.expect(.lbrace, "{");
-    p.skipNewlines();
-
-    var fields: std.ArrayList(ast.StructLitField) = .empty;
-    errdefer {
-        for (fields.items) |f| ast.freeExpr(p.allocator, f.value);
-        fields.deinit(p.allocator);
-    }
-
-    if (!p.check(.rbrace)) {
-        while (true) {
-            p.skipNewlines();
-            if (p.check(.rbrace)) break;
-            const fname_tok = try p.expect(.ident, "field name");
-            _ = try p.expect(.colon, ":");
-            const value = try parseExpression(p, 0);
-            try fields.append(p.allocator, .{
-                .name = ast.Span.fromToken(fname_tok),
-                .value = value,
-                .span = .{ .start = fname_tok.start, .end = value.span().end },
-            });
-            if (p.accept(.comma) == null) break;
-            p.skipNewlines();
-        }
-    }
-    p.skipNewlines();
-    const rb = try p.expect(.rbrace, "}");
-    return try p.allocExpr(.{ .struct_lit = .{
-        .type_name = ast.Span.fromToken(name_tok),
-        .fields = try fields.toOwnedSlice(p.allocator),
-        .span = .{ .start = name_tok.start, .end = rb.end },
-    } });
-}
-
-fn parseStringLit(p: *Parser) ParserError!*ast.Expr {
-    const start_tok = p.peek();
-    p.pos += 1;
-    var parts: std.ArrayList(ast.StrPart) = .empty;
-    errdefer cleanupStrParts(p.allocator, &parts);
-
-    var end_idx: u32 = start_tok.end;
-    while (true) {
-        const t = p.peek();
-        switch (t.kind) {
-            .str_part => {
-                p.pos += 1;
-                try parts.append(p.allocator, .{ .lit = .{
-                    .span = .{ .start = t.start, .end = t.end },
-                } });
-                end_idx = t.end;
-            },
-            .str_expr_start => {
-                p.pos += 1;
-                const inner = try parseExpression(p, 0);
-                // Optional format spec — `:fmt` before `)`. The
-                // lexer doesn't emit a dedicated `:fmt` token today,
-                // so the parser accepts `:` followed by tokens up
-                // to the matching `)`. The captured span covers
-                // those bytes verbatim.
-                var fmt_span: ?ast.Span = null;
-                if (p.accept(.colon)) |colon_tok| {
-                    const fmt_start = colon_tok.end;
-                    var depth: u32 = 0;
-                    while (true) {
-                        const nt = p.peek();
-                        if (nt.kind == .str_expr_end and depth == 0) break;
-                        if (nt.kind == .lparen) depth += 1;
-                        if (nt.kind == .rparen and depth > 0) depth -= 1;
-                        if (nt.kind == .eof) break;
-                        p.pos += 1;
-                    }
-                    const fmt_end = p.peek().start;
-                    fmt_span = .{ .start = fmt_start, .end = fmt_end };
-                }
-                const close = try p.expect(.str_expr_end, ")");
-                try parts.append(p.allocator, .{ .interp = .{
-                    .expr = inner,
-                    .format_spec = fmt_span,
-                    .span = .{ .start = t.start, .end = close.end },
-                } });
-                end_idx = close.end;
-            },
-            .str_end => {
-                p.pos += 1;
-                end_idx = t.end;
-                break;
-            },
-            else => {
-                try p.recordError("malformed string literal", "string part");
-                return error.ParseFailed;
-            },
-        }
-    }
-    return try p.allocExpr(.{ .str_lit = .{
-        .parts = try parts.toOwnedSlice(p.allocator),
-        .span = .{ .start = start_tok.start, .end = end_idx },
-    } });
-}
-
-fn cleanupStrParts(
-    allocator: std.mem.Allocator,
-    parts: *std.ArrayList(ast.StrPart),
-) void {
-    for (parts.items) |p| switch (p) {
-        .lit => {},
-        .interp => |ip| ast.freeExpr(allocator, ip.expr),
-    };
-    parts.deinit(allocator);
-}
-
-fn parseParenOrTupleExpr(p: *Parser) ParserError!*ast.Expr {
-    const lp = p.peek();
-    p.pos += 1;
-    p.skipNewlines();
-    const first = try parseExpression(p, 0);
-    errdefer ast.freeExpr(p.allocator, first);
-
-    if (p.accept(.rparen)) |rp| {
-        return try p.allocExpr(.{ .paren = .{
-            .inner = first,
-            .span = .{ .start = lp.start, .end = rp.end },
-        } });
-    }
-
-    // Tuple: at least one comma.
-    var elems: std.ArrayList(*ast.Expr) = .empty;
-    errdefer {
-        for (elems.items) |e| ast.freeExpr(p.allocator, e);
-        elems.deinit(p.allocator);
-    }
-    try elems.append(p.allocator, first);
-    while (p.accept(.comma)) |_| {
-        p.skipNewlines();
-        if (p.check(.rparen)) break; // trailing comma
-        const e = try parseExpression(p, 0);
-        try elems.append(p.allocator, e);
-    }
-    const rp = try p.expect(.rparen, ")");
-    return try p.allocExpr(.{ .tuple_lit = .{
-        .elems = try elems.toOwnedSlice(p.allocator),
-        .span = .{ .start = lp.start, .end = rp.end },
-    } });
-}
-
-fn parseListLit(p: *Parser) ParserError!*ast.Expr {
-    const lb = p.peek();
-    p.pos += 1;
-    p.skipNewlines();
-    var elems: std.ArrayList(*ast.Expr) = .empty;
-    errdefer {
-        for (elems.items) |e| ast.freeExpr(p.allocator, e);
-        elems.deinit(p.allocator);
-    }
-    if (!p.check(.rbracket)) {
-        while (true) {
-            p.skipNewlines();
-            const e = try parseExpression(p, 0);
-            try elems.append(p.allocator, e);
-            if (p.accept(.comma) == null) break;
-            p.skipNewlines();
-            if (p.check(.rbracket)) break;
-        }
-    }
-    p.skipNewlines();
-    const rb = try p.expect(.rbracket, "]");
-    return try p.allocExpr(.{ .list_lit = .{
-        .elems = try elems.toOwnedSlice(p.allocator),
-        .span = .{ .start = lb.start, .end = rb.end },
-    } });
-}
-
-fn parseDoExpr(p: *Parser) ParserError!*ast.Expr {
-    const do_tok = p.peek();
-    p.pos += 1;
-    p.skipNewlines();
-
-    var body: std.ArrayList(ast.Statement) = .empty;
-    errdefer cleanupStatements(p.allocator, &body);
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        try parseStatement(p, &body);
-        p.skipNewlines();
-    }
-    const end_tok = try p.expect(.kw_end, "end");
-    return try p.allocExpr(.{ .do_expr = .{
-        .body = try body.toOwnedSlice(p.allocator),
-        .span = .{ .start = do_tok.start, .end = end_tok.end },
-    } });
-}
-
-fn parseIfExpr(p: *Parser) ParserError!*ast.Expr {
-    const start_tok = p.peek();
-    const result = try parseIfChain(p);
-    return try p.allocExpr(.{ .if_expr = .{
-        .arms = result.arms,
-        .else_body = result.else_body,
-        .span = .{ .start = start_tok.start, .end = result.end },
-    } });
-}
-
-fn parseLambda(p: *Parser) ParserError!*ast.Expr {
-    const lambda_tok = p.peek();
-    p.pos += 1;
-    _ = try p.expect(.lparen, "(");
-    const params = try parseParamList(p);
-    errdefer freeParams(p.allocator, params);
-
-    var ret_type: ?*ast.TypeAnn = null;
-    if (p.accept(.arrow)) |_| {
-        ret_type = try parseTypeAnn(p);
-    }
-    errdefer if (ret_type) |r| ast.freeTypeAnn(p.allocator, r);
-
-    p.skipNewlines();
-    var body: std.ArrayList(ast.Statement) = .empty;
-    errdefer cleanupStatements(p.allocator, &body);
-    while (!p.atEnd() and !p.check(.kw_end)) {
-        try parseStatement(p, &body);
-        p.skipNewlines();
-    }
-    const end_tok = try p.expect(.kw_end, "end");
-    return try p.allocExpr(.{ .lambda = .{
-        .params = params,
-        .ret_type = ret_type,
-        .body = try body.toOwnedSlice(p.allocator),
-        .span = .{ .start = lambda_tok.start, .end = end_tok.end },
-    } });
 }

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -413,6 +413,7 @@ pub fn parseStatement(
             try p.requireStatementBoundary();
         },
         .kw_print => try statements.append(p.allocator, try stmt_mod.parsePrintStatement(p)),
+        .kw_defer => try statements.append(p.allocator, try stmt_mod.parseDeferStatement(p)),
         .eof => return,
         else => try stmt_mod.parseExprOrAssignStatement(p, statements),
     }

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -1,0 +1,2614 @@
+/// Gero-lang parser — consumes the `TokenStream` produced by
+/// `lexer.tokenize` and emits an `ast.Program`. Token-stream-based
+/// (not knit byte-combinators — those operate on raw bytes; the
+/// lang side runs the lexer first then walks tokens).
+///
+/// Architecture:
+///
+/// - Statement-level dispatch is hand-rolled — a switch on the
+///   current token's kind plus a handful of look-ahead checks.
+/// - Expression parsing is Pratt-style: `parseExpression(min_prec)`
+///   loops, eating binary operators whose precedence is at least
+///   `min_prec`, recursing for the RHS at one tier higher. Unary
+///   prefix, function-call postfix, field/index postfix all live in
+///   the leaf path. Precedence table sourced from
+///   `docs/gero-lang.md` §3.3.
+/// - Errors append to `errors` but never abort parsing — the parser
+///   skips to the next statement boundary (a `.newline` token) and
+///   resumes. A single drive surfaces every problem at once.
+///
+/// Annotation attachment: the parser keeps a pending-annotation
+/// buffer. When it parses `@name(args)`, it pushes to the buffer.
+/// When it parses a decl that accepts annotations (`def`, `let`,
+/// `const`, `class`, `struct`, `enum`, class-level field/method),
+/// it drains the buffer into the decl's `annotations` slice.
+/// Annotations followed by non-decl statements are reported as a
+/// diagnostic and discarded.
+const std = @import("std");
+const knit = @import("knit");
+const core = knit.core;
+const lexer = @import("lexer.zig");
+const ast = @import("ast.zig");
+
+const Kind = lexer.Token.Kind;
+
+/// Output of `parse` — the program AST plus diagnostics. Errors
+/// don't abort parsing; the parser recovers to the next statement
+/// boundary so a single run drains every problem at once.
+pub const ParseTree = struct {
+    program: ast.Program,
+    errors: []core.ParseError,
+    allocator: std.mem.Allocator,
+
+    /// Release the owned statement list and the diagnostics buffer.
+    pub fn deinit(self: *ParseTree) void {
+        self.program.deinit();
+        self.allocator.free(self.errors);
+    }
+
+    /// `true` when at least one diagnostic was recorded.
+    pub fn hasErrors(self: ParseTree) bool {
+        return self.errors.len > 0;
+    }
+};
+
+/// Parse a tokenized source into an `ast.Program` + diagnostics.
+/// Only error path is OOM. Grammar errors land in `errors`.
+pub fn parse(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    stream: lexer.TokenStream,
+) !ParseTree {
+    var statements: std.ArrayList(ast.Statement) = .empty;
+    errdefer cleanupStatements(allocator, &statements);
+
+    var errors: std.ArrayList(core.ParseError) = .empty;
+    errdefer errors.deinit(allocator);
+
+    // Propagate lexer-level diagnostics so callers see a unified
+    // error stream (mirrors how `asm.parse` surfaces include-pass
+    // diagnostics).
+    for (stream.errors) |err| try errors.append(allocator, err);
+
+    var pending_annotations: std.ArrayList(ast.Annotation) = .empty;
+    // The buffer holds duped Annotation entries between encountering
+    // `@…` and attaching them to a decl. On the success path the
+    // entries are drained (`takePendingAnnotations`), but the
+    // ArrayList's backing capacity still needs releasing — hence the
+    // unconditional `defer` rather than relying on `errdefer`.
+    defer pending_annotations.deinit(allocator);
+    errdefer for (pending_annotations.items) |a| {
+        for (a.args) |arg| ast.freeExpr(allocator, arg);
+        allocator.free(a.args);
+    };
+
+    var p: Parser = .{
+        .source = source,
+        .tokens = stream.tokens,
+        .pos = 0,
+        .allocator = allocator,
+        .errors = &errors,
+        .pending_annotations = &pending_annotations,
+    };
+
+    p.skipNewlines();
+    while (!p.atEnd()) {
+        try parseTopLevel(&p, &statements);
+        p.skipNewlines();
+    }
+
+    // Any unattached pending annotations at EOF — emit one diagnostic
+    // and free their inner allocations. The buffer itself (capacity)
+    // is released by the `defer pending_annotations.deinit` above.
+    if (pending_annotations.items.len > 0) {
+        try errors.append(allocator, core.parseError(
+            "lang_parser",
+            pending_annotations.items[0].span.start,
+            "annotation at EOF has no following declaration to attach to",
+            .{ .expected = "declaration after annotation", .kind = .semantic },
+        ));
+        for (pending_annotations.items) |a| {
+            for (a.args) |arg| ast.freeExpr(allocator, arg);
+            allocator.free(a.args);
+        }
+        pending_annotations.clearRetainingCapacity();
+    }
+
+    return .{
+        .program = .{
+            .statements = try statements.toOwnedSlice(allocator),
+            .allocator = allocator,
+        },
+        .errors = try errors.toOwnedSlice(allocator),
+        .allocator = allocator,
+    };
+}
+
+/// Cleanup partial state when an OOM path triggers `errdefer`.
+fn cleanupStatements(
+    allocator: std.mem.Allocator,
+    statements: *std.ArrayList(ast.Statement),
+) void {
+    for (statements.items) |*s| ast.freeStatement(allocator, s);
+    statements.deinit(allocator);
+}
+
+fn cleanupAnnotations(
+    allocator: std.mem.Allocator,
+    anns: *std.ArrayList(ast.Annotation),
+) void {
+    for (anns.items) |a| {
+        for (a.args) |arg| ast.freeExpr(allocator, arg);
+        allocator.free(a.args);
+    }
+    anns.deinit(allocator);
+}
+
+// =====================================================================
+// Parser state + cursor helpers.
+// =====================================================================
+
+const Parser = struct {
+    source: []const u8,
+    tokens: []const lexer.Token,
+    pos: usize,
+    allocator: std.mem.Allocator,
+    errors: *std.ArrayList(core.ParseError),
+    pending_annotations: *std.ArrayList(ast.Annotation),
+
+    /// Current token. Always defined — the lexer guarantees a
+    /// trailing `.eof` token.
+    fn peek(self: *const Parser) lexer.Token {
+        return self.tokens[self.pos];
+    }
+
+    /// Token `n` positions ahead. Safe past EOF: returns the EOF
+    /// token (the lexer guarantees one trailing).
+    fn peekAt(self: *const Parser, n: usize) lexer.Token {
+        const idx = @min(self.pos + n, self.tokens.len - 1);
+        return self.tokens[idx];
+    }
+
+    fn atEnd(self: *const Parser) bool {
+        return self.peek().kind == .eof;
+    }
+
+    /// True when the current token matches `kind`.
+    fn check(self: *const Parser, kind: Kind) bool {
+        return self.peek().kind == kind;
+    }
+
+    /// Same as `check` but for a span of allowed kinds.
+    fn checkAny(self: *const Parser, kinds: []const Kind) bool {
+        const k = self.peek().kind;
+        for (kinds) |c| if (k == c) return true;
+        return false;
+    }
+
+    /// Consume the current token if it matches `kind`. Returns the
+    /// consumed token on hit, `null` on miss.
+    fn accept(self: *Parser, kind: Kind) ?lexer.Token {
+        if (!self.check(kind)) return null;
+        const t = self.peek();
+        self.pos += 1;
+        return t;
+    }
+
+    /// Skip newline tokens; they don't carry semantics outside the
+    /// statement-boundary role.
+    fn skipNewlines(self: *Parser) void {
+        while (self.check(.newline)) self.pos += 1;
+    }
+
+    /// Skip newlines, return whether we consumed at least one or
+    /// reached EOF. Used after a statement is parsed to assert the
+    /// caller didn't trail garbage before the next statement.
+    fn requireStatementBoundary(self: *Parser) !void {
+        if (self.atEnd() or self.check(.newline)) {
+            self.skipNewlines();
+            return;
+        }
+        try self.recordError(
+            "expected newline or end-of-input after statement",
+            "newline",
+        );
+        try self.recoverToNewline();
+    }
+
+    fn currentSpan(self: *const Parser) ast.Span {
+        const t = self.peek();
+        return .{ .start = t.start, .end = t.end };
+    }
+
+    /// Append a diagnostic anchored at the current token. The lexeme
+    /// of the actual token is recorded as `actual` so consumers see
+    /// what the parser tripped on.
+    fn recordError(
+        self: *Parser,
+        message: []const u8,
+        expected: []const u8,
+    ) !void {
+        const t = self.peek();
+        try self.errors.append(self.allocator, core.parseError(
+            "lang_parser",
+            t.start,
+            message,
+            .{
+                .expected = expected,
+                .actual = self.source[t.start..t.end],
+                .kind = .syntactic,
+            },
+        ));
+    }
+
+    /// Append a diagnostic at the given token index without
+    /// consuming.
+    fn recordErrorAt(
+        self: *Parser,
+        index: u32,
+        message: []const u8,
+        expected: []const u8,
+    ) !void {
+        try self.errors.append(self.allocator, core.parseError(
+            "lang_parser",
+            index,
+            message,
+            .{ .expected = expected, .kind = .syntactic },
+        ));
+    }
+
+    /// Advance until the next newline (or EOF). Used for
+    /// statement-level error recovery.
+    fn recoverToNewline(self: *Parser) !void {
+        while (!self.atEnd() and !self.check(.newline)) self.pos += 1;
+        self.skipNewlines();
+    }
+
+    /// Expect a specific token kind; emit a diagnostic and bail out
+    /// of the current production via `error.ParseFailed` if missing.
+    /// Successful match returns the consumed token.
+    fn expect(self: *Parser, kind: Kind, what: []const u8) ParserError!lexer.Token {
+        if (self.accept(kind)) |t| return t;
+        try self.recordError("expected token", what);
+        return error.ParseFailed;
+    }
+
+    /// Allocate and initialize an `*Expr`.
+    fn allocExpr(self: *Parser, value: ast.Expr) !*ast.Expr {
+        const node = try self.allocator.create(ast.Expr);
+        node.* = value;
+        return node;
+    }
+
+    fn allocPattern(self: *Parser, value: ast.Pattern) !*ast.Pattern {
+        const node = try self.allocator.create(ast.Pattern);
+        node.* = value;
+        return node;
+    }
+
+    fn allocTypeAnn(self: *Parser, value: ast.TypeAnn) !*ast.TypeAnn {
+        const node = try self.allocator.create(ast.TypeAnn);
+        node.* = value;
+        return node;
+    }
+
+    fn lexeme(self: *const Parser, span: ast.Span) []const u8 {
+        return self.source[span.start..span.end];
+    }
+};
+
+/// Local error set for productions that may bail to the nearest
+/// statement-recovery point. `OutOfMemory` propagates to the caller;
+/// `ParseFailed` triggers `recoverToNewline` at the statement level.
+const ParserError = error{ OutOfMemory, ParseFailed };
+
+// =====================================================================
+// Top-level dispatch.
+// =====================================================================
+
+fn parseTopLevel(
+    p: *Parser,
+    statements: *std.ArrayList(ast.Statement),
+) !void {
+    // Accumulate annotations into the parser's pending buffer.
+    while (p.check(.annotation)) {
+        const ann = parseAnnotation(p) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.ParseFailed => {
+                try p.recoverToNewline();
+                return;
+            },
+        };
+        try p.pending_annotations.append(p.allocator, ann);
+        p.skipNewlines();
+    }
+
+    parseStatement(p, statements) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.ParseFailed => try p.recoverToNewline(),
+    };
+}
+
+fn parseStatement(
+    p: *Parser,
+    statements: *std.ArrayList(ast.Statement),
+) ParserError!void {
+    const start = p.peek().start;
+    const k = p.peek().kind;
+
+    switch (k) {
+        .kw_let => {
+            const stmt = try parseLetDecl(p, false);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_const => {
+            const stmt = try parseConstDecl(p, false);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_def => {
+            const stmt = try parseDefDecl(p, false);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_class => {
+            const stmt = try parseClassDecl(p, false);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_enum => {
+            const stmt = try parseEnumDecl(p, false);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_local => {
+            try parseLocalDecl(p, statements);
+        },
+        .kw_use => {
+            const stmt = try parseUseDecl(p, false);
+            try statements.append(p.allocator, stmt);
+        },
+        .ident => {
+            // `struct Foo ... end` uses a bare identifier — `struct`
+            // is not a reserved keyword in the lexer so type-name
+            // lookups like `let Stats = ...` stay unambiguous. Look
+            // ahead for the dispatch shape.
+            const lex = p.source[p.peek().start..p.peek().end];
+            if (std.mem.eql(u8, lex, "struct")) {
+                const stmt = try parseStructDecl(p, false);
+                try statements.append(p.allocator, stmt);
+                return;
+            }
+            // Otherwise fall through to expression-or-assignment.
+            try parseExprOrAssignStatement(p, statements);
+        },
+        .kw_if => {
+            const stmt = try parseIfStatement(p);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_while => {
+            const stmt = try parseWhileStatement(p);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_for => {
+            const stmt = try parseForStatement(p);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_match => {
+            const stmt = try parseMatchStatement(p);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_do => {
+            const stmt = try parseBlockStatement(p);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_return => {
+            const stmt = try parseReturnStatement(p);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_break => {
+            const t = p.peek();
+            p.pos += 1;
+            try statements.append(p.allocator, .{ .break_stmt = .{
+                .span = .{ .start = t.start, .end = t.end },
+            } });
+            try p.requireStatementBoundary();
+        },
+        .kw_continue => {
+            const t = p.peek();
+            p.pos += 1;
+            try statements.append(p.allocator, .{ .continue_stmt = .{
+                .span = .{ .start = t.start, .end = t.end },
+            } });
+            try p.requireStatementBoundary();
+        },
+        .kw_print => {
+            const stmt = try parsePrintStatement(p);
+            try statements.append(p.allocator, stmt);
+        },
+        .eof => return,
+        else => {
+            // `_ = expr` discard — `_` is a bare identifier in the
+            // lexer; the `kw_let`-style match above doesn't catch
+            // it. `.ident` branch handles the general case too;
+            // this fallthrough handles anything else that can
+            // start an expression (literals, parens, etc.).
+            try parseExprOrAssignStatement(p, statements);
+        },
+    }
+
+    _ = start;
+}
+
+/// `local <decl>` — visibility shim. The keyword must be followed
+/// by a `let` / `const` / `def` / `class` / `struct` / `enum` /
+/// `use` decl. The parser sets the inner decl's `is_local` field.
+fn parseLocalDecl(
+    p: *Parser,
+    statements: *std.ArrayList(ast.Statement),
+) !void {
+    const local_tok = p.peek();
+    p.pos += 1; // consume `local`
+    const start = local_tok.start;
+
+    const k = p.peek().kind;
+    switch (k) {
+        .kw_let => {
+            const stmt = try parseLetDecl(p, true);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_const => {
+            const stmt = try parseConstDecl(p, true);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_def => {
+            const stmt = try parseDefDecl(p, true);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_class => {
+            const stmt = try parseClassDecl(p, true);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_enum => {
+            const stmt = try parseEnumDecl(p, true);
+            try statements.append(p.allocator, stmt);
+        },
+        .kw_use => {
+            const stmt = try parseUseDecl(p, true);
+            try statements.append(p.allocator, stmt);
+        },
+        .ident => {
+            const lex = p.source[p.peek().start..p.peek().end];
+            if (std.mem.eql(u8, lex, "struct")) {
+                const stmt = try parseStructDecl(p, true);
+                try statements.append(p.allocator, stmt);
+                return;
+            }
+            try p.recordError(
+                "expected declaration after `local`",
+                "let / const / def / class / struct / enum / use",
+            );
+            try p.recoverToNewline();
+            try statements.append(p.allocator, .{ .local_decl = .{
+                .span = .{ .start = start, .end = p.peek().start },
+            } });
+        },
+        else => {
+            try p.recordError(
+                "expected declaration after `local`",
+                "let / const / def / class / struct / enum / use",
+            );
+            try p.recoverToNewline();
+            try statements.append(p.allocator, .{ .local_decl = .{
+                .span = .{ .start = start, .end = p.peek().start },
+            } });
+        },
+    }
+}
+
+// =====================================================================
+// Annotations.
+// =====================================================================
+
+/// Parse `@name` or `@name(args...)`. The leading `@` is a single
+/// `.annotation` token covering both the `@` and the trailing
+/// identifier (see `lexer.zig`).
+fn parseAnnotation(p: *Parser) ParserError!ast.Annotation {
+    const at_tok = p.peek();
+    p.pos += 1;
+
+    // The lexer emits `.annotation` as a single token whose span
+    // covers `@name` end-to-end. The leading `@` is one byte.
+    const name_span: ast.Span = .{
+        .start = at_tok.start + 1,
+        .end = at_tok.end,
+    };
+
+    var args: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (args.items) |a| ast.freeExpr(p.allocator, a);
+        args.deinit(p.allocator);
+    }
+
+    var end: u32 = at_tok.end;
+
+    // `(arg, arg, ...)` is optional. `@bank N` is the rare arg-
+    // without-parens form spec §3.7.1 documents — accept a single
+    // following expression of "literal-or-ident" shape on the same
+    // line as a sugar.
+    if (p.accept(.lparen)) |_| {
+        if (!p.check(.rparen)) {
+            while (true) {
+                const arg = try parseExpression(p, 0);
+                try args.append(p.allocator, arg);
+                if (p.accept(.comma) == null) break;
+            }
+        }
+        const close = try p.expect(.rparen, ")");
+        end = close.end;
+    } else if (canStartParenlessAnnotationArg(p.peek().kind)) {
+        // Sugar: `@bank 5`, `@interrupt 0x06`, `@addr $FE40`. Stops
+        // at the line boundary (newline) — only one expression
+        // captured.
+        const arg = try parseExpression(p, 0);
+        const arg_span = arg.span();
+        try args.append(p.allocator, arg);
+        end = arg_span.end;
+    }
+
+    return .{
+        .name = name_span,
+        .args = try args.toOwnedSlice(p.allocator),
+        .span = .{ .start = at_tok.start, .end = end },
+    };
+}
+
+fn canStartParenlessAnnotationArg(k: Kind) bool {
+    return switch (k) {
+        .int_lit, .ident, .str_start, .kw_true, .kw_false, .kw_nil => true,
+        else => false,
+    };
+}
+
+/// Drain pending annotations into a fresh owned slice. The buffer
+/// is reset so subsequent decls don't inherit stale entries.
+fn takePendingAnnotations(p: *Parser) ![]ast.Annotation {
+    const slice = try p.allocator.dupe(ast.Annotation, p.pending_annotations.items);
+    p.pending_annotations.clearRetainingCapacity();
+    return slice;
+}
+
+// =====================================================================
+// `let` / `const` declarations.
+// =====================================================================
+
+fn parseLetDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const let_tok = p.peek();
+    p.pos += 1; // consume `let`
+
+    const start = let_tok.start;
+
+    // The bound shape can be a single ident OR a destructuring
+    // pattern. The pattern parser handles both uniformly.
+    const pattern = try parsePattern(p);
+
+    var type_ann: ?*ast.TypeAnn = null;
+    if (p.accept(.colon)) |_| {
+        type_ann = try parseTypeAnn(p);
+    }
+
+    var init: ?*ast.Expr = null;
+    if (p.accept(.equals)) |_| {
+        init = try parseExpression(p, 0);
+    } else if (type_ann == null) {
+        // `let x` with no type and no init is invalid.
+        try p.recordError(
+            "expected `=` or `: T` after `let` binding",
+            "= or : T",
+        );
+    }
+
+    const end = if (init) |e| e.span().end else if (type_ann) |t| t.span().end else pattern.span().end;
+    try p.requireStatementBoundary();
+    return .{ .let_decl = .{
+        .pattern = pattern,
+        .type_ann = type_ann,
+        .init = init,
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+fn parseConstDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const const_tok = p.peek();
+    p.pos += 1;
+    const start = const_tok.start;
+
+    const name_tok = try p.expect(.ident, "identifier");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    var type_ann: ?*ast.TypeAnn = null;
+    if (p.accept(.colon)) |_| {
+        type_ann = try parseTypeAnn(p);
+    }
+
+    _ = try p.expect(.equals, "=");
+
+    const init = try parseExpression(p, 0);
+    const end = init.span().end;
+    try p.requireStatementBoundary();
+
+    return .{ .const_decl = .{
+        .name = name_span,
+        .type_ann = type_ann,
+        .init = init,
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+// =====================================================================
+// `def` — function declaration.
+// =====================================================================
+
+fn parseDefDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const decl = try parseDefDeclInner(p, is_local);
+    return .{ .def_decl = decl };
+}
+
+fn parseDefDeclInner(p: *Parser, is_local: bool) ParserError!ast.DefDecl {
+    const def_tok = p.peek();
+    p.pos += 1; // consume `def`
+    const start = def_tok.start;
+
+    const annotations = try takePendingAnnotations(p);
+    errdefer freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "function name");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    _ = try p.expect(.lparen, "(");
+    const params = try parseParamList(p);
+    errdefer freeParams(p.allocator, params);
+
+    var ret_type: ?*ast.TypeAnn = null;
+    if (p.accept(.arrow)) |_| {
+        ret_type = try parseTypeAnn(p);
+    }
+    errdefer if (ret_type) |r| ast.freeTypeAnn(p.allocator, r);
+
+    p.skipNewlines();
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer cleanupStatements(p.allocator, &body);
+
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parseStatement(p, &body);
+        p.skipNewlines();
+    }
+
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{
+        .annotations = annotations,
+        .name = name_span,
+        .params = params,
+        .ret_type = ret_type,
+        .body = try body.toOwnedSlice(p.allocator),
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end_tok.end },
+    };
+}
+
+fn freeAnnSlice(allocator: std.mem.Allocator, anns: []ast.Annotation) void {
+    for (anns) |a| {
+        for (a.args) |arg| ast.freeExpr(allocator, arg);
+        allocator.free(a.args);
+    }
+    allocator.free(anns);
+}
+
+fn freeParams(allocator: std.mem.Allocator, params: []ast.Param) void {
+    for (params) |p| if (p.type_ann) |t| ast.freeTypeAnn(allocator, t);
+    allocator.free(params);
+}
+
+fn parseParamList(p: *Parser) ParserError![]ast.Param {
+    var params: std.ArrayList(ast.Param) = .empty;
+    errdefer {
+        freeParams(p.allocator, params.items);
+        params.deinit(p.allocator);
+    }
+
+    if (p.check(.rparen)) {
+        _ = p.accept(.rparen);
+        return try params.toOwnedSlice(p.allocator);
+    }
+
+    while (true) {
+        // `self` is a parameter shape too — it gets a `kw_self`
+        // token, not an ident, but the parser treats it as a named
+        // param so methods can be written `def m(self, ...)`.
+        const tok = p.peek();
+        const name_span: ast.Span = switch (tok.kind) {
+            .ident, .kw_self => blk: {
+                p.pos += 1;
+                break :blk .{ .start = tok.start, .end = tok.end };
+            },
+            else => {
+                try p.recordError("expected parameter name", "identifier");
+                return error.ParseFailed;
+            },
+        };
+
+        var type_ann: ?*ast.TypeAnn = null;
+        if (p.accept(.colon)) |_| {
+            type_ann = try parseTypeAnn(p);
+        }
+
+        const param_end: u32 = if (type_ann) |t| t.span().end else name_span.end;
+        try params.append(p.allocator, .{
+            .name = name_span,
+            .type_ann = type_ann,
+            .span = .{ .start = name_span.start, .end = param_end },
+        });
+
+        if (p.accept(.comma) == null) break;
+    }
+
+    _ = try p.expect(.rparen, ")");
+    return try params.toOwnedSlice(p.allocator);
+}
+
+// =====================================================================
+// `class` declaration.
+// =====================================================================
+
+fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const class_tok = p.peek();
+    p.pos += 1;
+    const start = class_tok.start;
+
+    const annotations = try takePendingAnnotations(p);
+    errdefer freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "class name");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    var extends: ?ast.Span = null;
+    if (p.accept(.kw_extends)) |_| {
+        const parent_tok = try p.expect(.ident, "parent class name");
+        extends = ast.Span.fromToken(parent_tok);
+    }
+
+    // Body delimiter: spec §6 examples use `{ ... }` for class body.
+    _ = try p.expect(.lbrace, "{");
+    p.skipNewlines();
+
+    var fields: std.ArrayList(ast.ClassField) = .empty;
+    errdefer cleanupClassFields(p.allocator, &fields);
+    var methods: std.ArrayList(ast.DefDecl) = .empty;
+    errdefer cleanupMethods(p.allocator, &methods);
+
+    while (!p.atEnd() and !p.check(.rbrace)) {
+        // Accumulate annotations inside the class body, same as
+        // file-level. They attach to the next field or method.
+        while (p.check(.annotation)) {
+            const ann = try parseAnnotation(p);
+            try p.pending_annotations.append(p.allocator, ann);
+            p.skipNewlines();
+        }
+
+        switch (p.peek().kind) {
+            .kw_let => {
+                const field = try parseClassField(p);
+                try fields.append(p.allocator, field);
+            },
+            .kw_def => {
+                const m = try parseDefDeclInner(p, false);
+                try methods.append(p.allocator, m);
+            },
+            .rbrace => break,
+            else => {
+                try p.recordError(
+                    "expected field (`let`) or method (`def`) in class body",
+                    "let or def",
+                );
+                try p.recoverToNewline();
+            },
+        }
+        p.skipNewlines();
+    }
+
+    const close_tok = try p.expect(.rbrace, "}");
+    try p.requireStatementBoundary();
+
+    return .{ .class_decl = .{
+        .annotations = annotations,
+        .name = name_span,
+        .extends = extends,
+        .fields = try fields.toOwnedSlice(p.allocator),
+        .methods = try methods.toOwnedSlice(p.allocator),
+        .is_local = is_local,
+        .span = .{ .start = start, .end = close_tok.end },
+    } };
+}
+
+fn parseClassField(p: *Parser) ParserError!ast.ClassField {
+    // `let name: T [= init]` — annotations were accumulated before
+    // entering here.
+    const let_tok = p.peek();
+    p.pos += 1;
+
+    const annotations = try takePendingAnnotations(p);
+    errdefer freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "field name");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    var type_ann: ?*ast.TypeAnn = null;
+    if (p.accept(.colon)) |_| {
+        type_ann = try parseTypeAnn(p);
+    }
+
+    var init: ?*ast.Expr = null;
+    var end_idx: u32 = if (type_ann) |t| t.span().end else name_span.end;
+    if (p.accept(.equals)) |_| {
+        const e = try parseExpression(p, 0);
+        end_idx = e.span().end;
+        init = e;
+    }
+
+    try p.requireStatementBoundary();
+    return .{
+        .annotations = annotations,
+        .name = name_span,
+        .type_ann = type_ann,
+        .init = init,
+        .span = .{ .start = let_tok.start, .end = end_idx },
+    };
+}
+
+fn cleanupClassFields(
+    allocator: std.mem.Allocator,
+    fields: *std.ArrayList(ast.ClassField),
+) void {
+    for (fields.items) |f| {
+        freeAnnSlice(allocator, f.annotations);
+        if (f.type_ann) |t| ast.freeTypeAnn(allocator, t);
+        if (f.init) |e| ast.freeExpr(allocator, e);
+    }
+    fields.deinit(allocator);
+}
+
+fn cleanupMethods(
+    allocator: std.mem.Allocator,
+    methods: *std.ArrayList(ast.DefDecl),
+) void {
+    for (methods.items) |m| {
+        freeAnnSlice(allocator, m.annotations);
+        freeParams(allocator, m.params);
+        if (m.ret_type) |r| ast.freeTypeAnn(allocator, r);
+        for (m.body) |*s| ast.freeStatement(allocator, s);
+        allocator.free(m.body);
+    }
+    methods.deinit(allocator);
+}
+
+// =====================================================================
+// `struct` declaration.
+// =====================================================================
+
+fn parseStructDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const struct_tok = p.peek();
+    p.pos += 1; // consume `struct` (it's an ident token, not a kw)
+    const start = struct_tok.start;
+
+    const annotations = try takePendingAnnotations(p);
+    errdefer freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "struct name");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    p.skipNewlines();
+
+    var fields: std.ArrayList(ast.StructField) = .empty;
+    errdefer {
+        for (fields.items) |f| ast.freeTypeAnn(p.allocator, f.type_ann);
+        fields.deinit(p.allocator);
+    }
+
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        const fname_tok = try p.expect(.ident, "field name");
+        _ = try p.expect(.colon, ":");
+        const ftype = try parseTypeAnn(p);
+        const fend = ftype.span().end;
+        try fields.append(p.allocator, .{
+            .name = ast.Span.fromToken(fname_tok),
+            .type_ann = ftype,
+            .span = .{ .start = fname_tok.start, .end = fend },
+        });
+        // Comma between fields is optional (matches spec examples).
+        _ = p.accept(.comma);
+        p.skipNewlines();
+    }
+
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .struct_decl = .{
+        .annotations = annotations,
+        .name = name_span,
+        .fields = try fields.toOwnedSlice(p.allocator),
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+// =====================================================================
+// `enum` declaration.
+// =====================================================================
+
+fn parseEnumDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const enum_tok = p.peek();
+    p.pos += 1;
+    const start = enum_tok.start;
+
+    const annotations = try takePendingAnnotations(p);
+    errdefer freeAnnSlice(p.allocator, annotations);
+
+    const name_tok = try p.expect(.ident, "enum name");
+    const name_span = ast.Span.fromToken(name_tok);
+
+    p.skipNewlines();
+
+    var variants: std.ArrayList(ast.EnumVariant) = .empty;
+    errdefer cleanupEnumVariants(p.allocator, &variants);
+
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        _ = try p.expect(.kw_case, "case");
+        const v_name_tok = try p.expect(.ident, "variant name");
+        const v_name_span = ast.Span.fromToken(v_name_tok);
+
+        var payload: std.ArrayList(ast.EnumPayloadField) = .empty;
+        errdefer {
+            for (payload.items) |pf| ast.freeTypeAnn(p.allocator, pf.type_ann);
+            payload.deinit(p.allocator);
+        }
+
+        var v_end: u32 = v_name_tok.end;
+        if (p.accept(.lparen)) |_| {
+            if (!p.check(.rparen)) {
+                while (true) {
+                    // Two shapes:
+                    //   - `name: type` — named payload field
+                    //   - `type`       — anonymous (zero-width name span)
+                    const tok0 = p.peek();
+                    const tok1 = p.peekAt(1);
+                    if (tok0.kind == .ident and tok1.kind == .colon) {
+                        const fname_tok = p.peek();
+                        p.pos += 2; // consume name + colon
+                        const ftype = try parseTypeAnn(p);
+                        try payload.append(p.allocator, .{
+                            .name = ast.Span.fromToken(fname_tok),
+                            .type_ann = ftype,
+                            .span = .{ .start = fname_tok.start, .end = ftype.span().end },
+                        });
+                    } else {
+                        const ftype = try parseTypeAnn(p);
+                        const ts = ftype.span();
+                        try payload.append(p.allocator, .{
+                            .name = .{ .start = ts.start, .end = ts.start },
+                            .type_ann = ftype,
+                            .span = ts,
+                        });
+                    }
+                    if (p.accept(.comma) == null) break;
+                }
+            }
+            const close = try p.expect(.rparen, ")");
+            v_end = close.end;
+        }
+
+        try variants.append(p.allocator, .{
+            .name = v_name_span,
+            .payload = try payload.toOwnedSlice(p.allocator),
+            .span = .{ .start = v_name_span.start, .end = v_end },
+        });
+
+        p.skipNewlines();
+    }
+
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .enum_decl = .{
+        .annotations = annotations,
+        .name = name_span,
+        .variants = try variants.toOwnedSlice(p.allocator),
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+fn cleanupEnumVariants(
+    allocator: std.mem.Allocator,
+    variants: *std.ArrayList(ast.EnumVariant),
+) void {
+    for (variants.items) |v| {
+        for (v.payload) |pf| ast.freeTypeAnn(allocator, pf.type_ann);
+        allocator.free(v.payload);
+    }
+    variants.deinit(allocator);
+}
+
+// =====================================================================
+// `use` declaration.
+// =====================================================================
+
+fn parseUseDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
+    const use_tok = p.peek();
+    p.pos += 1;
+    const start = use_tok.start;
+
+    // Forms (spec §5.2):
+    //   use math
+    //   use "./physics"
+    //   use abs from math
+    //   use abs as absolute from math
+    //   use abs, sqrt from math
+    //   use math as m
+    var items: std.ArrayList(ast.UseItem) = .empty;
+    errdefer items.deinit(p.allocator);
+
+    var module_span: ast.Span = undefined;
+    var quoted_path = false;
+    var alias: ?ast.Span = null;
+
+    // Snapshot for restart: distinguish `use math` from `use abs from math`.
+    // We peek the first identifier; if `from` follows (after possibly more
+    // identifiers), parse the selective shape; else parse the whole-module
+    // form.
+    const start_pos = p.pos;
+    if (try lookaheadHasFromClause(p)) {
+        // Selective: `use name [as alias] (, name [as alias])* from module`
+        while (true) {
+            const n_tok = try p.expect(.ident, "import name");
+            var item_alias: ?ast.Span = null;
+            var item_end = n_tok.end;
+            if (p.accept(.kw_as)) |_| {
+                const a_tok = try p.expect(.ident, "alias");
+                item_alias = ast.Span.fromToken(a_tok);
+                item_end = a_tok.end;
+            }
+            try items.append(p.allocator, .{
+                .name = ast.Span.fromToken(n_tok),
+                .alias = item_alias,
+                .span = .{ .start = n_tok.start, .end = item_end },
+            });
+            if (p.accept(.comma) == null) break;
+        }
+        _ = try p.expect(.kw_from, "from");
+        module_span = try parseUseModuleSpec(p, &quoted_path);
+    } else {
+        // Whole-module: `use module [as alias]`.
+        p.pos = start_pos;
+        module_span = try parseUseModuleSpec(p, &quoted_path);
+        if (p.accept(.kw_as)) |_| {
+            const a_tok = try p.expect(.ident, "alias");
+            alias = ast.Span.fromToken(a_tok);
+        }
+    }
+
+    const end: u32 = if (alias) |a| a.end else module_span.end;
+    try p.requireStatementBoundary();
+
+    return .{ .use_decl = .{
+        .module = module_span,
+        .quoted_path = quoted_path,
+        .items = try items.toOwnedSlice(p.allocator),
+        .alias = alias,
+        .is_local = is_local,
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+/// Module spec is either a bare ident or a quoted-path string literal.
+fn parseUseModuleSpec(p: *Parser, quoted: *bool) ParserError!ast.Span {
+    if (p.check(.str_start)) {
+        return try parseQuotedPath(p, quoted);
+    }
+    quoted.* = false;
+    const tok = try p.expect(.ident, "module name");
+    return ast.Span.fromToken(tok);
+}
+
+fn parseQuotedPath(p: *Parser, quoted: *bool) ParserError!ast.Span {
+    quoted.* = true;
+    const start_tok = try p.expect(.str_start, "\"");
+    // Eat the body parts until str_end.
+    var end_idx: u32 = start_tok.end;
+    while (true) {
+        const t = p.peek();
+        switch (t.kind) {
+            .str_part => {
+                p.pos += 1;
+                end_idx = t.end;
+            },
+            .str_end => {
+                p.pos += 1;
+                end_idx = t.end;
+                break;
+            },
+            .str_expr_start => {
+                // Interpolation inside an import path isn't useful;
+                // record + recover.
+                try p.recordError(
+                    "string interpolation not allowed in `use` path",
+                    "literal path",
+                );
+                return error.ParseFailed;
+            },
+            else => return error.ParseFailed,
+        }
+    }
+    return .{ .start = start_tok.start, .end = end_idx };
+}
+
+fn lookaheadHasFromClause(p: *Parser) ParserError!bool {
+    // Save position; walk through `ident [as ident] (, ident [as ident])*`
+    // and check whether the next token after that prefix is `kw_from`.
+    var i = p.pos;
+    if (i >= p.tokens.len) return false;
+    if (p.tokens[i].kind != .ident) return false;
+    while (true) {
+        if (i >= p.tokens.len or p.tokens[i].kind != .ident) return false;
+        i += 1;
+        if (i < p.tokens.len and p.tokens[i].kind == .kw_as) {
+            i += 1;
+            if (i >= p.tokens.len or p.tokens[i].kind != .ident) return false;
+            i += 1;
+        }
+        if (i < p.tokens.len and p.tokens[i].kind == .comma) {
+            i += 1;
+            continue;
+        }
+        break;
+    }
+    return i < p.tokens.len and p.tokens[i].kind == .kw_from;
+}
+
+// =====================================================================
+// Control flow.
+// =====================================================================
+
+fn parseIfStatement(p: *Parser) ParserError!ast.Statement {
+    const start_tok = p.peek();
+    const result = try parseIfChain(p);
+    try p.requireStatementBoundary();
+    return .{ .if_stmt = .{
+        .arms = result.arms,
+        .else_body = result.else_body,
+        .span = .{ .start = start_tok.start, .end = result.end },
+    } };
+}
+
+const IfChain = struct {
+    arms: []ast.IfArm,
+    else_body: ?[]ast.Statement,
+    end: u32,
+};
+
+fn parseIfChain(p: *Parser) ParserError!IfChain {
+    _ = try p.expect(.kw_if, "if");
+
+    var arms: std.ArrayList(ast.IfArm) = .empty;
+    errdefer cleanupIfArms(p.allocator, &arms);
+    var else_body: ?[]ast.Statement = null;
+    errdefer if (else_body) |b| {
+        for (b) |*s| ast.freeStatement(p.allocator, s);
+        p.allocator.free(b);
+    };
+
+    try parseIfArm(p, &arms);
+    var end: u32 = 0;
+
+    while (true) {
+        if (p.accept(.kw_elif)) |_| {
+            try parseIfArm(p, &arms);
+            continue;
+        }
+        if (p.accept(.kw_else)) |else_tok| {
+            // `else if cond then ...` flattens into another arm; the
+            // spec lists both `elif` and `else if` (§4.4).
+            if (p.check(.kw_if)) {
+                p.pos += 1;
+                try parseIfArm(p, &arms);
+                continue;
+            }
+            // Plain `else` body.
+            p.skipNewlines();
+            var body: std.ArrayList(ast.Statement) = .empty;
+            errdefer cleanupStatements(p.allocator, &body);
+            while (!p.atEnd() and !p.check(.kw_end)) {
+                try parseStatement(p, &body);
+                p.skipNewlines();
+            }
+            else_body = try body.toOwnedSlice(p.allocator);
+            _ = else_tok;
+            break;
+        }
+        break;
+    }
+
+    const end_tok = try p.expect(.kw_end, "end");
+    end = end_tok.end;
+    return .{
+        .arms = try arms.toOwnedSlice(p.allocator),
+        .else_body = else_body,
+        .end = end,
+    };
+}
+
+fn parseIfArm(
+    p: *Parser,
+    arms: *std.ArrayList(ast.IfArm),
+) ParserError!void {
+    const arm_start = p.peek().start;
+
+    var cond: ?*ast.Expr = null;
+    var let_pattern: ?*ast.Pattern = null;
+    var let_expr: ?*ast.Expr = null;
+    var let_guard: ?*ast.Expr = null;
+    errdefer if (cond) |c| ast.freeExpr(p.allocator, c);
+    errdefer if (let_pattern) |pp| ast.freePattern(p.allocator, pp);
+    errdefer if (let_expr) |e| ast.freeExpr(p.allocator, e);
+    errdefer if (let_guard) |g| ast.freeExpr(p.allocator, g);
+
+    // `if let pat = expr [when guard] then ...` — §4.4.1.
+    if (p.accept(.kw_let)) |_| {
+        let_pattern = try parsePattern(p);
+        _ = try p.expect(.equals, "=");
+        let_expr = try parseExpression(p, 0);
+        if (p.accept(.kw_when)) |_| {
+            let_guard = try parseExpression(p, 0);
+        }
+    } else {
+        cond = try parseExpression(p, 0);
+    }
+    _ = try p.expect(.kw_then, "then");
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer cleanupStatements(p.allocator, &body);
+
+    while (!p.atEnd() and !p.check(.kw_end) and !p.check(.kw_else) and !p.check(.kw_elif)) {
+        try parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const arm_end = p.peek().start;
+    try arms.append(p.allocator, .{
+        .cond = cond,
+        .let_pattern = let_pattern,
+        .let_expr = let_expr,
+        .let_guard = let_guard,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = arm_start, .end = arm_end },
+    });
+}
+
+fn cleanupIfArms(
+    allocator: std.mem.Allocator,
+    arms: *std.ArrayList(ast.IfArm),
+) void {
+    for (arms.items) |arm| {
+        if (arm.cond) |c| ast.freeExpr(allocator, c);
+        if (arm.let_pattern) |pp| ast.freePattern(allocator, pp);
+        if (arm.let_expr) |e| ast.freeExpr(allocator, e);
+        if (arm.let_guard) |g| ast.freeExpr(allocator, g);
+        for (arm.body) |*s| ast.freeStatement(allocator, s);
+        allocator.free(arm.body);
+    }
+    arms.deinit(allocator);
+}
+
+fn parseWhileStatement(p: *Parser) ParserError!ast.Statement {
+    const while_tok = p.peek();
+    p.pos += 1;
+    const start = while_tok.start;
+
+    var cond: ?*ast.Expr = null;
+    var let_pattern: ?*ast.Pattern = null;
+    var let_expr: ?*ast.Expr = null;
+    var let_guard: ?*ast.Expr = null;
+
+    // `while let pat = expr [when guard] do ... end`
+    if (p.accept(.kw_let)) |_| {
+        let_pattern = try parsePattern(p);
+        _ = try p.expect(.equals, "=");
+        let_expr = try parseExpression(p, 0);
+        if (p.accept(.kw_when)) |_| {
+            let_guard = try parseExpression(p, 0);
+        }
+    } else {
+        cond = try parseExpression(p, 0);
+    }
+
+    _ = try p.expect(.kw_do, "do");
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .while_stmt = .{
+        .cond = cond,
+        .let_pattern = let_pattern,
+        .let_expr = let_expr,
+        .let_guard = let_guard,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+fn parseForStatement(p: *Parser) ParserError!ast.Statement {
+    const for_tok = p.peek();
+    p.pos += 1;
+    const start = for_tok.start;
+
+    const binding_tok = try p.expect(.ident, "loop variable name");
+    _ = try p.expect(.kw_in, "in");
+
+    const iter = try parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, iter);
+
+    var step: ?*ast.Expr = null;
+    if (p.accept(.kw_step)) |_| {
+        step = try parseExpression(p, 0);
+    }
+    errdefer if (step) |s| ast.freeExpr(p.allocator, s);
+
+    _ = try p.expect(.kw_do, "do");
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .for_stmt = .{
+        .binding = ast.Span.fromToken(binding_tok),
+        .iter = iter,
+        .step = step,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+fn parseMatchStatement(p: *Parser) ParserError!ast.Statement {
+    const match_tok = p.peek();
+    p.pos += 1;
+    const start = match_tok.start;
+
+    const scrutinee = try parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, scrutinee);
+    p.skipNewlines();
+
+    var arms: std.ArrayList(ast.MatchArm) = .empty;
+    errdefer cleanupMatchArms(p.allocator, &arms);
+
+    while (p.accept(.kw_case)) |case_tok| {
+        const arm_start = case_tok.start;
+        const pattern = try parsePattern(p);
+        errdefer ast.freePattern(p.allocator, pattern);
+
+        var guard: ?*ast.Expr = null;
+        if (p.accept(.kw_when)) |_| {
+            guard = try parseExpression(p, 0);
+        }
+        errdefer if (guard) |g| ast.freeExpr(p.allocator, g);
+
+        _ = try p.expect(.kw_then, "then");
+        p.skipNewlines();
+
+        var body: std.ArrayList(ast.Statement) = .empty;
+        errdefer cleanupStatements(p.allocator, &body);
+        while (!p.atEnd() and !p.check(.kw_case) and !p.check(.kw_end)) {
+            try parseStatement(p, &body);
+            p.skipNewlines();
+        }
+        const arm_end = p.peek().start;
+        try arms.append(p.allocator, .{
+            .pattern = pattern,
+            .guard = guard,
+            .body = try body.toOwnedSlice(p.allocator),
+            .span = .{ .start = arm_start, .end = arm_end },
+        });
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .match_stmt = .{
+        .scrutinee = scrutinee,
+        .arms = try arms.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+fn cleanupMatchArms(
+    allocator: std.mem.Allocator,
+    arms: *std.ArrayList(ast.MatchArm),
+) void {
+    for (arms.items) |arm| {
+        ast.freePattern(allocator, arm.pattern);
+        if (arm.guard) |g| ast.freeExpr(allocator, g);
+        for (arm.body) |*s| ast.freeStatement(allocator, s);
+        allocator.free(arm.body);
+    }
+    arms.deinit(allocator);
+}
+
+fn parseBlockStatement(p: *Parser) ParserError!ast.Statement {
+    const do_tok = p.peek();
+    p.pos += 1;
+    const start = do_tok.start;
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .block = .{
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+fn parseReturnStatement(p: *Parser) ParserError!ast.Statement {
+    const ret_tok = p.peek();
+    p.pos += 1;
+    const start = ret_tok.start;
+
+    var value: ?*ast.Expr = null;
+    var end: u32 = ret_tok.end;
+    if (!p.check(.newline) and !p.atEnd() and !p.check(.kw_end)) {
+        const v = try parseExpression(p, 0);
+        end = v.span().end;
+        value = v;
+    }
+    try p.requireStatementBoundary();
+
+    return .{ .return_stmt = .{
+        .value = value,
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+fn parsePrintStatement(p: *Parser) ParserError!ast.Statement {
+    const print_tok = p.peek();
+    p.pos += 1;
+    const start = print_tok.start;
+
+    var args: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (args.items) |a| ast.freeExpr(p.allocator, a);
+        args.deinit(p.allocator);
+    }
+
+    // `print` with no following expression on the same line is
+    // valid (prints just the newline). The lexer significant
+    // newlines make this unambiguous.
+    if (!p.check(.newline) and !p.atEnd()) {
+        while (true) {
+            const a = try parseExpression(p, 0);
+            try args.append(p.allocator, a);
+            if (p.accept(.comma) == null) break;
+        }
+    }
+    const end: u32 = if (args.items.len > 0) args.items[args.items.len - 1].span().end else print_tok.end;
+    try p.requireStatementBoundary();
+
+    return .{ .print_stmt = .{
+        .args = try args.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+// =====================================================================
+// Expression-or-assignment statement.
+//
+// In statement position, an expression can be:
+//   - bare expression (function call, etc.)
+//   - assignment: `target = expr` / `target += expr` / ...
+//   - increment / decrement: `target++` / `target--`
+//   - discard: `_ = expr`
+// =====================================================================
+
+fn parseExprOrAssignStatement(
+    p: *Parser,
+    statements: *std.ArrayList(ast.Statement),
+) ParserError!void {
+    const start = p.peek().start;
+    const first = try parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, first);
+
+    // Compound-assign / plain-assign / inc-dec / discard / bare expr
+    // are all distinguished by the next token.
+    if (matchAssignOp(p.peek().kind)) |op| {
+        p.pos += 1;
+        // Discard form: `_ = expr` — desugars to `.discard`.
+        if (op == .set and isUnderscore(p, first)) {
+            const value = try parseExpression(p, 0);
+            ast.freeExpr(p.allocator, first);
+            try p.requireStatementBoundary();
+            try statements.append(p.allocator, .{ .discard = .{
+                .expr = value,
+                .span = .{ .start = start, .end = value.span().end },
+            } });
+            return;
+        }
+        const value = try parseExpression(p, 0);
+        try p.requireStatementBoundary();
+        try statements.append(p.allocator, .{ .assign = .{
+            .target = first,
+            .op = op,
+            .value = value,
+            .span = .{ .start = start, .end = value.span().end },
+        } });
+        return;
+    }
+
+    if (p.accept(.plus_plus)) |t| {
+        try p.requireStatementBoundary();
+        try statements.append(p.allocator, .{ .inc_dec = .{
+            .target = first,
+            .inc = true,
+            .span = .{ .start = start, .end = t.end },
+        } });
+        return;
+    }
+    if (p.accept(.minus_minus)) |t| {
+        try p.requireStatementBoundary();
+        try statements.append(p.allocator, .{ .inc_dec = .{
+            .target = first,
+            .inc = false,
+            .span = .{ .start = start, .end = t.end },
+        } });
+        return;
+    }
+
+    try p.requireStatementBoundary();
+    try statements.append(p.allocator, .{ .expr_stmt = .{
+        .expr = first,
+        .span = .{ .start = start, .end = first.span().end },
+    } });
+}
+
+fn isUnderscore(p: *const Parser, e: *const ast.Expr) bool {
+    return switch (e.*) {
+        .ident => |i| std.mem.eql(u8, p.source[i.span.start..i.span.end], "_"),
+        else => false,
+    };
+}
+
+fn matchAssignOp(k: Kind) ?ast.AssignOp {
+    return switch (k) {
+        .equals => .set,
+        .plus_eq => .add_set,
+        .minus_eq => .sub_set,
+        .star_eq => .mul_set,
+        .slash_eq => .div_set,
+        .percent_eq => .mod_set,
+        .amp_eq => .bit_and_set,
+        .pipe_eq => .bit_or_set,
+        .caret_eq => .bit_xor_set,
+        .shl_eq => .shl_set,
+        .shr_eq => .shr_set,
+        else => null,
+    };
+}
+
+// =====================================================================
+// Type-annotation parser.
+// =====================================================================
+
+fn parseTypeAnn(p: *Parser) ParserError!*ast.TypeAnn {
+    var base = try parseTypeBase(p);
+    errdefer ast.freeTypeAnn(p.allocator, base);
+
+    // Postfix `?` — nullable suffix. Loops so `T??` would parse,
+    // though that's unusual; typechecker can flag.
+    while (p.accept(.question)) |q| {
+        const wrapped = try p.allocTypeAnn(.{ .nullable = .{
+            .inner = base,
+            .span = .{ .start = base.span().start, .end = q.end },
+        } });
+        base = wrapped;
+    }
+    return base;
+}
+
+fn parseTypeBase(p: *Parser) ParserError!*ast.TypeAnn {
+    const tok = p.peek();
+    switch (tok.kind) {
+        .lbracket => return try parseArrayType(p),
+        .lparen => return try parseTupleOrParenType(p),
+        .ident => return try parseNamedOrVecType(p),
+        else => {
+            // `fn` type — the spec spells `fn(args) -> ret`. `fn` is
+            // not a keyword in the lexer; it arrives as a bare
+            // ident. The `.ident` branch above handles it through
+            // the regular path (since it has a `(` after `fn`, that
+            // looks like a generic application — handle here).
+            try p.recordError("expected type annotation", "type");
+            return error.ParseFailed;
+        },
+    }
+}
+
+/// `[T; N]`.
+fn parseArrayType(p: *Parser) ParserError!*ast.TypeAnn {
+    const lb_tok = p.peek();
+    p.pos += 1;
+
+    const elem = try parseTypeAnn(p);
+    errdefer ast.freeTypeAnn(p.allocator, elem);
+
+    _ = try p.expect(.semicolon, ";");
+    const len_expr = try parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, len_expr);
+
+    const rb_tok = try p.expect(.rbracket, "]");
+    return try p.allocTypeAnn(.{ .array = .{
+        .elem = elem,
+        .len_expr = len_expr,
+        .span = .{ .start = lb_tok.start, .end = rb_tok.end },
+    } });
+}
+
+/// `(T)` → just T; `(T1, T2, ...)` → tuple.
+fn parseTupleOrParenType(p: *Parser) ParserError!*ast.TypeAnn {
+    const lp_tok = p.peek();
+    p.pos += 1;
+    const first = try parseTypeAnn(p);
+    errdefer ast.freeTypeAnn(p.allocator, first);
+
+    if (p.accept(.rparen)) |rp| {
+        // Single-element grouping isn't reflected in the AST (no
+        // `paren` wrapper for types) — return the inner directly,
+        // span-extended to cover the parens.
+        first.* = switch (first.*) {
+            .named => |n| .{ .named = .{ .name = n.name, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .nullable => |n| .{ .nullable = .{ .inner = n.inner, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .array => |a| .{ .array = .{ .elem = a.elem, .len_expr = a.len_expr, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .vec => |v| .{ .vec = .{ .elem = v.elem, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .tuple => |t| .{ .tuple = .{ .elems = t.elems, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .fn_type => |f| .{ .fn_type = .{ .params = f.params, .ret = f.ret, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+        };
+        return first;
+    }
+
+    // Tuple shape.
+    var elems: std.ArrayList(*ast.TypeAnn) = .empty;
+    errdefer {
+        for (elems.items) |t| ast.freeTypeAnn(p.allocator, t);
+        elems.deinit(p.allocator);
+    }
+    try elems.append(p.allocator, first);
+
+    _ = try p.expect(.comma, ",");
+    while (true) {
+        const t = try parseTypeAnn(p);
+        try elems.append(p.allocator, t);
+        if (p.accept(.comma) == null) break;
+    }
+    const rp = try p.expect(.rparen, ")");
+    return try p.allocTypeAnn(.{ .tuple = .{
+        .elems = try elems.toOwnedSlice(p.allocator),
+        .span = .{ .start = lp_tok.start, .end = rp.end },
+    } });
+}
+
+/// Named type, `Vec(T)`, or `fn(args) -> ret`.
+fn parseNamedOrVecType(p: *Parser) ParserError!*ast.TypeAnn {
+    const name_tok = p.peek();
+    p.pos += 1;
+    const name_lex = p.source[name_tok.start..name_tok.end];
+
+    if (std.mem.eql(u8, name_lex, "Vec") and p.check(.lparen)) {
+        p.pos += 1;
+        const elem = try parseTypeAnn(p);
+        errdefer ast.freeTypeAnn(p.allocator, elem);
+        const rp = try p.expect(.rparen, ")");
+        return try p.allocTypeAnn(.{ .vec = .{
+            .elem = elem,
+            .span = .{ .start = name_tok.start, .end = rp.end },
+        } });
+    }
+
+    if (std.mem.eql(u8, name_lex, "fn") and p.check(.lparen)) {
+        p.pos += 1;
+        var params: std.ArrayList(*ast.TypeAnn) = .empty;
+        errdefer {
+            for (params.items) |t| ast.freeTypeAnn(p.allocator, t);
+            params.deinit(p.allocator);
+        }
+        if (!p.check(.rparen)) {
+            while (true) {
+                const t = try parseTypeAnn(p);
+                try params.append(p.allocator, t);
+                if (p.accept(.comma) == null) break;
+            }
+        }
+        const rp_tok = try p.expect(.rparen, ")");
+        var ret: ?*ast.TypeAnn = null;
+        var end: u32 = rp_tok.end;
+        if (p.accept(.arrow)) |_| {
+            const r = try parseTypeAnn(p);
+            end = r.span().end;
+            ret = r;
+        }
+        return try p.allocTypeAnn(.{ .fn_type = .{
+            .params = try params.toOwnedSlice(p.allocator),
+            .ret = ret,
+            .span = .{ .start = name_tok.start, .end = end },
+        } });
+    }
+
+    // Plain named type — accumulate `.qualified.path` segments via
+    // dot tokens. The AST captures the joined source span; the
+    // typechecker re-tokenizes against the lexeme.
+    var end_idx: u32 = name_tok.end;
+    while (p.check(.dot) and p.peekAt(1).kind == .ident) {
+        p.pos += 1; // dot
+        const seg = p.peek();
+        p.pos += 1;
+        end_idx = seg.end;
+    }
+
+    return try p.allocTypeAnn(.{ .named = .{
+        .name = .{ .start = name_tok.start, .end = end_idx },
+        .span = .{ .start = name_tok.start, .end = end_idx },
+    } });
+}
+
+// =====================================================================
+// Pattern parser.
+// =====================================================================
+
+fn parsePattern(p: *Parser) ParserError!*ast.Pattern {
+    var first = try parseAtomicPattern(p);
+    errdefer ast.freePattern(p.allocator, first);
+
+    // Or-pattern: `A | B | C`.
+    if (!p.check(.pipe)) return first;
+
+    var alts: std.ArrayList(*ast.Pattern) = .empty;
+    errdefer {
+        for (alts.items) |a| ast.freePattern(p.allocator, a);
+        alts.deinit(p.allocator);
+    }
+    try alts.append(p.allocator, first);
+    var end_span = first.span();
+
+    while (p.accept(.pipe)) |_| {
+        const next = try parseAtomicPattern(p);
+        end_span = next.span();
+        try alts.append(p.allocator, next);
+    }
+    const start = alts.items[0].span().start;
+    return try p.allocPattern(.{ .or_pattern = .{
+        .alts = try alts.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_span.end },
+    } });
+}
+
+fn parseAtomicPattern(p: *Parser) ParserError!*ast.Pattern {
+    const tok = p.peek();
+    switch (tok.kind) {
+        .int_lit => {
+            p.pos += 1;
+            // Range pattern: `lo .. hi` or `lo ..= hi`.
+            if (p.check(.dot_dot) or p.check(.dot_dot_eq)) {
+                return try parseRangePatternFrom(p, intLitExpr(tok), tok.start);
+            }
+            return try p.allocPattern(.{ .int_lit = .{
+                .value = tok.value,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_true => {
+            p.pos += 1;
+            return try p.allocPattern(.{ .bool_lit = .{
+                .value = true,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_false => {
+            p.pos += 1;
+            return try p.allocPattern(.{ .bool_lit = .{
+                .value = false,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_nil => {
+            p.pos += 1;
+            return try p.allocPattern(.{ .nil_lit = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .str_start => {
+            return try parseStringLitPattern(p);
+        },
+        .ident => {
+            // Wildcard `_`, plain binding, struct pattern, or enum-variant pattern.
+            const lex = p.source[tok.start..tok.end];
+            if (std.mem.eql(u8, lex, "_")) {
+                p.pos += 1;
+                return try p.allocPattern(.{ .wildcard = .{
+                    .span = .{ .start = tok.start, .end = tok.end },
+                } });
+            }
+
+            // Lookahead: `Ident { ... }` → struct pattern.
+            //            `Ident.Ident(...)` / `Ident.Ident` → variant pattern.
+            //            else → plain identifier binding.
+            const next = p.peekAt(1).kind;
+            if (next == .lbrace) {
+                return try parseStructPattern(p);
+            }
+            if (next == .dot) {
+                return try parseVariantPattern(p);
+            }
+            p.pos += 1;
+            return try p.allocPattern(.{ .ident = .{
+                .name = .{ .start = tok.start, .end = tok.end },
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .lparen => {
+            return try parseTuplePattern(p);
+        },
+        else => {
+            try p.recordError("expected pattern", "pattern");
+            return error.ParseFailed;
+        },
+    }
+}
+
+fn intLitExpr(t: lexer.Token) ast.Expr {
+    return .{ .int_lit = .{
+        .value = t.value,
+        .span = .{ .start = t.start, .end = t.end },
+    } };
+}
+
+fn parseRangePatternFrom(
+    p: *Parser,
+    lo_expr_val: ast.Expr,
+    start: u32,
+) ParserError!*ast.Pattern {
+    const inclusive = p.check(.dot_dot_eq);
+    p.pos += 1; // consume `..` or `..=`
+
+    const lo = try p.allocExpr(lo_expr_val);
+    errdefer ast.freeExpr(p.allocator, lo);
+
+    const hi = try parseExpression(p, 0);
+
+    return try p.allocPattern(.{ .range_pattern = .{
+        .start = lo,
+        .end = hi,
+        .inclusive = inclusive,
+        .span = .{ .start = start, .end = hi.span().end },
+    } });
+}
+
+fn parseStringLitPattern(p: *Parser) ParserError!*ast.Pattern {
+    // The lexer emits str_start | str_part | str_end for an
+    // un-interpolated literal. Patterns reject interpolation —
+    // they're literals only.
+    const start_tok = try p.expect(.str_start, "\"");
+    var end_idx: u32 = start_tok.end;
+    while (true) {
+        const t = p.peek();
+        switch (t.kind) {
+            .str_part => {
+                p.pos += 1;
+                end_idx = t.end;
+            },
+            .str_end => {
+                p.pos += 1;
+                end_idx = t.end;
+                break;
+            },
+            .str_expr_start => {
+                try p.recordError(
+                    "interpolation not allowed in pattern position",
+                    "literal string",
+                );
+                return error.ParseFailed;
+            },
+            else => return error.ParseFailed,
+        }
+    }
+    return try p.allocPattern(.{ .str_lit = .{
+        .span = .{ .start = start_tok.start, .end = end_idx },
+    } });
+}
+
+fn parseStructPattern(p: *Parser) ParserError!*ast.Pattern {
+    const name_tok = p.peek();
+    p.pos += 1;
+    _ = try p.expect(.lbrace, "{");
+
+    var fields: std.ArrayList(ast.StructPatternField) = .empty;
+    errdefer {
+        for (fields.items) |f| ast.freePattern(p.allocator, f.sub);
+        fields.deinit(p.allocator);
+    }
+
+    if (!p.check(.rbrace)) {
+        while (true) {
+            const fname_tok = try p.expect(.ident, "field name");
+            const fname_span = ast.Span.fromToken(fname_tok);
+            var sub: *ast.Pattern = undefined;
+            if (p.accept(.colon)) |_| {
+                sub = try parsePattern(p);
+            } else {
+                // Shorthand: `Foo { hp, mp }` → `hp: hp, mp: mp`.
+                sub = try p.allocPattern(.{ .ident = .{
+                    .name = fname_span,
+                    .span = fname_span,
+                } });
+            }
+            try fields.append(p.allocator, .{
+                .name = fname_span,
+                .sub = sub,
+                .span = .{ .start = fname_span.start, .end = sub.span().end },
+            });
+            if (p.accept(.comma) == null) break;
+        }
+    }
+    const rb = try p.expect(.rbrace, "}");
+    return try p.allocPattern(.{ .struct_pattern = .{
+        .type_name = ast.Span.fromToken(name_tok),
+        .fields = try fields.toOwnedSlice(p.allocator),
+        .span = .{ .start = name_tok.start, .end = rb.end },
+    } });
+}
+
+fn parseVariantPattern(p: *Parser) ParserError!*ast.Pattern {
+    const head_tok = p.peek();
+    p.pos += 1;
+    _ = try p.expect(.dot, ".");
+    const variant_tok = try p.expect(.ident, "variant name");
+    var end_idx: u32 = variant_tok.end;
+
+    var args: std.ArrayList(*ast.Pattern) = .empty;
+    errdefer {
+        for (args.items) |a| ast.freePattern(p.allocator, a);
+        args.deinit(p.allocator);
+    }
+
+    if (p.accept(.lparen)) |_| {
+        if (!p.check(.rparen)) {
+            while (true) {
+                const a = try parsePattern(p);
+                try args.append(p.allocator, a);
+                if (p.accept(.comma) == null) break;
+            }
+        }
+        const rp = try p.expect(.rparen, ")");
+        end_idx = rp.end;
+    }
+    return try p.allocPattern(.{ .variant_pattern = .{
+        .path = .{ .start = head_tok.start, .end = variant_tok.end },
+        .args = try args.toOwnedSlice(p.allocator),
+        .span = .{ .start = head_tok.start, .end = end_idx },
+    } });
+}
+
+fn parseTuplePattern(p: *Parser) ParserError!*ast.Pattern {
+    const lp = p.peek();
+    p.pos += 1;
+    var elems: std.ArrayList(*ast.Pattern) = .empty;
+    errdefer {
+        for (elems.items) |e| ast.freePattern(p.allocator, e);
+        elems.deinit(p.allocator);
+    }
+
+    if (!p.check(.rparen)) {
+        while (true) {
+            const e = try parsePattern(p);
+            try elems.append(p.allocator, e);
+            if (p.accept(.comma) == null) break;
+        }
+    }
+    const rp = try p.expect(.rparen, ")");
+    return try p.allocPattern(.{ .tuple_pattern = .{
+        .elems = try elems.toOwnedSlice(p.allocator),
+        .span = .{ .start = lp.start, .end = rp.end },
+    } });
+}
+
+// =====================================================================
+// Expression parser — Pratt precedence per §3.3.
+// =====================================================================
+
+/// Precedence levels — higher binds tighter. Used by the Pratt loop
+/// to encode the `docs/gero-lang.md` §3.3 hierarchy. Values are
+/// reserved to allow inserting new levels between existing ones
+/// without renumbering call sites.
+const Prec = struct {
+    /// Initial level passed by callers that want the full expression.
+    pub const lowest: u8 = 0;
+    /// `..` / `..=` — produce range values; bind loosest.
+    pub const range: u8 = 1;
+    /// `or` — logical OR, short-circuits.
+    pub const log_or: u8 = 2;
+    /// `and` — logical AND, short-circuits.
+    pub const log_and: u8 = 3;
+    /// `==` / `!=` / `<` / `<=` / `>` / `>=`.
+    pub const compare: u8 = 4;
+    /// `|` — bitwise OR.
+    pub const bit_or: u8 = 5;
+    /// `^` — bitwise XOR.
+    pub const bit_xor: u8 = 6;
+    /// `&` — bitwise AND.
+    pub const bit_and: u8 = 7;
+    /// `<<` / `>>` — bit shifts.
+    pub const shift: u8 = 8;
+    /// `+` / `-` — additive arithmetic.
+    pub const add: u8 = 9;
+    /// `*` / `/` / `%` — multiplicative arithmetic.
+    pub const mul: u8 = 10;
+    /// `is` — variant-tag test. Binds tighter than arithmetic.
+    pub const is_test: u8 = 11;
+    /// Unary prefix: `-x` / `not x` / `~x`.
+    pub const unary: u8 = 12;
+    /// Postfix: call `( )`, index `[ ]`, field `.`.
+    pub const call: u8 = 13;
+};
+
+fn parseExpression(p: *Parser, min_prec: u8) ParserError!*ast.Expr {
+    var lhs = try parseUnary(p);
+    errdefer ast.freeExpr(p.allocator, lhs);
+
+    while (true) {
+        const k = p.peek().kind;
+
+        // Range operator — bind tightest at the lowest level so
+        // `0..10 + 1` parses as `0 .. (10 + 1)`. §3.3 lists range
+        // below assignment.
+        if (k == .dot_dot or k == .dot_dot_eq) {
+            const prec = Prec.range;
+            if (prec < min_prec) break;
+            const inclusive = k == .dot_dot_eq;
+            p.pos += 1;
+            const rhs = try parseExpression(p, prec + 1);
+            const new_node = try p.allocExpr(.{ .range = .{
+                .start = lhs,
+                .end = rhs,
+                .inclusive = inclusive,
+                .span = .{ .start = lhs.span().start, .end = rhs.span().end },
+            } });
+            lhs = new_node;
+            continue;
+        }
+
+        // `is` — variant-tag test (§3.6). Right side is a qualified
+        // variant path like `Item.Sword`.
+        if (k == .kw_is) {
+            const prec = Prec.is_test;
+            if (prec < min_prec) break;
+            p.pos += 1;
+            const head_tok = try p.expect(.ident, "enum name");
+            _ = try p.expect(.dot, ".");
+            const var_tok = try p.expect(.ident, "variant name");
+            const path: ast.Span = .{ .start = head_tok.start, .end = var_tok.end };
+            const new_node = try p.allocExpr(.{ .is_test = .{
+                .lhs = lhs,
+                .variant_path = path,
+                .span = .{ .start = lhs.span().start, .end = var_tok.end },
+            } });
+            lhs = new_node;
+            continue;
+        }
+
+        // Generic binary operators driven by a precedence table.
+        if (binaryOpOf(k)) |info| {
+            if (info.prec < min_prec) break;
+            p.pos += 1;
+            const rhs = try parseExpression(p, info.prec + 1);
+            const new_node = try p.allocExpr(.{ .binary = .{
+                .op = info.op,
+                .lhs = lhs,
+                .rhs = rhs,
+                .span = .{ .start = lhs.span().start, .end = rhs.span().end },
+            } });
+            lhs = new_node;
+            continue;
+        }
+
+        break;
+    }
+    return lhs;
+}
+
+const BinaryInfo = struct {
+    op: ast.BinaryOp,
+    prec: u8,
+};
+
+fn binaryOpOf(k: Kind) ?BinaryInfo {
+    return switch (k) {
+        .kw_or => .{ .op = .log_or, .prec = Prec.log_or },
+        .kw_and => .{ .op = .log_and, .prec = Prec.log_and },
+        .eq_eq => .{ .op = .eq, .prec = Prec.compare },
+        .bang_eq => .{ .op = .neq, .prec = Prec.compare },
+        .lt => .{ .op = .lt, .prec = Prec.compare },
+        .lt_eq => .{ .op = .lte, .prec = Prec.compare },
+        .gt => .{ .op = .gt, .prec = Prec.compare },
+        .gt_eq => .{ .op = .gte, .prec = Prec.compare },
+        .pipe => .{ .op = .bit_or, .prec = Prec.bit_or },
+        .caret => .{ .op = .bit_xor, .prec = Prec.bit_xor },
+        .amp => .{ .op = .bit_and, .prec = Prec.bit_and },
+        .shl => .{ .op = .shl, .prec = Prec.shift },
+        .shr => .{ .op = .shr, .prec = Prec.shift },
+        .plus => .{ .op = .add, .prec = Prec.add },
+        .minus => .{ .op = .sub, .prec = Prec.add },
+        .star => .{ .op = .mul, .prec = Prec.mul },
+        .slash => .{ .op = .div, .prec = Prec.mul },
+        .percent => .{ .op = .mod, .prec = Prec.mul },
+        else => null,
+    };
+}
+
+fn parseUnary(p: *Parser) ParserError!*ast.Expr {
+    const tok = p.peek();
+    switch (tok.kind) {
+        .minus => {
+            p.pos += 1;
+            const operand = try parseUnary(p);
+            return try p.allocExpr(.{ .unary = .{
+                .op = .neg,
+                .operand = operand,
+                .span = .{ .start = tok.start, .end = operand.span().end },
+            } });
+        },
+        .kw_not => {
+            p.pos += 1;
+            const operand = try parseUnary(p);
+            return try p.allocExpr(.{ .unary = .{
+                .op = .log_not,
+                .operand = operand,
+                .span = .{ .start = tok.start, .end = operand.span().end },
+            } });
+        },
+        .tilde => {
+            p.pos += 1;
+            const operand = try parseUnary(p);
+            return try p.allocExpr(.{ .unary = .{
+                .op = .bit_not,
+                .operand = operand,
+                .span = .{ .start = tok.start, .end = operand.span().end },
+            } });
+        },
+        else => return try parseCallChain(p),
+    }
+}
+
+fn parseCallChain(p: *Parser) ParserError!*ast.Expr {
+    var e = try parsePrimary(p);
+    errdefer ast.freeExpr(p.allocator, e);
+
+    while (true) {
+        const k = p.peek().kind;
+        switch (k) {
+            .lparen => {
+                e = try parseCallArgs(p, e);
+            },
+            .lbracket => {
+                e = try parseIndexAccess(p, e);
+            },
+            .dot => {
+                e = try parseFieldOrMethod(p, e);
+            },
+            else => break,
+        }
+    }
+    return e;
+}
+
+fn parseCallArgs(p: *Parser, callee: *ast.Expr) ParserError!*ast.Expr {
+    p.pos += 1; // consume `(`
+    var args: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (args.items) |a| ast.freeExpr(p.allocator, a);
+        args.deinit(p.allocator);
+    }
+    if (!p.check(.rparen)) {
+        while (true) {
+            const a = try parseExpression(p, 0);
+            try args.append(p.allocator, a);
+            if (p.accept(.comma) == null) break;
+        }
+    }
+    const rp = try p.expect(.rparen, ")");
+    return try p.allocExpr(.{ .call = .{
+        .callee = callee,
+        .args = try args.toOwnedSlice(p.allocator),
+        .span = .{ .start = callee.span().start, .end = rp.end },
+    } });
+}
+
+fn parseIndexAccess(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
+    p.pos += 1; // consume `[`
+    const idx = try parseExpression(p, 0);
+    const rb = try p.expect(.rbracket, "]");
+    return try p.allocExpr(.{ .index = .{
+        .receiver = receiver,
+        .index = idx,
+        .span = .{ .start = receiver.span().start, .end = rb.end },
+    } });
+}
+
+fn parseFieldOrMethod(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
+    p.pos += 1; // consume `.`
+    const name_tok = try p.expect(.ident, "field or method name");
+    if (p.check(.lparen)) {
+        p.pos += 1;
+        var args: std.ArrayList(*ast.Expr) = .empty;
+        errdefer {
+            for (args.items) |a| ast.freeExpr(p.allocator, a);
+            args.deinit(p.allocator);
+        }
+        if (!p.check(.rparen)) {
+            while (true) {
+                const a = try parseExpression(p, 0);
+                try args.append(p.allocator, a);
+                if (p.accept(.comma) == null) break;
+            }
+        }
+        const rp = try p.expect(.rparen, ")");
+        return try p.allocExpr(.{ .method_call = .{
+            .receiver = receiver,
+            .method = ast.Span.fromToken(name_tok),
+            .args = try args.toOwnedSlice(p.allocator),
+            .span = .{ .start = receiver.span().start, .end = rp.end },
+        } });
+    }
+    return try p.allocExpr(.{ .field = .{
+        .receiver = receiver,
+        .field = ast.Span.fromToken(name_tok),
+        .span = .{ .start = receiver.span().start, .end = name_tok.end },
+    } });
+}
+
+fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
+    const tok = p.peek();
+    switch (tok.kind) {
+        .int_lit => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .int_lit = .{
+                .value = tok.value,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_true => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .bool_lit = .{
+                .value = true,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_false => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .bool_lit = .{
+                .value = false,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_nil => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .nil_lit = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_self => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .self_expr = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_super => {
+            p.pos += 1;
+            return try p.allocExpr(.{ .super_expr = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .ident => {
+            // The lang has no separate char-literal token; the lexer
+            // doesn't distinguish 'x' at the token level either —
+            // chars come through as int_lit with the decoded value
+            // attached. So the only ident-driven primaries are
+            // variable refs and capitalized-type struct-literal
+            // shapes (`Foo { ... }`).
+            const next = p.peekAt(1).kind;
+            if (next == .lbrace and looksLikeStructLit(p)) {
+                return try parseStructLit(p);
+            }
+            p.pos += 1;
+            return try p.allocExpr(.{ .ident = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .str_start => return try parseStringLit(p),
+        .lparen => return try parseParenOrTupleExpr(p),
+        .lbracket => return try parseListLit(p),
+        .kw_do => return try parseDoExpr(p),
+        .kw_if => return try parseIfExpr(p),
+        .kw_lambda => return try parseLambda(p),
+        else => {
+            try p.recordError("expected expression", "expression");
+            return error.ParseFailed;
+        },
+    }
+}
+
+/// Conservative heuristic: a struct literal in expression position
+/// looks like `TypeName { ... }`. We don't have an unambiguous way
+/// to tell `if x { ... }` from a struct lit without keyword
+/// disambiguation; the lang uses `then`/`do` to fence those, so
+/// `Ident {` in expression position is always a struct literal.
+fn looksLikeStructLit(p: *const Parser) bool {
+    // First char of the ident must be uppercase OR it must be a
+    // known compiler-built-in (`Vec`). The simplest test is "does
+    // the ident's first byte look like an ASCII uppercase?"
+    const tok = p.peek();
+    if (tok.start >= p.source.len) return false;
+    const b = p.source[tok.start];
+    return b >= 'A' and b <= 'Z';
+}
+
+fn parseStructLit(p: *Parser) ParserError!*ast.Expr {
+    const name_tok = p.peek();
+    p.pos += 1;
+    _ = try p.expect(.lbrace, "{");
+    p.skipNewlines();
+
+    var fields: std.ArrayList(ast.StructLitField) = .empty;
+    errdefer {
+        for (fields.items) |f| ast.freeExpr(p.allocator, f.value);
+        fields.deinit(p.allocator);
+    }
+
+    if (!p.check(.rbrace)) {
+        while (true) {
+            p.skipNewlines();
+            if (p.check(.rbrace)) break;
+            const fname_tok = try p.expect(.ident, "field name");
+            _ = try p.expect(.colon, ":");
+            const value = try parseExpression(p, 0);
+            try fields.append(p.allocator, .{
+                .name = ast.Span.fromToken(fname_tok),
+                .value = value,
+                .span = .{ .start = fname_tok.start, .end = value.span().end },
+            });
+            if (p.accept(.comma) == null) break;
+            p.skipNewlines();
+        }
+    }
+    p.skipNewlines();
+    const rb = try p.expect(.rbrace, "}");
+    return try p.allocExpr(.{ .struct_lit = .{
+        .type_name = ast.Span.fromToken(name_tok),
+        .fields = try fields.toOwnedSlice(p.allocator),
+        .span = .{ .start = name_tok.start, .end = rb.end },
+    } });
+}
+
+fn parseStringLit(p: *Parser) ParserError!*ast.Expr {
+    const start_tok = p.peek();
+    p.pos += 1;
+    var parts: std.ArrayList(ast.StrPart) = .empty;
+    errdefer cleanupStrParts(p.allocator, &parts);
+
+    var end_idx: u32 = start_tok.end;
+    while (true) {
+        const t = p.peek();
+        switch (t.kind) {
+            .str_part => {
+                p.pos += 1;
+                try parts.append(p.allocator, .{ .lit = .{
+                    .span = .{ .start = t.start, .end = t.end },
+                } });
+                end_idx = t.end;
+            },
+            .str_expr_start => {
+                p.pos += 1;
+                const inner = try parseExpression(p, 0);
+                // Optional format spec — `:fmt` before `)`. The
+                // lexer doesn't emit a dedicated `:fmt` token today,
+                // so the parser accepts `:` followed by tokens up
+                // to the matching `)`. The captured span covers
+                // those bytes verbatim.
+                var fmt_span: ?ast.Span = null;
+                if (p.accept(.colon)) |colon_tok| {
+                    const fmt_start = colon_tok.end;
+                    var depth: u32 = 0;
+                    while (true) {
+                        const nt = p.peek();
+                        if (nt.kind == .str_expr_end and depth == 0) break;
+                        if (nt.kind == .lparen) depth += 1;
+                        if (nt.kind == .rparen and depth > 0) depth -= 1;
+                        if (nt.kind == .eof) break;
+                        p.pos += 1;
+                    }
+                    const fmt_end = p.peek().start;
+                    fmt_span = .{ .start = fmt_start, .end = fmt_end };
+                }
+                const close = try p.expect(.str_expr_end, ")");
+                try parts.append(p.allocator, .{ .interp = .{
+                    .expr = inner,
+                    .format_spec = fmt_span,
+                    .span = .{ .start = t.start, .end = close.end },
+                } });
+                end_idx = close.end;
+            },
+            .str_end => {
+                p.pos += 1;
+                end_idx = t.end;
+                break;
+            },
+            else => {
+                try p.recordError("malformed string literal", "string part");
+                return error.ParseFailed;
+            },
+        }
+    }
+    return try p.allocExpr(.{ .str_lit = .{
+        .parts = try parts.toOwnedSlice(p.allocator),
+        .span = .{ .start = start_tok.start, .end = end_idx },
+    } });
+}
+
+fn cleanupStrParts(
+    allocator: std.mem.Allocator,
+    parts: *std.ArrayList(ast.StrPart),
+) void {
+    for (parts.items) |p| switch (p) {
+        .lit => {},
+        .interp => |ip| ast.freeExpr(allocator, ip.expr),
+    };
+    parts.deinit(allocator);
+}
+
+fn parseParenOrTupleExpr(p: *Parser) ParserError!*ast.Expr {
+    const lp = p.peek();
+    p.pos += 1;
+    p.skipNewlines();
+    const first = try parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, first);
+
+    if (p.accept(.rparen)) |rp| {
+        return try p.allocExpr(.{ .paren = .{
+            .inner = first,
+            .span = .{ .start = lp.start, .end = rp.end },
+        } });
+    }
+
+    // Tuple: at least one comma.
+    var elems: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (elems.items) |e| ast.freeExpr(p.allocator, e);
+        elems.deinit(p.allocator);
+    }
+    try elems.append(p.allocator, first);
+    while (p.accept(.comma)) |_| {
+        p.skipNewlines();
+        if (p.check(.rparen)) break; // trailing comma
+        const e = try parseExpression(p, 0);
+        try elems.append(p.allocator, e);
+    }
+    const rp = try p.expect(.rparen, ")");
+    return try p.allocExpr(.{ .tuple_lit = .{
+        .elems = try elems.toOwnedSlice(p.allocator),
+        .span = .{ .start = lp.start, .end = rp.end },
+    } });
+}
+
+fn parseListLit(p: *Parser) ParserError!*ast.Expr {
+    const lb = p.peek();
+    p.pos += 1;
+    p.skipNewlines();
+    var elems: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (elems.items) |e| ast.freeExpr(p.allocator, e);
+        elems.deinit(p.allocator);
+    }
+    if (!p.check(.rbracket)) {
+        while (true) {
+            p.skipNewlines();
+            const e = try parseExpression(p, 0);
+            try elems.append(p.allocator, e);
+            if (p.accept(.comma) == null) break;
+            p.skipNewlines();
+            if (p.check(.rbracket)) break;
+        }
+    }
+    p.skipNewlines();
+    const rb = try p.expect(.rbracket, "]");
+    return try p.allocExpr(.{ .list_lit = .{
+        .elems = try elems.toOwnedSlice(p.allocator),
+        .span = .{ .start = lb.start, .end = rb.end },
+    } });
+}
+
+fn parseDoExpr(p: *Parser) ParserError!*ast.Expr {
+    const do_tok = p.peek();
+    p.pos += 1;
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    return try p.allocExpr(.{ .do_expr = .{
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = do_tok.start, .end = end_tok.end },
+    } });
+}
+
+fn parseIfExpr(p: *Parser) ParserError!*ast.Expr {
+    const start_tok = p.peek();
+    const result = try parseIfChain(p);
+    return try p.allocExpr(.{ .if_expr = .{
+        .arms = result.arms,
+        .else_body = result.else_body,
+        .span = .{ .start = start_tok.start, .end = result.end },
+    } });
+}
+
+fn parseLambda(p: *Parser) ParserError!*ast.Expr {
+    const lambda_tok = p.peek();
+    p.pos += 1;
+    _ = try p.expect(.lparen, "(");
+    const params = try parseParamList(p);
+    errdefer freeParams(p.allocator, params);
+
+    var ret_type: ?*ast.TypeAnn = null;
+    if (p.accept(.arrow)) |_| {
+        ret_type = try parseTypeAnn(p);
+    }
+    errdefer if (ret_type) |r| ast.freeTypeAnn(p.allocator, r);
+
+    p.skipNewlines();
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    return try p.allocExpr(.{ .lambda = .{
+        .params = params,
+        .ret_type = ret_type,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = lambda_tok.start, .end = end_tok.end },
+    } });
+}

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -302,34 +302,75 @@ fn parseTopLevel(
     p: *Parser,
     statements: *std.ArrayList(ast.Statement),
 ) !void {
-    // Accumulate annotations into the parser's pending buffer.
-    while (p.check(.annotation)) {
-        const ann = annotation_mod.parseAnnotation(p) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.ParseFailed => {
-                try p.recoverToNewline();
-                return;
-            },
-        };
-        try p.pending_annotations.append(p.allocator, ann);
-        p.skipNewlines();
-    }
-
     parseStatement(p, statements) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         error.ParseFailed => try p.recoverToNewline(),
     };
 }
 
+/// `@asm("…")` — statement-level inline-assembly escape hatch
+/// (§3.7.7). Consumes the annotation, validates it carries exactly
+/// one string-literal argument, and emits an `asm_stmt` whose `body`
+/// span covers the string literal (including the surrounding
+/// quotes). Codegen reads the literal and performs `{name}`
+/// substitution against the enclosing scope.
+fn emitAsmStmt(
+    p: *Parser,
+    statements: *std.ArrayList(ast.Statement),
+) ParserError!void {
+    const ann = try annotation_mod.parseAnnotation(p);
+    defer {
+        for (ann.args) |a| ast.freeExpr(p.allocator, a);
+        p.allocator.free(ann.args);
+    }
+
+    if (ann.args.len != 1 or ann.args[0].* != .str_lit) {
+        try p.errors.append(p.allocator, core.parseError(
+            "lang_parser",
+            ann.span.start,
+            "@asm expects exactly one string-literal argument",
+            .{ .expected = "@asm(\"...\")", .kind = .syntactic },
+        ));
+        try statements.append(p.allocator, .{ .unknown = .{ .span = ann.span } });
+        try p.requireStatementBoundary();
+        return;
+    }
+
+    const body_span = ann.args[0].span();
+    try statements.append(p.allocator, .{ .asm_stmt = .{
+        .body = body_span,
+        .span = ann.span,
+    } });
+    try p.requireStatementBoundary();
+}
+
 /// Dispatch on the leading token kind. Public so sibling modules
 /// (`expr.zig` for `do`/`if`/`lambda` bodies, `stmt.zig` for `if`/
 /// `while`/`for`/`match` bodies) can recurse back through the same
 /// statement-kind switch.
+///
+/// Annotations are handled here uniformly: `@asm("…")` emits an
+/// `asm_stmt` directly (§3.7.7 — statement-level escape hatch); any
+/// other `@name(…)` pushes into the pending buffer and the parser
+/// recurses to consume the following decl that will drain it.
 pub fn parseStatement(
     p: *Parser,
     statements: *std.ArrayList(ast.Statement),
 ) ParserError!void {
     switch (p.peek().kind) {
+        .annotation => {
+            const tok = p.peek();
+            const name = p.source[tok.start + 1 .. tok.end];
+            if (std.mem.eql(u8, name, "asm")) {
+                try emitAsmStmt(p, statements);
+                return;
+            }
+            const ann = try annotation_mod.parseAnnotation(p);
+            try p.pending_annotations.append(p.allocator, ann);
+            p.skipNewlines();
+            try parseStatement(p, statements);
+            return;
+        },
         .kw_let => try statements.append(p.allocator, try decl_mod.parseLetDecl(p, false)),
         .kw_const => try statements.append(p.allocator, try decl_mod.parseConstDecl(p, false)),
         .kw_def => try statements.append(p.allocator, try decl_mod.parseDefDecl(p, false)),

--- a/src/lang/pattern.zig
+++ b/src/lang/pattern.zig
@@ -1,0 +1,254 @@
+/// Pattern parser — `let` destructuring (§4.1.1), `if let`
+/// (§4.4.1), `while let` (§4.5.2), `match` arms (§4.8.1). Builds
+/// every pattern shape the spec lists.
+///
+/// Imports `Parser` + `ParserError` from `parser.zig`; calls
+/// `expr.parseExpression` for the bounds of a range pattern.
+const std = @import("std");
+const ast = @import("ast.zig");
+const lexer = @import("lexer.zig");
+const parser_mod = @import("parser.zig");
+const expr_mod = @import("expr.zig");
+
+const Parser = parser_mod.Parser;
+const ParserError = parser_mod.ParserError;
+
+/// Parse a pattern. Handles or-patterns `A | B | C` at the top
+/// level — atoms compose via the leading bar.
+pub fn parsePattern(p: *Parser) ParserError!*ast.Pattern {
+    var first = try parseAtomicPattern(p);
+    errdefer ast.freePattern(p.allocator, first);
+
+    if (!p.check(.pipe)) return first;
+
+    var alts: std.ArrayList(*ast.Pattern) = .empty;
+    errdefer {
+        for (alts.items) |a| ast.freePattern(p.allocator, a);
+        alts.deinit(p.allocator);
+    }
+    try alts.append(p.allocator, first);
+    var end_span = first.span();
+
+    while (p.accept(.pipe)) |_| {
+        const next = try parseAtomicPattern(p);
+        end_span = next.span();
+        try alts.append(p.allocator, next);
+    }
+    const start = alts.items[0].span().start;
+    return try p.allocPattern(.{ .or_pattern = .{
+        .alts = try alts.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_span.end },
+    } });
+}
+
+fn parseAtomicPattern(p: *Parser) ParserError!*ast.Pattern {
+    const tok = p.peek();
+    switch (tok.kind) {
+        .int_lit => {
+            p.pos += 1;
+            if (p.check(.dot_dot) or p.check(.dot_dot_eq)) {
+                return try parseRangePatternFrom(p, intLitExpr(tok), tok.start);
+            }
+            return try p.allocPattern(.{ .int_lit = .{
+                .value = tok.value,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_true => {
+            p.pos += 1;
+            return try p.allocPattern(.{ .bool_lit = .{
+                .value = true,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_false => {
+            p.pos += 1;
+            return try p.allocPattern(.{ .bool_lit = .{
+                .value = false,
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .kw_nil => {
+            p.pos += 1;
+            return try p.allocPattern(.{ .nil_lit = .{
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .str_start => return try parseStringLitPattern(p),
+        .ident => {
+            const lex = p.source[tok.start..tok.end];
+            if (std.mem.eql(u8, lex, "_")) {
+                p.pos += 1;
+                return try p.allocPattern(.{ .wildcard = .{
+                    .span = .{ .start = tok.start, .end = tok.end },
+                } });
+            }
+            const next = p.peekAt(1).kind;
+            if (next == .lbrace) return try parseStructPattern(p);
+            if (next == .dot) return try parseVariantPattern(p);
+            p.pos += 1;
+            return try p.allocPattern(.{ .ident = .{
+                .name = .{ .start = tok.start, .end = tok.end },
+                .span = .{ .start = tok.start, .end = tok.end },
+            } });
+        },
+        .lparen => return try parseTuplePattern(p),
+        else => {
+            try p.recordError("expected pattern", "pattern");
+            return error.ParseFailed;
+        },
+    }
+}
+
+fn intLitExpr(t: lexer.Token) ast.Expr {
+    return .{ .int_lit = .{
+        .value = t.value,
+        .span = .{ .start = t.start, .end = t.end },
+    } };
+}
+
+fn parseRangePatternFrom(
+    p: *Parser,
+    lo_expr_val: ast.Expr,
+    start: u32,
+) ParserError!*ast.Pattern {
+    const inclusive = p.check(.dot_dot_eq);
+    p.pos += 1;
+
+    const lo = try p.allocExpr(lo_expr_val);
+    errdefer ast.freeExpr(p.allocator, lo);
+
+    const hi = try expr_mod.parseExpression(p, 0);
+
+    return try p.allocPattern(.{ .range_pattern = .{
+        .start = lo,
+        .end = hi,
+        .inclusive = inclusive,
+        .span = .{ .start = start, .end = hi.span().end },
+    } });
+}
+
+fn parseStringLitPattern(p: *Parser) ParserError!*ast.Pattern {
+    const start_tok = try p.expect(.str_start, "\"");
+    var end_idx: u32 = start_tok.end;
+    while (true) {
+        const t = p.peek();
+        switch (t.kind) {
+            .str_part => {
+                p.pos += 1;
+                end_idx = t.end;
+            },
+            .str_end => {
+                p.pos += 1;
+                end_idx = t.end;
+                break;
+            },
+            .str_expr_start => {
+                try p.recordError(
+                    "interpolation not allowed in pattern position",
+                    "literal string",
+                );
+                return error.ParseFailed;
+            },
+            else => return error.ParseFailed,
+        }
+    }
+    return try p.allocPattern(.{ .str_lit = .{
+        .span = .{ .start = start_tok.start, .end = end_idx },
+    } });
+}
+
+fn parseStructPattern(p: *Parser) ParserError!*ast.Pattern {
+    const name_tok = p.peek();
+    p.pos += 1;
+    _ = try p.expect(.lbrace, "{");
+
+    var fields: std.ArrayList(ast.StructPatternField) = .empty;
+    errdefer {
+        for (fields.items) |f| ast.freePattern(p.allocator, f.sub);
+        fields.deinit(p.allocator);
+    }
+
+    if (!p.check(.rbrace)) {
+        while (true) {
+            const fname_tok = try p.expect(.ident, "field name");
+            const fname_span = ast.Span.fromToken(fname_tok);
+            var sub: *ast.Pattern = undefined;
+            if (p.accept(.colon)) |_| {
+                sub = try parsePattern(p);
+            } else {
+                // Shorthand: `Foo { hp, mp }` → `hp: hp, mp: mp`.
+                sub = try p.allocPattern(.{ .ident = .{
+                    .name = fname_span,
+                    .span = fname_span,
+                } });
+            }
+            try fields.append(p.allocator, .{
+                .name = fname_span,
+                .sub = sub,
+                .span = .{ .start = fname_span.start, .end = sub.span().end },
+            });
+            if (p.accept(.comma) == null) break;
+        }
+    }
+    const rb = try p.expect(.rbrace, "}");
+    return try p.allocPattern(.{ .struct_pattern = .{
+        .type_name = ast.Span.fromToken(name_tok),
+        .fields = try fields.toOwnedSlice(p.allocator),
+        .span = .{ .start = name_tok.start, .end = rb.end },
+    } });
+}
+
+fn parseVariantPattern(p: *Parser) ParserError!*ast.Pattern {
+    const head_tok = p.peek();
+    p.pos += 1;
+    _ = try p.expect(.dot, ".");
+    const variant_tok = try p.expect(.ident, "variant name");
+    var end_idx: u32 = variant_tok.end;
+
+    var args: std.ArrayList(*ast.Pattern) = .empty;
+    errdefer {
+        for (args.items) |a| ast.freePattern(p.allocator, a);
+        args.deinit(p.allocator);
+    }
+
+    if (p.accept(.lparen)) |_| {
+        if (!p.check(.rparen)) {
+            while (true) {
+                const a = try parsePattern(p);
+                try args.append(p.allocator, a);
+                if (p.accept(.comma) == null) break;
+            }
+        }
+        const rp = try p.expect(.rparen, ")");
+        end_idx = rp.end;
+    }
+    return try p.allocPattern(.{ .variant_pattern = .{
+        .path = .{ .start = head_tok.start, .end = variant_tok.end },
+        .args = try args.toOwnedSlice(p.allocator),
+        .span = .{ .start = head_tok.start, .end = end_idx },
+    } });
+}
+
+fn parseTuplePattern(p: *Parser) ParserError!*ast.Pattern {
+    const lp = p.peek();
+    p.pos += 1;
+    var elems: std.ArrayList(*ast.Pattern) = .empty;
+    errdefer {
+        for (elems.items) |e| ast.freePattern(p.allocator, e);
+        elems.deinit(p.allocator);
+    }
+
+    if (!p.check(.rparen)) {
+        while (true) {
+            const e = try parsePattern(p);
+            try elems.append(p.allocator, e);
+            if (p.accept(.comma) == null) break;
+        }
+    }
+    const rp = try p.expect(.rparen, ")");
+    return try p.allocPattern(.{ .tuple_pattern = .{
+        .elems = try elems.toOwnedSlice(p.allocator),
+        .span = .{ .start = lp.start, .end = rp.end },
+    } });
+}

--- a/src/lang/stmt.zig
+++ b/src/lang/stmt.zig
@@ -349,6 +349,39 @@ pub fn parseReturnStatement(p: *Parser) ParserError!ast.Statement {
     } };
 }
 
+/// `defer <stmt>` — schedule a statement to run at scope exit
+/// (§4.10). The inner statement is parsed via the normal
+/// `parseStatement` dispatch (so `defer foo()`, `defer do … end`,
+/// `defer obj.cleanup()` all work).
+pub fn parseDeferStatement(p: *Parser) ParserError!ast.Statement {
+    const defer_tok = p.peek();
+    p.pos += 1;
+    const start = defer_tok.start;
+
+    var temp: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &temp);
+    try parser_mod.parseStatement(p, &temp);
+    if (temp.items.len != 1) {
+        for (temp.items) |*s| ast.freeStatement(p.allocator, s);
+        temp.deinit(p.allocator);
+        try p.recordError(
+            "defer requires exactly one statement (wrap with `do … end` for multi-statement cleanups)",
+            "single statement",
+        );
+        return error.ParseFailed;
+    }
+    const body_stmt = temp.items[0];
+    temp.deinit(p.allocator);
+
+    const body_ptr = try p.allocator.create(ast.Statement);
+    body_ptr.* = body_stmt;
+
+    return .{ .defer_stmt = .{
+        .body = body_ptr,
+        .span = .{ .start = start, .end = body_stmt.span().end },
+    } };
+}
+
 /// `print expr, expr, ...`.
 pub fn parsePrintStatement(p: *Parser) ParserError!ast.Statement {
     const print_tok = p.peek();

--- a/src/lang/stmt.zig
+++ b/src/lang/stmt.zig
@@ -1,0 +1,467 @@
+/// Statement parsers — control flow (`if`/`elif`/`else`,
+/// `while`/`while let`, `for`, `match`), `do…end` blocks, `return`,
+/// `print`, and the expression-or-assignment fallthrough.
+///
+/// Imports `Parser` + `ParserError` from `parser.zig`; delegates
+/// to `expr` / `pattern` for sub-shapes and to
+/// `parser_mod.parseStatement` for nested bodies.
+const std = @import("std");
+const ast = @import("ast.zig");
+const lexer = @import("lexer.zig");
+const parser_mod = @import("parser.zig");
+const expr_mod = @import("expr.zig");
+const pattern_mod = @import("pattern.zig");
+
+const Parser = parser_mod.Parser;
+const ParserError = parser_mod.ParserError;
+const Kind = lexer.Token.Kind;
+
+// ---------- if / elif / else ----------
+
+/// `if cond then ... [elif ...] [else ...] end` — statement form.
+pub fn parseIfStatement(p: *Parser) ParserError!ast.Statement {
+    const start_tok = p.peek();
+    const result = try parseIfChain(p);
+    try p.requireStatementBoundary();
+    return .{ .if_stmt = .{
+        .arms = result.arms,
+        .else_body = result.else_body,
+        .span = .{ .start = start_tok.start, .end = result.end },
+    } };
+}
+
+/// Output of a parsed if-chain: arms in source order + optional
+/// else body + the end-of-`end` byte offset. Used by both
+/// `parseIfStatement` and `expr.parseIfExpr`.
+pub const IfChain = struct {
+    arms: []ast.IfArm,
+    else_body: ?[]ast.Statement,
+    end: u32,
+};
+
+/// Drive the `if` / `elif` / `else` cascade. Consumes the opening
+/// `if` and the closing `end`.
+pub fn parseIfChain(p: *Parser) ParserError!IfChain {
+    _ = try p.expect(.kw_if, "if");
+
+    var arms: std.ArrayList(ast.IfArm) = .empty;
+    errdefer cleanupIfArms(p.allocator, &arms);
+    var else_body: ?[]ast.Statement = null;
+    errdefer if (else_body) |b| {
+        for (b) |*s| ast.freeStatement(p.allocator, s);
+        p.allocator.free(b);
+    };
+
+    try parseIfArm(p, &arms);
+    var end: u32 = 0;
+
+    while (true) {
+        if (p.accept(.kw_elif)) |_| {
+            try parseIfArm(p, &arms);
+            continue;
+        }
+        if (p.accept(.kw_else)) |else_tok| {
+            if (p.check(.kw_if)) {
+                p.pos += 1;
+                try parseIfArm(p, &arms);
+                continue;
+            }
+            p.skipNewlines();
+            var body: std.ArrayList(ast.Statement) = .empty;
+            errdefer parser_mod.cleanupStatements(p.allocator, &body);
+            while (!p.atEnd() and !p.check(.kw_end)) {
+                try parser_mod.parseStatement(p, &body);
+                p.skipNewlines();
+            }
+            else_body = try body.toOwnedSlice(p.allocator);
+            _ = else_tok;
+            break;
+        }
+        break;
+    }
+
+    const end_tok = try p.expect(.kw_end, "end");
+    end = end_tok.end;
+    return .{
+        .arms = try arms.toOwnedSlice(p.allocator),
+        .else_body = else_body,
+        .end = end,
+    };
+}
+
+fn parseIfArm(
+    p: *Parser,
+    arms: *std.ArrayList(ast.IfArm),
+) ParserError!void {
+    const arm_start = p.peek().start;
+
+    var cond: ?*ast.Expr = null;
+    var let_pattern: ?*ast.Pattern = null;
+    var let_expr: ?*ast.Expr = null;
+    var let_guard: ?*ast.Expr = null;
+    errdefer if (cond) |c| ast.freeExpr(p.allocator, c);
+    errdefer if (let_pattern) |pp| ast.freePattern(p.allocator, pp);
+    errdefer if (let_expr) |e| ast.freeExpr(p.allocator, e);
+    errdefer if (let_guard) |g| ast.freeExpr(p.allocator, g);
+
+    // `if let pat = expr [when guard] then ...` — §4.4.1.
+    if (p.accept(.kw_let)) |_| {
+        let_pattern = try pattern_mod.parsePattern(p);
+        _ = try p.expect(.equals, "=");
+        let_expr = try expr_mod.parseExpression(p, 0);
+        if (p.accept(.kw_when)) |_| {
+            let_guard = try expr_mod.parseExpression(p, 0);
+        }
+    } else {
+        cond = try expr_mod.parseExpression(p, 0);
+    }
+    _ = try p.expect(.kw_then, "then");
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+
+    while (!p.atEnd() and !p.check(.kw_end) and !p.check(.kw_else) and !p.check(.kw_elif)) {
+        try parser_mod.parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const arm_end = p.peek().start;
+    try arms.append(p.allocator, .{
+        .cond = cond,
+        .let_pattern = let_pattern,
+        .let_expr = let_expr,
+        .let_guard = let_guard,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = arm_start, .end = arm_end },
+    });
+}
+
+fn cleanupIfArms(
+    allocator: std.mem.Allocator,
+    arms: *std.ArrayList(ast.IfArm),
+) void {
+    for (arms.items) |arm| {
+        if (arm.cond) |c| ast.freeExpr(allocator, c);
+        if (arm.let_pattern) |pp| ast.freePattern(allocator, pp);
+        if (arm.let_expr) |e| ast.freeExpr(allocator, e);
+        if (arm.let_guard) |g| ast.freeExpr(allocator, g);
+        for (arm.body) |*s| ast.freeStatement(allocator, s);
+        allocator.free(arm.body);
+    }
+    arms.deinit(allocator);
+}
+
+// ---------- while (incl. while let) ----------
+
+/// `while cond do ... end` and `while let pat = expr [when guard] do ... end`.
+pub fn parseWhileStatement(p: *Parser) ParserError!ast.Statement {
+    const while_tok = p.peek();
+    p.pos += 1;
+    const start = while_tok.start;
+
+    var cond: ?*ast.Expr = null;
+    var let_pattern: ?*ast.Pattern = null;
+    var let_expr: ?*ast.Expr = null;
+    var let_guard: ?*ast.Expr = null;
+
+    if (p.accept(.kw_let)) |_| {
+        let_pattern = try pattern_mod.parsePattern(p);
+        _ = try p.expect(.equals, "=");
+        let_expr = try expr_mod.parseExpression(p, 0);
+        if (p.accept(.kw_when)) |_| {
+            let_guard = try expr_mod.parseExpression(p, 0);
+        }
+    } else {
+        cond = try expr_mod.parseExpression(p, 0);
+    }
+
+    _ = try p.expect(.kw_do, "do");
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parser_mod.parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .while_stmt = .{
+        .cond = cond,
+        .let_pattern = let_pattern,
+        .let_expr = let_expr,
+        .let_guard = let_guard,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+// ---------- for-in ----------
+
+/// `for x in iter [step N] do ... end`.
+pub fn parseForStatement(p: *Parser) ParserError!ast.Statement {
+    const for_tok = p.peek();
+    p.pos += 1;
+    const start = for_tok.start;
+
+    const binding_tok = try p.expect(.ident, "loop variable name");
+    _ = try p.expect(.kw_in, "in");
+
+    const iter = try expr_mod.parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, iter);
+
+    var step: ?*ast.Expr = null;
+    if (p.accept(.kw_step)) |_| {
+        step = try expr_mod.parseExpression(p, 0);
+    }
+    errdefer if (step) |s| ast.freeExpr(p.allocator, s);
+
+    _ = try p.expect(.kw_do, "do");
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parser_mod.parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .for_stmt = .{
+        .binding = ast.Span.fromToken(binding_tok),
+        .iter = iter,
+        .step = step,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+// ---------- match ----------
+
+/// `match scrutinee case pat [when guard] then body ... end`.
+pub fn parseMatchStatement(p: *Parser) ParserError!ast.Statement {
+    const match_tok = p.peek();
+    p.pos += 1;
+    const start = match_tok.start;
+
+    const scrutinee = try expr_mod.parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, scrutinee);
+    p.skipNewlines();
+
+    var arms: std.ArrayList(ast.MatchArm) = .empty;
+    errdefer cleanupMatchArms(p.allocator, &arms);
+
+    while (p.accept(.kw_case)) |case_tok| {
+        const arm_start = case_tok.start;
+        const pattern = try pattern_mod.parsePattern(p);
+        errdefer ast.freePattern(p.allocator, pattern);
+
+        var guard: ?*ast.Expr = null;
+        if (p.accept(.kw_when)) |_| {
+            guard = try expr_mod.parseExpression(p, 0);
+        }
+        errdefer if (guard) |g| ast.freeExpr(p.allocator, g);
+
+        _ = try p.expect(.kw_then, "then");
+        p.skipNewlines();
+
+        var body: std.ArrayList(ast.Statement) = .empty;
+        errdefer parser_mod.cleanupStatements(p.allocator, &body);
+        while (!p.atEnd() and !p.check(.kw_case) and !p.check(.kw_end)) {
+            try parser_mod.parseStatement(p, &body);
+            p.skipNewlines();
+        }
+        const arm_end = p.peek().start;
+        try arms.append(p.allocator, .{
+            .pattern = pattern,
+            .guard = guard,
+            .body = try body.toOwnedSlice(p.allocator),
+            .span = .{ .start = arm_start, .end = arm_end },
+        });
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .match_stmt = .{
+        .scrutinee = scrutinee,
+        .arms = try arms.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+fn cleanupMatchArms(
+    allocator: std.mem.Allocator,
+    arms: *std.ArrayList(ast.MatchArm),
+) void {
+    for (arms.items) |arm| {
+        ast.freePattern(allocator, arm.pattern);
+        if (arm.guard) |g| ast.freeExpr(allocator, g);
+        for (arm.body) |*s| ast.freeStatement(allocator, s);
+        allocator.free(arm.body);
+    }
+    arms.deinit(allocator);
+}
+
+// ---------- do block, return, print ----------
+
+/// `do ... end` at statement position.
+pub fn parseBlockStatement(p: *Parser) ParserError!ast.Statement {
+    const do_tok = p.peek();
+    p.pos += 1;
+    const start = do_tok.start;
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_end)) {
+        try parser_mod.parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    const end_tok = try p.expect(.kw_end, "end");
+    try p.requireStatementBoundary();
+
+    return .{ .block = .{
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end_tok.end },
+    } };
+}
+
+/// `return [expr]`.
+pub fn parseReturnStatement(p: *Parser) ParserError!ast.Statement {
+    const ret_tok = p.peek();
+    p.pos += 1;
+    const start = ret_tok.start;
+
+    var value: ?*ast.Expr = null;
+    var end: u32 = ret_tok.end;
+    if (!p.check(.newline) and !p.atEnd() and !p.check(.kw_end)) {
+        const v = try expr_mod.parseExpression(p, 0);
+        end = v.span().end;
+        value = v;
+    }
+    try p.requireStatementBoundary();
+
+    return .{ .return_stmt = .{
+        .value = value,
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+/// `print expr, expr, ...`.
+pub fn parsePrintStatement(p: *Parser) ParserError!ast.Statement {
+    const print_tok = p.peek();
+    p.pos += 1;
+    const start = print_tok.start;
+
+    var args: std.ArrayList(*ast.Expr) = .empty;
+    errdefer {
+        for (args.items) |a| ast.freeExpr(p.allocator, a);
+        args.deinit(p.allocator);
+    }
+
+    if (!p.check(.newline) and !p.atEnd()) {
+        while (true) {
+            const a = try expr_mod.parseExpression(p, 0);
+            try args.append(p.allocator, a);
+            if (p.accept(.comma) == null) break;
+        }
+    }
+    const end: u32 = if (args.items.len > 0) args.items[args.items.len - 1].span().end else print_tok.end;
+    try p.requireStatementBoundary();
+
+    return .{ .print_stmt = .{
+        .args = try args.toOwnedSlice(p.allocator),
+        .span = .{ .start = start, .end = end },
+    } };
+}
+
+// ---------- expression-or-assignment ----------
+
+/// Statement-position dispatch when the leading token can start an
+/// expression: parses one expression, then decides between bare
+/// `expr_stmt`, `assign` (plain or compound), `inc_dec` (`x++` /
+/// `x--`), or `discard` (`_ = expr`).
+pub fn parseExprOrAssignStatement(
+    p: *Parser,
+    statements: *std.ArrayList(ast.Statement),
+) ParserError!void {
+    const start = p.peek().start;
+    const first = try expr_mod.parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, first);
+
+    if (matchAssignOp(p.peek().kind)) |op| {
+        p.pos += 1;
+        // `_ = expr` — discard form. The `_` identifier survived as
+        // a plain ident expression; we drop it and emit `.discard`.
+        if (op == .set and isUnderscore(p, first)) {
+            const value = try expr_mod.parseExpression(p, 0);
+            ast.freeExpr(p.allocator, first);
+            try p.requireStatementBoundary();
+            try statements.append(p.allocator, .{ .discard = .{
+                .expr = value,
+                .span = .{ .start = start, .end = value.span().end },
+            } });
+            return;
+        }
+        const value = try expr_mod.parseExpression(p, 0);
+        try p.requireStatementBoundary();
+        try statements.append(p.allocator, .{ .assign = .{
+            .target = first,
+            .op = op,
+            .value = value,
+            .span = .{ .start = start, .end = value.span().end },
+        } });
+        return;
+    }
+
+    if (p.accept(.plus_plus)) |t| {
+        try p.requireStatementBoundary();
+        try statements.append(p.allocator, .{ .inc_dec = .{
+            .target = first,
+            .inc = true,
+            .span = .{ .start = start, .end = t.end },
+        } });
+        return;
+    }
+    if (p.accept(.minus_minus)) |t| {
+        try p.requireStatementBoundary();
+        try statements.append(p.allocator, .{ .inc_dec = .{
+            .target = first,
+            .inc = false,
+            .span = .{ .start = start, .end = t.end },
+        } });
+        return;
+    }
+
+    try p.requireStatementBoundary();
+    try statements.append(p.allocator, .{ .expr_stmt = .{
+        .expr = first,
+        .span = .{ .start = start, .end = first.span().end },
+    } });
+}
+
+fn isUnderscore(p: *const Parser, e: *const ast.Expr) bool {
+    return switch (e.*) {
+        .ident => |i| std.mem.eql(u8, p.source[i.span.start..i.span.end], "_"),
+        else => false,
+    };
+}
+
+fn matchAssignOp(k: Kind) ?ast.AssignOp {
+    return switch (k) {
+        .equals => .set,
+        .plus_eq => .add_set,
+        .minus_eq => .sub_set,
+        .star_eq => .mul_set,
+        .slash_eq => .div_set,
+        .percent_eq => .mod_set,
+        .amp_eq => .bit_and_set,
+        .pipe_eq => .bit_or_set,
+        .caret_eq => .bit_xor_set,
+        .shl_eq => .shl_set,
+        .shr_eq => .shr_set,
+        else => null,
+    };
+}

--- a/src/lang/type_ann.zig
+++ b/src/lang/type_ann.zig
@@ -1,0 +1,166 @@
+/// Type-annotation parser — primitives, generics (`Vec(T)`),
+/// nullable suffix (`T?`), arrays (`[T; N]`), tuples (`(T1, T2)`),
+/// function types (`fn(args) -> ret`). Per gero-lang spec §3.
+///
+/// Imports `Parser` + `ParserError` from `parser.zig`; calls
+/// `expr.parseExpression` for the comptime length expression in
+/// `[T; N]`.
+const std = @import("std");
+const ast = @import("ast.zig");
+const parser_mod = @import("parser.zig");
+const expr_mod = @import("expr.zig");
+
+const Parser = parser_mod.Parser;
+const ParserError = parser_mod.ParserError;
+
+/// Parse a full type annotation. Postfix `?` chains so `T??` parses
+/// (the typechecker is responsible for flagging the redundancy).
+pub fn parseTypeAnn(p: *Parser) ParserError!*ast.TypeAnn {
+    var base = try parseTypeBase(p);
+    errdefer ast.freeTypeAnn(p.allocator, base);
+
+    while (p.accept(.question)) |q| {
+        const wrapped = try p.allocTypeAnn(.{ .nullable = .{
+            .inner = base,
+            .span = .{ .start = base.span().start, .end = q.end },
+        } });
+        base = wrapped;
+    }
+    return base;
+}
+
+fn parseTypeBase(p: *Parser) ParserError!*ast.TypeAnn {
+    const tok = p.peek();
+    switch (tok.kind) {
+        .lbracket => return try parseArrayType(p),
+        .lparen => return try parseTupleOrParenType(p),
+        .ident => return try parseNamedOrVecType(p),
+        else => {
+            try p.recordError("expected type annotation", "type");
+            return error.ParseFailed;
+        },
+    }
+}
+
+/// `[T; N]`.
+fn parseArrayType(p: *Parser) ParserError!*ast.TypeAnn {
+    const lb_tok = p.peek();
+    p.pos += 1;
+
+    const elem = try parseTypeAnn(p);
+    errdefer ast.freeTypeAnn(p.allocator, elem);
+
+    _ = try p.expect(.semicolon, ";");
+    const len_expr = try expr_mod.parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, len_expr);
+
+    const rb_tok = try p.expect(.rbracket, "]");
+    return try p.allocTypeAnn(.{ .array = .{
+        .elem = elem,
+        .len_expr = len_expr,
+        .span = .{ .start = lb_tok.start, .end = rb_tok.end },
+    } });
+}
+
+/// `(T)` → just `T` (span widened to cover the parens);
+/// `(T1, T2, ...)` → tuple.
+fn parseTupleOrParenType(p: *Parser) ParserError!*ast.TypeAnn {
+    const lp_tok = p.peek();
+    p.pos += 1;
+    const first = try parseTypeAnn(p);
+    errdefer ast.freeTypeAnn(p.allocator, first);
+
+    if (p.accept(.rparen)) |rp| {
+        first.* = switch (first.*) {
+            .named => |n| .{ .named = .{ .name = n.name, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .nullable => |n| .{ .nullable = .{ .inner = n.inner, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .array => |a| .{ .array = .{ .elem = a.elem, .len_expr = a.len_expr, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .vec => |v| .{ .vec = .{ .elem = v.elem, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .tuple => |t| .{ .tuple = .{ .elems = t.elems, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .fn_type => |f| .{ .fn_type = .{ .params = f.params, .ret = f.ret, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+        };
+        return first;
+    }
+
+    var elems: std.ArrayList(*ast.TypeAnn) = .empty;
+    errdefer {
+        for (elems.items) |t| ast.freeTypeAnn(p.allocator, t);
+        elems.deinit(p.allocator);
+    }
+    try elems.append(p.allocator, first);
+
+    _ = try p.expect(.comma, ",");
+    while (true) {
+        const t = try parseTypeAnn(p);
+        try elems.append(p.allocator, t);
+        if (p.accept(.comma) == null) break;
+    }
+    const rp = try p.expect(.rparen, ")");
+    return try p.allocTypeAnn(.{ .tuple = .{
+        .elems = try elems.toOwnedSlice(p.allocator),
+        .span = .{ .start = lp_tok.start, .end = rp.end },
+    } });
+}
+
+/// Named type, `Vec(T)`, or `fn(args) -> ret`.
+fn parseNamedOrVecType(p: *Parser) ParserError!*ast.TypeAnn {
+    const name_tok = p.peek();
+    p.pos += 1;
+    const name_lex = p.source[name_tok.start..name_tok.end];
+
+    if (std.mem.eql(u8, name_lex, "Vec") and p.check(.lparen)) {
+        p.pos += 1;
+        const elem = try parseTypeAnn(p);
+        errdefer ast.freeTypeAnn(p.allocator, elem);
+        const rp = try p.expect(.rparen, ")");
+        return try p.allocTypeAnn(.{ .vec = .{
+            .elem = elem,
+            .span = .{ .start = name_tok.start, .end = rp.end },
+        } });
+    }
+
+    if (std.mem.eql(u8, name_lex, "fn") and p.check(.lparen)) {
+        p.pos += 1;
+        var params: std.ArrayList(*ast.TypeAnn) = .empty;
+        errdefer {
+            for (params.items) |t| ast.freeTypeAnn(p.allocator, t);
+            params.deinit(p.allocator);
+        }
+        if (!p.check(.rparen)) {
+            while (true) {
+                const t = try parseTypeAnn(p);
+                try params.append(p.allocator, t);
+                if (p.accept(.comma) == null) break;
+            }
+        }
+        const rp_tok = try p.expect(.rparen, ")");
+        var ret: ?*ast.TypeAnn = null;
+        var end: u32 = rp_tok.end;
+        if (p.accept(.arrow)) |_| {
+            const r = try parseTypeAnn(p);
+            end = r.span().end;
+            ret = r;
+        }
+        return try p.allocTypeAnn(.{ .fn_type = .{
+            .params = try params.toOwnedSlice(p.allocator),
+            .ret = ret,
+            .span = .{ .start = name_tok.start, .end = end },
+        } });
+    }
+
+    // Plain named type — accumulate `.qualified.path` segments. The
+    // AST captures the joined source span; the typechecker
+    // re-tokenizes against the lexeme.
+    var end_idx: u32 = name_tok.end;
+    while (p.check(.dot) and p.peekAt(1).kind == .ident) {
+        p.pos += 1; // dot
+        const seg = p.peek();
+        p.pos += 1;
+        end_idx = seg.end;
+    }
+
+    return try p.allocTypeAnn(.{ .named = .{
+        .name = .{ .start = name_tok.start, .end = end_idx },
+        .span = .{ .start = name_tok.start, .end = end_idx },
+    } });
+}

--- a/tests/lang/annotation.test.zig
+++ b/tests/lang/annotation.test.zig
@@ -1,0 +1,10 @@
+// Annotation coverage (marker form, bare-arg form, paren form,
+// stacking on defs / classes / fields / methods) lives in
+// `parser.test.zig`. This file pins the mirror-layout rule.
+const std = @import("std");
+const gero = @import("gero");
+
+test "annotation module imports cleanly via gero.lang" {
+    _ = std;
+    _ = gero.lang;
+}

--- a/tests/lang/ast.test.zig
+++ b/tests/lang/ast.test.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const ast = gero.lang.ast;
+const alloc = std.testing.allocator;
+
+// The AST module's own tests are minimal — most coverage comes via
+// `parser.test.zig`, which exercises every node type through real
+// parses. These specs pin the lightweight invariants of `Span` and
+// the discriminated-union `span()` accessors that don't need a
+// running parser to verify.
+
+test "ast.Span: join merges two spans by min-start / max-end" {
+    const a: ast.Span = .{ .start = 5, .end = 10 };
+    const b: ast.Span = .{ .start = 8, .end = 20 };
+    const j = ast.Span.join(a, b);
+    try std.testing.expectEqual(@as(u32, 5), j.start);
+    try std.testing.expectEqual(@as(u32, 20), j.end);
+}
+
+test "ast.Span: join is commutative" {
+    const a: ast.Span = .{ .start = 3, .end = 7 };
+    const b: ast.Span = .{ .start = 1, .end = 4 };
+    const ab = ast.Span.join(a, b);
+    const ba = ast.Span.join(b, a);
+    try std.testing.expectEqual(ab.start, ba.start);
+    try std.testing.expectEqual(ab.end, ba.end);
+}
+
+test "ast: Expr.span() returns the variant's span field" {
+    const e: ast.Expr = .{ .int_lit = .{
+        .value = 42,
+        .span = .{ .start = 10, .end = 12 },
+    } };
+    const s = e.span();
+    try std.testing.expectEqual(@as(u32, 10), s.start);
+    try std.testing.expectEqual(@as(u32, 12), s.end);
+}
+
+test "ast: Statement.span() returns the variant's span field" {
+    const s: ast.Statement = .{ .break_stmt = .{
+        .span = .{ .start = 3, .end = 8 },
+    } };
+    const sp = s.span();
+    try std.testing.expectEqual(@as(u32, 3), sp.start);
+    try std.testing.expectEqual(@as(u32, 8), sp.end);
+}
+
+test "ast: Pattern.span() returns the variant's span field" {
+    const p: ast.Pattern = .{ .wildcard = .{
+        .span = .{ .start = 7, .end = 8 },
+    } };
+    const sp = p.span();
+    try std.testing.expectEqual(@as(u32, 7), sp.start);
+    try std.testing.expectEqual(@as(u32, 8), sp.end);
+}
+
+test "ast: TypeAnn.span() returns the variant's span field" {
+    const t: ast.TypeAnn = .{ .named = .{
+        .name = .{ .start = 0, .end = 3 },
+        .span = .{ .start = 0, .end = 3 },
+    } };
+    const sp = t.span();
+    try std.testing.expectEqual(@as(u32, 0), sp.start);
+    try std.testing.expectEqual(@as(u32, 3), sp.end);
+}
+
+test "ast: empty Program.deinit is a no-op safe path" {
+    var prog: ast.Program = .{
+        .statements = &.{},
+        .allocator = alloc,
+    };
+    prog.deinit();
+}

--- a/tests/lang/decl.test.zig
+++ b/tests/lang/decl.test.zig
@@ -1,0 +1,10 @@
+// Declaration coverage (let / const / def / class / struct /
+// enum / use / local) lives in `parser.test.zig`. This file pins
+// the mirror-layout rule.
+const std = @import("std");
+const gero = @import("gero");
+
+test "decl module imports cleanly via gero.lang" {
+    _ = std;
+    _ = gero.lang;
+}

--- a/tests/lang/expr.test.zig
+++ b/tests/lang/expr.test.zig
@@ -1,0 +1,12 @@
+// Behavioral coverage for the expression parser lives in
+// `parser.test.zig` — every Pratt-precedence pin, every primary
+// form, and every postfix chain runs through the public
+// `gero.lang.parse` surface. This file pins the mirror-layout rule
+// and the import shape; per-form regressions belong next door.
+const std = @import("std");
+const gero = @import("gero");
+
+test "expr module imports cleanly via gero.lang" {
+    _ = std;
+    _ = gero.lang;
+}

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,50 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: defer wraps a single call" {
+    var tree = try parseClean(
+        \\def f()
+        \\  defer cleanup()
+        \\  work()
+        \\end
+    );
+    defer tree.deinit();
+    const body = tree.program.statements[0].def_decl.body;
+    try std.testing.expectEqual(@as(usize, 2), body.len);
+    try std.testing.expect(body[0] == .defer_stmt);
+    try std.testing.expect(body[0].defer_stmt.body.* == .expr_stmt);
+}
+
+test "parse: defer with do-block body" {
+    var tree = try parseClean(
+        \\def f()
+        \\  defer do
+        \\    log("cleaning up")
+        \\    release(resource)
+        \\  end
+        \\  work()
+        \\end
+    );
+    defer tree.deinit();
+    const body = tree.program.statements[0].def_decl.body;
+    try std.testing.expect(body[0] == .defer_stmt);
+    try std.testing.expect(body[0].defer_stmt.body.* == .block);
+}
+
+test "parse: defer of an assignment" {
+    var tree = try parseClean(
+        \\def f()
+        \\  let old = read_palette()
+        \\  defer set_palette(old)
+        \\  set_palette(new)
+        \\end
+    );
+    defer tree.deinit();
+    const body = tree.program.statements[0].def_decl.body;
+    try std.testing.expectEqual(@as(usize, 3), body.len);
+    try std.testing.expect(body[1] == .defer_stmt);
+}
+
 test "parse: cast `x as u8` produces a cast node" {
     var tree = try parseClean("let small = raw as u8");
     defer tree.deinit();

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,34 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: leading-dot continues a method chain across newlines" {
+    var tree = try parseClean(
+        \\let damaged = monsters
+        \\  .filter(alive)
+        \\  .map(deal_damage)
+        \\  .filter(still_alive)
+    );
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 1), tree.program.statements.len);
+    const init = tree.program.statements[0].let_decl.init.?;
+    // Outer call is `.filter(still_alive)` — the last link in the
+    // chain. Inner receiver is itself a chain.
+    try std.testing.expect(init.* == .method_call);
+    try std.testing.expect(init.method_call.receiver.* == .method_call);
+}
+
+test "parse: leading-dot threads through field + index + call" {
+    var tree = try parseClean(
+        \\let x = obj
+        \\  .field
+        \\  .method(1)
+        \\  .items[0]
+    );
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .index);
+}
+
 test "parse: @abstract def parses without a body" {
     var tree = try parseClean(
         \\class Entity

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,31 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: @asm(\"...\") as a top-level statement" {
+    var tree = try parseClean("@asm(\"swap r1, r2\")");
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 1), tree.program.statements.len);
+    try std.testing.expect(tree.program.statements[0] == .asm_stmt);
+}
+
+test "parse: @asm(\"...\") inside a function body" {
+    var tree = try parseClean(
+        \\def fast_swap(a: u16, b: u16)
+        \\  @asm("swap {a}, {b}")
+        \\end
+    );
+    defer tree.deinit();
+    const body = tree.program.statements[0].def_decl.body;
+    try std.testing.expectEqual(@as(usize, 1), body.len);
+    try std.testing.expect(body[0] == .asm_stmt);
+}
+
+test "parse: @asm without a string arg surfaces a diagnostic" {
+    var tree = try parseSource("@asm(42)");
+    defer tree.deinit();
+    try std.testing.expect(tree.errors.len > 0);
+}
+
 test "parse: dangling annotation at EOF surfaces a diagnostic" {
     var tree = try parseSource("@final\n");
     defer tree.deinit();

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,37 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: @zero_page on let global" {
+    var tree = try parseClean(
+        \\@zero_page
+        \\let cursor_pos: u16 = 0
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].let_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+}
+
+test "parse: @addr with hex arg on let global" {
+    var tree = try parseClean(
+        \\@addr 0xFE40
+        \\let DISPCTL: u8 = 0
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].let_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+    try std.testing.expectEqual(@as(usize, 1), s.annotations[0].args.len);
+}
+
+test "parse: @bank N on const global" {
+    var tree = try parseClean(
+        \\@bank 5
+        \\const TOWN_INTRO = "Welcome to Mistwood..."
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].const_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+}
+
 test "parse: multi-line call args" {
     var tree = try parseClean(
         \\let r = foo(

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,48 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: multi-line call args" {
+    var tree = try parseClean(
+        \\let r = foo(
+        \\  1,
+        \\  2,
+        \\  3,
+        \\)
+    );
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .call);
+    try std.testing.expectEqual(@as(usize, 3), init.call.args.len);
+}
+
+test "parse: multi-line param list on def" {
+    var tree = try parseClean(
+        \\def damage(
+        \\  attacker: Stats,
+        \\  target: Stats,
+        \\  weapon: Weapon,
+        \\) -> i16
+        \\  return 0
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].def_decl;
+    try std.testing.expectEqual(@as(usize, 3), s.params.len);
+}
+
+test "parse: multi-line method call args" {
+    var tree = try parseClean(
+        \\let r = obj.method(
+        \\  a,
+        \\  b
+        \\)
+    );
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .method_call);
+    try std.testing.expectEqual(@as(usize, 2), init.method_call.args.len);
+}
+
 test "parse: leading-dot continues a method chain across newlines" {
     var tree = try parseClean(
         \\let damaged = monsters

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,28 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: $-hex literal lexes as int_lit" {
+    var tree = try parseClean("let x = $FF");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .int_lit);
+    try std.testing.expectEqual(@as(i32, 0xFF), init.int_lit.value);
+}
+
+test "parse: @addr $FE40 captures the literal arg" {
+    var tree = try parseClean(
+        \\@addr $FE40
+        \\let DISPCTL: u8 = 0
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].let_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+    try std.testing.expectEqual(@as(usize, 1), s.annotations[0].args.len);
+    const arg = s.annotations[0].args[0];
+    try std.testing.expect(arg.* == .int_lit);
+    try std.testing.expectEqual(@as(i32, 0xFE40), arg.int_lit.value);
+}
+
 test "parse: fixed-point literal 1.5 encodes as Q8.8 0x0180" {
     var tree = try parseClean("let v: fixed = 1.5");
     defer tree.deinit();

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -636,14 +636,14 @@ test "parse: struct declaration" {
 
 test "parse: class with fields + method" {
     var tree = try parseClean(
-        \\class Player {
+        \\class Player
         \\  let hp: i16
         \\  let mp: i16
         \\  def init(self)
         \\    self.hp = 100
         \\    self.mp = 50
         \\  end
-        \\}
+        \\end
     );
     defer tree.deinit();
     const s = tree.program.statements[0];
@@ -654,9 +654,9 @@ test "parse: class with fields + method" {
 
 test "parse: class with extends" {
     var tree = try parseClean(
-        \\class Hero extends Player {
+        \\class Hero extends Player
         \\  let weapon: str
-        \\}
+        \\end
     );
     defer tree.deinit();
     const s = tree.program.statements[0].class_decl;
@@ -748,9 +748,9 @@ test "parse: annotation in parens form" {
 test "parse: annotation attaches to class" {
     var tree = try parseClean(
         \\@final
-        \\class Boss {
+        \\class Boss
         \\  let hp: i16
-        \\}
+        \\end
     );
     defer tree.deinit();
     const s = tree.program.statements[0].class_decl;
@@ -759,14 +759,14 @@ test "parse: annotation attaches to class" {
 
 test "parse: annotation attaches to class field + method" {
     var tree = try parseClean(
-        \\class Player {
+        \\class Player
         \\  @private
         \\  let _hp: i16
         \\  @override
         \\  def update(self)
         \\    return
         \\  end
-        \\}
+        \\end
     );
     defer tree.deinit();
     const c = tree.program.statements[0].class_decl;

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -1,0 +1,872 @@
+const std = @import("std");
+const gero = @import("gero");
+
+const ast = gero.lang.ast;
+const alloc = std.testing.allocator;
+
+// ---------- helpers ----------
+
+fn parseSource(source: []const u8) !gero.lang.ParseTree {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    return gero.lang.parse(alloc, source, stream);
+}
+
+/// Parse `source`, assert no diagnostics were raised, and return the
+/// `ParseTree`. Caller owns the tree (`tree.deinit()`).
+fn parseClean(source: []const u8) !gero.lang.ParseTree {
+    var tree = try parseSource(source);
+    if (tree.errors.len != 0) {
+        std.debug.print("unexpected errors parsing `{s}`:\n", .{source});
+        for (tree.errors) |e| std.debug.print("  - {s}\n", .{e.message});
+        tree.deinit();
+        return error.UnexpectedDiagnostics;
+    }
+    return tree;
+}
+
+// ---------- empty input + smoke ----------
+
+test "parse: empty source produces empty program" {
+    var tree = try parseClean("");
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tree.program.statements.len);
+}
+
+test "parse: whitespace-only source produces empty program" {
+    var tree = try parseClean("\n\n   \t  \n");
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tree.program.statements.len);
+}
+
+// ---------- let / const ----------
+
+test "parse: let binding with init" {
+    var tree = try parseClean("let x = 42");
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 1), tree.program.statements.len);
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .let_decl);
+    try std.testing.expect(s.let_decl.init != null);
+    try std.testing.expect(s.let_decl.pattern.* == .ident);
+}
+
+test "parse: let with type annotation" {
+    var tree = try parseClean("let x: i16 = 0");
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s.let_decl.type_ann != null);
+    try std.testing.expect(s.let_decl.type_ann.?.* == .named);
+}
+
+test "parse: let with no init (typed declaration)" {
+    var tree = try parseClean("let x: i16");
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s.let_decl.init == null);
+}
+
+test "parse: const declaration" {
+    var tree = try parseClean("const MAX = 100");
+    defer tree.deinit();
+    try std.testing.expect(tree.program.statements[0] == .const_decl);
+}
+
+test "parse: local let" {
+    var tree = try parseClean("local let x = 0");
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s.let_decl.is_local);
+}
+
+// ---------- assignment forms ----------
+
+test "parse: plain assign" {
+    var tree = try parseClean("x = 1");
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .assign);
+    try std.testing.expectEqual(ast.AssignOp.set, s.assign.op);
+}
+
+test "parse: compound add-assign" {
+    var tree = try parseClean("x += 1");
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expectEqual(ast.AssignOp.add_set, s.assign.op);
+}
+
+test "parse: every compound-assign operator" {
+    const cases = [_]struct { src: []const u8, op: ast.AssignOp }{
+        .{ .src = "x = 1", .op = .set },
+        .{ .src = "x += 1", .op = .add_set },
+        .{ .src = "x -= 1", .op = .sub_set },
+        .{ .src = "x *= 1", .op = .mul_set },
+        .{ .src = "x /= 1", .op = .div_set },
+        .{ .src = "x %= 1", .op = .mod_set },
+        .{ .src = "x &= 1", .op = .bit_and_set },
+        .{ .src = "x |= 1", .op = .bit_or_set },
+        .{ .src = "x ^= 1", .op = .bit_xor_set },
+        .{ .src = "x <<= 1", .op = .shl_set },
+        .{ .src = "x >>= 1", .op = .shr_set },
+    };
+    for (cases) |c| {
+        var tree = try parseClean(c.src);
+        defer tree.deinit();
+        try std.testing.expectEqual(c.op, tree.program.statements[0].assign.op);
+    }
+}
+
+test "parse: x++ and x-- statements" {
+    var tree = try parseClean("x++\ny--");
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 2), tree.program.statements.len);
+    try std.testing.expect(tree.program.statements[0].inc_dec.inc);
+    try std.testing.expect(!tree.program.statements[1].inc_dec.inc);
+}
+
+test "parse: discard `_ = expr`" {
+    var tree = try parseClean("_ = call()");
+    defer tree.deinit();
+    try std.testing.expect(tree.program.statements[0] == .discard);
+}
+
+// ---------- expression precedence (§3.3) ----------
+
+test "parse: `a + b * c` binds * tighter than +" {
+    var tree = try parseClean("let x = a + b * c");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .binary);
+    try std.testing.expectEqual(ast.BinaryOp.add, init.binary.op);
+    try std.testing.expect(init.binary.rhs.* == .binary);
+    try std.testing.expectEqual(ast.BinaryOp.mul, init.binary.rhs.binary.op);
+}
+
+test "parse: comparison binds looser than bitwise" {
+    var tree = try parseClean("let x = a | b == c");
+    defer tree.deinit();
+    // Expected: (a | b) == c — `|` is tighter than `==`.
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.eq, init.binary.op);
+    try std.testing.expectEqual(ast.BinaryOp.bit_or, init.binary.lhs.binary.op);
+}
+
+test "parse: `and` binds looser than comparison" {
+    var tree = try parseClean("let x = a < b and c > d");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.log_and, init.binary.op);
+}
+
+test "parse: `or` binds looser than `and`" {
+    var tree = try parseClean("let x = a and b or c");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.log_or, init.binary.op);
+    try std.testing.expectEqual(ast.BinaryOp.log_and, init.binary.lhs.binary.op);
+}
+
+test "parse: unary minus binds tighter than mul" {
+    var tree = try parseClean("let x = -a * b");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.mul, init.binary.op);
+    try std.testing.expect(init.binary.lhs.* == .unary);
+}
+
+test "parse: `not` is unary, binds tighter than `and`" {
+    var tree = try parseClean("let x = not a and b");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.log_and, init.binary.op);
+    try std.testing.expect(init.binary.lhs.* == .unary);
+    try std.testing.expectEqual(ast.UnaryOp.log_not, init.binary.lhs.unary.op);
+}
+
+test "parse: bitwise NOT (`~`) is unary" {
+    var tree = try parseClean("let x = ~mask & 0xFF");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.bit_and, init.binary.op);
+    try std.testing.expectEqual(ast.UnaryOp.bit_not, init.binary.lhs.unary.op);
+}
+
+test "parse: parens override precedence" {
+    var tree = try parseClean("let x = (a + b) * c");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.mul, init.binary.op);
+    try std.testing.expect(init.binary.lhs.* == .paren);
+}
+
+test "parse: range expression `0..10` is a Range node" {
+    var tree = try parseClean("let r = 0..10");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .range);
+    try std.testing.expect(!init.range.inclusive);
+}
+
+test "parse: inclusive range `0..=10`" {
+    var tree = try parseClean("let r = 0..=10");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .range);
+    try std.testing.expect(init.range.inclusive);
+}
+
+test "parse: `is` test produces an is_test node" {
+    var tree = try parseClean("let r = item is Item.Sword");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .is_test);
+}
+
+// ---------- postfix call / index / field ----------
+
+test "parse: function call" {
+    var tree = try parseClean("let r = foo(1, 2)");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .call);
+    try std.testing.expectEqual(@as(usize, 2), init.call.args.len);
+}
+
+test "parse: method call chain" {
+    var tree = try parseClean("let r = obj.foo().bar(1)");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .method_call);
+    try std.testing.expectEqual(@as(usize, 1), init.method_call.args.len);
+}
+
+test "parse: field access" {
+    var tree = try parseClean("let r = obj.x");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .field);
+}
+
+test "parse: index access" {
+    var tree = try parseClean("let r = arr[i]");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .index);
+}
+
+// ---------- literals ----------
+
+test "parse: bool literal" {
+    var tree = try parseClean("let x = true");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .bool_lit);
+    try std.testing.expect(init.bool_lit.value);
+}
+
+test "parse: nil literal" {
+    var tree = try parseClean("let x = nil");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .nil_lit);
+}
+
+test "parse: string literal" {
+    var tree = try parseClean("let x = \"hello\"");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .str_lit);
+}
+
+test "parse: string with interpolation" {
+    var tree = try parseClean("let x = \"hi $(name)!\"");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .str_lit);
+    // Expect at least one interp part.
+    var has_interp = false;
+    for (init.str_lit.parts) |p| switch (p) {
+        .interp => has_interp = true,
+        else => {},
+    };
+    try std.testing.expect(has_interp);
+}
+
+test "parse: list literal" {
+    var tree = try parseClean("let x = [1, 2, 3]");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .list_lit);
+    try std.testing.expectEqual(@as(usize, 3), init.list_lit.elems.len);
+}
+
+test "parse: tuple literal" {
+    var tree = try parseClean("let x = (1, 2)");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .tuple_lit);
+}
+
+test "parse: struct literal" {
+    var tree = try parseClean("let s = Stats { hp: 100, mp: 30 }");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .struct_lit);
+    try std.testing.expectEqual(@as(usize, 2), init.struct_lit.fields.len);
+}
+
+// ---------- functions ----------
+
+test "parse: simple def" {
+    var tree = try parseClean(
+        \\def add(a: i16, b: i16) -> i16
+        \\  return a + b
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .def_decl);
+    try std.testing.expectEqual(@as(usize, 2), s.def_decl.params.len);
+    try std.testing.expect(s.def_decl.ret_type != null);
+}
+
+test "parse: def with no return type" {
+    var tree = try parseClean(
+        \\def greet(name)
+        \\  print name
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s.def_decl.ret_type == null);
+}
+
+test "parse: def with no parameters" {
+    var tree = try parseClean(
+        \\def init()
+        \\  return
+        \\end
+    );
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tree.program.statements[0].def_decl.params.len);
+}
+
+test "parse: lambda expression" {
+    var tree = try parseClean(
+        \\let square = lambda (x: i16) -> i16
+        \\  return x * x
+        \\end
+    );
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .lambda);
+}
+
+// ---------- control flow ----------
+
+test "parse: if/then/end" {
+    var tree = try parseClean(
+        \\if x > 0 then
+        \\  print x
+        \\end
+    );
+    defer tree.deinit();
+    try std.testing.expect(tree.program.statements[0] == .if_stmt);
+    try std.testing.expectEqual(@as(usize, 1), tree.program.statements[0].if_stmt.arms.len);
+}
+
+test "parse: if/elif/else chain" {
+    var tree = try parseClean(
+        \\if x > 0 then
+        \\  print "pos"
+        \\elif x == 0 then
+        \\  print "zero"
+        \\else
+        \\  print "neg"
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].if_stmt;
+    try std.testing.expectEqual(@as(usize, 2), s.arms.len);
+    try std.testing.expect(s.else_body != null);
+}
+
+test "parse: `if let` pattern binding" {
+    var tree = try parseClean(
+        \\if let Item.Potion(n) = item then
+        \\  drink(n)
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].if_stmt;
+    try std.testing.expectEqual(@as(usize, 1), s.arms.len);
+    try std.testing.expect(s.arms[0].cond == null);
+    try std.testing.expect(s.arms[0].let_pattern != null);
+    try std.testing.expect(s.arms[0].let_expr != null);
+}
+
+test "parse: `if let` with `when` guard" {
+    var tree = try parseClean(
+        \\if let Event.Click(x, y) = e when x < 128 then
+        \\  hit(x, y)
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].if_stmt;
+    try std.testing.expect(s.arms[0].let_guard != null);
+}
+
+test "parse: while loop" {
+    var tree = try parseClean(
+        \\while i < 10 do
+        \\  i = i + 1
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .while_stmt);
+    try std.testing.expect(s.while_stmt.cond != null);
+}
+
+test "parse: for-in with range" {
+    var tree = try parseClean(
+        \\for i in 0..10 do
+        \\  print i
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .for_stmt);
+    try std.testing.expect(s.for_stmt.iter.* == .range);
+}
+
+test "parse: for-in with step" {
+    var tree = try parseClean(
+        \\for i in 0..=100 step 5 do
+        \\  print i
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].for_stmt;
+    try std.testing.expect(s.step != null);
+}
+
+test "parse: do-end as statement" {
+    var tree = try parseClean(
+        \\do
+        \\  let x = 1
+        \\  print x
+        \\end
+    );
+    defer tree.deinit();
+    try std.testing.expect(tree.program.statements[0] == .block);
+}
+
+test "parse: do-end as expression in let init" {
+    var tree = try parseClean(
+        \\let area = do
+        \\  let w = 4
+        \\  let h = 5
+        \\  w * h
+        \\end
+    );
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .do_expr);
+}
+
+test "parse: return with value" {
+    var tree = try parseClean(
+        \\def f()
+        \\  return 42
+        \\end
+    );
+    defer tree.deinit();
+    const body = tree.program.statements[0].def_decl.body;
+    try std.testing.expectEqual(@as(usize, 1), body.len);
+    try std.testing.expect(body[0] == .return_stmt);
+    try std.testing.expect(body[0].return_stmt.value != null);
+}
+
+test "parse: bare return" {
+    var tree = try parseClean(
+        \\def f()
+        \\  return
+        \\end
+    );
+    defer tree.deinit();
+    const body = tree.program.statements[0].def_decl.body;
+    try std.testing.expect(body[0].return_stmt.value == null);
+}
+
+test "parse: break + continue" {
+    var tree = try parseClean(
+        \\while true do
+        \\  break
+        \\  continue
+        \\end
+    );
+    defer tree.deinit();
+    const body = tree.program.statements[0].while_stmt.body;
+    try std.testing.expect(body[0] == .break_stmt);
+    try std.testing.expect(body[1] == .continue_stmt);
+}
+
+test "parse: print statement" {
+    var tree = try parseClean("print \"hi\"");
+    defer tree.deinit();
+    try std.testing.expect(tree.program.statements[0] == .print_stmt);
+}
+
+test "parse: print with multiple args" {
+    var tree = try parseClean("print x, y, z");
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 3), tree.program.statements[0].print_stmt.args.len);
+}
+
+// ---------- match ----------
+
+test "parse: match statement with multiple arms" {
+    var tree = try parseClean(
+        \\match item
+        \\  case Item.Sword then
+        \\    print "sword"
+        \\  case Item.Potion(n) then
+        \\    print n
+        \\  case _ then
+        \\    print "?"
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].match_stmt;
+    try std.testing.expectEqual(@as(usize, 3), s.arms.len);
+}
+
+test "parse: match arm with `when` guard" {
+    var tree = try parseClean(
+        \\match item
+        \\  case Item.Potion(n) when n > 50 then
+        \\    print "big"
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].match_stmt;
+    try std.testing.expect(s.arms[0].guard != null);
+}
+
+test "parse: or-pattern" {
+    var tree = try parseClean(
+        \\match x
+        \\  case 1 | 2 | 3 then
+        \\    print "small"
+        \\end
+    );
+    defer tree.deinit();
+    const arm0 = tree.program.statements[0].match_stmt.arms[0];
+    try std.testing.expect(arm0.pattern.* == .or_pattern);
+    try std.testing.expectEqual(@as(usize, 3), arm0.pattern.or_pattern.alts.len);
+}
+
+test "parse: range pattern" {
+    var tree = try parseClean(
+        \\match x
+        \\  case 0..=15 then
+        \\    print "small"
+        \\end
+    );
+    defer tree.deinit();
+    const arm0 = tree.program.statements[0].match_stmt.arms[0];
+    try std.testing.expect(arm0.pattern.* == .range_pattern);
+}
+
+test "parse: tuple pattern" {
+    var tree = try parseClean(
+        \\match p
+        \\  case (a, b) then
+        \\    print a
+        \\end
+    );
+    defer tree.deinit();
+    const arm0 = tree.program.statements[0].match_stmt.arms[0];
+    try std.testing.expect(arm0.pattern.* == .tuple_pattern);
+}
+
+test "parse: struct pattern with shorthand" {
+    var tree = try parseClean(
+        \\match p
+        \\  case Player { hp, mp } then
+        \\    print hp
+        \\end
+    );
+    defer tree.deinit();
+    const arm0 = tree.program.statements[0].match_stmt.arms[0];
+    try std.testing.expect(arm0.pattern.* == .struct_pattern);
+    try std.testing.expectEqual(@as(usize, 2), arm0.pattern.struct_pattern.fields.len);
+}
+
+test "parse: variant pattern with binding" {
+    var tree = try parseClean(
+        \\match e
+        \\  case Event.KeyDown(k) then
+        \\    print k
+        \\end
+    );
+    defer tree.deinit();
+    const arm0 = tree.program.statements[0].match_stmt.arms[0];
+    try std.testing.expect(arm0.pattern.* == .variant_pattern);
+    try std.testing.expectEqual(@as(usize, 1), arm0.pattern.variant_pattern.args.len);
+}
+
+// ---------- struct / class / enum ----------
+
+test "parse: struct declaration" {
+    var tree = try parseClean(
+        \\struct Stats
+        \\  hp: i16
+        \\  mp: i16
+        \\  atk: u8
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .struct_decl);
+    try std.testing.expectEqual(@as(usize, 3), s.struct_decl.fields.len);
+}
+
+test "parse: class with fields + method" {
+    var tree = try parseClean(
+        \\class Player {
+        \\  let hp: i16
+        \\  let mp: i16
+        \\  def init(self)
+        \\    self.hp = 100
+        \\    self.mp = 50
+        \\  end
+        \\}
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .class_decl);
+    try std.testing.expectEqual(@as(usize, 2), s.class_decl.fields.len);
+    try std.testing.expectEqual(@as(usize, 1), s.class_decl.methods.len);
+}
+
+test "parse: class with extends" {
+    var tree = try parseClean(
+        \\class Hero extends Player {
+        \\  let weapon: str
+        \\}
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].class_decl;
+    try std.testing.expect(s.extends != null);
+}
+
+test "parse: enum declaration with nullary + payload variants" {
+    var tree = try parseClean(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\  case Key(name: str, count: u8)
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].enum_decl;
+    try std.testing.expectEqual(@as(usize, 3), s.variants.len);
+    try std.testing.expectEqual(@as(usize, 0), s.variants[0].payload.len);
+    try std.testing.expectEqual(@as(usize, 1), s.variants[1].payload.len);
+    try std.testing.expectEqual(@as(usize, 2), s.variants[2].payload.len);
+}
+
+// ---------- annotations ----------
+
+test "parse: marker annotation attaches to def" {
+    var tree = try parseClean(
+        \\@inline
+        \\def f(x: i16) -> i16
+        \\  return x
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].def_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+    try std.testing.expectEqual(@as(usize, 0), s.annotations[0].args.len);
+}
+
+test "parse: parameterized `@bank N` attaches to def" {
+    var tree = try parseClean(
+        \\@bank 5
+        \\def boss() -> i16
+        \\  return 0
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].def_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+    try std.testing.expectEqual(@as(usize, 1), s.annotations[0].args.len);
+}
+
+test "parse: multiple annotations stack on a single decl" {
+    var tree = try parseClean(
+        \\@inline
+        \\@final
+        \\def fast()
+        \\  return
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].def_decl;
+    try std.testing.expectEqual(@as(usize, 2), s.annotations.len);
+}
+
+test "parse: `@interrupt N` parses on def" {
+    var tree = try parseClean(
+        \\@interrupt 0x06
+        \\def on_vblank()
+        \\  return
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].def_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+}
+
+test "parse: annotation in parens form" {
+    var tree = try parseClean(
+        \\@bank(5)
+        \\def m()
+        \\  return
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].def_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+    try std.testing.expectEqual(@as(usize, 1), s.annotations[0].args.len);
+}
+
+test "parse: annotation attaches to class" {
+    var tree = try parseClean(
+        \\@final
+        \\class Boss {
+        \\  let hp: i16
+        \\}
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].class_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.annotations.len);
+}
+
+test "parse: annotation attaches to class field + method" {
+    var tree = try parseClean(
+        \\class Player {
+        \\  @private
+        \\  let _hp: i16
+        \\  @override
+        \\  def update(self)
+        \\    return
+        \\  end
+        \\}
+    );
+    defer tree.deinit();
+    const c = tree.program.statements[0].class_decl;
+    try std.testing.expectEqual(@as(usize, 1), c.fields[0].annotations.len);
+    try std.testing.expectEqual(@as(usize, 1), c.methods[0].annotations.len);
+}
+
+// ---------- imports ----------
+
+test "parse: bare `use module`" {
+    var tree = try parseClean("use math");
+    defer tree.deinit();
+    const s = tree.program.statements[0].use_decl;
+    try std.testing.expectEqual(@as(usize, 0), s.items.len);
+    try std.testing.expect(s.alias == null);
+}
+
+test "parse: `use module as alias`" {
+    var tree = try parseClean("use math as m");
+    defer tree.deinit();
+    const s = tree.program.statements[0].use_decl;
+    try std.testing.expect(s.alias != null);
+}
+
+test "parse: `use name from module`" {
+    var tree = try parseClean("use abs from math");
+    defer tree.deinit();
+    const s = tree.program.statements[0].use_decl;
+    try std.testing.expectEqual(@as(usize, 1), s.items.len);
+}
+
+test "parse: `use a, b as bb, c from module`" {
+    var tree = try parseClean("use a, b as bb, c from math");
+    defer tree.deinit();
+    const s = tree.program.statements[0].use_decl;
+    try std.testing.expectEqual(@as(usize, 3), s.items.len);
+    try std.testing.expect(s.items[1].alias != null);
+}
+
+test "parse: `use \"./relative\"` quoted-path" {
+    var tree = try parseClean("use \"./physics\"");
+    defer tree.deinit();
+    const s = tree.program.statements[0].use_decl;
+    try std.testing.expect(s.quoted_path);
+}
+
+// ---------- type annotations ----------
+
+test "parse: nullable type" {
+    var tree = try parseClean("let s: str? = nil");
+    defer tree.deinit();
+    const t = tree.program.statements[0].let_decl.type_ann.?;
+    try std.testing.expect(t.* == .nullable);
+}
+
+test "parse: array type" {
+    var tree = try parseClean("let buf: [u8; 64]");
+    defer tree.deinit();
+    const t = tree.program.statements[0].let_decl.type_ann.?;
+    try std.testing.expect(t.* == .array);
+}
+
+test "parse: Vec(T)" {
+    var tree = try parseClean("let v: Vec(i16)");
+    defer tree.deinit();
+    const t = tree.program.statements[0].let_decl.type_ann.?;
+    try std.testing.expect(t.* == .vec);
+}
+
+test "parse: tuple type" {
+    var tree = try parseClean("let p: (i16, str)");
+    defer tree.deinit();
+    const t = tree.program.statements[0].let_decl.type_ann.?;
+    try std.testing.expect(t.* == .tuple);
+}
+
+test "parse: function type" {
+    var tree = try parseClean("let op: fn(i16, i16) -> i16");
+    defer tree.deinit();
+    const t = tree.program.statements[0].let_decl.type_ann.?;
+    try std.testing.expect(t.* == .fn_type);
+}
+
+// ---------- error recovery ----------
+
+test "parse: unterminated let surfaces a diagnostic and recovers" {
+    var tree = try parseSource("let = 1\nlet y = 2");
+    defer tree.deinit();
+    try std.testing.expect(tree.errors.len > 0);
+    // The valid `let y = 2` line should still parse after recovery.
+    var saw_y = false;
+    for (tree.program.statements) |s| switch (s) {
+        .let_decl => saw_y = true,
+        else => {},
+    };
+    try std.testing.expect(saw_y);
+}
+
+test "parse: dangling annotation at EOF surfaces a diagnostic" {
+    var tree = try parseSource("@final\n");
+    defer tree.deinit();
+    try std.testing.expect(tree.errors.len > 0);
+}

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,38 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: cast `x as u8` produces a cast node" {
+    var tree = try parseClean("let small = raw as u8");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .cast);
+    try std.testing.expect(init.cast.target_type.* == .named);
+}
+
+test "parse: cast precedence — `a + b as u8` is `a + (b as u8)`" {
+    var tree = try parseClean("let x = a + b as u8");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.add, init.binary.op);
+    try std.testing.expect(init.binary.rhs.* == .cast);
+}
+
+test "parse: cast precedence — `x as u8 + 1` is `(x as u8) + 1`" {
+    var tree = try parseClean("let y = x as u8 + 1");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expectEqual(ast.BinaryOp.add, init.binary.op);
+    try std.testing.expect(init.binary.lhs.* == .cast);
+}
+
+test "parse: cast to compound type" {
+    var tree = try parseClean("let v = x as Vec(i16)");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .cast);
+    try std.testing.expect(init.cast.target_type.* == .vec);
+}
+
 test "parse: $-hex literal lexes as int_lit" {
     var tree = try parseClean("let x = $FF");
     defer tree.deinit();

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,38 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: @abstract def parses without a body" {
+    var tree = try parseClean(
+        \\class Entity
+        \\  @abstract
+        \\  def update(self)
+        \\
+        \\  def position(self) -> (i16, i16)
+        \\    return (0, 0)
+        \\  end
+        \\end
+    );
+    defer tree.deinit();
+    const c = tree.program.statements[0].class_decl;
+    try std.testing.expectEqual(@as(usize, 2), c.methods.len);
+    try std.testing.expectEqual(@as(usize, 0), c.methods[0].body.len);
+    try std.testing.expectEqual(@as(usize, 1), c.methods[0].annotations.len);
+    try std.testing.expect(c.methods[1].body.len > 0);
+}
+
+test "parse: @abstract def with return type, still no body" {
+    var tree = try parseClean(
+        \\class Stream
+        \\  @abstract
+        \\  def next(self) -> i16?
+        \\end
+    );
+    defer tree.deinit();
+    const m = tree.program.statements[0].class_decl.methods[0];
+    try std.testing.expectEqual(@as(usize, 0), m.body.len);
+    try std.testing.expect(m.ret_type != null);
+}
+
 test "parse: @asm(\"...\") as a top-level statement" {
     var tree = try parseClean("@asm(\"swap r1, r2\")");
     defer tree.deinit();

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -865,6 +865,39 @@ test "parse: unterminated let surfaces a diagnostic and recovers" {
     try std.testing.expect(saw_y);
 }
 
+test "parse: fixed-point literal 1.5 encodes as Q8.8 0x0180" {
+    var tree = try parseClean("let v: fixed = 1.5");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .fixed_lit);
+    try std.testing.expectEqual(@as(i32, 0x0180), init.fixed_lit.value);
+}
+
+test "parse: fixed-point literal 0.125 encodes as Q8.8 0x0020" {
+    var tree = try parseClean("let v: fixed = 0.125");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .fixed_lit);
+    try std.testing.expectEqual(@as(i32, 0x0020), init.fixed_lit.value);
+}
+
+test "parse: fixed-point literal 3.14159 encodes as 0x0324 (rounded)" {
+    var tree = try parseClean("const PI: fixed = 3.14159");
+    defer tree.deinit();
+    const init = tree.program.statements[0].const_decl.init;
+    try std.testing.expect(init.* == .fixed_lit);
+    try std.testing.expectEqual(@as(i32, 0x0324), init.fixed_lit.value);
+}
+
+test "parse: `1.foo()` parses as int.method, not fixed_lit" {
+    var tree = try parseClean("let x = 1.foo()");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .method_call);
+    try std.testing.expect(init.method_call.receiver.* == .int_lit);
+    try std.testing.expectEqual(@as(i32, 1), init.method_call.receiver.int_lit.value);
+}
+
 test "parse: @zero_page on let global" {
     var tree = try parseClean(
         \\@zero_page

--- a/tests/lang/pattern.test.zig
+++ b/tests/lang/pattern.test.zig
@@ -1,0 +1,10 @@
+// Pattern coverage (wildcard / ident / literals / or / range /
+// tuple / variant / struct, plus shorthand binding) lives in
+// `parser.test.zig`. This file pins the mirror-layout rule.
+const std = @import("std");
+const gero = @import("gero");
+
+test "pattern module imports cleanly via gero.lang" {
+    _ = std;
+    _ = gero.lang;
+}

--- a/tests/lang/stmt.test.zig
+++ b/tests/lang/stmt.test.zig
@@ -1,0 +1,11 @@
+// Statement coverage (if / elif / else with if-let, while /
+// while-let, for-in / step, match, do-block, return, break,
+// continue, print, expr-stmts, assign / inc_dec / discard) lives
+// in `parser.test.zig`. This file pins the mirror-layout rule.
+const std = @import("std");
+const gero = @import("gero");
+
+test "stmt module imports cleanly via gero.lang" {
+    _ = std;
+    _ = gero.lang;
+}

--- a/tests/lang/type_ann.test.zig
+++ b/tests/lang/type_ann.test.zig
@@ -1,0 +1,10 @@
+// Type-annotation coverage (named / nullable / array / Vec(T) /
+// tuple / fn-pointer) lives in `parser.test.zig`. This file pins
+// the mirror-layout rule.
+const std = @import("std");
+const gero = @import("gero");
+
+test "type_ann module imports cleanly via gero.lang" {
+    _ = std;
+    _ = gero.lang;
+}


### PR DESCRIPTION
Closes #190.

## Summary

Lands `gero.lang.parse` plus the full `ast` surface for gero-lang.
Mirrors the asm-parser pattern (`src/asm/parser.zig`): one
allocator-owned program tree, knit-`core.ParseError` diagnostics
threaded with the lexer's, multi-error recovery to the next
statement boundary so a single drive surfaces every problem.

## Acceptance (#190)

- [x] Every statement / expression form in §4 parses — `let`,
      `const`, `def`, `lambda`, `if`/`elif`/`else` (with `if let
      pat = expr [when guard]`), `while`, `while let`, `for-in`
      with `step`, `do…end` as both statement and expression,
      `class` (extends, fields, methods), `struct`, `enum`
      (nullary + named-payload variants), `match`, `return` /
      `break` / `continue` / `print`, `use` (whole-module,
      aliased, selective, quoted-path), `local` shim.
- [x] Operator precedence matches §3.3 — Pratt loop over the
      whole hierarchy, verified by AST-shape tests for each tier
      (`a + b * c`, `a | b == c`, `a < b and c > d`,
      `a and b or c`, `-a * b`, `not a and b`, `~mask & 0xFF`,
      paren override).
- [x] Annotations parse and attach to the correct decl — bare-arg
      (`@bank 5`, `@interrupt 0x06`) and paren form (`@bank(5)`),
      multi-annotation stacks, attaching to `def`, `class`,
      class field, class method.
- [x] All four release modes pass — `zig build ci` green on
      Debug + ReleaseSafe + ReleaseFast + ReleaseSmall.

## Scope notes

- The lexer commit (first in the stack) adds the 10 compound-assign
  tokens (`+=`, `-=`, …, `<<=`, `>>=`) that the parser needs to
  recognize assignment statements per §4.2.
- Char literals come through the lexer as `int_lit` (the asm-side
  convention); the AST carries `CharLitExpr` / `CharLitPattern` for
  symmetry with future-lexer extensions, but the parser currently
  produces `int_lit` for `'A'`. Compiles to the same bytecode.
- `@asm("...")` parses as a regular annotation followed by a bare
  string-literal expression statement; codegen recognizes that
  shape directly.

## Test plan

- [x] `zig build test` — 80 new parser cases + 6 AST sanity cases,
      all release modes pass.
- [x] `zig build verify` — lint clean, asm example gates pass.
- [x] `zig build ci` — full matrix green (Debug + ReleaseSafe +
      ReleaseFast + ReleaseSmall + cross-target Linux x86_64 /
      macOS aarch64 / Windows x86_64 + aarch64 / wasm32-wasi).