### PR TITLE
feat(lang): complete v0.3 front-end — refs, bake, varargs, array-repeat

### DIFF
--- a/.changeset/lang-complete-front-end.md
+++ b/.changeset/lang-complete-front-end.md
@@ -1,0 +1,47 @@
+---
+bump: minor
+---
+
+Complete the v0.3 lang front-end: parser-level support for every
+feature the spec locks in. After this, the AST is the final shape
+the typechecker can build against.
+
+**References `&T`** (§3.4.4)
+
+- `TypeAnn.reference` variant for `&T` in annotation position.
+- `Expr.ref_of` variant for `&x` prefix in expression position.
+- Same precedence as other unary prefix operators; `&Stats?` parses
+  as `reference(nullable(Stats))` because postfix `?` binds inside
+  the reference's inner type-ann recursion.
+
+**`bake def` / `bake do`** (§3.8)
+
+- `DefDecl.is_bake: bool` flag for `bake def name(...) end`.
+- `DoExpr.is_bake: bool` flag for `bake do … end`.
+- `kw_bake` dispatch at statement position handles both forms; at
+  expression position (`const PALETTE = bake do … end`) only `bake
+  do` is accepted.
+- `bake` not followed by `def` or `do` surfaces a diagnostic.
+
+**Variadic parameters `args: ...`** (§4.6.2)
+
+- New `dot_dot_dot` token (`...`); the lexer uses longest-match so
+  `..=` / `..` / `...` are unambiguous.
+- `Param.variadic: bool` flag.
+- Parser accepts `name: ...` as the last param of a list and breaks
+  out of the param-parse loop — anything after surfaces as
+  `expected )`.
+
+**Array-repeat literals `[value; count]`** (§3.4)
+
+- `Expr.list_repeat` variant. Parser disambiguates from
+  `[a, b, c]` by the `;` after the first element.
+- Empty `[]` now parses as an empty `list_lit`.
+- Spec §3.4 table updated to mention the two literal forms.
+
+**Fix**
+
+- Pre-existing double-free in `parseParamList`'s errdefer (the
+  errdefer called `freeParams` on `params.items` and then
+  `params.deinit`, both freeing the same buffer). The variadic-
+  rejection path was the first to actually exercise it.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -308,7 +308,7 @@ PICO-8, Sonic, early Doom used.
 
 | Form | Example | Notes |
 |------|---------|-------|
-| Array (fixed-size) | `[u8; 64]` | N is comptime. Stack-allocated if local. |
+| Array (fixed-size) | `[u8; 64]` | N is comptime. Stack-allocated if local. Literals: `[a, b, c]` for explicit elements or `[value; count]` to repeat a single value. |
 | Dynamic array | `Vec(i16)` | Growable buffer with `push` / `pop` / `len` / `at`. See §3.4.3. |
 | Tuple | `(i16, str)` | Anonymous heterogeneous pair / triple / etc. Max 4 elements (5+ → use a struct). Destructurable in `let` and `match`. Field access via `.0`, `.1`, …. |
 | Optional | `T?` | Nullable pointer type — see §3.4.1. |

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -84,6 +84,9 @@ pub const TypeAnn = union(enum) {
     /// `fn(args...) -> ret` — function pointer type. `ret` is
     /// optional (defaults to `nil`).
     fn_type: FnType,
+    /// `&T` — borrowed reference (§3.4.4). Always mutates through;
+    /// no `&const` distinction.
+    reference: ReferenceType,
 
     /// Smallest `Span` covering the whole type annotation.
     pub fn span(self: TypeAnn) Span {
@@ -94,6 +97,7 @@ pub const TypeAnn = union(enum) {
             .vec => |v| v.span,
             .tuple => |t| t.span,
             .fn_type => |f| f.span,
+            .reference => |r| r.span,
         };
     }
 };
@@ -140,6 +144,13 @@ pub const FnType = struct {
     /// "no return type" to `nil`. Provided here so the printer can
     /// round-trip the source shape.
     ret: ?*TypeAnn,
+    span: Span,
+};
+
+/// `&T` — borrowed reference type (§3.4.4). Auto-derefs for field
+/// access and method calls. No arithmetic, no `&&T`, no `&temp`.
+pub const ReferenceType = struct {
+    inner: *TypeAnn,
     span: Span,
 };
 
@@ -354,6 +365,9 @@ pub const Expr = union(enum) {
     /// `[expr, expr, ...]` — array literal. Used for `[T; N]` init
     /// and `Vec.from([...])` arg.
     list_lit: ListLit,
+    /// `[value; count]` — array-repeat literal. `value` is replicated
+    /// `count` times. `count` must be a comptime integer expression.
+    list_repeat: ListRepeatLit,
     /// `Type { field: expr, ... }` — struct literal.
     struct_lit: StructLit,
     /// `(a, b, ...)` — tuple literal (at least 2 elements; singletons
@@ -367,6 +381,10 @@ pub const Expr = union(enum) {
     /// sign / zero extension, fixed↔int rounding); the parser just
     /// captures the inner expression + target type annotation.
     cast: CastExpr,
+    /// `&x` — take a borrowed reference to `x` (§3.4.4). Inner must
+    /// be a place expression (ident / field / index); the
+    /// typechecker rejects `&(a+b)` and similar temporaries.
+    ref_of: RefOfExpr,
 
     /// Smallest `Span` covering the whole expression.
     pub fn span(self: Expr) Span {
@@ -390,10 +408,12 @@ pub const Expr = union(enum) {
             .if_expr => |e| e.span,
             .lambda => |e| e.span,
             .list_lit => |e| e.span,
+            .list_repeat => |e| e.span,
             .struct_lit => |e| e.span,
             .tuple_lit => |e| e.span,
             .is_test => |e| e.span,
             .cast => |e| e.span,
+            .ref_of => |e| e.span,
         };
     }
 };
@@ -581,6 +601,10 @@ pub const IndexExpr = struct {
 /// `do ... end` used as an expression.
 pub const DoExpr = struct {
     body: []Statement,
+    /// `true` when written as `bake do … end` (§3.8). The block is
+    /// evaluated at compile time and the result is lowered to static
+    /// data.
+    is_bake: bool = false,
     span: Span,
 };
 
@@ -622,6 +646,16 @@ pub const ListLit = struct {
     span: Span,
 };
 
+/// `[value; count]` — array-repeat literal. `value` is the element
+/// to replicate and `count` is the number of copies (must be a
+/// compile-time integer expression at typecheck time; the parser
+/// accepts any expression).
+pub const ListRepeatLit = struct {
+    value: *Expr,
+    count: *Expr,
+    span: Span,
+};
+
 /// `Type { field: expr, ... }` — struct literal.
 pub const StructLit = struct {
     /// Type name (`Player`, `Stats`, etc.).
@@ -658,6 +692,15 @@ pub const CastExpr = struct {
     span: Span,
 };
 
+/// `&x` — take a borrowed reference to a place expression. The
+/// parser accepts any expression as `inner`; the typechecker
+/// rejects non-place targets (temporaries, results of `+`/`*`, etc.)
+/// per §3.4.4.
+pub const RefOfExpr = struct {
+    inner: *Expr,
+    span: Span,
+};
+
 // =====================================================================
 // Function parameters — shared between `def`, `lambda`, and class
 // methods.
@@ -667,8 +710,14 @@ pub const CastExpr = struct {
 pub const Param = struct {
     name: Span,
     /// `null` when the parameter has no explicit type — inference
-    /// will pin it from call-site usage (§3.5).
+    /// will pin it from call-site usage (§3.5). For a variadic
+    /// parameter (`name: ...`) the type is also `null`; the
+    /// `variadic` flag carries the intent.
     type_ann: ?*TypeAnn,
+    /// `true` for the variadic last parameter (`name: ...`, §4.6.2).
+    /// Only the last param of a list may be variadic; the parser
+    /// enforces that.
+    variadic: bool = false,
     span: Span,
 };
 
@@ -959,6 +1008,10 @@ pub const DefDecl = struct {
     ret_type: ?*TypeAnn,
     body: []Statement,
     is_local: bool,
+    /// `true` when prefixed with `bake` (§3.8). Bake functions are
+    /// evaluated by the compile-time interpreter and their results
+    /// are baked into static data.
+    is_bake: bool = false,
     span: Span,
 };
 
@@ -1302,6 +1355,10 @@ pub fn freeExpr(allocator: std.mem.Allocator, e: *Expr) void {
             for (ll.elems) |x| freeExpr(allocator, x);
             allocator.free(ll.elems);
         },
+        .list_repeat => |lr| {
+            freeExpr(allocator, lr.value);
+            freeExpr(allocator, lr.count);
+        },
         .struct_lit => |sl| {
             for (sl.fields) |f| freeExpr(allocator, f.value);
             allocator.free(sl.fields);
@@ -1315,6 +1372,7 @@ pub fn freeExpr(allocator: std.mem.Allocator, e: *Expr) void {
             freeExpr(allocator, c.inner);
             freeTypeAnn(allocator, c.target_type);
         },
+        .ref_of => |r| freeExpr(allocator, r.inner),
     }
     allocator.destroy(e);
 }
@@ -1373,6 +1431,7 @@ pub fn freeTypeAnn(allocator: std.mem.Allocator, t: *TypeAnn) void {
             allocator.free(fn_t.params);
             if (fn_t.ret) |r| freeTypeAnn(allocator, r);
         },
+        .reference => |r| freeTypeAnn(allocator, r.inner),
     }
     allocator.destroy(t);
 }

--- a/src/lang/decl.zig
+++ b/src/lang/decl.zig
@@ -172,7 +172,10 @@ fn hasAnnotationNamed(
 pub fn parseParamList(p: *Parser) ParserError![]ast.Param {
     var params: std.ArrayList(ast.Param) = .empty;
     errdefer {
-        freeParams(p.allocator, params.items);
+        // Free nested type-anns then let the ArrayList free its own
+        // backing buffer. (Don't call `freeParams` here — that takes
+        // an owned slice and would double-free the ArrayList buffer.)
+        for (params.items) |item| if (item.type_ann) |t| ast.freeTypeAnn(p.allocator, t);
         params.deinit(p.allocator);
     }
 
@@ -196,16 +199,32 @@ pub fn parseParamList(p: *Parser) ParserError![]ast.Param {
         };
 
         var type_ann: ?*ast.TypeAnn = null;
+        var variadic = false;
+        var variadic_end: u32 = name_span.end;
         if (p.accept(.colon)) |_| {
-            type_ann = try type_mod.parseTypeAnn(p);
+            // `name: ...` — variadic marker (§4.6.2). No type
+            // annotation; the typechecker pins the element type from
+            // call-site usage.
+            if (p.accept(.dot_dot_dot)) |dots| {
+                variadic = true;
+                variadic_end = dots.end;
+            } else {
+                type_ann = try type_mod.parseTypeAnn(p);
+            }
         }
 
-        const param_end: u32 = if (type_ann) |t| t.span().end else name_span.end;
+        const param_end: u32 = if (variadic) variadic_end else if (type_ann) |t| t.span().end else name_span.end;
         try params.append(p.allocator, .{
             .name = name_span,
             .type_ann = type_ann,
+            .variadic = variadic,
             .span = .{ .start = name_span.start, .end = param_end },
         });
+
+        // A variadic parameter must be the last one. We break here
+        // so any trailing `, more_param` would surface as
+        // `expected )` at the next iteration boundary.
+        if (variadic) break;
 
         if (p.accept(.comma) == null) break;
         p.skipNewlines();

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -193,6 +193,16 @@ fn parseUnary(p: *Parser) ParserError!*ast.Expr {
                 .span = .{ .start = tok.start, .end = operand.span().end },
             } });
         },
+        .amp => {
+            // `&x` — take a borrowed reference (§3.4.4). Same
+            // precedence as other unary prefix operators.
+            p.pos += 1;
+            const operand = try parseUnary(p);
+            return try p.allocExpr(.{ .ref_of = .{
+                .inner = operand,
+                .span = .{ .start = tok.start, .end = operand.span().end },
+            } });
+        },
         else => return try parseCallChain(p),
     }
 }
@@ -356,6 +366,7 @@ fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
         .lparen => return try parseParenOrTupleExpr(p),
         .lbracket => return try parseListLit(p),
         .kw_do => return try parseDoExpr(p),
+        .kw_bake => return try parseBakeExpr(p),
         .kw_if => return try parseIfExpr(p),
         .kw_lambda => return try parseLambda(p),
         // Short lambda form `|x| expr`, `|x, y| expr`, `|| expr`.
@@ -533,15 +544,39 @@ fn parseListLit(p: *Parser) ParserError!*ast.Expr {
         for (elems.items) |e| ast.freeExpr(p.allocator, e);
         elems.deinit(p.allocator);
     }
-    if (!p.check(.rbracket)) {
-        while (true) {
-            p.skipNewlines();
-            const e = try parseExpression(p, 0);
-            try elems.append(p.allocator, e);
-            if (p.accept(.comma) == null) break;
-            p.skipNewlines();
-            if (p.check(.rbracket)) break;
-        }
+    if (p.check(.rbracket)) {
+        // `[]` — empty list.
+        const rb_empty = p.peek();
+        p.pos += 1;
+        return try p.allocExpr(.{ .list_lit = .{
+            .elems = try elems.toOwnedSlice(p.allocator),
+            .span = .{ .start = lb.start, .end = rb_empty.end },
+        } });
+    }
+
+    const first = try parseExpression(p, 0);
+
+    // `[value; count]` — array-repeat literal. Disambiguated by the
+    // `;` after the first element.
+    if (p.accept(.semicolon)) |_| {
+        errdefer ast.freeExpr(p.allocator, first);
+        const count = try parseExpression(p, 0);
+        errdefer ast.freeExpr(p.allocator, count);
+        p.skipNewlines();
+        const rb_rep = try p.expect(.rbracket, "]");
+        return try p.allocExpr(.{ .list_repeat = .{
+            .value = first,
+            .count = count,
+            .span = .{ .start = lb.start, .end = rb_rep.end },
+        } });
+    }
+
+    try elems.append(p.allocator, first);
+    while (p.accept(.comma)) |_| {
+        p.skipNewlines();
+        if (p.check(.rbracket)) break;
+        const e = try parseExpression(p, 0);
+        try elems.append(p.allocator, e);
     }
     p.skipNewlines();
     const rb = try p.expect(.rbracket, "]");
@@ -567,6 +602,35 @@ fn parseDoExpr(p: *Parser) ParserError!*ast.Expr {
         .body = try body.toOwnedSlice(p.allocator),
         .span = .{ .start = do_tok.start, .end = end_tok.end },
     } });
+}
+
+/// `bake do … end` — `do`-expression flagged for compile-time
+/// evaluation (§3.8). `bake_start` is the start byte of the `bake`
+/// keyword so the resulting span covers the whole `bake do … end`.
+/// Caller must already have consumed the `bake` keyword and have
+/// the parser positioned at `kw_do`.
+pub fn parseBakeDoExpr(p: *Parser, bake_start: u32) ParserError!*ast.Expr {
+    const inner = try parseDoExpr(p);
+    inner.do_expr.is_bake = true;
+    inner.do_expr.span = .{ .start = bake_start, .end = inner.do_expr.span.end };
+    return inner;
+}
+
+/// `bake do … end` in expression position — e.g. `const X = bake do
+/// … end`. Only `bake do` is accepted here; `bake def` lives at
+/// statement position only.
+fn parseBakeExpr(p: *Parser) ParserError!*ast.Expr {
+    const bake_tok = p.peek();
+    p.pos += 1; // consume `bake`
+    p.skipNewlines();
+    if (!p.check(.kw_do)) {
+        try p.recordError(
+            "in expression position `bake` must prefix a `do` block",
+            "bake do",
+        );
+        return error.ParseFailed;
+    }
+    return try parseBakeDoExpr(p, bake_tok.start);
 }
 
 fn parseIfExpr(p: *Parser) ParserError!*ast.Expr {

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -203,6 +203,8 @@ pub const Token = struct {
         dot_dot,
         /// `..=` — inclusive range.
         dot_dot_eq,
+        /// `...` — variadic-parameter marker (§4.6.2).
+        dot_dot_dot,
 
         // -- end of stream -----------------------------------
         eof,
@@ -830,6 +832,9 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
             if (state.index < source.len and source[state.index] == '=') {
                 state.index += 1;
                 try pushToken(&state, .dot_dot_eq, start, state.index, 0);
+            } else if (state.index < source.len and source[state.index] == '.') {
+                state.index += 1;
+                try pushToken(&state, .dot_dot_dot, start, state.index, 0);
             } else {
                 try pushToken(&state, .dot_dot, start, state.index, 0);
             }

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -26,6 +26,7 @@ const ast = @import("ast.zig");
 const annotation_mod = @import("annotation.zig");
 const decl_mod = @import("decl.zig");
 const stmt_mod = @import("stmt.zig");
+const expr_mod = @import("expr.zig");
 
 const Kind = lexer.Token.Kind;
 
@@ -308,6 +309,44 @@ fn parseTopLevel(
     };
 }
 
+/// `bake def …` or `bake do … end` at statement position (§3.8).
+/// The `bake` prefix marks the construct for compile-time
+/// evaluation; codegen later runs the bake interpreter and lowers
+/// the result to static data.
+fn parseBakeStatement(p: *Parser) ParserError!ast.Statement {
+    const bake_tok = p.peek();
+    p.pos += 1; // consume `bake`
+    p.skipNewlines();
+
+    switch (p.peek().kind) {
+        .kw_def => {
+            var decl = try decl_mod.parseDefDeclInner(p, false);
+            decl.is_bake = true;
+            decl.span = .{ .start = bake_tok.start, .end = decl.span.end };
+            try p.requireStatementBoundary();
+            return .{ .def_decl = decl };
+        },
+        .kw_do => {
+            // `bake do … end` at statement position — evaluate the
+            // block at compile time and discard the result. Wrap
+            // in an `expr_stmt` carrying the bake-flagged DoExpr.
+            const do_expr = try expr_mod.parseBakeDoExpr(p, bake_tok.start);
+            try p.requireStatementBoundary();
+            return .{ .expr_stmt = .{
+                .expr = do_expr,
+                .span = do_expr.span(),
+            } };
+        },
+        else => {
+            try p.recordError(
+                "`bake` must prefix a `def` or `do` block",
+                "bake def | bake do",
+            );
+            return error.ParseFailed;
+        },
+    }
+}
+
 /// Parse an optional `:label` suffix on a loop head or
 /// `break` / `continue`. Returns `null` when the next token is not
 /// a colon — that's the unlabeled form. Identifiers after `:` must
@@ -403,6 +442,7 @@ pub fn parseStatement(
         .kw_let => try statements.append(p.allocator, try decl_mod.parseLetDecl(p, false)),
         .kw_const => try statements.append(p.allocator, try decl_mod.parseConstDecl(p, false)),
         .kw_def => try statements.append(p.allocator, try decl_mod.parseDefDecl(p, false)),
+        .kw_bake => try statements.append(p.allocator, try parseBakeStatement(p)),
         .kw_class => try statements.append(p.allocator, try decl_mod.parseClassDecl(p, false)),
         .kw_enum => try statements.append(p.allocator, try decl_mod.parseEnumDecl(p, false)),
         .kw_local => try decl_mod.parseLocalDecl(p, statements),

--- a/src/lang/type_ann.zig
+++ b/src/lang/type_ann.zig
@@ -34,12 +34,26 @@ fn parseTypeBase(p: *Parser) ParserError!*ast.TypeAnn {
     switch (tok.kind) {
         .lbracket => return try parseArrayType(p),
         .lparen => return try parseTupleOrParenType(p),
+        .amp => return try parseReferenceType(p),
         .ident => return try parseNamedOrVecType(p),
         else => {
             try p.recordError("expected type annotation", "type");
             return error.ParseFailed;
         },
     }
+}
+
+/// `&T` — borrowed reference (§3.4.4). The parser accepts `&&T`
+/// syntactically; the typechecker rejects it.
+fn parseReferenceType(p: *Parser) ParserError!*ast.TypeAnn {
+    const amp_tok = p.peek();
+    p.pos += 1;
+    const inner = try parseTypeAnn(p);
+    errdefer ast.freeTypeAnn(p.allocator, inner);
+    return try p.allocTypeAnn(.{ .reference = .{
+        .inner = inner,
+        .span = .{ .start = amp_tok.start, .end = inner.span().end },
+    } });
 }
 
 /// `[T; N]`.
@@ -78,6 +92,7 @@ fn parseTupleOrParenType(p: *Parser) ParserError!*ast.TypeAnn {
             .vec => |v| .{ .vec = .{ .elem = v.elem, .span = .{ .start = lp_tok.start, .end = rp.end } } },
             .tuple => |t| .{ .tuple = .{ .elems = t.elems, .span = .{ .start = lp_tok.start, .end = rp.end } } },
             .fn_type => |f| .{ .fn_type = .{ .params = f.params, .ret = f.ret, .span = .{ .start = lp_tok.start, .end = rp.end } } },
+            .reference => |r| .{ .reference = .{ .inner = r.inner, .span = .{ .start = lp_tok.start, .end = rp.end } } },
         };
         return first;
     }

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -301,6 +301,24 @@ test "parse: list literal" {
     try std.testing.expectEqual(@as(usize, 3), init.list_lit.elems.len);
 }
 
+test "parse: empty list literal `[]`" {
+    var tree = try parseClean("let x = []");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .list_lit);
+    try std.testing.expectEqual(@as(usize, 0), init.list_lit.elems.len);
+}
+
+test "parse: array-repeat literal `[value; count]`" {
+    var tree = try parseClean("let buf: [u8; 64] = [0; 64]");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .list_repeat);
+    try std.testing.expect(init.list_repeat.value.* == .int_lit);
+    try std.testing.expectEqual(@as(i32, 0), init.list_repeat.value.int_lit.value);
+    try std.testing.expectEqual(@as(i32, 64), init.list_repeat.count.int_lit.value);
+}
+
 test "parse: tuple literal" {
     var tree = try parseClean("let x = (1, 2)");
     defer tree.deinit();
@@ -933,6 +951,113 @@ test "parse: `use \"./relative\"` quoted-path" {
     defer tree.deinit();
     const s = tree.program.statements[0].use_decl;
     try std.testing.expect(s.quoted_path);
+}
+
+// ---------- references &T + &x ----------
+
+test "parse: `&T` reference type annotation" {
+    var tree = try parseClean("def foo(s: &Stats) end");
+    defer tree.deinit();
+    const params = tree.program.statements[0].def_decl.params;
+    try std.testing.expect(params[0].type_ann.?.* == .reference);
+}
+
+test "parse: `&x` prefix takes a reference" {
+    var tree = try parseClean("let r = &x");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .ref_of);
+    try std.testing.expect(init.ref_of.inner.* == .ident);
+}
+
+test "parse: `&` binds as unary prefix, tighter than `*`" {
+    var tree = try parseClean("let r = &a.field");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .ref_of);
+    // `&` consumed the whole call-chain expression `a.field`
+    try std.testing.expect(init.ref_of.inner.* == .field);
+}
+
+test "parse: `&T?` is reference-to-nullable (postfix `?` binds inside)" {
+    // `&` is a prefix that recursively parses a full type-ann,
+    // including the postfix `?`, so `&Stats?` resolves to
+    // `reference(nullable(Stats))`. References themselves are
+    // non-nullable; the inner type may be.
+    var tree = try parseClean("def foo(p: &Stats?) end");
+    defer tree.deinit();
+    const t = tree.program.statements[0].def_decl.params[0].type_ann.?;
+    try std.testing.expect(t.* == .reference);
+    try std.testing.expect(t.reference.inner.* == .nullable);
+}
+
+// ---------- bake def / bake do ----------
+
+test "parse: `bake def` sets is_bake on the DefDecl" {
+    var tree = try parseClean(
+        \\bake def make_table() -> i16
+        \\  let x = 1
+        \\  return x * 2
+        \\end
+    );
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s == .def_decl);
+    try std.testing.expect(s.def_decl.is_bake);
+}
+
+test "parse: `bake do` in const init sets is_bake on the DoExpr" {
+    var tree = try parseClean(
+        \\const SEED = bake do
+        \\  let x = 42
+        \\  x
+        \\end
+    );
+    defer tree.deinit();
+    const init = tree.program.statements[0].const_decl.init;
+    try std.testing.expect(init.* == .do_expr);
+    try std.testing.expect(init.do_expr.is_bake);
+}
+
+test "parse: `bake` without `def` or `do` is an error" {
+    var tree = try parseSource("bake 42");
+    defer tree.deinit();
+    try std.testing.expect(tree.errors.len > 0);
+}
+
+// ---------- varargs ----------
+
+test "parse: variadic last param `args: ...`" {
+    var tree = try parseClean(
+        \\def log(fmt: str, args: ...)
+        \\end
+    );
+    defer tree.deinit();
+    const params = tree.program.statements[0].def_decl.params;
+    try std.testing.expectEqual(@as(usize, 2), params.len);
+    try std.testing.expect(!params[0].variadic);
+    try std.testing.expect(params[1].variadic);
+    try std.testing.expect(params[1].type_ann == null);
+}
+
+test "parse: variadic with zero leading params" {
+    var tree = try parseClean(
+        \\def collect(args: ...)
+        \\end
+    );
+    defer tree.deinit();
+    const params = tree.program.statements[0].def_decl.params;
+    try std.testing.expectEqual(@as(usize, 1), params.len);
+    try std.testing.expect(params[0].variadic);
+}
+
+test "parse: variadic followed by another param is rejected" {
+    var tree = try parseSource(
+        \\def bad(a: ..., b: i16)
+        \\end
+    );
+    defer tree.deinit();
+    try std.testing.expect(tree.errors.len > 0);
 }
 
 // ---------- type annotations ----------


### PR DESCRIPTION
Closes the parser-level slices of #216, #217, #221, and adds array-repeat literals (used in §3.4 / §3.8 spec examples but never formally parser-supported).

## Summary

After this PR, the AST is the final shape for what the v1 spec covers — the typechecker can build against it.

- **References `&T`** (§3.4.4) — `TypeAnn.reference`, `Expr.ref_of`, prefix-unary precedence.
- **`bake def` / `bake do`** (§3.8) — `DefDecl.is_bake`, `DoExpr.is_bake`, dispatch from both statement and expression positions.
- **Varargs `args: ...`** (§4.6.2) — new `dot_dot_dot` token, `Param.variadic` flag, last-position rule.
- **Array-repeat literals `[value; count]`** (§3.4) — new `Expr.list_repeat`, parser disambiguates from `[a, b, c]` by the trailing `;` after the first element. Empty `[]` now parses too.
- **Fix** — pre-existing double-free in `parseParamList`'s errdefer (`freeParams` + `params.deinit` both freed the same buffer). The variadic-rejection path was the first to exercise it.

## Test plan

- [x] `zig build verify` — fmt + lint + asm gates green
- [x] `zig build ci` — full matrix green
- [x] 138 parser tests, including new coverage for: `&T` annotation, `&x` prefix, `&Stats?` nesting, `bake def`, `bake do`, `bake` without `def`/`do`, variadic in last position, variadic in middle (error), array-repeat `[0; 64]`, empty `[]`.
- [x] Spec §3.4 table updated to mention the two literal forms.

## What remains for each follow-up issue

- **#216** (refs): parser done. Typechecker (lifetime check, `&const` distinction handling, auto-deref) + codegen remain.
- **#217** (bake): parser done. Bake interpreter + codegen to static data remain.
- **#221** (varargs): parser done. Typechecker (homogeneous-type enforcement) + per-arity codegen specialization remain.