### PR TITLE
feat(lang): syntax patches — no then/do, => arms, |x| lambdas, $ hex, asm stmt, break labels

### DIFF
--- a/.changeset/lang-syntax-patches.md
+++ b/.changeset/lang-syntax-patches.md
@@ -8,28 +8,35 @@ matches the spec.
 
 **Lexer**
 
-- New tokens: `fat_arrow` (`=>`), `kw_asm`, `kw_bake`.
-- `then` and `do` remain reserved keywords (the parser uses them
-  for friendly migration diagnostics).
+- New tokens: `fat_arrow` (`=>`), `kw_asm`, `kw_bake`, `kw_repeat`,
+  `kw_until`.
+- `then` is no longer a reserved word (becomes an identifier);
+  `do` remains reserved for `do … end` blocks (§4.3).
 - `0x...` hex literals are rejected with a hint pointing at the
   `$...` form.
 
 **Parser**
 
-- `if` / `elif` heads end at the newline — no `then` required.
-  Writing `if cond then …` surfaces a clear diagnostic.
-- `while` / `for` heads end at the newline — no `do` required.
-  Writing `while cond do …` surfaces a clear diagnostic.
-- `match` arms use `case PAT => BODY` instead of `case PAT then
-  BODY`; the legacy `then` form errors with a hint pointing at `=>`.
+- `if` / `elif` heads end at the newline — no `then`.
+- `while` / `for` heads end at the newline — no `do`; the parser
+  rejects a stranded `do` after a loop head.
+- `match` arms use `case PAT => BODY`.
 - Short lambda form `|x| x*2`, `|x, y| x + y`, `|| read_input()`,
   with optional type annotations (`|x: i16| -> i16 x*2`). Desugars
   to a `LambdaExpr` whose body is a single `return <expr>`.
-- `asm "<instruction>"` is now a builtin statement (§4.11); the
-  legacy `@asm("...")` annotation form errors with a migration
-  diagnostic.
+- `asm "<instruction>"` is a builtin statement (§4.11). `@asm("...")`
+  as an annotation is rejected with a clear error pointing at the
+  statement form.
 - Labeled loops: `<while|for> head :label`, with `break :label`
   and `continue :label` targeting the labeled loop. Unlabeled
   jumps still target the innermost loop. `WhileStmt` / `ForStmt`
   gain a `?Span` label field; `break_stmt` / `continue_stmt` move
   from `SpanOnly` to a new `LoopJumpStmt { label, span }` struct.
+
+**Repeat-until loop (§4.5.4)**
+
+`repeat … until cond` — Lua/Pascal-style do-while loop. Body runs
+at least once; loop exits when the trailing expression evaluates
+true. No `end` (the `until <cond>` line terminates). Labels work
+as on `while` / `for`. Adds `kw_repeat` / `kw_until` keywords and
+a new `RepeatStmt { body, cond, label, span }` AST node.

--- a/.changeset/lang-syntax-patches.md
+++ b/.changeset/lang-syntax-patches.md
@@ -1,0 +1,35 @@
+---
+bump: minor
+---
+
+Apply the spec-locked syntax decisions from `docs/gero-lang.md` v1.
+Lexer and parser updates land together so the entire surface
+matches the spec.
+
+**Lexer**
+
+- New tokens: `fat_arrow` (`=>`), `kw_asm`, `kw_bake`.
+- `then` and `do` remain reserved keywords (the parser uses them
+  for friendly migration diagnostics).
+- `0x...` hex literals are rejected with a hint pointing at the
+  `$...` form.
+
+**Parser**
+
+- `if` / `elif` heads end at the newline — no `then` required.
+  Writing `if cond then …` surfaces a clear diagnostic.
+- `while` / `for` heads end at the newline — no `do` required.
+  Writing `while cond do …` surfaces a clear diagnostic.
+- `match` arms use `case PAT => BODY` instead of `case PAT then
+  BODY`; the legacy `then` form errors with a hint pointing at `=>`.
+- Short lambda form `|x| x*2`, `|x, y| x + y`, `|| read_input()`,
+  with optional type annotations (`|x: i16| -> i16 x*2`). Desugars
+  to a `LambdaExpr` whose body is a single `return <expr>`.
+- `asm "<instruction>"` is now a builtin statement (§4.11); the
+  legacy `@asm("...")` annotation form errors with a migration
+  diagnostic.
+- Labeled loops: `<while|for> head :label`, with `break :label`
+  and `continue :label` targeting the labeled loop. Unlabeled
+  jumps still target the innermost loop. `WhileStmt` / `ForStmt`
+  gain a `?Span` label field; `break_stmt` / `continue_stmt` move
+  from `SpanOnly` to a new `LoopJumpStmt { label, span }` struct.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -20,10 +20,7 @@ for J-RPG-class games and similar carts; see §1 for the philosophy.
 - **No semicolons** — statement boundaries are newlines. Cheap to
   type, less visual noise. (Modern Lua, Go, Python convention.)
 - **Mutable `let` by default** — `let x = 0` is mutable, `const X = 0`
-  is immutable. Style follows Lua / JS / BASIC, not Rust / Swift.
-  This is a deliberate choice for the teaching-language audience the
-  syntax targets; the cost is a small friction for devs arriving from
-  Rust/Swift where `let` means immutable.
+  is immutable. Style follows Lua / JS / BASIC.
 - **Typed at the variable / function boundary** — every `let` /
   parameter / return type gets an annotation OR is inferred from
   context. Once compiled, types are erased — runtime is fully
@@ -1142,9 +1139,7 @@ error. Two flavors handled by the compiler:
   read_input()`), the binding gets a stack/static slot but is
   read-only — you can't `player_name = "x"` later.
 
-Same model as JavaScript / TypeScript `const`. Old-school BASIC's
-`LET` was always mutable; we add `const` for the cases where intent
-matters and the compiler can help catch reassignment bugs.
+Same model as JavaScript / TypeScript `const`.
 
 ```
 const PI_FIXED = $0324       -- comptime, inlined
@@ -2543,6 +2538,3 @@ and the compiler simple; the absence isn't a missing feature.
   borrows; lifetime checking is limited to "no return ref to stack
   local" (§3.4.4). The cart audience doesn't need Rust-grade memory
   safety on top of what `T?` and explicit checks already provide.
-- **`then` / `do` as block-head separators.** Removed for source
-  noise reduction; the parser is recursive-descent and doesn't
-  need them. See §4.4 / §4.5.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -142,8 +142,8 @@ both languages.
 
 ```
 let const def lambda return
-if else end
-while for in step
+if then elif else end
+while do for in step
 match case when
 class extends self super
 enum is
@@ -155,9 +155,13 @@ print
 asm bake
 ```
 
-`then` after `if`/`elif` and `do` after `while`/`for` are **not**
-keywords. The head expression ends at the newline; the body starts
-on the next line. Writing `if cond then …` is a syntax error.
+`then` is reserved but not a syntactic separator anywhere — `if` /
+`elif` / `match case` end their heads at the newline (§4.4 / §4.8),
+no `then` needed. Writing `if cond then …` is a syntax error.
+
+`do` is still a keyword — it opens a block (`do … end`, §4.3) — but
+no longer required after `while` / `for` heads. Writing `while cond
+do …` is a syntax error.
 
 `asm` is a builtin statement (§4.11) for one-instruction inline
 assembly. `bake` marks a `def` or `do`-block for compile-time
@@ -2517,7 +2521,8 @@ and the compiler simple; the absence isn't a missing feature.
   borrows; lifetime checking is limited to "no return ref to stack
   local" (§3.4.4). The cart audience doesn't need Rust-grade memory
   safety on top of what `T?` and explicit checks already provide.
-- **`then` / `do` after block heads.** Removed for source noise
-  reduction; the parser is recursive-descent and doesn't need them.
-  See §4.4 / §4.5. (Lua keeps them for LR-parser reasons that don't
-  apply here.)
+- **`then` / `do` as block-head separators.** Removed for source
+  noise reduction; the parser is recursive-descent and doesn't need
+  them. See §4.4 / §4.5. (Lua keeps them for LR-parser reasons that
+  don't apply here.) `then` is still reserved as a keyword for clear
+  diagnostics; `do` remains the opener for `do…end` blocks (§4.3).

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -142,8 +142,8 @@ both languages.
 
 ```
 let const def lambda return
-if then elif else end
-while do for in step
+if elif else end
+while do for in step repeat until
 match case when
 class extends self super
 enum is
@@ -155,17 +155,9 @@ print
 asm bake
 ```
 
-`then` is reserved but not a syntactic separator anywhere — `if` /
-`elif` / `match case` end their heads at the newline (§4.4 / §4.8),
-no `then` needed. Writing `if cond then …` is a syntax error.
-
-`do` is still a keyword — it opens a block (`do … end`, §4.3) — but
-no longer required after `while` / `for` heads. Writing `while cond
-do …` is a syntax error.
-
-`asm` is a builtin statement (§4.11) for one-instruction inline
-assembly. `bake` marks a `def` or `do`-block for compile-time
-evaluation (§3.8).
+`do` opens a `do … end` block (§4.3); it's not a loop-head
+separator. `asm` is a builtin statement (§4.11). `bake` marks a
+`def` or `do`-block for compile-time evaluation (§3.8).
 
 `and`, `or`, `not` are the boolean operators (short-circuit). The
 bitwise counterparts use symbolic operators `&` `|` `^` `<<` `>>`
@@ -1553,7 +1545,37 @@ by the compiler — `for-in` over them emits direct memory access
 with no `next()` call. The user-visible model is identical to a
 custom iterator; the special-case is invisible.
 
-#### 4.5.4 Labeled loops
+#### 4.5.4 `repeat … until` (do-while)
+
+Body runs at least once; the loop exits when the trailing
+expression evaluates true:
+
+```
+repeat
+  let cmd = read_input()
+  process(cmd)
+until cmd == "quit"
+```
+
+The condition is tested **after** each iteration, so the body is
+guaranteed to execute at least once. To exit early use `break`; to
+skip to the next iteration use `continue` (the condition is still
+tested after the skipped tail).
+
+There is no `end` — the `until <cond>` line terminates the loop.
+Statement boundary follows the condition.
+
+Labels work as on `while` / `for`:
+
+```
+repeat :outer
+  for x in 0..width
+    if found(x) break :outer end
+  end
+until exhausted
+```
+
+#### 4.5.5 Labeled loops
 
 A loop may carry a `:label` after its head; `break :label` and
 `continue :label` target the labeled loop instead of the innermost:
@@ -2522,7 +2544,5 @@ and the compiler simple; the absence isn't a missing feature.
   local" (§3.4.4). The cart audience doesn't need Rust-grade memory
   safety on top of what `T?` and explicit checks already provide.
 - **`then` / `do` as block-head separators.** Removed for source
-  noise reduction; the parser is recursive-descent and doesn't need
-  them. See §4.4 / §4.5. (Lua keeps them for LR-parser reasons that
-  don't apply here.) `then` is still reserved as a keyword for clear
-  diagnostics; `do` remains the opener for `do…end` blocks (§4.3).
+  noise reduction; the parser is recursive-descent and doesn't
+  need them. See §4.4 / §4.5.

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -700,8 +700,11 @@ pub const Statement = union(enum) {
     if_stmt: IfStmt,
     /// `while cond do ... end`.
     while_stmt: WhileStmt,
-    /// `for binding in iter [step expr] do ... end`.
+    /// `for binding in iter [step expr] ... end`.
     for_stmt: ForStmt,
+    /// `repeat ... until cond` — body runs at least once; loop exits
+    /// when `cond` evaluates true. §4.5.5.
+    repeat_stmt: RepeatStmt,
     /// `match scrutinee case pat [when guard] then body ... end`.
     match_stmt: MatchStmt,
     /// `return [expr]`.
@@ -750,6 +753,7 @@ pub const Statement = union(enum) {
             .if_stmt => |s| s.span,
             .while_stmt => |s| s.span,
             .for_stmt => |s| s.span,
+            .repeat_stmt => |s| s.span,
             .match_stmt => |s| s.span,
             .return_stmt => |s| s.span,
             .break_stmt, .continue_stmt => |s| s.span,
@@ -900,6 +904,18 @@ pub const ForStmt = struct {
     /// Loop label, if the head carried a `:name` suffix.
     label: ?Span,
     body: []Statement,
+    span: Span,
+};
+
+/// `repeat ... until cond` — do-while-style loop. Body runs at
+/// least once; `cond` is tested **after** each iteration and the
+/// loop exits when it evaluates true (§4.5.5).
+pub const RepeatStmt = struct {
+    body: []Statement,
+    /// Termination expression — loop exits when this is truthy.
+    cond: *Expr,
+    /// Loop label, if the head carried a `:name` suffix.
+    label: ?Span,
     span: Span,
 };
 
@@ -1145,6 +1161,10 @@ pub fn freeStatement(allocator: std.mem.Allocator, s: *Statement) void {
             freeExpr(allocator, fs.iter);
             if (fs.step) |s_| freeExpr(allocator, s_);
             freeStatementList(allocator, fs.body);
+        },
+        .repeat_stmt => |rs| {
+            freeStatementList(allocator, rs.body);
+            freeExpr(allocator, rs.cond);
         },
         .match_stmt => |ms| {
             freeExpr(allocator, ms.scrutinee);

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -706,10 +706,10 @@ pub const Statement = union(enum) {
     match_stmt: MatchStmt,
     /// `return [expr]`.
     return_stmt: ReturnStmt,
-    /// `break`.
-    break_stmt: SpanOnly,
-    /// `continue`.
-    continue_stmt: SpanOnly,
+    /// `break [:label]` (§4.5.4).
+    break_stmt: LoopJumpStmt,
+    /// `continue [:label]` (§4.5.4).
+    continue_stmt: LoopJumpStmt,
     /// `print expr1, expr2, ...`.
     print_stmt: PrintStmt,
     /// `def name(params) [-> T] body end`.
@@ -868,20 +868,26 @@ pub const IfStmt = struct {
     span: Span,
 };
 
-/// `while cond do ... end` (or the `while let` variant).
+/// `while cond ... end` (or the `while let` variant). Optional
+/// trailing `:label` (§4.5.4) lets nested loops target this one via
+/// `break :label` / `continue :label`.
 pub const WhileStmt = struct {
-    /// For `while let pat = expr do ... end`, `cond` is null and
+    /// For `while let pat = expr ... end`, `cond` is null and
     /// `let_pattern` / `let_expr` carry the binding shape.
     cond: ?*Expr,
     let_pattern: ?*Pattern,
     let_expr: ?*Expr,
     /// Optional `when guard` clause on the `while let` form.
     let_guard: ?*Expr,
+    /// Loop label, if the head carried a `:name` suffix. `null` for
+    /// unlabeled loops.
+    label: ?Span,
     body: []Statement,
     span: Span,
 };
 
-/// `for x in iter [step N] do ... end`.
+/// `for x in iter [step N] ... end`. Optional trailing `:label`
+/// (§4.5.4) — see `WhileStmt`.
 pub const ForStmt = struct {
     /// Binding name (typical `for x in xs` form). Tuple destructuring
     /// can be added later by upgrading to a `Pattern`; today the
@@ -891,6 +897,8 @@ pub const ForStmt = struct {
     iter: *Expr,
     /// `null` unless the source explicitly carried `step N`.
     step: ?*Expr,
+    /// Loop label, if the head carried a `:name` suffix.
+    label: ?Span,
     body: []Statement,
     span: Span,
 };
@@ -1051,6 +1059,15 @@ pub const AsmStmt = struct {
     /// quotes). Codegen reads the bytes and performs `{name}`
     /// substitution against the enclosing scope.
     body: Span,
+    span: Span,
+};
+
+/// `break` / `continue` with optional `:label` (§4.5.4). When the
+/// source has no label, `label` is `null` and the statement targets
+/// the innermost enclosing loop; otherwise it targets the loop
+/// whose `WhileStmt.label` / `ForStmt.label` matches.
+pub const LoopJumpStmt = struct {
+    label: ?Span,
     span: Span,
 };
 

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -358,6 +358,11 @@ fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
         .kw_do => return try parseDoExpr(p),
         .kw_if => return try parseIfExpr(p),
         .kw_lambda => return try parseLambda(p),
+        // Short lambda form `|x| expr`, `|x, y| expr`, `|| expr`.
+        // §4.7.1. At expression start, a leading `|` always means a
+        // short lambda — bitwise OR is binary and never appears at
+        // primary position.
+        .pipe => return try parseShortLambda(p),
         else => {
             try p.recordError("expected expression", "expression");
             return error.ParseFailed;
@@ -602,5 +607,74 @@ fn parseLambda(p: *Parser) ParserError!*ast.Expr {
         .ret_type = ret_type,
         .body = try body.toOwnedSlice(p.allocator),
         .span = .{ .start = lambda_tok.start, .end = end_tok.end },
+    } });
+}
+
+/// Short lambda form per §4.7.1:
+///
+///   |x| x*2                         -- one param, expression body
+///   |x, y| x + y                    -- multiple params
+///   || read_input()                 -- zero params (`||` lexes as
+///                                      two consecutive `pipe` tokens)
+///   |x: i16| -> i16  x * 2          -- explicit types
+///
+/// Desugars to a `LambdaExpr` whose body is a single `return <expr>`
+/// statement, so downstream passes (typechecker, codegen) handle one
+/// shape only.
+fn parseShortLambda(p: *Parser) ParserError!*ast.Expr {
+    const open_tok = p.peek();
+    p.pos += 1; // consume opening `|`
+
+    var params: std.ArrayList(ast.Param) = .empty;
+    errdefer decl_mod.freeParams(p.allocator, params.toOwnedSlice(p.allocator) catch &.{});
+
+    if (!p.check(.pipe)) {
+        while (true) {
+            p.skipNewlines();
+            const name_tok = try p.expect(.ident, "parameter name");
+            var type_ann: ?*ast.TypeAnn = null;
+            if (p.accept(.colon)) |_| {
+                const type_mod = @import("type_ann.zig");
+                type_ann = try type_mod.parseTypeAnn(p);
+            }
+            try params.append(p.allocator, .{
+                .name = ast.Span.fromToken(name_tok),
+                .type_ann = type_ann,
+                .span = ast.Span.fromToken(name_tok),
+            });
+            p.skipNewlines();
+            if (!p.check(.comma)) break;
+            p.pos += 1; // consume `,`
+        }
+    }
+    _ = try p.expect(.pipe, "|");
+
+    var ret_type: ?*ast.TypeAnn = null;
+    if (p.accept(.arrow)) |_| {
+        const type_mod = @import("type_ann.zig");
+        ret_type = try type_mod.parseTypeAnn(p);
+    }
+    errdefer if (ret_type) |r| ast.freeTypeAnn(p.allocator, r);
+
+    const body_expr = try parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, body_expr);
+
+    // Wrap the body expression in a `return` statement so the
+    // resulting `LambdaExpr` body is `[]Statement` like the long
+    // form.
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+    const body_span = body_expr.span();
+    try body.append(p.allocator, .{ .return_stmt = .{
+        .value = body_expr,
+        .span = body_span,
+    } });
+
+    const params_slice = try params.toOwnedSlice(p.allocator);
+    return try p.allocExpr(.{ .lambda = .{
+        .params = params_slice,
+        .ret_type = ret_type,
+        .body = try body.toOwnedSlice(p.allocator),
+        .span = .{ .start = open_tok.start, .end = body_span.end },
     } });
 }

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -28,7 +28,7 @@ pub const Token = struct {
     pub const Kind = enum {
         // -- literals + identifiers ---------------------------
         ident,
-        /// Integer literal — decimal, hex (`0x…`), or binary
+        /// Integer literal — decimal, hex (`$…`), or binary
         /// (`0b…`). Underscores allowed as digit separators
         /// (`1_000`, `0b1010_0101`). Optional leading `-` is
         /// captured into the token when the lexer is at an
@@ -38,8 +38,8 @@ pub const Token = struct {
         /// Fixed-point literal — decimal with fractional part
         /// (`1.5`, `0.125`, `3.14159`). Pre-encoded as Q8.8 in the
         /// `value` field: top byte is the integer part, bottom byte
-        /// is `round(frac * 256)`. `1.5` → `0x0180`, `0.125` →
-        /// `0x0020`. Negative form via the unary minus operator,
+        /// is `round(frac * 256)`. `1.5` → `$0180`, `0.125` →
+        /// `$0020`. Negative form via the unary minus operator,
         /// not the literal itself.
         fixed_lit,
         /// `@`-prefixed annotation marker. `start` covers the
@@ -69,18 +69,27 @@ pub const Token = struct {
         /// `"` — closes the string literal.
         str_end,
 
-        // -- keywords (28+ per spec §2.6) ---------------------
+        // -- keywords (per spec §2.6) -------------------------
         kw_let,
         kw_const,
         kw_def,
         kw_lambda,
         kw_return,
         kw_if,
+        /// Reserved but no longer a syntactic separator. The parser
+        /// emits a diagnostic if `then` appears after `if` / `elif`
+        /// / `match case` heads (§4.4 / §4.8 no longer use it; bodies
+        /// start on the next line). Kept reserved so identifiers
+        /// can't accidentally shadow it.
         kw_then,
         kw_else,
         kw_elif,
         kw_end,
         kw_while,
+        /// `do` — block opener (`do … end`, §4.3). Still a keyword;
+        /// only its use as a loop-head separator (after `while` /
+        /// `for`) was removed. The parser emits a diagnostic if it
+        /// appears in that position.
         kw_do,
         kw_for,
         kw_in,
@@ -110,6 +119,14 @@ pub const Token = struct {
         /// `defer` — schedule a statement to run when the enclosing
         /// block exits (§4.10). LIFO order across multiple defers.
         kw_defer,
+        /// `asm` — builtin statement for one-instruction inline
+        /// assembly (§4.11). Body is a single string literal with
+        /// `{name}` operand substitution.
+        kw_asm,
+        /// `bake` — compile-time evaluation marker on `def` /
+        /// `do`-block (§3.8). Evaluated by the bake interpreter at
+        /// compile time; result lowered to static data.
+        kw_bake,
 
         // -- punctuation --------------------------------------
         newline,
@@ -179,6 +196,8 @@ pub const Token = struct {
         // -- arrows + range ---------------------------------
         /// `->` — lambda + function-return arrows.
         arrow,
+        /// `=>` — match-arm separator (§4.8): `case PAT => BODY`.
+        fat_arrow,
         /// `..` — exclusive range.
         dot_dot,
         /// `..=` — inclusive range.
@@ -257,6 +276,8 @@ const keyword_table = [_]KeywordEntry{
     .{ .lex = "continue", .kind = .kw_continue },
     .{ .lex = "print", .kind = .kw_print },
     .{ .lex = "defer", .kind = .kw_defer },
+    .{ .lex = "asm", .kind = .kw_asm },
+    .{ .lex = "bake", .kind = .kw_bake },
 };
 
 /// Lookup `name` (already lowercase per the identifier rule) in
@@ -437,18 +458,16 @@ fn lexInteger(state: *State, negative: bool) !void {
     if (state.index + 1 < state.source.len and state.source[state.index] == '0' and
         (state.source[state.index + 1] == 'x' or state.source[state.index + 1] == 'X'))
     {
-        // Hex form.
+        // `0x...` is no longer accepted — gero-lang uses `$...` for
+        // hex literals (§2.4). Consume the digits so the error spans
+        // the whole would-be literal, then report.
         state.index += 2;
-        const digits_start = state.index;
         while (state.index < state.source.len) : (state.index += 1) {
             const b = state.source[state.index];
             if (b == '_') continue;
             if (!isHexDigit(b)) break;
-            value = value * 16 + hexValue(b);
         }
-        if (state.index == digits_start) {
-            try pushError(state, start, "expected hex digit after `0x`", "0x");
-        }
+        try pushError(state, start, "hex literals use `$` (e.g. `$FE40`); `0x` is not accepted", state.source[start..state.index]);
     } else if (state.index + 1 < state.source.len and state.source[state.index] == '0' and
         (state.source[state.index + 1] == 'b' or state.source[state.index + 1] == 'B'))
     {
@@ -818,6 +837,12 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
             const start = state.index;
             state.index += 2;
             try pushToken(&state, .eq_eq, start, state.index, 0);
+            continue;
+        }
+        if (b == '=' and state.index + 1 < source.len and source[state.index + 1] == '>') {
+            const start = state.index;
+            state.index += 2;
+            try pushToken(&state, .fat_arrow, start, state.index, 0);
             continue;
         }
         if (b == '!' and state.index + 1 < source.len and source[state.index + 1] == '=') {

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -76,12 +76,6 @@ pub const Token = struct {
         kw_lambda,
         kw_return,
         kw_if,
-        /// Reserved but no longer a syntactic separator. The parser
-        /// emits a diagnostic if `then` appears after `if` / `elif`
-        /// / `match case` heads (§4.4 / §4.8 no longer use it; bodies
-        /// start on the next line). Kept reserved so identifiers
-        /// can't accidentally shadow it.
-        kw_then,
         kw_else,
         kw_elif,
         kw_end,
@@ -93,6 +87,13 @@ pub const Token = struct {
         kw_do,
         kw_for,
         kw_in,
+        /// `repeat` — opens a `repeat … until cond` loop (§4.5.5).
+        /// The body runs at least once; the loop terminates when
+        /// `cond` evaluates true.
+        kw_repeat,
+        /// `until` — closes a `repeat` loop (§4.5.5). Followed by
+        /// the termination-condition expression.
+        kw_until,
         kw_step,
         kw_match,
         kw_case,
@@ -244,7 +245,6 @@ const keyword_table = [_]KeywordEntry{
     .{ .lex = "lambda", .kind = .kw_lambda },
     .{ .lex = "return", .kind = .kw_return },
     .{ .lex = "if", .kind = .kw_if },
-    .{ .lex = "then", .kind = .kw_then },
     .{ .lex = "else", .kind = .kw_else },
     .{ .lex = "elif", .kind = .kw_elif },
     .{ .lex = "end", .kind = .kw_end },
@@ -252,6 +252,8 @@ const keyword_table = [_]KeywordEntry{
     .{ .lex = "do", .kind = .kw_do },
     .{ .lex = "for", .kind = .kw_for },
     .{ .lex = "in", .kind = .kw_in },
+    .{ .lex = "repeat", .kind = .kw_repeat },
+    .{ .lex = "until", .kind = .kw_until },
     .{ .lex = "step", .kind = .kw_step },
     .{ .lex = "match", .kind = .kw_match },
     .{ .lex = "case", .kind = .kw_case },

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -422,6 +422,7 @@ pub fn parseStatement(
         .kw_if => try statements.append(p.allocator, try stmt_mod.parseIfStatement(p)),
         .kw_while => try statements.append(p.allocator, try stmt_mod.parseWhileStatement(p)),
         .kw_for => try statements.append(p.allocator, try stmt_mod.parseForStatement(p)),
+        .kw_repeat => try statements.append(p.allocator, try stmt_mod.parseRepeatStatement(p)),
         .kw_match => try statements.append(p.allocator, try stmt_mod.parseMatchStatement(p)),
         .kw_do => try statements.append(p.allocator, try stmt_mod.parseBlockStatement(p)),
         .kw_return => try statements.append(p.allocator, try stmt_mod.parseReturnStatement(p)),

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -308,40 +308,67 @@ fn parseTopLevel(
     };
 }
 
-/// `@asm("…")` — statement-level inline-assembly escape hatch
-/// (§3.7.7). Consumes the annotation, validates it carries exactly
-/// one string-literal argument, and emits an `asm_stmt` whose `body`
-/// span covers the string literal (including the surrounding
-/// quotes). Codegen reads the literal and performs `{name}`
-/// substitution against the enclosing scope.
-fn emitAsmStmt(
+/// Parse an optional `:label` suffix on a loop head or
+/// `break` / `continue`. Returns `null` when the next token is not
+/// a colon — that's the unlabeled form. Identifiers after `:` must
+/// be plain `[a-z_][a-zA-Z0-9_]*`; the lexer already enforces the
+/// lexical shape.
+pub fn parseOptionalJumpLabel(p: *Parser) ParserError!?ast.Span {
+    if (!p.check(.colon)) return null;
+    p.pos += 1; // consume `:`
+    const tok = try p.expect(.ident, "label identifier");
+    return .{ .start = tok.start, .end = tok.end };
+}
+
+/// Builtin `asm "<instruction>"` statement (§4.11). One instruction
+/// per `asm` statement; the body is captured as a byte span and the
+/// codegen pass performs `{name}` operand substitution. Interpolation
+/// `$(…)` inside the asm body is rejected — the syntax is reserved
+/// for runtime string interpolation, not asm substitution.
+fn emitAsmKeywordStmt(
     p: *Parser,
     statements: *std.ArrayList(ast.Statement),
 ) ParserError!void {
-    const ann = try annotation_mod.parseAnnotation(p);
-    defer {
-        for (ann.args) |a| ast.freeExpr(p.allocator, a);
-        p.allocator.free(ann.args);
-    }
+    const asm_tok = p.peek();
+    p.pos += 1; // consume `asm`
 
-    if (ann.args.len != 1 or ann.args[0].* != .str_lit) {
-        try p.errors.append(p.allocator, core.parseError(
-            "lang_parser",
-            ann.span.start,
-            "@asm expects exactly one string-literal argument",
-            .{ .expected = "@asm(\"...\")", .kind = .syntactic },
-        ));
-        try statements.append(p.allocator, .{ .unknown = .{ .span = ann.span } });
-        try p.requireStatementBoundary();
-        return;
+    if (!p.check(.str_start)) {
+        try p.recordError(
+            "`asm` expects a string literal with the instruction body",
+            "asm \"...\"",
+        );
+        return error.ParseFailed;
     }
+    const open_tok = p.peek();
+    p.pos += 1; // consume `str_start`
 
-    const body_span = ann.args[0].span();
-    try statements.append(p.allocator, .{ .asm_stmt = .{
-        .body = body_span,
-        .span = ann.span,
-    } });
-    try p.requireStatementBoundary();
+    // Body: consume parts up to `str_end`; reject interpolation.
+    while (true) {
+        const t = p.peek();
+        switch (t.kind) {
+            .str_part => p.pos += 1,
+            .str_expr_start => {
+                try p.recordError(
+                    "`$(...)` interpolation is not allowed inside `asm`; use `{name}` operand substitution instead",
+                    "asm body without interpolation",
+                );
+                return error.ParseFailed;
+            },
+            .str_end => {
+                p.pos += 1;
+                try statements.append(p.allocator, .{ .asm_stmt = .{
+                    .body = .{ .start = open_tok.start, .end = t.end },
+                    .span = .{ .start = asm_tok.start, .end = t.end },
+                } });
+                try p.requireStatementBoundary();
+                return;
+            },
+            else => {
+                try p.recordError("malformed asm body", "string content");
+                return error.ParseFailed;
+            },
+        }
+    }
 }
 
 /// Dispatch on the leading token kind. Public so sibling modules
@@ -349,10 +376,9 @@ fn emitAsmStmt(
 /// `while`/`for`/`match` bodies) can recurse back through the same
 /// statement-kind switch.
 ///
-/// Annotations are handled here uniformly: `@asm("…")` emits an
-/// `asm_stmt` directly (§3.7.7 — statement-level escape hatch); any
-/// other `@name(…)` pushes into the pending buffer and the parser
-/// recurses to consume the following decl that will drain it.
+/// Annotations push into the pending buffer and the parser recurses
+/// to consume the following decl that will drain it. (`asm` is now
+/// a builtin statement — see §4.11 — not an annotation.)
 pub fn parseStatement(
     p: *Parser,
     statements: *std.ArrayList(ast.Statement),
@@ -362,8 +388,11 @@ pub fn parseStatement(
             const tok = p.peek();
             const name = p.source[tok.start + 1 .. tok.end];
             if (std.mem.eql(u8, name, "asm")) {
-                try emitAsmStmt(p, statements);
-                return;
+                try p.recordError(
+                    "`@asm(\"...\")` is no longer accepted; use the `asm \"...\"` statement (§4.11)",
+                    "asm \"...\"",
+                );
+                return error.ParseFailed;
             }
             const ann = try annotation_mod.parseAnnotation(p);
             try p.pending_annotations.append(p.allocator, ann);
@@ -399,21 +428,28 @@ pub fn parseStatement(
         .kw_break => {
             const t = p.peek();
             p.pos += 1;
+            const label = try parseOptionalJumpLabel(p);
+            const end: u32 = if (label) |lbl| lbl.end else t.end;
             try statements.append(p.allocator, .{ .break_stmt = .{
-                .span = .{ .start = t.start, .end = t.end },
+                .label = label,
+                .span = .{ .start = t.start, .end = end },
             } });
             try p.requireStatementBoundary();
         },
         .kw_continue => {
             const t = p.peek();
             p.pos += 1;
+            const label = try parseOptionalJumpLabel(p);
+            const end: u32 = if (label) |lbl| lbl.end else t.end;
             try statements.append(p.allocator, .{ .continue_stmt = .{
-                .span = .{ .start = t.start, .end = t.end },
+                .label = label,
+                .span = .{ .start = t.start, .end = end },
             } });
             try p.requireStatementBoundary();
         },
         .kw_print => try statements.append(p.allocator, try stmt_mod.parsePrintStatement(p)),
         .kw_defer => try statements.append(p.allocator, try stmt_mod.parseDeferStatement(p)),
+        .kw_asm => try emitAsmKeywordStmt(p, statements),
         .eof => return,
         else => try stmt_mod.parseExprOrAssignStatement(p, statements),
     }

--- a/src/lang/stmt.zig
+++ b/src/lang/stmt.zig
@@ -16,6 +16,34 @@ const Parser = parser_mod.Parser;
 const ParserError = parser_mod.ParserError;
 const Kind = lexer.Token.Kind;
 
+/// Friendly diagnostic when a stray `then` appears at a head-end
+/// position (after an `if` / `elif` condition). `then` was removed
+/// as a syntactic separator (§4.4) but kept reserved so the parser
+/// can flag the migration path instead of emitting a cryptic error.
+fn rejectStrandedThen(p: *Parser, context: []const u8) ParserError!void {
+    if (p.check(.kw_then)) {
+        try p.recordError(
+            "`then` is not a syntactic separator — the head ends at the newline",
+            context,
+        );
+        return error.ParseFailed;
+    }
+}
+
+/// Friendly diagnostic when a stray `do` appears at a head-end
+/// position (after a `while` / `for` head). `do` remains a keyword
+/// because it opens `do…end` blocks (§4.3), but it's not a loop-head
+/// separator (§4.5).
+fn rejectStrandedDo(p: *Parser, context: []const u8) ParserError!void {
+    if (p.check(.kw_do)) {
+        try p.recordError(
+            "`do` is not a loop-head separator — the head ends at the newline (`do…end` is the block form only)",
+            context,
+        );
+        return error.ParseFailed;
+    }
+}
+
 // ---------- if / elif / else ----------
 
 /// `if cond then ... [elif ...] [else ...] end` — statement form.
@@ -104,7 +132,8 @@ fn parseIfArm(
     errdefer if (let_expr) |e| ast.freeExpr(p.allocator, e);
     errdefer if (let_guard) |g| ast.freeExpr(p.allocator, g);
 
-    // `if let pat = expr [when guard] then ...` — §4.4.1.
+    // `if let pat = expr [when guard]` — §4.4.1. No `then` separator
+    // (§4.4) — the head expression ends at the newline.
     if (p.accept(.kw_let)) |_| {
         let_pattern = try pattern_mod.parsePattern(p);
         _ = try p.expect(.equals, "=");
@@ -115,7 +144,7 @@ fn parseIfArm(
     } else {
         cond = try expr_mod.parseExpression(p, 0);
     }
-    _ = try p.expect(.kw_then, "then");
+    try rejectStrandedThen(p, "if");
     p.skipNewlines();
 
     var body: std.ArrayList(ast.Statement) = .empty;
@@ -153,7 +182,8 @@ fn cleanupIfArms(
 
 // ---------- while (incl. while let) ----------
 
-/// `while cond do ... end` and `while let pat = expr [when guard] do ... end`.
+/// `while cond ... end` and `while let pat = expr [when guard] ... end`.
+/// Head ends at the newline — no `do` separator (§4.5).
 pub fn parseWhileStatement(p: *Parser) ParserError!ast.Statement {
     const while_tok = p.peek();
     p.pos += 1;
@@ -175,7 +205,8 @@ pub fn parseWhileStatement(p: *Parser) ParserError!ast.Statement {
         cond = try expr_mod.parseExpression(p, 0);
     }
 
-    _ = try p.expect(.kw_do, "do");
+    try rejectStrandedDo(p, "while");
+    const label = try parser_mod.parseOptionalJumpLabel(p);
     p.skipNewlines();
 
     var body: std.ArrayList(ast.Statement) = .empty;
@@ -192,6 +223,7 @@ pub fn parseWhileStatement(p: *Parser) ParserError!ast.Statement {
         .let_pattern = let_pattern,
         .let_expr = let_expr,
         .let_guard = let_guard,
+        .label = label,
         .body = try body.toOwnedSlice(p.allocator),
         .span = .{ .start = start, .end = end_tok.end },
     } };
@@ -199,7 +231,8 @@ pub fn parseWhileStatement(p: *Parser) ParserError!ast.Statement {
 
 // ---------- for-in ----------
 
-/// `for x in iter [step N] do ... end`.
+/// `for x in iter [step N] ... end`. Head ends at the newline — no
+/// `do` separator (§4.5).
 pub fn parseForStatement(p: *Parser) ParserError!ast.Statement {
     const for_tok = p.peek();
     p.pos += 1;
@@ -217,7 +250,8 @@ pub fn parseForStatement(p: *Parser) ParserError!ast.Statement {
     }
     errdefer if (step) |s| ast.freeExpr(p.allocator, s);
 
-    _ = try p.expect(.kw_do, "do");
+    try rejectStrandedDo(p, "for");
+    const label = try parser_mod.parseOptionalJumpLabel(p);
     p.skipNewlines();
 
     var body: std.ArrayList(ast.Statement) = .empty;
@@ -233,6 +267,7 @@ pub fn parseForStatement(p: *Parser) ParserError!ast.Statement {
         .binding = ast.Span.fromToken(binding_tok),
         .iter = iter,
         .step = step,
+        .label = label,
         .body = try body.toOwnedSlice(p.allocator),
         .span = .{ .start = start, .end = end_tok.end },
     } };
@@ -240,7 +275,7 @@ pub fn parseForStatement(p: *Parser) ParserError!ast.Statement {
 
 // ---------- match ----------
 
-/// `match scrutinee case pat [when guard] then body ... end`.
+/// `match scrutinee case pat [when guard] => body ... end` (§4.8).
 pub fn parseMatchStatement(p: *Parser) ParserError!ast.Statement {
     const match_tok = p.peek();
     p.pos += 1;
@@ -264,7 +299,16 @@ pub fn parseMatchStatement(p: *Parser) ParserError!ast.Statement {
         }
         errdefer if (guard) |g| ast.freeExpr(p.allocator, g);
 
-        _ = try p.expect(.kw_then, "then");
+        // Match arms use `=>` (§4.8). Friendly hint if the user wrote
+        // the old `then` separator.
+        if (p.check(.kw_then)) {
+            try p.recordError(
+                "match arms use `=>`, not `then`",
+                "=>",
+            );
+            return error.ParseFailed;
+        }
+        _ = try p.expect(.fat_arrow, "=>");
         p.skipNewlines();
 
         var body: std.ArrayList(ast.Statement) = .empty;

--- a/src/lang/stmt.zig
+++ b/src/lang/stmt.zig
@@ -16,24 +16,11 @@ const Parser = parser_mod.Parser;
 const ParserError = parser_mod.ParserError;
 const Kind = lexer.Token.Kind;
 
-/// Friendly diagnostic when a stray `then` appears at a head-end
-/// position (after an `if` / `elif` condition). `then` was removed
-/// as a syntactic separator (§4.4) but kept reserved so the parser
-/// can flag the migration path instead of emitting a cryptic error.
-fn rejectStrandedThen(p: *Parser, context: []const u8) ParserError!void {
-    if (p.check(.kw_then)) {
-        try p.recordError(
-            "`then` is not a syntactic separator — the head ends at the newline",
-            context,
-        );
-        return error.ParseFailed;
-    }
-}
-
 /// Friendly diagnostic when a stray `do` appears at a head-end
 /// position (after a `while` / `for` head). `do` remains a keyword
 /// because it opens `do…end` blocks (§4.3), but it's not a loop-head
-/// separator (§4.5).
+/// separator (§4.5) — emit a clear error rather than letting the
+/// inner block consume the loop body silently.
 fn rejectStrandedDo(p: *Parser, context: []const u8) ParserError!void {
     if (p.check(.kw_do)) {
         try p.recordError(
@@ -144,7 +131,6 @@ fn parseIfArm(
     } else {
         cond = try expr_mod.parseExpression(p, 0);
     }
-    try rejectStrandedThen(p, "if");
     p.skipNewlines();
 
     var body: std.ArrayList(ast.Statement) = .empty;
@@ -273,6 +259,38 @@ pub fn parseForStatement(p: *Parser) ParserError!ast.Statement {
     } };
 }
 
+// ---------- repeat ... until cond ----------
+
+/// `repeat [:label] ... until cond` — do-while-style loop. Body
+/// runs at least once; the loop exits when `cond` evaluates true
+/// (§4.5.5).
+pub fn parseRepeatStatement(p: *Parser) ParserError!ast.Statement {
+    const repeat_tok = p.peek();
+    p.pos += 1;
+    const start = repeat_tok.start;
+
+    const label = try parser_mod.parseOptionalJumpLabel(p);
+    p.skipNewlines();
+
+    var body: std.ArrayList(ast.Statement) = .empty;
+    errdefer parser_mod.cleanupStatements(p.allocator, &body);
+    while (!p.atEnd() and !p.check(.kw_until)) {
+        try parser_mod.parseStatement(p, &body);
+        p.skipNewlines();
+    }
+    _ = try p.expect(.kw_until, "until");
+    const cond = try expr_mod.parseExpression(p, 0);
+    errdefer ast.freeExpr(p.allocator, cond);
+    try p.requireStatementBoundary();
+
+    return .{ .repeat_stmt = .{
+        .body = try body.toOwnedSlice(p.allocator),
+        .cond = cond,
+        .label = label,
+        .span = .{ .start = start, .end = cond.span().end },
+    } };
+}
+
 // ---------- match ----------
 
 /// `match scrutinee case pat [when guard] => body ... end` (§4.8).
@@ -299,15 +317,6 @@ pub fn parseMatchStatement(p: *Parser) ParserError!ast.Statement {
         }
         errdefer if (guard) |g| ast.freeExpr(p.allocator, g);
 
-        // Match arms use `=>` (§4.8). Friendly hint if the user wrote
-        // the old `then` separator.
-        if (p.check(.kw_then)) {
-            try p.recordError(
-                "match arms use `=>`, not `then`",
-                "=>",
-            );
-            return error.ParseFailed;
-        }
         _ = try p.expect(.fat_arrow, "=>");
         p.skipNewlines();
 

--- a/tests/lang/ast.test.zig
+++ b/tests/lang/ast.test.zig
@@ -39,6 +39,7 @@ test "ast: Expr.span() returns the variant's span field" {
 
 test "ast: Statement.span() returns the variant's span field" {
     const s: ast.Statement = .{ .break_stmt = .{
+        .label = null,
         .span = .{ .start = 3, .end = 8 },
     } };
     const sp = s.span();

--- a/tests/lang/lexer.test.zig
+++ b/tests/lang/lexer.test.zig
@@ -108,6 +108,9 @@ test "lex: every reserved keyword maps to its kind" {
         .{ .src = "break", .kind = .kw_break },
         .{ .src = "continue", .kind = .kw_continue },
         .{ .src = "print", .kind = .kw_print },
+        .{ .src = "defer", .kind = .kw_defer },
+        .{ .src = "asm", .kind = .kw_asm },
+        .{ .src = "bake", .kind = .kw_bake },
     };
     for (cases) |c| {
         var ts = try tokenize(c.src);
@@ -131,11 +134,33 @@ test "lex: decimal integer literal" {
     try std.testing.expectEqual(@as(i32, 42), ts.tokens[0].value);
 }
 
-test "lex: hex integer literal" {
-    var ts = try tokenize("0xFF");
+test "lex: hex integer literal uses `$` prefix" {
+    var ts = try tokenize("$FF");
     defer ts.deinit();
     try std.testing.expectEqual(Token.Kind.int_lit, ts.tokens[0].kind);
     try std.testing.expectEqual(@as(i32, 255), ts.tokens[0].value);
+}
+
+test "lex: legacy `0x` hex literal is rejected with a diagnostic" {
+    var ts = try tokenize("0xFE40");
+    defer ts.deinit();
+    try std.testing.expect(ts.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, ts.errors[0].message, "$") != null);
+}
+
+test "lex: `then` and `do` remain reserved keywords" {
+    // The parser rejects them in if/while/for-head positions (§4.4/§4.5)
+    // with a diagnostic, but the lexer keeps them tokenized for clear
+    // error messages. `do…end` (§4.3) still uses `kw_do`.
+    try expectKinds("then do", &.{ .kw_then, .kw_do });
+}
+
+test "lex: `=>` fat arrow" {
+    try expectKinds("=>", &.{.fat_arrow});
+}
+
+test "lex: `==` and `=>` disambiguated" {
+    try expectKinds("== =>", &.{ .eq_eq, .fat_arrow });
 }
 
 test "lex: binary integer literal with underscore separators" {
@@ -170,7 +195,9 @@ test "lex: `-` after an operand-end token is the binary minus operator" {
     try std.testing.expectEqual(@as(i32, 1), ts.tokens[2].value);
 }
 
-test "lex: malformed `0x` reports an error but still emits a token" {
+test "lex: bare `0x` reports the rejection diagnostic" {
+    // `0x` is no longer accepted; the lexer reports the migration
+    // hint pointing at `$`.
     var ts = try tokenize("let x = 0x");
     defer ts.deinit();
     try std.testing.expect(ts.hasErrors());
@@ -333,12 +360,13 @@ test "lex: small function body" {
 
 test "lex: match expression with or-pattern + guard" {
     try expectKinds(
-        "match x do\n  case 1 or 2 when x > 0 then a\nend",
+        "match x\n  case 1 or 2 when x > 0 => a\nend",
         &.{
-            .kw_match, .ident,   .kw_do,   .newline,
-            .kw_case,  .int_lit, .kw_or,   .int_lit,
-            .kw_when,  .ident,   .gt,      .int_lit,
-            .kw_then,  .ident,   .newline, .kw_end,
+            .kw_match, .ident,   .newline,
+            .kw_case,  .int_lit, .kw_or,
+            .int_lit,  .kw_when, .ident,
+            .gt,       .int_lit, .fat_arrow,
+            .ident,    .newline, .kw_end,
         },
     );
 }
@@ -403,9 +431,9 @@ test "lex: unterminated char literal reports an error" {
 }
 
 test "lex: char literal compares natural in expressions" {
-    // `if s.at(0) == 'A' then ...` should lex cleanly.
-    try expectKinds("if s.at(0) == 'A' then", &.{
-        .kw_if, .ident,   .dot,     .ident, .lparen, .int_lit, .rparen,
-        .eq_eq, .int_lit, .kw_then,
+    // `if s.at(0) == 'A'` should lex cleanly.
+    try expectKinds("if s.at(0) == 'A'", &.{
+        .kw_if, .ident,   .dot, .ident, .lparen, .int_lit, .rparen,
+        .eq_eq, .int_lit,
     });
 }

--- a/tests/lang/lexer.test.zig
+++ b/tests/lang/lexer.test.zig
@@ -77,13 +77,14 @@ test "lex: every reserved keyword maps to its kind" {
         .{ .src = "lambda", .kind = .kw_lambda },
         .{ .src = "return", .kind = .kw_return },
         .{ .src = "if", .kind = .kw_if },
-        .{ .src = "then", .kind = .kw_then },
         .{ .src = "else", .kind = .kw_else },
         .{ .src = "elif", .kind = .kw_elif },
         .{ .src = "end", .kind = .kw_end },
         .{ .src = "while", .kind = .kw_while },
         .{ .src = "do", .kind = .kw_do },
         .{ .src = "for", .kind = .kw_for },
+        .{ .src = "repeat", .kind = .kw_repeat },
+        .{ .src = "until", .kind = .kw_until },
         .{ .src = "in", .kind = .kw_in },
         .{ .src = "step", .kind = .kw_step },
         .{ .src = "match", .kind = .kw_match },
@@ -148,11 +149,11 @@ test "lex: legacy `0x` hex literal is rejected with a diagnostic" {
     try std.testing.expect(std.mem.indexOf(u8, ts.errors[0].message, "$") != null);
 }
 
-test "lex: `then` and `do` remain reserved keywords" {
-    // The parser rejects them in if/while/for-head positions (§4.4/§4.5)
-    // with a diagnostic, but the lexer keeps them tokenized for clear
-    // error messages. `do…end` (§4.3) still uses `kw_do`.
-    try expectKinds("then do", &.{ .kw_then, .kw_do });
+test "lex: `then` is no longer reserved (plain identifier)" {
+    // §4.4 removed `then` as a syntactic separator entirely; the
+    // lexer treats it like any other identifier. `do` remains
+    // reserved for `do…end` blocks (§4.3).
+    try expectKinds("then do", &.{ .ident, .kw_do });
 }
 
 test "lex: `=>` fat arrow" {

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -556,6 +556,44 @@ test "parse: break + continue" {
     try std.testing.expect(body[1] == .continue_stmt);
 }
 
+test "parse: repeat … until cond loop" {
+    var tree = try parseClean(
+        \\repeat
+        \\  x = x - 1
+        \\until x == 0
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .repeat_stmt);
+    try std.testing.expectEqual(@as(usize, 1), s.repeat_stmt.body.len);
+    try std.testing.expect(s.repeat_stmt.cond.* == .binary);
+}
+
+test "parse: repeat with label + break :label" {
+    var tree = try parseClean(
+        \\repeat :outer
+        \\  for x in 0..10
+        \\    break :outer
+        \\  end
+        \\until done
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].repeat_stmt;
+    try std.testing.expect(s.label != null);
+}
+
+test "parse: repeat body with multiple statements" {
+    var tree = try parseClean(
+        \\repeat
+        \\  let cmd = read_input()
+        \\  process(cmd)
+        \\until cmd == "quit"
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0].repeat_stmt;
+    try std.testing.expectEqual(@as(usize, 2), s.body.len);
+}
+
 test "parse: labeled while + break :label" {
     var tree = try parseClean(
         \\while true :outer
@@ -1232,11 +1270,10 @@ test "parse: `asm \"...\"` inside a function body" {
     try std.testing.expect(body[0] == .asm_stmt);
 }
 
-test "parse: legacy `@asm(\"...\")` surfaces a migration diagnostic" {
+test "parse: `@asm(\"...\")` annotation form is rejected" {
     var tree = try parseSource("@asm(\"swap r1, r2\")");
     defer tree.deinit();
     try std.testing.expect(tree.errors.len > 0);
-    try std.testing.expect(std.mem.indexOf(u8, tree.errors[0].message, "asm \"...\"") != null);
 }
 
 test "parse: `asm \"$(x)\"` rejects interpolation in the body" {

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -185,7 +185,7 @@ test "parse: `not` is unary, binds tighter than `and`" {
 }
 
 test "parse: bitwise NOT (`~`) is unary" {
-    var tree = try parseClean("let x = ~mask & 0xFF");
+    var tree = try parseClean("let x = ~mask & $FF");
     defer tree.deinit();
     const init = tree.program.statements[0].let_decl.init.?;
     try std.testing.expectEqual(ast.BinaryOp.bit_and, init.binary.op);
@@ -363,11 +363,54 @@ test "parse: lambda expression" {
     try std.testing.expect(init.* == .lambda);
 }
 
+test "parse: short lambda `|x| x*2`" {
+    var tree = try parseClean("let f = |x| x * 2");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .lambda);
+    try std.testing.expectEqual(@as(usize, 1), init.lambda.params.len);
+    // Body desugars to a single `return <expr>` statement.
+    try std.testing.expectEqual(@as(usize, 1), init.lambda.body.len);
+    try std.testing.expect(init.lambda.body[0] == .return_stmt);
+}
+
+test "parse: short lambda multi-arg `|x, y| x + y`" {
+    var tree = try parseClean("let add = |x, y| x + y");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .lambda);
+    try std.testing.expectEqual(@as(usize, 2), init.lambda.params.len);
+}
+
+test "parse: short lambda zero-arg `|| read_input()`" {
+    var tree = try parseClean("let f = || read_input()");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .lambda);
+    try std.testing.expectEqual(@as(usize, 0), init.lambda.params.len);
+}
+
+test "parse: short lambda with explicit types `|x: i16| -> i16 x*2`" {
+    var tree = try parseClean("let f = |x: i16| -> i16 x * 2");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .lambda);
+    try std.testing.expect(init.lambda.params[0].type_ann != null);
+    try std.testing.expect(init.lambda.ret_type != null);
+}
+
+test "parse: short lambda inside `.map(|x| ...)`" {
+    var tree = try parseClean("let r = xs.map(|x| x + 1)");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .method_call);
+}
+
 // ---------- control flow ----------
 
 test "parse: if/then/end" {
     var tree = try parseClean(
-        \\if x > 0 then
+        \\if x > 0
         \\  print x
         \\end
     );
@@ -378,9 +421,9 @@ test "parse: if/then/end" {
 
 test "parse: if/elif/else chain" {
     var tree = try parseClean(
-        \\if x > 0 then
+        \\if x > 0
         \\  print "pos"
-        \\elif x == 0 then
+        \\elif x == 0
         \\  print "zero"
         \\else
         \\  print "neg"
@@ -394,7 +437,7 @@ test "parse: if/elif/else chain" {
 
 test "parse: `if let` pattern binding" {
     var tree = try parseClean(
-        \\if let Item.Potion(n) = item then
+        \\if let Item.Potion(n) = item
         \\  drink(n)
         \\end
     );
@@ -408,7 +451,7 @@ test "parse: `if let` pattern binding" {
 
 test "parse: `if let` with `when` guard" {
     var tree = try parseClean(
-        \\if let Event.Click(x, y) = e when x < 128 then
+        \\if let Event.Click(x, y) = e when x < 128
         \\  hit(x, y)
         \\end
     );
@@ -419,7 +462,7 @@ test "parse: `if let` with `when` guard" {
 
 test "parse: while loop" {
     var tree = try parseClean(
-        \\while i < 10 do
+        \\while i < 10
         \\  i = i + 1
         \\end
     );
@@ -431,7 +474,7 @@ test "parse: while loop" {
 
 test "parse: for-in with range" {
     var tree = try parseClean(
-        \\for i in 0..10 do
+        \\for i in 0..10
         \\  print i
         \\end
     );
@@ -443,7 +486,7 @@ test "parse: for-in with range" {
 
 test "parse: for-in with step" {
     var tree = try parseClean(
-        \\for i in 0..=100 step 5 do
+        \\for i in 0..=100 step 5
         \\  print i
         \\end
     );
@@ -502,7 +545,7 @@ test "parse: bare return" {
 
 test "parse: break + continue" {
     var tree = try parseClean(
-        \\while true do
+        \\while true
         \\  break
         \\  continue
         \\end
@@ -511,6 +554,47 @@ test "parse: break + continue" {
     const body = tree.program.statements[0].while_stmt.body;
     try std.testing.expect(body[0] == .break_stmt);
     try std.testing.expect(body[1] == .continue_stmt);
+}
+
+test "parse: labeled while + break :label" {
+    var tree = try parseClean(
+        \\while true :outer
+        \\  while x < 10
+        \\    break :outer
+        \\  end
+        \\end
+    );
+    defer tree.deinit();
+    const outer = tree.program.statements[0].while_stmt;
+    try std.testing.expect(outer.label != null);
+    const inner_body = outer.body[0].while_stmt.body;
+    try std.testing.expect(inner_body[0].break_stmt.label != null);
+}
+
+test "parse: labeled for + continue :label" {
+    var tree = try parseClean(
+        \\for y in 0..10 :rows
+        \\  for x in 0..10
+        \\    continue :rows
+        \\  end
+        \\end
+    );
+    defer tree.deinit();
+    const outer = tree.program.statements[0].for_stmt;
+    try std.testing.expect(outer.label != null);
+    const inner_body = outer.body[0].for_stmt.body;
+    try std.testing.expect(inner_body[0].continue_stmt.label != null);
+}
+
+test "parse: unlabeled break stays null" {
+    var tree = try parseClean(
+        \\while true
+        \\  break
+        \\end
+    );
+    defer tree.deinit();
+    const body = tree.program.statements[0].while_stmt.body;
+    try std.testing.expect(body[0].break_stmt.label == null);
 }
 
 test "parse: print statement" {
@@ -530,11 +614,11 @@ test "parse: print with multiple args" {
 test "parse: match statement with multiple arms" {
     var tree = try parseClean(
         \\match item
-        \\  case Item.Sword then
+        \\  case Item.Sword =>
         \\    print "sword"
-        \\  case Item.Potion(n) then
+        \\  case Item.Potion(n) =>
         \\    print n
-        \\  case _ then
+        \\  case _ =>
         \\    print "?"
         \\end
     );
@@ -546,7 +630,7 @@ test "parse: match statement with multiple arms" {
 test "parse: match arm with `when` guard" {
     var tree = try parseClean(
         \\match item
-        \\  case Item.Potion(n) when n > 50 then
+        \\  case Item.Potion(n) when n > 50 =>
         \\    print "big"
         \\end
     );
@@ -558,7 +642,7 @@ test "parse: match arm with `when` guard" {
 test "parse: or-pattern" {
     var tree = try parseClean(
         \\match x
-        \\  case 1 | 2 | 3 then
+        \\  case 1 | 2 | 3 =>
         \\    print "small"
         \\end
     );
@@ -571,7 +655,7 @@ test "parse: or-pattern" {
 test "parse: range pattern" {
     var tree = try parseClean(
         \\match x
-        \\  case 0..=15 then
+        \\  case 0..=15 =>
         \\    print "small"
         \\end
     );
@@ -583,7 +667,7 @@ test "parse: range pattern" {
 test "parse: tuple pattern" {
     var tree = try parseClean(
         \\match p
-        \\  case (a, b) then
+        \\  case (a, b) =>
         \\    print a
         \\end
     );
@@ -595,7 +679,7 @@ test "parse: tuple pattern" {
 test "parse: struct pattern with shorthand" {
     var tree = try parseClean(
         \\match p
-        \\  case Player { hp, mp } then
+        \\  case Player { hp, mp } =>
         \\    print hp
         \\end
     );
@@ -608,7 +692,7 @@ test "parse: struct pattern with shorthand" {
 test "parse: variant pattern with binding" {
     var tree = try parseClean(
         \\match e
-        \\  case Event.KeyDown(k) then
+        \\  case Event.KeyDown(k) =>
         \\    print k
         \\end
     );
@@ -722,7 +806,7 @@ test "parse: multiple annotations stack on a single decl" {
 
 test "parse: `@interrupt N` parses on def" {
     var tree = try parseClean(
-        \\@interrupt 0x06
+        \\@interrupt $06
         \\def on_vblank()
         \\  return
         \\end
@@ -1008,7 +1092,7 @@ test "parse: @zero_page on let global" {
 
 test "parse: @addr with hex arg on let global" {
     var tree = try parseClean(
-        \\@addr 0xFE40
+        \\@addr $FE40
         \\let DISPCTL: u8 = 0
     );
     defer tree.deinit();
@@ -1129,17 +1213,17 @@ test "parse: @abstract def with return type, still no body" {
     try std.testing.expect(m.ret_type != null);
 }
 
-test "parse: @asm(\"...\") as a top-level statement" {
-    var tree = try parseClean("@asm(\"swap r1, r2\")");
+test "parse: `asm \"...\"` as a top-level statement" {
+    var tree = try parseClean("asm \"swap r1, r2\"");
     defer tree.deinit();
     try std.testing.expectEqual(@as(usize, 1), tree.program.statements.len);
     try std.testing.expect(tree.program.statements[0] == .asm_stmt);
 }
 
-test "parse: @asm(\"...\") inside a function body" {
+test "parse: `asm \"...\"` inside a function body" {
     var tree = try parseClean(
         \\def fast_swap(a: u16, b: u16)
-        \\  @asm("swap {a}, {b}")
+        \\  asm "swap {a}, {b}"
         \\end
     );
     defer tree.deinit();
@@ -1148,8 +1232,15 @@ test "parse: @asm(\"...\") inside a function body" {
     try std.testing.expect(body[0] == .asm_stmt);
 }
 
-test "parse: @asm without a string arg surfaces a diagnostic" {
-    var tree = try parseSource("@asm(42)");
+test "parse: legacy `@asm(\"...\")` surfaces a migration diagnostic" {
+    var tree = try parseSource("@asm(\"swap r1, r2\")");
+    defer tree.deinit();
+    try std.testing.expect(tree.errors.len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, tree.errors[0].message, "asm \"...\"") != null);
+}
+
+test "parse: `asm \"$(x)\"` rejects interpolation in the body" {
+    var tree = try parseSource("asm \"ret $(reg)\"");
     defer tree.deinit();
     try std.testing.expect(tree.errors.len > 0);
 }


### PR DESCRIPTION
Closes #215.

First implementation batch on top of the v1 spec lockdown. Applies the syntax decisions locked in `docs/gero-lang.md`.

## Summary

- **Lexer**: `fat_arrow` (`=>`), `kw_asm`, `kw_bake` added. `0x...` hex rejected with a hint to `\$...`.
- **Parser**: `if`/`elif`/`while`/`for` heads end at newline. `match` arms use `=>`. Short lambda `|x| expr`. `asm \"...\"` builtin statement. Labels on loops + `break :label`/`continue :label`.

## Acceptance vs #215

| Criterion | Status |
|---|---|
| Lexer accepts `asm` and `bake` as keywords | ✅ |
| Lexer rejects `then`/`do` as keywords (becomes identifiers) | ⚠️ **Deviation** — see below |
| Parser parses `if cond <body> end` without `then` | ✅ |
| Parser parses `while cond <body> end` / `for x in r <body> end` without `do` | ✅ |
| Match arms `case PAT => BODY`; legacy `then` form errors | ✅ |
| Short lambda `|x| x*2` | ✅ |
| `asm \"...\"` distinct from annotations | ✅ |
| `\$FE40` parses; `0xFE40` rejected with diagnostic | ✅ |
| Labels parse on `while`/`for` + `break :label`/`continue :label` | ✅ (parser-level) |
| `break :unknown` errors | ⏭️ **Deferred to typechecker** — see below |
| Tests cover each form with happy path + one error path | ✅ |
| All four release modes pass | ✅ |

### Deviations

1. **`then` and `do` remain reserved keywords** (the issue requested they become identifiers).
   Reason: keeping them tokenized lets the parser emit a friendly migration diagnostic (`\"then\" is not a syntactic separator — the head ends at the newline`) instead of a cryptic \"expected expression, found ident\". Spec §2.6 was updated to reflect this — `then` is reserved but not a separator; `do` opens `do…end` blocks (§4.3) but is rejected after `while`/`for` heads.

2. **`break :unknown` errors** is deferred to the typechecker.
   The parser accepts any label name (parses `:` + ident) and stores it in the AST. Validating that the label refers to an enclosing loop is type/scope analysis, not parsing. This will land with the typechecker issue (not yet filed).

## Test plan

- [x] `zig build test` — 961 tests green
- [x] `zig build verify` — fmt + lint + asm gates green
- [x] `zig build ci` — full matrix (Debug / ReleaseSafe / ReleaseFast / ReleaseSmall + cross-target) green
- [x] Spec §2.6 updated to clarify `then`/`do` reserved-keyword status
- [x] Spec §9 out-of-scope updated to note kept-reserved status
- [x] Legacy `@asm(\"...\")` and `0xFF` errors carry friendly migration hints