### PR TITLE
fix(lang): wire char_lit AST + add fixture-driven printer round-trip

### DIFF
--- a/.changeset/lang-char-lit-wire-through.md
+++ b/.changeset/lang-char-lit-wire-through.md
@@ -1,0 +1,28 @@
+---
+bump: patch
+---
+
+Wire the `char_lit` AST variant through the lang front-end. Before
+this change, `'A'` parsed as `Expr.int_lit{value=65}` — char-ness
+was lost in the AST, and the `Expr.char_lit` / `Pattern.char_lit`
+variants were dead code.
+
+**What changed**
+
+- `expr.zig` / `pattern.zig` parsers inspect `source[tok.start]`
+  on `int_lit` tokens; when it's `'`, the parser emits a `char_lit`
+  variant instead. The lexer's existing `int_lit` normalization
+  (carrying the byte value) is preserved.
+- `typecheck.zig` types `char_lit` as the `char` primitive
+  (previously typed as `u8`). Per spec §3.1, `char` is a distinct
+  primitive from `u8` with a no-op cast between them.
+
+**User-visible behavior**
+
+- `let c = 'A'` now infers `c: char` (was `c: u8`).
+- `let c: u8 = 'A'` now errors with `E_TYPE_MISMATCH` (was
+  accepted via the prior u8 typing). Use `'A' as u8` to opt in.
+- `let c: char = 'A'` accepts.
+- Pattern matching on `case 'A' =>` now produces a `char_lit`
+  pattern node (was `int_lit`). No user-visible difference at
+  match time.

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -308,6 +308,17 @@ fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
     switch (tok.kind) {
         .int_lit => {
             p.pos += 1;
+            // The lexer emits char literals (`'A'`) as `int_lit`
+            // tokens whose span starts with `'`. Disambiguate here
+            // so the AST preserves the source form — `char` is a
+            // distinct primitive per spec §3.1.
+            if (tok.start < p.source.len and p.source[tok.start] == '\'') {
+                // safety: lexer stores the byte value of a char literal in `tok.value` as u8 widened to i32; truncating back to u8 preserves bytes.
+                return try p.allocExpr(.{ .char_lit = .{
+                    .value = @intCast(tok.value),
+                    .span = .{ .start = tok.start, .end = tok.end },
+                } });
+            }
             return try p.allocExpr(.{ .int_lit = .{
                 .value = tok.value,
                 .span = .{ .start = tok.start, .end = tok.end },

--- a/src/lang/pattern.zig
+++ b/src/lang/pattern.zig
@@ -49,6 +49,17 @@ fn parseAtomicPattern(p: *Parser) ParserError!*ast.Pattern {
             if (p.check(.dot_dot) or p.check(.dot_dot_eq)) {
                 return try parseRangePatternFrom(p, intLitExpr(tok), tok.start);
             }
+            // Char literals lex as `int_lit` (lexer normalizes `'A'`
+            // to int_lit with the byte value). Disambiguate here so
+            // pattern matching against `'A'` produces a `char_lit`
+            // pattern, not an int_lit pattern.
+            if (tok.start < p.source.len and p.source[tok.start] == '\'') {
+                // safety: lexer stores byte value of a char literal as u8 widened to i32; truncating back to u8 preserves bytes.
+                return try p.allocPattern(.{ .char_lit = .{
+                    .value = @intCast(tok.value),
+                    .span = .{ .start = tok.start, .end = tok.end },
+                } });
+            }
             return try p.allocPattern(.{ .int_lit = .{
                 .value = tok.value,
                 .span = .{ .start = tok.start, .end = tok.end },

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1139,7 +1139,7 @@ const Checker = struct {
             .fixed_lit => return try self.primitive(.fixed),
             .bool_lit => return try self.primitive(.bool_),
             .nil_lit => |lit| return try self.inferNilLit(lit, hint),
-            .char_lit => return try self.primitive(.u8),
+            .char_lit => return try self.primitive(.char),
             .str_lit => |s| {
                 for (s.parts) |part| switch (part) {
                     .lit => {},

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -770,27 +770,33 @@ test "parse: wildcard pattern alone" {
     try std.testing.expect(arm0.pattern.* == .wildcard);
 }
 
-test "parse: literal patterns (int / str / bool / nil)" {
-    // Char-literal patterns are lexed as `int_lit` tokens with the
-    // byte value (the lexer normalizes `'A'` to int_lit(65)); the
-    // `Pattern.char_lit` AST variant therefore stays unused by the
-    // current parser. Tracked as a follow-up; the working forms
-    // are exercised here.
+test "parse: literal patterns (int / str / char / bool / nil)" {
     var tree = try parseClean(
         \\match x
         \\  case 42 => print "int"
         \\  case "hello" => print "str"
+        \\  case 'A' => print "char"
         \\  case true => print "bool"
         \\  case nil => print "nil"
         \\end
     );
     defer tree.deinit();
     const arms = tree.program.statements[0].match_stmt.arms;
-    try std.testing.expectEqual(@as(usize, 4), arms.len);
+    try std.testing.expectEqual(@as(usize, 5), arms.len);
     try std.testing.expect(arms[0].pattern.* == .int_lit);
     try std.testing.expect(arms[1].pattern.* == .str_lit);
-    try std.testing.expect(arms[2].pattern.* == .bool_lit);
-    try std.testing.expect(arms[3].pattern.* == .nil_lit);
+    try std.testing.expect(arms[2].pattern.* == .char_lit);
+    try std.testing.expectEqual(@as(u8, 'A'), arms[2].pattern.char_lit.value);
+    try std.testing.expect(arms[3].pattern.* == .bool_lit);
+    try std.testing.expect(arms[4].pattern.* == .nil_lit);
+}
+
+test "parse: char literal in expression position produces char_lit AST" {
+    var tree = try parseClean("let c = 'Z'");
+    defer tree.deinit();
+    const s = tree.program.statements[0];
+    try std.testing.expect(s.let_decl.init.?.* == .char_lit);
+    try std.testing.expectEqual(@as(u8, 'Z'), s.let_decl.init.?.char_lit.value);
 }
 
 test "parse: nested variant + tuple + or-pattern with guard" {

--- a/tests/lang/print.test.zig
+++ b/tests/lang/print.test.zig
@@ -1,14 +1,18 @@
 /// Tests for `gero.lang.print` — the canonical pretty-printer.
 ///
-/// Two flavors of coverage:
+/// Three flavors of coverage:
 ///   1. `expectPrint(source, expected)` — exact-output tests for
 ///      individual AST variants, calibrating the canonical shape.
 ///   2. `expectIdempotent(source)` — round-trip property tests
 ///      asserting `print(parse(print(parse(s)))) == print(parse(s))`.
 ///      Once a source canonicalizes, re-parsing + re-printing
 ///      yields byte-identical output.
+///   3. A fixture-driven loop over `print_fixtures.fixtures` so
+///      printer drift on a node variant is caught even when the
+///      variant only appears in the wider corpus.
 const std = @import("std");
 const gero = @import("gero");
+const fixtures_mod = @import("print_fixtures.zig");
 
 const alloc = std.testing.allocator;
 
@@ -514,4 +518,15 @@ test "print: idempotent on nested expressions" {
 
 test "print: idempotent on HOF chains" {
     try expectIdempotent("let r = xs.filter(|x| x > 0).map(|x| x * 2)");
+}
+
+// ---------- fixture-driven round-trip property ----------
+
+test "print: round-trip every fixture" {
+    for (fixtures_mod.fixtures) |src| {
+        expectIdempotent(src) catch |err| {
+            std.debug.print("round-trip failed on fixture:\n--- src ---\n{s}\n", .{src});
+            return err;
+        };
+    }
 }

--- a/tests/lang/print_fixtures.zig
+++ b/tests/lang/print_fixtures.zig
@@ -1,0 +1,163 @@
+/// Canonical-syntax source fixtures used by the pretty-printer
+/// round-trip property test. Each entry covers a different AST
+/// shape so a printer drift on a node variant gets caught.
+///
+/// The round-trip property is:
+///     print(parse(src)) == print(parse(print(parse(src))))
+///
+/// (printer idempotency — the strict-AST round-trip stays out of
+/// scope for now; the weaker form catches every regression we've
+/// hit in practice).
+///
+/// New AST variants extending the printer should add at least one
+/// fixture here.
+pub const fixtures = [_][]const u8{
+    // ---------- bindings ----------
+    "let x = 0",
+    "let x: i16 = 0",
+    "let s: str = \"hi\"",
+    "let v: fixed = 1.5",
+    "let b: bool = true",
+    "let c: char = 'A'",
+    "let p: i16? = nil",
+    "let r = &x",
+    "const MAX: i16 = 100",
+    "let buf: [i16; 64] = [0; 64]",
+    "let v = [1, 2, 3]",
+    "let t = (1, 2, 3)",
+
+    // ---------- assignment / inc-dec / discard ----------
+    "x = 5",
+    "x += 1",
+    "x <<= 2",
+    "x++",
+    "_ = expensive_call()",
+
+    // ---------- operator precedence ----------
+    "let r = a + b * c - d / (e + f)",
+    "let r = (a & MASK) == TARGET",
+    "let r = x as u8 + 1",
+    "let r = a + b as u8",
+    "let r = -x * 2",
+    "let r = not (a and b)",
+
+    // ---------- control flow ----------
+    \\if cond
+    \\  x = 1
+    \\end
+    ,
+    \\if cond
+    \\  x = 1
+    \\else
+    \\  x = 2
+    \\end
+    ,
+    \\while x > 0
+    \\  x -= 1
+    \\end
+    ,
+    \\for i in 0..10
+    \\  print i
+    \\end
+    ,
+    \\for i in 0..10 :rows
+    \\  break :rows
+    \\end
+    ,
+    \\repeat
+    \\  x += 1
+    \\until x > 10
+    ,
+
+    // ---------- match ----------
+    \\match it
+    \\  case Item.Sword => print "blade"
+    \\  case Item.Potion(n) => print n
+    \\  case _ => print "other"
+    \\end
+    ,
+    \\match e
+    \\  case Event.Hit((x, 0 | 1)) when x > 0 =>
+    \\    print x
+    \\end
+    ,
+
+    // ---------- functions + lambdas ----------
+    \\def add(a: i16, b: i16) -> i16
+    \\  return a + b
+    \\end
+    ,
+    \\def greet(name: str)
+    \\  print "hi, ", name
+    \\end
+    ,
+    "let f = |x| x * 2",
+    "let g = |x, y| x + y",
+
+    // ---------- struct / class / enum ----------
+    \\struct Stats
+    \\  hp: i16
+    \\  mp: i16
+    \\end
+    ,
+    \\class Player
+    \\  let hp: i16
+    \\
+    \\  def greet(self)
+    \\    print "hi"
+    \\  end
+    \\end
+    ,
+    \\enum Item
+    \\  case Sword
+    \\  case Potion(amount: i16)
+    \\end
+    ,
+
+    // ---------- imports ----------
+    "use math",
+    "use math as m",
+    "use abs from math",
+    "use sin, cos from math",
+
+    // ---------- annotations ----------
+    \\@bank 5
+    \\def town_intro_dialog() -> str
+    \\  return "Welcome to Mistwood..."
+    \\end
+    ,
+    \\@addr $FE40
+    \\@volatile
+    \\let DISPCTL: u8 = 0
+    ,
+
+    // ---------- defer + asm ----------
+    \\def cleanup() end
+    \\
+    \\def f()
+    \\  defer cleanup()
+    \\  asm "noop"
+    \\end
+    ,
+
+    // ---------- bake ----------
+    \\bake def make() -> i16
+    \\  return 42
+    \\end
+    ,
+
+    // ---------- references ----------
+    \\def apply_damage(stats: &Stats, dmg: i16)
+    \\  stats.hp = stats.hp - dmg
+    \\end
+    ,
+
+    // ---------- nullable + flow ----------
+    \\def lookup(s: str?) -> i16
+    \\  if s == nil
+    \\    return 0
+    \\  end
+    \\  return s.len
+    \\end
+    ,
+};

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -1227,6 +1227,27 @@ test "typecheck: multi-return bail propagates non-nil to sibling slot" {
     );
 }
 
+// ---------- char literal typing ----------
+
+test "typecheck: char literal infers as `char` primitive" {
+    try expectClean(
+        \\let c: char = 'A'
+    );
+}
+
+test "typecheck: char literal does not match `u8` annotation (cast required)" {
+    try expectCode(
+        \\let c: u8 = 'A'
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: char ↔ u8 explicit cast accepts" {
+    try expectClean(
+        \\let c: char = 'A'
+        \\let b: u8 = c as u8
+    );
+}
+
 // ---------- CheckedProgram surface ----------
 
 test "typecheck: CheckedProgram retains program pointer" {


### PR DESCRIPTION
## Summary

Bundles the two Phase 10 self-review backlog items.

Closes #247.

### Item 1 — \`char_lit\` AST wire-through

Before: \`'A'\` parsed as \`Expr.int_lit{value=65}\` — char-ness lost in the AST. The \`Expr.char_lit\` / \`Pattern.char_lit\` variants were dead.

After: \`expr.zig\` and \`pattern.zig\` parsers inspect \`source[tok.start]\` on \`int_lit\` tokens; when it's \`'\`, the parser emits a \`char_lit\` variant. The typechecker types \`char_lit\` as the \`char\` primitive (not \`u8\`), per spec §3.1.

**User-visible behavior change:** \`let c = 'A'\` now infers \`c: char\` (was \`u8\`). \`let c: u8 = 'A'\` now errors with \`E_TYPE_MISMATCH\` — use \`'A' as u8\` for the byte. Changeset filed.

### Item 2 — fixture-driven printer round-trip

New \`tests/lang/print_fixtures.zig\` exports ~45 source strings covering every AST shape. New test \`print: round-trip every fixture\` loops \`expectIdempotent\` over each, naming the failing fixture on a regression. Catches printer drift on variants that only appear in the wider corpus.

### Public surface

No new exports. Behavior change is the \`char\` typing of \`'A'\` literals (see changeset).

## Test plan

- [x] \`zig build verify\` green
- [x] \`zig build test\` — parser 138 (+1), typecheck 127 (+3), print 64 (+1)
- [x] \`zig build test-modes\` — Debug / ReleaseSafe / ReleaseFast / ReleaseSmall
- [x] \`zig build test-all\` — linux / macos / windows / wasm32-wasi