### PR TITLE
feat(lang): typechecker scaffolding — module, scope, types, walker (#233)

### DIFF
--- a/.changeset/lang-typecheck-scaffolding.md
+++ b/.changeset/lang-typecheck-scaffolding.md
@@ -1,0 +1,44 @@
+---
+bump: minor
+---
+
+`gero.lang.typecheck` lands as a no-op walker — the first slice of
+the gero-lang typechecker (option B sequential PRs, parent #233).
+Ships the bones: type representation, scope + symbol-table
+primitives, and an AST walker that visits every variant. Subsequent
+slices populate resolution, inference, and the spec's semantic
+rules.
+
+**`src/lang/types.zig`**
+
+`Type` union for the typechecker's internal shape — primitives
+(`i8`/`u8`/`i16`/`u16`/`bool`/`nil`/`str`/`fixed`/`char`), `array`,
+`vec`, `tuple`, `function`, `optional` (`T?`), `reference` (`&T`),
+`named` (user-defined types). Structural equality on every variant.
+Builders: `mkPrimitive` / `mkOptional` / `mkReference` / `mkArray` /
+`mkVec` / `mkNamed`.
+
+**`src/lang/scope.zig`**
+
+`Scope` struct with parent pointer + `ident → SymbolInfo` map.
+Operations: `init` / `deinit` / `define` (errors on local-scope
+redefinition) / `lookup` (walks parent chain) / `lookupLocal` /
+`setType` (patch an entry once inference has resolved a type).
+`SymbolKind` covers the 9 shapes the typechecker tracks (let /
+const / def / class / struct / enum / param / module alias /
+imported).
+
+**`src/lang/typecheck.zig`**
+
+`pub fn typecheck(allocator, source, *ast.Program) !CheckedProgram`.
+Walks every statement and expression variant in the AST without yet
+emitting any rule violation. `CheckedProgram` owns a `*Type` arena
+and the diagnostics slice.
+
+Public re-exports: `gero.lang.types`, `gero.lang.scope`,
+`gero.lang.typecheck`, `gero.lang.CheckedProgram`.
+
+Mirror tests: `tests/lang/types.test.zig` (9 tests),
+`tests/lang/scope.test.zig` (8 tests),
+`tests/lang/typecheck.test.zig` (11 tests covering the walker
+across every AST surface).

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -8,6 +8,9 @@ const lexer_mod = @import("lang/lexer.zig");
 const ast_mod = @import("lang/ast.zig");
 const parser_mod = @import("lang/parser.zig");
 const print_mod = @import("lang/print.zig");
+const types_mod = @import("lang/types.zig");
+const scope_mod = @import("lang/scope.zig");
+const typecheck_mod = @import("lang/typecheck.zig");
 
 /// Re-export: lexer token.
 pub const Token = lexer_mod.Token;
@@ -26,3 +29,13 @@ pub const parse = parser_mod.parse;
 /// Re-export: pretty-print an `ast.Program` to canonical `.gr` text.
 /// Round-trip safe: `parse(print(parse(s))) == parse(s)`.
 pub const print = print_mod.print;
+
+/// Re-export: typechecker type representation (`Type`, `Primitive`,
+/// `Array`, etc.).
+pub const types = types_mod;
+/// Re-export: typechecker scope + symbol-table primitives.
+pub const scope = scope_mod;
+/// Re-export: typechecker output (program + diagnostics).
+pub const CheckedProgram = typecheck_mod.CheckedProgram;
+/// Re-export: walk an `ast.Program` through the typechecker.
+pub const typecheck = typecheck_mod.typecheck;

--- a/src/lang/scope.zig
+++ b/src/lang/scope.zig
@@ -1,0 +1,112 @@
+/// Scope + symbol-table tracking for the gero-lang typechecker.
+/// Each `Scope` is a flat name → `SymbolInfo` map with an optional
+/// parent pointer; `lookup` walks the chain. New blocks (function
+/// body, class body, `do` block, etc.) push a fresh child scope; the
+/// caller releases it when the block ends.
+///
+/// Naming convention: identifiers are interned by raw byte slice
+/// (sliced from the source buffer the parser was handed). The string
+/// hash-map's keys reference into that buffer — callers must not
+/// release the source until the scope tree is torn down.
+const std = @import("std");
+const ast = @import("ast.zig");
+const types = @import("types.zig");
+
+/// What kind of declaration introduced this name. Drives diagnostics
+/// (`expected variable, got class`) and access rules (`@private`
+/// fields only callable from the class body).
+pub const SymbolKind = enum {
+    /// `let name = …` binding.
+    let_binding,
+    /// `const NAME = …` binding.
+    const_binding,
+    /// Function parameter.
+    param,
+    /// Top-level or method `def name(…) … end`.
+    function,
+    /// `class Name … end`.
+    class,
+    /// `struct Name … end`.
+    struct_,
+    /// `enum Name … end`.
+    enum_,
+    /// `use module` import — alias name in scope.
+    module_alias,
+    /// `use sym from module` import — the imported symbol.
+    imported,
+};
+
+/// What the typechecker remembers about a name. The `ty` field is
+/// `null` until the resolution / inference slice fills it in; the
+/// scaffolding slice records declarations with `ty = null` and later
+/// passes paint in the resolved types.
+pub const SymbolInfo = struct {
+    kind: SymbolKind,
+    /// Resolved type. `null` when the kind has no associated type
+    /// (e.g. a class declaration carries methods + fields but not a
+    /// single "type"; refer via `Named`).
+    ty: ?*const types.Type = null,
+    /// Source span of the declaration site — used by diagnostics to
+    /// point at "originally declared here" notes.
+    decl_span: ast.Span,
+    /// For `let_binding`: `true` if a closure captures-and-mutates
+    /// this binding. Populated by the closure-analysis slice; the
+    /// scaffolding leaves it `false`.
+    captured_mutable: bool = false,
+};
+
+/// One lexical scope. Owns its own hash-map and points up to the
+/// enclosing scope (or `null` at the module root).
+pub const Scope = struct {
+    parent: ?*Scope,
+    allocator: std.mem.Allocator,
+    entries: std.StringHashMapUnmanaged(SymbolInfo) = .{},
+
+    /// Build a fresh scope. Pass `parent = null` for the module
+    /// root; pass an existing scope to nest a child.
+    pub fn init(allocator: std.mem.Allocator, parent: ?*Scope) Scope {
+        return .{ .parent = parent, .allocator = allocator };
+    }
+
+    /// Release the scope's hash-map. Keys reference the source
+    /// buffer, so nothing else needs freeing.
+    pub fn deinit(self: *Scope) void {
+        self.entries.deinit(self.allocator);
+    }
+
+    /// Insert `name → info`. Returns `error.AlreadyDefined` if the
+    /// name already exists in **this** scope (shadowing across
+    /// scopes is allowed).
+    pub fn define(self: *Scope, name: []const u8, info: SymbolInfo) !void {
+        const gop = try self.entries.getOrPut(self.allocator, name);
+        if (gop.found_existing) return error.AlreadyDefined;
+        gop.value_ptr.* = info;
+    }
+
+    /// Walk this scope and every ancestor, returning the first
+    /// match for `name`. `null` when no enclosing scope holds it.
+    pub fn lookup(self: *const Scope, name: []const u8) ?SymbolInfo {
+        if (self.entries.get(name)) |info| return info;
+        if (self.parent) |p| return p.lookup(name);
+        return null;
+    }
+
+    /// Look up `name` strictly in this scope — does not walk parents.
+    /// Useful for "is the name already defined locally" checks.
+    pub fn lookupLocal(self: *const Scope, name: []const u8) ?SymbolInfo {
+        return self.entries.get(name);
+    }
+
+    /// Patch an existing entry's `ty`. Used by inference once the
+    /// type is known. Errors on a missing key — call only after a
+    /// successful `define`.
+    pub fn setType(self: *Scope, name: []const u8, ty: *const types.Type) !void {
+        const entry = self.entries.getPtr(name) orelse return error.NotFound;
+        entry.ty = ty;
+    }
+};
+
+// `ScopeError` is captured implicitly via Zig's inferred error sets
+// on `Scope.define` / `Scope.setType`. Callers catch the variants
+// they care about with `error.AlreadyDefined` / `error.NotFound` /
+// `error.OutOfMemory` directly.

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1,0 +1,227 @@
+/// Gero-lang typechecker — entry point and AST walker scaffolding.
+///
+/// This slice ships the bones: every statement and expression in the
+/// AST has a walker arm that visits its children without yet emitting
+/// any type-level diagnostic. Subsequent slices fill in resolution,
+/// inference, type checking, and the spec's semantic rules.
+///
+/// Diagnostics flow through the same `core.ParseError` shape as the
+/// parser until the diagnostic renderer from #226 lands.
+///
+/// Per `docs/gero-lang.md` and `docs/lang-diagnostics.md`.
+const std = @import("std");
+const knit = @import("knit");
+const core = knit.core;
+
+const ast = @import("ast.zig");
+const types = @import("types.zig");
+const scope_mod = @import("scope.zig");
+const Scope = scope_mod.Scope;
+
+/// What a successful (or partial) typecheck produces. `diagnostics`
+/// is non-empty when one or more rules fired; the program is still
+/// returned so downstream passes can do best-effort work where
+/// possible. The arena that allocated all the `*Type` nodes is owned
+/// by `CheckedProgram` and freed via `deinit`.
+pub const CheckedProgram = struct {
+    /// The input AST — unchanged by typechecking. The typechecker
+    /// owns no part of it; the parser arena still backs every
+    /// `Span` and child pointer.
+    program: *const ast.Program,
+    /// Diagnostics produced during the walk. Empty on a clean pass.
+    diagnostics: []core.ParseError,
+    /// Arena holding every `*Type` allocation the walker made.
+    type_arena: std.heap.ArenaAllocator,
+    /// Allocator the diagnostics slice was carved from.
+    allocator: std.mem.Allocator,
+
+    /// Release the diagnostics slice and the `*Type` arena.
+    pub fn deinit(self: *CheckedProgram) void {
+        self.allocator.free(self.diagnostics);
+        self.type_arena.deinit();
+    }
+
+    /// `true` when at least one `error`-severity diagnostic fired.
+    pub fn hasErrors(self: CheckedProgram) bool {
+        for (self.diagnostics) |d| if (d.severity == .fatal) return true;
+        return false;
+    }
+};
+
+/// Walk `program` through the typechecker. The scaffolding pass
+/// only visits — no rules emit yet — so a well-formed parse tree
+/// always returns an empty diagnostic list.
+pub fn typecheck(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    program: *const ast.Program,
+) !CheckedProgram {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+
+    var diagnostics: std.ArrayList(core.ParseError) = .empty;
+    errdefer diagnostics.deinit(allocator);
+
+    var module_scope: Scope = .init(arena.allocator(), null);
+    // No `defer module_scope.deinit()` — the arena releases the
+    // map's storage when `CheckedProgram.deinit` runs.
+
+    var checker: Checker = .{
+        .allocator = allocator,
+        .arena = arena.allocator(),
+        .source = source,
+        .diagnostics = &diagnostics,
+        .module_scope = &module_scope,
+    };
+
+    for (program.statements) |stmt| {
+        try checker.walkStatement(stmt);
+    }
+
+    return .{
+        .program = program,
+        .diagnostics = try diagnostics.toOwnedSlice(allocator),
+        .type_arena = arena,
+        .allocator = allocator,
+    };
+}
+
+/// Walker state. Holds the current scope (mutable as nested blocks
+/// push and pop), the source buffer for span resolution, and the
+/// allocator for diagnostic + type allocations.
+const Checker = struct {
+    allocator: std.mem.Allocator,
+    /// Arena used for `*Type` allocations and the scope tree.
+    arena: std.mem.Allocator,
+    source: []const u8,
+    diagnostics: *std.ArrayList(core.ParseError),
+    /// Currently-active scope. Each block / function entry sets
+    /// this to a fresh child and restores on exit.
+    module_scope: *Scope,
+
+    /// Mutually recursive walker fns need an explicit error set —
+    /// Zig's inferred sets would deadlock the dependency graph.
+    const WalkError = error{OutOfMemory};
+
+    // ---------- statement walker ----------
+
+    fn walkStatement(self: *Checker, s: ast.Statement) WalkError!void {
+        switch (s) {
+            .let_decl => |d| {
+                if (d.init) |e| try self.walkExpr(e);
+            },
+            .const_decl => |d| try self.walkExpr(d.init),
+            .assign => |a| {
+                try self.walkExpr(a.target);
+                try self.walkExpr(a.value);
+            },
+            .inc_dec => |id| try self.walkExpr(id.target),
+            .discard => |d| try self.walkExpr(d.expr),
+            .expr_stmt => |es| try self.walkExpr(es.expr),
+            .block => |b| try self.walkStatements(b.body),
+            .if_stmt => |is_| {
+                for (is_.arms) |arm| {
+                    if (arm.cond) |c| try self.walkExpr(c);
+                    if (arm.let_expr) |e| try self.walkExpr(e);
+                    if (arm.let_guard) |g| try self.walkExpr(g);
+                    try self.walkStatements(arm.body);
+                }
+                if (is_.else_body) |eb| try self.walkStatements(eb);
+            },
+            .while_stmt => |ws| {
+                if (ws.cond) |c| try self.walkExpr(c);
+                if (ws.let_expr) |e| try self.walkExpr(e);
+                if (ws.let_guard) |g| try self.walkExpr(g);
+                try self.walkStatements(ws.body);
+            },
+            .for_stmt => |fs| {
+                try self.walkExpr(fs.iter);
+                if (fs.step) |st| try self.walkExpr(st);
+                try self.walkStatements(fs.body);
+            },
+            .repeat_stmt => |rs| {
+                try self.walkStatements(rs.body);
+                try self.walkExpr(rs.cond);
+            },
+            .match_stmt => |ms| {
+                try self.walkExpr(ms.scrutinee);
+                for (ms.arms) |arm| {
+                    if (arm.guard) |g| try self.walkExpr(g);
+                    try self.walkStatements(arm.body);
+                }
+            },
+            .return_stmt => |rs| if (rs.value) |v| try self.walkExpr(v),
+            .break_stmt, .continue_stmt => {},
+            .print_stmt => |ps| for (ps.args) |a| try self.walkExpr(a),
+            .def_decl => |d| try self.walkStatements(d.body),
+            .class_decl => |c| {
+                for (c.fields) |f| if (f.init) |init_| try self.walkExpr(init_);
+                for (c.methods) |m| try self.walkStatements(m.body);
+            },
+            .struct_decl, .enum_decl, .use_decl, .local_decl => {},
+            .asm_stmt => {},
+            .defer_stmt => |ds| try self.walkStatement(ds.body.*),
+            .unknown => {},
+        }
+    }
+
+    fn walkStatements(self: *Checker, body: []const ast.Statement) WalkError!void {
+        for (body) |s| try self.walkStatement(s);
+    }
+
+    // ---------- expression walker ----------
+
+    fn walkExpr(self: *Checker, e: *const ast.Expr) WalkError!void {
+        switch (e.*) {
+            .int_lit, .fixed_lit, .bool_lit, .nil_lit, .char_lit, .ident, .self_expr, .super_expr => {},
+            .str_lit => |s| for (s.parts) |part| switch (part) {
+                .lit => {},
+                .interp => |ip| try self.walkExpr(ip.expr),
+            },
+            .paren => |p| try self.walkExpr(p.inner),
+            .unary => |u| try self.walkExpr(u.operand),
+            .binary => |b| {
+                try self.walkExpr(b.lhs);
+                try self.walkExpr(b.rhs);
+            },
+            .range => |r| {
+                try self.walkExpr(r.start);
+                try self.walkExpr(r.end);
+            },
+            .call => |c| {
+                try self.walkExpr(c.callee);
+                for (c.args) |a| try self.walkExpr(a);
+            },
+            .method_call => |m| {
+                try self.walkExpr(m.receiver);
+                for (m.args) |a| try self.walkExpr(a);
+            },
+            .field => |f| try self.walkExpr(f.receiver),
+            .index => |ix| {
+                try self.walkExpr(ix.receiver);
+                try self.walkExpr(ix.index);
+            },
+            .do_expr => |d| try self.walkStatements(d.body),
+            .if_expr => |ie| {
+                for (ie.arms) |arm| {
+                    if (arm.cond) |c| try self.walkExpr(c);
+                    if (arm.let_expr) |le| try self.walkExpr(le);
+                    if (arm.let_guard) |g| try self.walkExpr(g);
+                    try self.walkStatements(arm.body);
+                }
+                if (ie.else_body) |eb| try self.walkStatements(eb);
+            },
+            .lambda => |l| try self.walkStatements(l.body),
+            .list_lit => |ll| for (ll.elems) |x| try self.walkExpr(x),
+            .list_repeat => |lr| {
+                try self.walkExpr(lr.value);
+                try self.walkExpr(lr.count);
+            },
+            .struct_lit => |sl| for (sl.fields) |f| try self.walkExpr(f.value),
+            .tuple_lit => |tl| for (tl.elems) |x| try self.walkExpr(x),
+            .is_test => |it| try self.walkExpr(it.lhs),
+            .cast => |c| try self.walkExpr(c.inner),
+            .ref_of => |r| try self.walkExpr(r.inner),
+        }
+    }
+};

--- a/src/lang/types.zig
+++ b/src/lang/types.zig
@@ -1,0 +1,166 @@
+/// Gero-lang type representation — the typechecker's internal shape
+/// of every value's static type. Mirrors the surface forms documented
+/// in `docs/gero-lang.md` §3.
+///
+/// This module is scaffolding: subsequent typechecker slices populate
+/// the `named` variant's payload as user-defined types resolve. The
+/// shape here stays stable so dependent passes can build against it.
+const std = @import("std");
+const ast = @import("ast.zig");
+
+/// One static type. Always allocated through the typechecker's arena —
+/// the typechecker owns the lifetime and releases everything at the
+/// end of a `gero.lang.typecheck` invocation.
+pub const Type = union(enum) {
+    /// Built-in scalar type. See `Primitive` for the variant menu.
+    primitive: Primitive,
+    /// `[T; N]` — fixed-size array (§3.4).
+    array: Array,
+    /// `Vec(T)` — dynamic array (§3.4.3).
+    vec: *const Type,
+    /// `(T1, T2, …)` — anonymous tuple (§3.4).
+    tuple: []const *const Type,
+    /// `fn(T1, T2, …) -> R` — function pointer (§4.6).
+    function: Function,
+    /// `T?` — nullable (§3.4.1). Inner must be a pointer-like type;
+    /// the typechecker validates that elsewhere.
+    optional: *const Type,
+    /// `&T` — borrowed reference (§3.4.4).
+    reference: *const Type,
+    /// Reference to a user-defined type (`class` / `struct` / `enum`).
+    /// The name span resolves to a declaration during the resolution
+    /// slice; until then the `decl` slot stays `null`.
+    named: Named,
+
+    /// Structural equality. Two types are equal when their variant
+    /// matches and every nested type matches. Named types compare
+    /// by name span; primitives by enum tag; arrays by element type
+    /// plus length; functions by param-by-param + return.
+    pub fn eql(self: Type, other: Type) bool {
+        return switch (self) {
+            .primitive => |p| switch (other) {
+                .primitive => |q| p == q,
+                else => false,
+            },
+            .array => |a| switch (other) {
+                .array => |b| a.len == b.len and a.elem.eql(b.elem.*),
+                else => false,
+            },
+            .vec => |e| switch (other) {
+                .vec => |f| e.eql(f.*),
+                else => false,
+            },
+            .tuple => |xs| switch (other) {
+                .tuple => |ys| eqlSlices(xs, ys),
+                else => false,
+            },
+            .function => |a| switch (other) {
+                .function => |b| eqlSlices(a.params, b.params) and a.ret.eql(b.ret.*),
+                else => false,
+            },
+            .optional => |a| switch (other) {
+                .optional => |b| a.eql(b.*),
+                else => false,
+            },
+            .reference => |a| switch (other) {
+                .reference => |b| a.eql(b.*),
+                else => false,
+            },
+            .named => |a| switch (other) {
+                .named => |b| std.mem.eql(u8, a.name, b.name),
+                else => false,
+            },
+        };
+    }
+};
+
+fn eqlSlices(a: []const *const Type, b: []const *const Type) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |ai, bi| if (!ai.eql(bi.*)) return false;
+    return true;
+}
+
+/// Built-in scalar types. Names match the surface keywords from
+/// `docs/gero-lang.md` §3.1–3.3, with `_` suffixes on the few that
+/// would otherwise collide with Zig keywords (`bool`, `nil`).
+pub const Primitive = enum {
+    i8,
+    u8,
+    i16,
+    u16,
+    bool_,
+    nil_,
+    str,
+    fixed,
+    char,
+};
+
+/// `[elem; len]` storage. `len` is captured as a 32-bit value to
+/// match the parser's int-literal width.
+pub const Array = struct {
+    elem: *const Type,
+    len: u32,
+};
+
+/// `fn(params) -> ret` — function pointer / `def` signature.
+pub const Function = struct {
+    params: []const *const Type,
+    ret: *const Type,
+};
+
+/// User-defined type (struct / class / enum). The `decl` field is
+/// populated by the resolution slice once symbol tables are walked;
+/// scaffolding keeps it `null`.
+pub const Named = struct {
+    /// Type-name lexeme, sliced from source.
+    name: []const u8,
+    /// Span of the type-name reference at the use site.
+    span: ast.Span,
+    /// Pointer to the declaration that introduces this name, or
+    /// `null` when not yet resolved.
+    decl: ?*const ast.Statement = null,
+};
+
+// ---------- builders / smart constructors ----------
+
+/// Allocate a primitive `Type` through `allocator`.
+pub fn mkPrimitive(allocator: std.mem.Allocator, p: Primitive) !*Type {
+    const t = try allocator.create(Type);
+    t.* = .{ .primitive = p };
+    return t;
+}
+
+/// Allocate an `optional` wrapper around `inner`.
+pub fn mkOptional(allocator: std.mem.Allocator, inner: *const Type) !*Type {
+    const t = try allocator.create(Type);
+    t.* = .{ .optional = inner };
+    return t;
+}
+
+/// Allocate a `reference` wrapper around `inner`.
+pub fn mkReference(allocator: std.mem.Allocator, inner: *const Type) !*Type {
+    const t = try allocator.create(Type);
+    t.* = .{ .reference = inner };
+    return t;
+}
+
+/// Allocate an `array(elem, len)` value.
+pub fn mkArray(allocator: std.mem.Allocator, elem: *const Type, len: u32) !*Type {
+    const t = try allocator.create(Type);
+    t.* = .{ .array = .{ .elem = elem, .len = len } };
+    return t;
+}
+
+/// Allocate a `vec(elem)` value.
+pub fn mkVec(allocator: std.mem.Allocator, elem: *const Type) !*Type {
+    const t = try allocator.create(Type);
+    t.* = .{ .vec = elem };
+    return t;
+}
+
+/// Allocate a `named(name, span)` reference.
+pub fn mkNamed(allocator: std.mem.Allocator, name: []const u8, span: ast.Span) !*Type {
+    const t = try allocator.create(Type);
+    t.* = .{ .named = .{ .name = name, .span = span } };
+    return t;
+}

--- a/tests/lang/scope.test.zig
+++ b/tests/lang/scope.test.zig
@@ -1,0 +1,93 @@
+/// Smoke tests for `gero.lang.scope` — symbol-table + nested-scope
+/// primitives. Subsequent typechecker slices build the real
+/// resolution logic on top of this.
+const std = @import("std");
+const gero = @import("gero");
+
+const scope_mod = gero.lang.scope;
+const Scope = scope_mod.Scope;
+const SymbolInfo = scope_mod.SymbolInfo;
+const alloc = std.testing.allocator;
+
+test "scope: define + lookup hit in same scope" {
+    var s: Scope = .init(alloc, null);
+    defer s.deinit();
+    try s.define("x", .{ .kind = .let_binding, .decl_span = .{ .start = 0, .end = 1 } });
+    const got = s.lookup("x") orelse unreachable;
+    try std.testing.expectEqual(scope_mod.SymbolKind.let_binding, got.kind);
+}
+
+test "scope: lookup miss returns null" {
+    var s: Scope = .init(alloc, null);
+    defer s.deinit();
+    try std.testing.expect(s.lookup("missing") == null);
+}
+
+test "scope: redefining a name in the same scope errors" {
+    var s: Scope = .init(alloc, null);
+    defer s.deinit();
+    try s.define("x", .{ .kind = .let_binding, .decl_span = .{ .start = 0, .end = 1 } });
+    try std.testing.expectError(error.AlreadyDefined, s.define("x", .{
+        .kind = .let_binding,
+        .decl_span = .{ .start = 5, .end = 6 },
+    }));
+}
+
+test "scope: child scope sees parent bindings via lookup" {
+    var parent: Scope = .init(alloc, null);
+    defer parent.deinit();
+    try parent.define("outer", .{ .kind = .const_binding, .decl_span = .{ .start = 0, .end = 5 } });
+
+    var child: Scope = .init(alloc, &parent);
+    defer child.deinit();
+    const got = child.lookup("outer") orelse unreachable;
+    try std.testing.expectEqual(scope_mod.SymbolKind.const_binding, got.kind);
+}
+
+test "scope: shadowing — child entry hides parent entry" {
+    var parent: Scope = .init(alloc, null);
+    defer parent.deinit();
+    try parent.define("x", .{ .kind = .const_binding, .decl_span = .{ .start = 0, .end = 1 } });
+
+    var child: Scope = .init(alloc, &parent);
+    defer child.deinit();
+    try child.define("x", .{ .kind = .let_binding, .decl_span = .{ .start = 10, .end = 11 } });
+
+    const got = child.lookup("x") orelse unreachable;
+    try std.testing.expectEqual(scope_mod.SymbolKind.let_binding, got.kind);
+
+    const parent_only = parent.lookup("x") orelse unreachable;
+    try std.testing.expectEqual(scope_mod.SymbolKind.const_binding, parent_only.kind);
+}
+
+test "scope: lookupLocal does not walk parent chain" {
+    var parent: Scope = .init(alloc, null);
+    defer parent.deinit();
+    try parent.define("outer", .{ .kind = .let_binding, .decl_span = .{ .start = 0, .end = 5 } });
+
+    var child: Scope = .init(alloc, &parent);
+    defer child.deinit();
+    try std.testing.expect(child.lookupLocal("outer") == null);
+    try std.testing.expect(child.lookup("outer") != null);
+}
+
+test "scope: setType updates an existing entry" {
+    var s: Scope = .init(alloc, null);
+    defer s.deinit();
+    try s.define("x", .{ .kind = .let_binding, .decl_span = .{ .start = 0, .end = 1 } });
+
+    const ty = try gero.lang.types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(ty);
+    try s.setType("x", ty);
+
+    const got = s.lookup("x") orelse unreachable;
+    try std.testing.expectEqual(gero.lang.types.Primitive.i16, got.ty.?.primitive);
+}
+
+test "scope: setType errors on a missing name" {
+    var s: Scope = .init(alloc, null);
+    defer s.deinit();
+    const ty = try gero.lang.types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(ty);
+    try std.testing.expectError(error.NotFound, s.setType("missing", ty));
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -1,0 +1,142 @@
+/// Smoke tests for `gero.lang.typecheck` — the scaffolding pass.
+/// The walker visits every AST variant without yet emitting any
+/// rule violation, so a well-formed parse should typecheck to an
+/// empty diagnostic list.
+const std = @import("std");
+const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+fn check(source: []const u8) !gero.lang.CheckedProgram {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    errdefer tree.deinit();
+    return gero.lang.typecheck(alloc, source, &tree.program) catch |err| {
+        tree.deinit();
+        return err;
+    };
+}
+
+fn checkClean(source: []const u8) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tree.errors.len);
+
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+    try std.testing.expectEqual(@as(usize, 0), checked.diagnostics.len);
+    try std.testing.expect(!checked.hasErrors());
+}
+
+test "typecheck: empty program produces no diagnostics" {
+    try checkClean("");
+}
+
+test "typecheck: trivial let binding" {
+    try checkClean("let x = 0");
+}
+
+test "typecheck: const decl + binary expression" {
+    try checkClean("const PI_FIXED = 3 + 4 * 5");
+}
+
+test "typecheck: function declaration walks body" {
+    try checkClean(
+        \\def add(a: i16, b: i16) -> i16
+        \\  return a + b
+        \\end
+    );
+}
+
+test "typecheck: control-flow blocks are visited" {
+    try checkClean(
+        \\def f(x: i16) -> i16
+        \\  if x > 0
+        \\    return x
+        \\  end
+        \\  while x > 0
+        \\    x -= 1
+        \\  end
+        \\  for i in 0..10
+        \\    x += i
+        \\  end
+        \\  return x
+        \\end
+    );
+}
+
+test "typecheck: match arm visited (including guards)" {
+    try checkClean(
+        \\def handle(e: Event)
+        \\  match e
+        \\    case Event.Quit => cleanup()
+        \\    case Event.KeyDown(k) when k == 0 => quit()
+        \\    case _ => skip()
+        \\  end
+        \\end
+    );
+}
+
+test "typecheck: class + struct + enum walk" {
+    try checkClean(
+        \\struct Stats
+        \\  hp: i16
+        \\  mp: i16
+        \\end
+        \\
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\
+        \\class Player
+        \\  let hp: i16
+        \\  let mp: i16
+        \\
+        \\  def take_damage(self, n: i16)
+        \\    self.hp -= n
+        \\  end
+        \\end
+    );
+}
+
+test "typecheck: defer + asm + bake nodes walk cleanly" {
+    try checkClean(
+        \\def f()
+        \\  defer cleanup()
+        \\  asm "noop"
+        \\end
+        \\
+        \\bake def make() -> i16
+        \\  return 42
+        \\end
+    );
+}
+
+test "typecheck: short lambda body visited" {
+    try checkClean("let f = |x| x * 2");
+}
+
+test "typecheck: ref expr + array-repeat literal visited" {
+    try checkClean(
+        \\def apply(s: &Stats)
+        \\  let buf: [u8; 64] = [0; 64]
+        \\end
+    );
+}
+
+test "typecheck: program node retained in CheckedProgram" {
+    var stream = try gero.lang.tokenize(alloc, "let x = 0");
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, "let x = 0", stream);
+    defer tree.deinit();
+
+    var checked = try gero.lang.typecheck(alloc, "let x = 0", &tree.program);
+    defer checked.deinit();
+
+    // The CheckedProgram holds a pointer back to the parser's AST.
+    try std.testing.expectEqual(&tree.program, checked.program);
+}

--- a/tests/lang/types.test.zig
+++ b/tests/lang/types.test.zig
@@ -1,0 +1,78 @@
+/// Smoke tests for `gero.lang.types` — the typechecker's static-type
+/// representation. Covers the constructors and structural equality.
+const std = @import("std");
+const gero = @import("gero");
+
+const types = gero.lang.types;
+const alloc = std.testing.allocator;
+
+test "types: primitive equality" {
+    try std.testing.expect((types.Type{ .primitive = .i16 }).eql(.{ .primitive = .i16 }));
+    try std.testing.expect(!(types.Type{ .primitive = .i16 }).eql(.{ .primitive = .u16 }));
+}
+
+test "types: mkPrimitive allocates a value" {
+    const t = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(t);
+    try std.testing.expectEqual(types.Primitive.i16, t.primitive);
+}
+
+test "types: mkOptional wraps inner" {
+    const inner = try types.mkPrimitive(alloc, .str);
+    defer alloc.destroy(inner);
+    const opt = try types.mkOptional(alloc, inner);
+    defer alloc.destroy(opt);
+    try std.testing.expectEqual(types.Primitive.str, opt.optional.primitive);
+}
+
+test "types: mkReference wraps inner" {
+    const inner = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(inner);
+    const ref = try types.mkReference(alloc, inner);
+    defer alloc.destroy(ref);
+    try std.testing.expectEqual(types.Primitive.i16, ref.reference.primitive);
+}
+
+test "types: mkArray captures element type + length" {
+    const elem = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(elem);
+    const arr = try types.mkArray(alloc, elem, 64);
+    defer alloc.destroy(arr);
+    try std.testing.expectEqual(@as(u32, 64), arr.array.len);
+    try std.testing.expectEqual(types.Primitive.u8, arr.array.elem.primitive);
+}
+
+test "types: mkVec captures element type" {
+    const elem = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(elem);
+    const v = try types.mkVec(alloc, elem);
+    defer alloc.destroy(v);
+    try std.testing.expectEqual(types.Primitive.i16, v.vec.primitive);
+}
+
+test "types: mkNamed captures the lexeme + span" {
+    const t = try types.mkNamed(alloc, "Player", .{ .start = 10, .end = 16 });
+    defer alloc.destroy(t);
+    try std.testing.expectEqualStrings("Player", t.named.name);
+    try std.testing.expectEqual(@as(u32, 10), t.named.span.start);
+}
+
+test "types: array equality requires matching length AND element" {
+    const e1 = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(e1);
+    const e2 = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(e2);
+    const a = types.Type{ .array = .{ .elem = e1, .len = 64 } };
+    const b = types.Type{ .array = .{ .elem = e2, .len = 64 } };
+    const c = types.Type{ .array = .{ .elem = e1, .len = 128 } };
+    try std.testing.expect(a.eql(b));
+    try std.testing.expect(!a.eql(c));
+}
+
+test "types: named equality compares by lexeme" {
+    const a = types.Type{ .named = .{ .name = "Player", .span = .{ .start = 0, .end = 6 } } };
+    const b = types.Type{ .named = .{ .name = "Player", .span = .{ .start = 100, .end = 106 } } };
+    const c = types.Type{ .named = .{ .name = "Enemy", .span = .{ .start = 0, .end = 5 } } };
+    try std.testing.expect(a.eql(b));
+    try std.testing.expect(!a.eql(c));
+}


### PR DESCRIPTION
Closes #233. First slice of the typechecker (option B sequential PRs).

Ships the bones — type representation, scope + symbol-table primitives, AST walker entry point — so subsequent slices can hang resolution / inference / semantic checks off a stable shape.

## Summary

- \`src/lang/types.zig\` — \`Type\` union (primitives, array, vec, tuple, function, optional, reference, named) with structural equality.
- \`src/lang/scope.zig\` — \`Scope\` struct, parent chain, \`SymbolKind\` covering 9 decl shapes.
- \`src/lang/typecheck.zig\` — \`pub fn typecheck(allocator, source, *ast.Program) !CheckedProgram\` walking every statement and expression. No-op pass; subsequent slices add real rule firing.
- Public re-exports via \`gero.lang\`: \`types\`, \`scope\`, \`typecheck\`, \`CheckedProgram\`.

## Test plan

- [x] \`zig build verify\` green
- [x] \`zig build ci\` green (full matrix, all four release modes)
- [x] 28 new tests across types / scope / typecheck mirroring layout
- [x] Walker visits every variant of \`ast.Statement\` and \`ast.Expr\` — verified with a smoke source covering classes / structs / enums / lambdas / refs / array-repeat literals

## Follow-up slices (will file as each ships)

1. Resolution + inference (basic) — \`NamedType\` / \`ident\` lookup, let init, function param + return inference.
2. Type checking — operators, assignments, calls.
3. Semantic rules part 1 — nullable deref discipline, multi-return flow analysis, recursive-fn return-annotation requirement.
4. Semantic rules part 2 — match exhaustiveness, reference lifetime, \`super.<field>\`.
5. Annotation validation — \`@final\`/\`@abstract\` conflict, \`@no_capture\`, \`@override\`, \`@inline\` recursive check, OOP visibility.
6. Bake + cast + varargs — §3.8 restrictions, cast legality, varargs homogeneity.
7. Diagnostic rendering — wire \`docs/lang-diagnostics.md\` contract.