### PR TITLE
feat(lang): typechecker slice 8 — diagnostic rendering + gero check wiring

### DIFF
--- a/.changeset/lang-typecheck-diagnostics-rendering.md
+++ b/.changeset/lang-typecheck-diagnostics-rendering.md
@@ -1,0 +1,105 @@
+---
+bump: minor
+---
+
+Eighth (final) slice of the gero-lang typechecker. Lands the
+diagnostic rendering pipeline documented in
+`docs/lang-diagnostics.md` and wires `gero check` to handle `.gr`
+files end-to-end.
+
+**Rich `Diagnostic` shape**
+
+New `src/lang/diagnostic.zig` defines the canonical lang
+`Diagnostic` carried through the front-end:
+
+- `severity: Severity { fatal, warning, note }`
+- `code: []const u8` — stable `E_TYPE_MISMATCH`-style identifier.
+- `message: []const u8`
+- `span: ast.Span` — full byte range, so the renderer can underline
+  the offending source slice with as many `^` carets as needed.
+- `help: ?[]const u8` — optional `help:` line printed after the
+  caret snippet.
+
+`CheckedProgram.diagnostics` changes type from
+`[]core.ParseError` to `[]Diagnostic`. The typechecker's `emit`
+helper is gone; everything goes through `emitSpan(code, span, msg)`
+(or `emitSpanHelp` for the rare diagnostic that ships actionable
+guidance).
+
+**Rendering**
+
+New `src/lang/render.zig` exposes:
+
+- `pretty(writer, []FileDiagnostics, Style)` — Cargo-style
+  per-file grouped output with summary header
+  (`3 errors in 2 files`), per-file path section, and the spec
+  layout (severity prefix + `[code]` + `--> path:line:col` +
+  excerpt with line-number gutter + `^^^` caret line + optional
+  `help:` block).
+- `prettyOne(writer, FileDiagnostics, Style)` — same body, no
+  per-file header (single-file mode).
+- `json(writer, []FileDiagnostics)` — line-delimited JSON, one
+  object per diagnostic, matching the schema in the diagnostics
+  doc.
+- `Style.none` / `Style.ansi` for plain vs colorized output.
+- `LineCol` + `lineColAt` + `lineAt` helpers (also used by the
+  CLI to format read-error fallback messages).
+
+**`gero check` wiring (`.gr` end-to-end)**
+
+`apps/gero-cli/check.zig`:
+
+- `collectGasFiles` → `collectSourceFiles` (now also picks up
+  `*.gr` during directory walks).
+- Per-file dispatch: `.gr` paths route through `checkOneGr` which
+  reads + tokenizes + parses + (when parsing succeeds)
+  typechecks, folds every parser / typechecker diagnostic into a
+  unified `Diagnostic` slice, and renders via
+  `gero.lang.render.pretty` / `.json`.
+- Exit code remains `4` when any diagnostic fires across either
+  pipeline (asm or lang).
+- Mixed-extension input is handled: asm and lang diagnostics
+  render in separate sections.
+
+**Parser-side diagnostics (interim shape)**
+
+The parser still emits human-prose messages via
+`core.ParseError`. The CLI converts them to `Diagnostic` with
+`code = "E_SYNTAX_GENERIC"` at the rendering boundary so the
+output is uniform. Per-error stable codes
+(`E_SYNTAX_UNEXPECTED_TOKEN` / `…_MISSING_TOKEN` / etc.) stay a
+follow-up — the rendering pipeline is the load-bearing piece and
+codes can be wired through later without changing the renderer.
+
+**Public surface**
+
+Three new re-exports on `gero.lang`:
+
+- `gero.lang.Diagnostic` (struct)
+- `gero.lang.Severity` (enum)
+- `gero.lang.render` (module — `pretty`, `prettyOne`, `json`,
+  `Style`, `FileDiagnostics`, `LineCol`, `lineColAt`, `lineAt`)
+
+`CheckedProgram.diagnostics` is the only breaking change: its
+element type went from `core.ParseError` to `Diagnostic`. Tests
+that scanned `d.expected` now scan `d.code`.
+
+**Tests**
+
+- 7 new tests in `tests/lang/render.test.zig` covering pretty +
+  JSON for single-diagnostic, with-help, with-warning-severity,
+  empty input, and the `lineColAt` / `lineAt` math.
+- 1 stub test in `tests/lang/diagnostic.test.zig` pinning the
+  mirror-layout rule.
+- All 148 existing typechecker tests pass against the new
+  `Diagnostic` shape.
+
+**Out of scope (future work)**
+
+- Parser-side `E_SYNTAX_*` code retrofit — separate follow-up
+  issue.
+- Multi-span diagnostics (the spec mockup has secondary spans
+  with their own labels — "expected because of this annotation"
+  etc.). The current renderer prints one span per diagnostic.
+- `--quiet` / `--no-color` flag plumbing on the CLI (the renderer
+  honors `Style.none` already).

--- a/.changeset/lang-typecheck-diagnostics-rendering.md
+++ b/.changeset/lang-typecheck-diagnostics-rendering.md
@@ -61,15 +61,29 @@ New `src/lang/render.zig` exposes:
 - Mixed-extension input is handled: asm and lang diagnostics
   render in separate sections.
 
-**Parser-side diagnostics (interim shape)**
+**Parser + lexer code retrofit**
 
-The parser still emits human-prose messages via
-`core.ParseError`. The CLI converts them to `Diagnostic` with
-`code = "E_SYNTAX_GENERIC"` at the rendering boundary so the
-output is uniform. Per-error stable codes
-(`E_SYNTAX_UNEXPECTED_TOKEN` / `…_MISSING_TOKEN` / etc.) stay a
-follow-up — the rendering pipeline is the load-bearing piece and
-codes can be wired through later without changing the renderer.
+Every parser / lexer error emission site now passes a stable
+`E_SYNTAX_*` code in the `expected` slot of `core.ParseError`:
+
+- `E_SYNTAX_UNEXPECTED_TOKEN` — wrong token in a position where the
+  grammar accepts something else (e.g. `bake` outside def/do).
+- `E_SYNTAX_MISSING_TOKEN` — required token missing (every
+  `expect()` failure plus "expected pattern / type / expression").
+  `expect()` allocPrint's a contextual message
+  (`"expected )"`); the parser tracks these via
+  `ParseTree.allocated_messages` so deinit frees them cleanly.
+- `E_SYNTAX_MALFORMED_LITERAL` — bad numeric / string / char
+  literal (every lexer literal-validation site).
+- `E_SYNTAX_HEX_PREFIX` — `0x…` rejected (use `$…` per
+  spec §2.4).
+- `E_SYNTAX_ANNOTATION_PLACEMENT` — annotation in wrong position
+  (EOF without decl, deprecated `@asm(...)` form).
+
+The CLI converter reads `e.expected.?` and uses it directly as
+the lang `Diagnostic.code` — no more `E_SYNTAX_GENERIC` placeholder
+in steady state. The fallback stays for forward-compat with any
+future emission site that hasn't been wired through.
 
 **Public surface**
 
@@ -96,8 +110,6 @@ that scanned `d.expected` now scan `d.code`.
 
 **Out of scope (future work)**
 
-- Parser-side `E_SYNTAX_*` code retrofit — separate follow-up
-  issue.
 - Multi-span diagnostics (the spec mockup has secondary spans
   with their own labels — "expected because of this annotation"
   etc.). The current renderer prints one span per diagnostic.

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -276,11 +276,15 @@ fn checkOneGr(
     const stream = try gero.lang.tokenize(arena, src);
     // Tokenizer / parser errors travel through the same lang.Diagnostic
     // shape so the renderer surfaces them in the canonical layout.
+    // The lexer + parser populate `expected` with the stable
+    // `E_SYNTAX_*` code (see `docs/lang-diagnostics.md`); we fall
+    // back to a generic code only when an emission site predates
+    // the retrofit.
     var combined: std.ArrayList(gero.lang.Diagnostic) = .empty;
     for (stream.errors) |e| {
         try combined.append(arena, .{
             .severity = .fatal,
-            .code = "E_SYNTAX_GENERIC",
+            .code = e.expected orelse "E_SYNTAX_GENERIC",
             // safety: ParseError.index fits in u32 — bounded by file size.
             .message = try arena.dupe(u8, e.message),
             .span = .{ .start = @intCast(e.index), .end = @intCast(e.index) },
@@ -291,7 +295,7 @@ fn checkOneGr(
     for (tree.errors) |e| {
         try combined.append(arena, .{
             .severity = .fatal,
-            .code = "E_SYNTAX_GENERIC",
+            .code = e.expected orelse "E_SYNTAX_GENERIC",
             // safety: ParseError.index fits in u32 — bounded by file size.
             .message = try arena.dupe(u8, e.message),
             .span = .{ .start = @intCast(e.index), .end = @intCast(e.index) },

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -60,16 +60,12 @@ pub fn execute(
         }
     } else {
         for (positionals) |path| {
-            if (std.mem.endsWith(u8, path, ".gr")) {
-                try term.err("gero check: .gr support is not yet implemented (waits on the gero-lang front-end)", .{});
-                return 1;
-            }
-            try collectGasFiles(io, arena, term, path, &files);
+            try collectSourceFiles(io, arena, term, path, &files);
         }
     }
 
     if (files.items.len == 0) {
-        try term.err("gero check: no .gas files found in the given paths", .{});
+        try term.err("gero check: no .gas or .gr files found in the given paths", .{});
         return 1;
     }
 
@@ -92,7 +88,24 @@ pub fn execute(
     var read_errors: std.ArrayList(diagnostics.ReadErrorEntry) = .empty;
     var pass: usize = 0;
     var failures: std.ArrayList(FileEntry) = .empty;
+    var gr_failures: std.ArrayList(GrFailure) = .empty;
     for (files.items) |path| {
+        // `.gr` files route through the gero-lang pipeline. Failures
+        // collect into `gr_failures` and render via
+        // `gero.lang.render.pretty` after the loop.
+        if (std.mem.endsWith(u8, path, ".gr")) {
+            const res = try checkOneGr(io, arena, path);
+            if (res.diagnostics.len == 0 and res.parse_errors.len == 0 and !res.read_error) {
+                pass += 1;
+                if (!opts.quiet and !json_mode) try printPassGr(stdout, style, path, single);
+            } else if (res.read_error) {
+                if (!json_mode) try term.err("gero check: cannot read {s}", .{path});
+                try failures.append(arena, .{ .path = path, .info = .read_error });
+            } else {
+                try gr_failures.append(arena, .{ .path = path, .source = res.source, .parse_errors = res.parse_errors, .diagnostics = res.diagnostics });
+            }
+            continue;
+        }
         const t_phase_start_include = std.Io.Timestamp.now(io, .awake);
         const fused = gero.asm_.resolveIncludes(io, arena, path) catch |err| {
             const err_name = @errorName(err);
@@ -149,7 +162,7 @@ pub fn execute(
         }
     }
 
-    const fail = failures.items.len;
+    const fail = failures.items.len + gr_failures.items.len;
 
     // JSON mode emits one object covering every diagnostic + read
     // error, then exits. No human-readable header / summary / footer.
@@ -160,7 +173,18 @@ pub fn execute(
             .from_pipeline => |pf| try pipeline_failures.append(arena, pf),
         };
         try diagnostics.printJsonReport(stdout, pipeline_failures.items, read_errors.items, files.items.len, fail);
-        return if (fail > 0) 4 else 0;
+        // Append lang diagnostics as ndjson lines on the same
+        // stdout — consumers parse line-by-line.
+        if (gr_failures.items.len > 0) {
+            var lang_files: std.ArrayList(gero.lang.render.FileDiagnostics) = .empty;
+            for (gr_failures.items) |gf| try lang_files.append(arena, .{
+                .path = gf.path,
+                .source = gf.source,
+                .diagnostics = gf.diagnostics,
+            });
+            try gero.lang.render.json(stdout, lang_files.items);
+        }
+        return if (fail > 0 or gr_failures.items.len > 0) 4 else 0;
     }
 
     // Pass 2: render the merged diagnostic report (if any failure).
@@ -178,6 +202,19 @@ pub fn execute(
             if (!single and !opts.quiet and pass > 0) try stdout.writeByte('\n');
             try diagnostics.printAllFailures(arena, stdout, style, pipeline_failures.items);
         }
+    }
+
+    // Pass 2b: render lang-side diagnostics.
+    if (gr_failures.items.len > 0) {
+        if (!single and !opts.quiet and (pass > 0 or failures.items.len > 0)) try stdout.writeByte('\n');
+        var lang_files: std.ArrayList(gero.lang.render.FileDiagnostics) = .empty;
+        for (gr_failures.items) |gf| try lang_files.append(arena, .{
+            .path = gf.path,
+            .source = gf.source,
+            .diagnostics = gf.diagnostics,
+        });
+        const lang_style: gero.lang.render.Style = if (term.color) .ansi else .none;
+        try gero.lang.render.pretty(stdout, lang_files.items, lang_style);
     }
 
     if (!single and !opts.quiet) {
@@ -204,6 +241,88 @@ const FileEntry = struct {
         from_pipeline: diagnostics.FileFailure,
     },
 };
+
+/// One `.gr` file's diagnostic context — source bytes + combined
+/// parser + typechecker diagnostics, ready for
+/// `gero.lang.render.pretty` / `.json`.
+const GrFailure = struct {
+    path: []const u8,
+    source: []const u8,
+    parse_errors: []const u8 = "", // placeholder field — kept for symmetry
+    diagnostics: []gero.lang.Diagnostic,
+};
+
+/// Result of running parse + typecheck on one `.gr` source.
+const GrCheckResult = struct {
+    source: []const u8,
+    parse_errors: []const u8 = "",
+    diagnostics: []gero.lang.Diagnostic,
+    read_error: bool = false,
+};
+
+/// Read + tokenize + parse + typecheck one `.gr` file. Parser
+/// diagnostics are folded into the returned slice as lang
+/// `Diagnostic`s with `E_SYNTAX_GENERIC` codes (the parser code
+/// retrofit lands as a follow-up).
+fn checkOneGr(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    path: []const u8,
+) !GrCheckResult {
+    const src = std.Io.Dir.cwd().readFileAlloc(io, path, arena, .unlimited) catch {
+        return .{ .source = "", .diagnostics = &.{}, .read_error = true };
+    };
+
+    const stream = try gero.lang.tokenize(arena, src);
+    // Tokenizer / parser errors travel through the same lang.Diagnostic
+    // shape so the renderer surfaces them in the canonical layout.
+    var combined: std.ArrayList(gero.lang.Diagnostic) = .empty;
+    for (stream.errors) |e| {
+        try combined.append(arena, .{
+            .severity = .fatal,
+            .code = "E_SYNTAX_GENERIC",
+            // safety: ParseError.index fits in u32 — bounded by file size.
+            .message = try arena.dupe(u8, e.message),
+            .span = .{ .start = @intCast(e.index), .end = @intCast(e.index) },
+        });
+    }
+
+    const tree = try gero.lang.parse(arena, src, stream);
+    for (tree.errors) |e| {
+        try combined.append(arena, .{
+            .severity = .fatal,
+            .code = "E_SYNTAX_GENERIC",
+            // safety: ParseError.index fits in u32 — bounded by file size.
+            .message = try arena.dupe(u8, e.message),
+            .span = .{ .start = @intCast(e.index), .end = @intCast(e.index) },
+        });
+    }
+
+    // Only typecheck when parsing succeeded — otherwise the AST
+    // shape can't carry semantic information.
+    if (tree.errors.len == 0) {
+        const checked = try gero.lang.typecheck(arena, src, &tree.program);
+        for (checked.diagnostics) |d| try combined.append(arena, d);
+    }
+
+    return .{
+        .source = src,
+        .diagnostics = try combined.toOwnedSlice(arena),
+    };
+}
+
+fn printPassGr(
+    stdout: *std.Io.Writer,
+    style: gero.asm_.Style,
+    src_path: []const u8,
+    single_mode: bool,
+) std.Io.Writer.Error!void {
+    if (single_mode) {
+        try stdout.print("{s}✓ {s}{s}\n", .{ style.location, src_path, style.reset });
+    } else {
+        try stdout.print("{s}✓{s} {s}\n", .{ style.location, style.reset, src_path });
+    }
+}
 
 const PhaseTimings = struct {
     include: i96,
@@ -241,11 +360,11 @@ fn printPass(
     }
 }
 
-/// Resolve `path` into 0+ `.gas` entries appended to `out`. A
-/// directory is walked recursively; a regular file is appended as-
-/// is. Anything else (broken link, special file) emits a host IO
-/// error and propagates up.
-fn collectGasFiles(
+/// Resolve `path` into 0+ source entries appended to `out`. A
+/// directory is walked recursively; both `.gas` and `.gr` files are
+/// collected. A regular file is appended as-is. Anything else
+/// (broken link, special file) emits a host IO error.
+fn collectSourceFiles(
     io: std.Io,
     arena: std.mem.Allocator,
     term: *term_mod.Term,
@@ -266,7 +385,8 @@ fn collectGasFiles(
         defer walker.deinit();
         while (try walker.next(io)) |entry| {
             if (entry.kind != .file) continue;
-            if (!std.mem.endsWith(u8, entry.path, ".gas")) continue;
+            if (!std.mem.endsWith(u8, entry.path, ".gas") and
+                !std.mem.endsWith(u8, entry.path, ".gr")) continue;
             const full = try std.fs.path.join(arena, &.{ path, entry.path });
             try out.append(arena, full);
         }

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -11,6 +11,8 @@ const print_mod = @import("lang/print.zig");
 const types_mod = @import("lang/types.zig");
 const scope_mod = @import("lang/scope.zig");
 const typecheck_mod = @import("lang/typecheck.zig");
+const diag_mod = @import("lang/diagnostic.zig");
+const render_mod = @import("lang/render.zig");
 
 /// Re-export: lexer token.
 pub const Token = lexer_mod.Token;
@@ -39,3 +41,11 @@ pub const scope = scope_mod;
 pub const CheckedProgram = typecheck_mod.CheckedProgram;
 /// Re-export: walk an `ast.Program` through the typechecker.
 pub const typecheck = typecheck_mod.typecheck;
+
+/// Re-export: rich diagnostic shape carried by `CheckedProgram`.
+pub const Diagnostic = diag_mod.Diagnostic;
+/// Re-export: severity classification on a `Diagnostic`.
+pub const Severity = diag_mod.Severity;
+/// Re-export: diagnostic-rendering primitives (pretty + JSON).
+/// Per `docs/lang-diagnostics.md`.
+pub const render = render_mod;

--- a/src/lang/decl.zig
+++ b/src/lang/decl.zig
@@ -30,11 +30,13 @@ pub fn parseLetDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
 
     const pattern = try pattern_mod.parsePattern(p);
+    errdefer ast.freePattern(p.allocator, pattern);
 
     var type_ann: ?*ast.TypeAnn = null;
     if (p.accept(.colon)) |_| {
         type_ann = try type_mod.parseTypeAnn(p);
     }
+    errdefer if (type_ann) |t| ast.freeTypeAnn(p.allocator, t);
 
     var init: ?*ast.Expr = null;
     if (p.accept(.equals)) |_| {
@@ -42,9 +44,10 @@ pub fn parseLetDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     } else if (type_ann == null) {
         try p.recordError(
             "expected `=` or `: T` after `let` binding",
-            "= or : T",
+            "E_SYNTAX_MISSING_TOKEN",
         );
     }
+    errdefer if (init) |e| ast.freeExpr(p.allocator, e);
 
     const end = if (init) |e| e.span().end else if (type_ann) |t| t.span().end else pattern.span().end;
     try p.requireStatementBoundary();
@@ -67,7 +70,7 @@ pub fn parseConstDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
     const annotations = try parser_mod.takePendingAnnotations(p);
     errdefer parser_mod.freeAnnSlice(p.allocator, annotations);
 
-    const name_tok = try p.expect(.ident, "identifier");
+    const name_tok = try p.expect(.ident, "E_SYNTAX_MISSING_TOKEN");
     const name_span = ast.Span.fromToken(name_tok);
 
     var type_ann: ?*ast.TypeAnn = null;
@@ -193,7 +196,7 @@ pub fn parseParamList(p: *Parser) ParserError![]ast.Param {
                 break :blk .{ .start = tok.start, .end = tok.end };
             },
             else => {
-                try p.recordError("expected parameter name", "identifier");
+                try p.recordError("expected parameter name", "E_SYNTAX_MISSING_TOKEN");
                 return error.ParseFailed;
             },
         };
@@ -295,7 +298,7 @@ pub fn parseClassDecl(p: *Parser, is_local: bool) ParserError!ast.Statement {
             else => {
                 try p.recordError(
                     "expected field (`let`) or method (`def`) in class body",
-                    "let or def",
+                    "E_SYNTAX_UNEXPECTED_TOKEN",
                 );
                 try p.recoverToNewline();
             },
@@ -599,7 +602,7 @@ fn parseQuotedPath(p: *Parser, quoted: *bool) ParserError!ast.Span {
             .str_expr_start => {
                 try p.recordError(
                     "string interpolation not allowed in `use` path",
-                    "literal path",
+                    "E_SYNTAX_UNEXPECTED_TOKEN",
                 );
                 return error.ParseFailed;
             },
@@ -657,7 +660,7 @@ pub fn parseLocalDecl(
             }
             try p.recordError(
                 "expected declaration after `local`",
-                "let / const / def / class / struct / enum / use",
+                "E_SYNTAX_MISSING_TOKEN",
             );
             try p.recoverToNewline();
             try statements.append(p.allocator, .{ .local_decl = .{
@@ -667,7 +670,7 @@ pub fn parseLocalDecl(
         else => {
             try p.recordError(
                 "expected declaration after `local`",
-                "let / const / def / class / struct / enum / use",
+                "E_SYNTAX_MISSING_TOKEN",
             );
             try p.recoverToNewline();
             try statements.append(p.allocator, .{ .local_decl = .{

--- a/src/lang/diagnostic.zig
+++ b/src/lang/diagnostic.zig
@@ -1,0 +1,35 @@
+/// Gero-lang diagnostic — the rich shape consumed by the
+/// renderer in `render.zig` and produced by `typecheck.zig` plus
+/// (eventually) the parser retrofit.
+///
+/// Carries everything the spec mockup in `docs/lang-diagnostics.md`
+/// needs to print one entry: severity prefix, stable code,
+/// message body, span (for `(line, col)` + caret length), optional
+/// `help:` and `note:` lines.
+const std = @import("std");
+const ast = @import("ast.zig");
+
+/// Diagnostic severity. Maps to the `error:` / `warning:` /
+/// `note:` prefix the renderer emits.
+pub const Severity = enum {
+    /// Hard error — typecheck failed for this source.
+    fatal,
+    /// Soft warning — code compiles, but the user should look.
+    warning,
+    /// Informational note — typically secondary; attaches help
+    /// context to a fatal diagnostic from a different code site.
+    note,
+};
+
+/// One diagnostic. The `span` covers the offending bytes in the
+/// source buffer; `code` is the stable `E_TYPE_MISMATCH`-style
+/// identifier from `docs/lang-diagnostics.md`.
+pub const Diagnostic = struct {
+    severity: Severity = .fatal,
+    code: []const u8,
+    message: []const u8,
+    span: ast.Span,
+    /// Optional `help: ...` block printed after the caret snippet.
+    /// The renderer wraps long lines at 78 cols.
+    help: ?[]const u8 = null,
+};

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -386,7 +386,7 @@ fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
         // primary position.
         .pipe => return try parseShortLambda(p),
         else => {
-            try p.recordError("expected expression", "expression");
+            try p.recordError("expected expression", "E_SYNTAX_MISSING_TOKEN");
             return error.ParseFailed;
         },
     }
@@ -491,7 +491,7 @@ fn parseStringLit(p: *Parser) ParserError!*ast.Expr {
                 break;
             },
             else => {
-                try p.recordError("malformed string literal", "string part");
+                try p.recordError("malformed string literal", "E_SYNTAX_MALFORMED_LITERAL");
                 return error.ParseFailed;
             },
         }
@@ -637,7 +637,7 @@ fn parseBakeExpr(p: *Parser) ParserError!*ast.Expr {
     if (!p.check(.kw_do)) {
         try p.recordError(
             "in expression position `bake` must prefix a `do` block",
-            "bake do",
+            "E_SYNTAX_UNEXPECTED_TOKEN",
         );
         return error.ParseFailed;
     }

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -393,13 +393,13 @@ fn pushToken(state: *State, kind: Token.Kind, start: u32, end: u32, value: i32) 
     state.last_kind = kind;
 }
 
-fn pushError(state: *State, index: u32, message: []const u8, actual: []const u8) !void {
+fn pushError(state: *State, index: u32, message: []const u8, code: []const u8) !void {
     try state.errors.append(state.allocator, .{
         .parser = "lang_lexer",
         .index = index,
         .message = message,
-        .expected = "",
-        .actual = actual,
+        .expected = code,
+        .actual = null,
         .kind = .syntactic,
     });
 }
@@ -445,7 +445,7 @@ fn lexAnnotation(state: *State) !void {
     const start = state.index;
     state.index += 1; // consume `@`
     if (state.index >= state.source.len or !isIdentStart(state.source[state.index])) {
-        try pushError(state, start, "expected identifier after `@`", "annotation");
+        try pushError(state, start, "expected identifier after `@`", "E_SYNTAX_ANNOTATION_PLACEMENT");
         // Best-effort: emit the bare `@` with zero-width ident so
         // the parser sees something it can skip.
         try pushToken(state, .annotation, start, state.index, 0);
@@ -471,7 +471,7 @@ fn lexInteger(state: *State, negative: bool) !void {
             if (b == '_') continue;
             if (!isHexDigit(b)) break;
         }
-        try pushError(state, start, "hex literals use `$` (e.g. `$FE40`); `0x` is not accepted", state.source[start..state.index]);
+        try pushError(state, start, "hex literals use `$` (e.g. `$FE40`); `0x` is not accepted", "E_SYNTAX_HEX_PREFIX");
     } else if (state.index + 1 < state.source.len and state.source[state.index] == '0' and
         (state.source[state.index + 1] == 'b' or state.source[state.index + 1] == 'B'))
     {
@@ -485,7 +485,7 @@ fn lexInteger(state: *State, negative: bool) !void {
             value = value * 2 + (b - '0');
         }
         if (state.index == digits_start) {
-            try pushError(state, start, "expected binary digit after `0b`", "0b");
+            try pushError(state, start, "expected binary digit after `0b`", "E_SYNTAX_MALFORMED_LITERAL");
         }
     } else {
         // Decimal form.
@@ -584,13 +584,13 @@ fn lexCharLit(state: *State) !void {
     const start = state.index;
     state.index += 1; // consume opening `'`
     if (state.index >= state.source.len) {
-        try pushError(state, start, "unterminated char literal", "'");
+        try pushError(state, start, "unterminated char literal", "E_SYNTAX_MALFORMED_LITERAL");
         try pushToken(state, .int_lit, start, state.index, 0);
         return;
     }
     const byte_opt = decodeOneByte(state);
     if (byte_opt == null) {
-        try pushError(state, start, "malformed escape in char literal", "");
+        try pushError(state, start, "malformed escape in char literal", "E_SYNTAX_MALFORMED_LITERAL");
         // Recover by skipping to the next `'` or newline.
         while (state.index < state.source.len and state.source[state.index] != '\'' and
             state.source[state.index] != '\n') : (state.index += 1)
@@ -600,7 +600,7 @@ fn lexCharLit(state: *State) !void {
         return;
     }
     if (state.index >= state.source.len or state.source[state.index] != '\'') {
-        try pushError(state, start, "unterminated char literal — expected closing `'`", "");
+        try pushError(state, start, "unterminated char literal — expected closing `'`", "E_SYNTAX_MALFORMED_LITERAL");
         try pushToken(state, .int_lit, start, state.index, byte_opt.?);
         return;
     }
@@ -681,7 +681,7 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
                 // Unterminated literal — surface as an error,
                 // close the frame so the rest of the stream
                 // tokenizes sanely, and exit the loop.
-                try pushError(&state, state.index, "unterminated string literal", "");
+                try pushError(&state, state.index, "unterminated string literal", "E_SYNTAX_MALFORMED_LITERAL");
                 _ = state.str_stack.pop();
                 break;
             }
@@ -987,7 +987,7 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
         }
 
         // Unknown byte — record and advance one.
-        try pushError(&state, state.index, "unknown byte in source", source[state.index .. state.index + 1]);
+        try pushError(&state, state.index, "unknown byte in source", "E_SYNTAX_UNEXPECTED_TOKEN");
         state.index += 1;
     }
 

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -36,10 +36,17 @@ const Kind = lexer.Token.Kind;
 pub const ParseTree = struct {
     program: ast.Program,
     errors: []core.ParseError,
+    /// Owned message strings the parser allocPrint'd for richer
+    /// diagnostics (e.g. `expect` building `"expected )"`).
+    /// String literals don't land here — only heap-allocated bytes
+    /// that need freeing at deinit.
+    allocated_messages: [][]const u8,
     allocator: std.mem.Allocator,
 
     /// Release the owned statement list and the diagnostics buffer.
     pub fn deinit(self: *ParseTree) void {
+        for (self.allocated_messages) |m| self.allocator.free(m);
+        self.allocator.free(self.allocated_messages);
         self.program.deinit();
         self.allocator.free(self.errors);
     }
@@ -80,6 +87,12 @@ pub fn parse(
         allocator.free(a.args);
     };
 
+    var allocated_messages: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (allocated_messages.items) |m| allocator.free(m);
+        allocated_messages.deinit(allocator);
+    }
+
     var p: Parser = .{
         .source = source,
         .tokens = stream.tokens,
@@ -87,6 +100,7 @@ pub fn parse(
         .allocator = allocator,
         .errors = &errors,
         .pending_annotations = &pending_annotations,
+        .allocated_messages = &allocated_messages,
     };
 
     p.skipNewlines();
@@ -103,7 +117,7 @@ pub fn parse(
             "lang_parser",
             pending_annotations.items[0].span.start,
             "annotation at EOF has no following declaration to attach to",
-            .{ .expected = "declaration after annotation", .kind = .semantic },
+            .{ .expected = "E_SYNTAX_ANNOTATION_PLACEMENT", .kind = .semantic },
         ));
         for (pending_annotations.items) |a| {
             for (a.args) |arg| ast.freeExpr(allocator, arg);
@@ -118,6 +132,7 @@ pub fn parse(
             .allocator = allocator,
         },
         .errors = try errors.toOwnedSlice(allocator),
+        .allocated_messages = try allocated_messages.toOwnedSlice(allocator),
         .allocator = allocator,
     };
 }
@@ -172,6 +187,10 @@ pub const Parser = struct {
     allocator: std.mem.Allocator,
     errors: *std.ArrayList(core.ParseError),
     pending_annotations: *std.ArrayList(ast.Annotation),
+    /// Heap-allocated message strings (`expect`'s formatted
+    /// "expected X"). Stashed here so `ParseTree.deinit` can free
+    /// them. String literals don't land here.
+    allocated_messages: *std.ArrayList([]const u8),
 
     /// Current token. Always defined — the lexer guarantees a
     /// trailing `.eof` token.
@@ -220,7 +239,7 @@ pub const Parser = struct {
         }
         try self.recordError(
             "expected newline or end-of-input after statement",
-            "newline",
+            "E_SYNTAX_MISSING_TOKEN",
         );
         try self.recoverToNewline();
     }
@@ -254,11 +273,15 @@ pub const Parser = struct {
     }
 
     /// Expect a specific token kind. Returns the consumed token on
-    /// hit; on miss, emits a diagnostic and bails with
-    /// `error.ParseFailed` (caller recovers to the next newline).
+    /// hit; on miss, emits a `E_SYNTAX_MISSING_TOKEN` diagnostic and
+    /// bails with `error.ParseFailed` (caller recovers to the next
+    /// newline). The `what` string is folded into the message body so
+    /// the user sees what was expected.
     pub fn expect(self: *Parser, kind: Kind, what: []const u8) ParserError!lexer.Token {
         if (self.accept(kind)) |t| return t;
-        try self.recordError("expected token", what);
+        const msg = try std.fmt.allocPrint(self.allocator, "expected {s}", .{what});
+        try self.allocated_messages.append(self.allocator, msg);
+        try self.recordError(msg, "E_SYNTAX_MISSING_TOKEN");
         return error.ParseFailed;
     }
 
@@ -342,7 +365,7 @@ fn parseBakeStatement(p: *Parser) ParserError!ast.Statement {
         else => {
             try p.recordError(
                 "`bake` must prefix a `def` or `do` block",
-                "bake def | bake do",
+                "E_SYNTAX_UNEXPECTED_TOKEN",
             );
             return error.ParseFailed;
         },
@@ -376,7 +399,7 @@ fn emitAsmKeywordStmt(
     if (!p.check(.str_start)) {
         try p.recordError(
             "`asm` expects a string literal with the instruction body",
-            "asm \"...\"",
+            "E_SYNTAX_MISSING_TOKEN",
         );
         return error.ParseFailed;
     }
@@ -391,7 +414,7 @@ fn emitAsmKeywordStmt(
             .str_expr_start => {
                 try p.recordError(
                     "`$(...)` interpolation is not allowed inside `asm`; use `{name}` operand substitution instead",
-                    "asm body without interpolation",
+                    "E_SYNTAX_UNEXPECTED_TOKEN",
                 );
                 return error.ParseFailed;
             },
@@ -405,7 +428,7 @@ fn emitAsmKeywordStmt(
                 return;
             },
             else => {
-                try p.recordError("malformed asm body", "string content");
+                try p.recordError("malformed asm body", "E_SYNTAX_MALFORMED_LITERAL");
                 return error.ParseFailed;
             },
         }
@@ -431,7 +454,7 @@ pub fn parseStatement(
             if (std.mem.eql(u8, name, "asm")) {
                 try p.recordError(
                     "`@asm(\"...\")` is no longer accepted; use the `asm \"...\"` statement (§4.11)",
-                    "asm \"...\"",
+                    "E_SYNTAX_ANNOTATION_PLACEMENT",
                 );
                 return error.ParseFailed;
             }

--- a/src/lang/pattern.zig
+++ b/src/lang/pattern.zig
@@ -105,7 +105,7 @@ fn parseAtomicPattern(p: *Parser) ParserError!*ast.Pattern {
         },
         .lparen => return try parseTuplePattern(p),
         else => {
-            try p.recordError("expected pattern", "pattern");
+            try p.recordError("expected pattern", "E_SYNTAX_MISSING_TOKEN");
             return error.ParseFailed;
         },
     }
@@ -157,7 +157,7 @@ fn parseStringLitPattern(p: *Parser) ParserError!*ast.Pattern {
             .str_expr_start => {
                 try p.recordError(
                     "interpolation not allowed in pattern position",
-                    "literal string",
+                    "E_SYNTAX_UNEXPECTED_TOKEN",
                 );
                 return error.ParseFailed;
             },

--- a/src/lang/render.zig
+++ b/src/lang/render.zig
@@ -1,0 +1,353 @@
+/// Render gero-lang diagnostics in the format documented by
+/// `docs/lang-diagnostics.md`.
+///
+/// Two surfaces:
+///   - `pretty(...)` — Cargo-style human output (default for
+///     `gero check`).
+///   - `json(...)` — line-delimited JSON, one diagnostic per
+///     line, for editor / CI consumers (the LSP wire schema).
+///
+/// Both consume `Diagnostic` slices plus the underlying source
+/// buffer (needed for line-extraction and column math) plus the
+/// file path (for the `--> path:line:col` header).
+const std = @import("std");
+const ast = @import("ast.zig");
+const diag_mod = @import("diagnostic.zig");
+
+const Diagnostic = diag_mod.Diagnostic;
+const Severity = diag_mod.Severity;
+
+/// ANSI escape codes for colorized output. `Style.none` strips
+/// all escapes for plain-text mode (no tty, `--no-color`, JSON).
+pub const Style = struct {
+    severity_error: []const u8 = "",
+    severity_warning: []const u8 = "",
+    severity_note: []const u8 = "",
+    code: []const u8 = "",
+    location: []const u8 = "",
+    gutter: []const u8 = "",
+    caret: []const u8 = "",
+    help: []const u8 = "",
+    reset: []const u8 = "",
+
+    /// Plain-text style — every field is empty so no ANSI escapes
+    /// leak into non-tty output (CI logs, file redirects, JSON).
+    pub const none: Style = .{};
+
+    /// Cargo-style ANSI 16-color style — bold for severity / code,
+    /// cyan for paths / location, red for carets, green for help.
+    pub const ansi: Style = .{
+        .severity_error = "\x1b[31;1m",
+        .severity_warning = "\x1b[33;1m",
+        .severity_note = "\x1b[36;1m",
+        .code = "\x1b[1m",
+        .location = "\x1b[36m",
+        .gutter = "\x1b[34m",
+        .caret = "\x1b[31;1m",
+        .help = "\x1b[32;1m",
+        .reset = "\x1b[0m",
+    };
+};
+
+/// One file's worth of diagnostics, paired with the source buffer
+/// they index into and the path the renderer prints in `--> ...`.
+pub const FileDiagnostics = struct {
+    path: []const u8,
+    source: []const u8,
+    diagnostics: []const Diagnostic,
+};
+
+/// Render every diagnostic across one or more files under a
+/// single Cargo-style summary header, grouped per file.
+///
+/// ```text
+/// 3 errors in 2 files
+///
+/// src/foo.gr
+///   error[E_TYPE_MISMATCH]: ...
+///   ...
+///
+/// src/bar.gr
+///   ...
+/// ```
+pub fn pretty(
+    writer: *std.Io.Writer,
+    files: []const FileDiagnostics,
+    style: Style,
+) !void {
+    var total: usize = 0;
+    var files_with_errors: usize = 0;
+    for (files) |f| {
+        if (f.diagnostics.len > 0) {
+            total += f.diagnostics.len;
+            files_with_errors += 1;
+        }
+    }
+    if (total == 0) return;
+    try writeSummaryHeader(writer, style, total, files_with_errors);
+
+    for (files) |f| {
+        if (f.diagnostics.len == 0) continue;
+        try writer.writeByte('\n');
+        try writer.print("{s}{s}{s}\n", .{ style.location, f.path, style.reset });
+        for (f.diagnostics) |d| try writeDiagnosticBody(writer, f.path, f.source, d, style);
+    }
+}
+
+/// Same as `pretty` but for a single file — skips the per-file
+/// header and just writes the diagnostics in order. Useful when
+/// the caller is rendering one source at a time.
+pub fn prettyOne(
+    writer: *std.Io.Writer,
+    file: FileDiagnostics,
+    style: Style,
+) !void {
+    for (file.diagnostics) |d| try writeDiagnosticFull(writer, file.path, file.source, d, style);
+}
+
+/// Render diagnostics as one JSON object per line — `ndjson`
+/// shape, easy to parse from editors / CI scripts.
+///
+/// Schema per line:
+/// ```
+/// { "path": "...", "line": 12, "col": 18, "end_line": 12,
+///   "end_col": 25, "severity": "error", "code": "E_TYPE_MISMATCH",
+///   "message": "...", "help": "..." }
+/// ```
+pub fn json(
+    writer: *std.Io.Writer,
+    files: []const FileDiagnostics,
+) !void {
+    for (files) |f| {
+        for (f.diagnostics) |d| {
+            const start_lc = lineColAt(f.source, d.span.start);
+            const end_lc = lineColAt(f.source, d.span.end);
+            try writer.writeAll("{\"path\":");
+            try writeJsonString(writer, f.path);
+            try writer.print(",\"line\":{d},\"col\":{d},\"end_line\":{d},\"end_col\":{d}", .{ start_lc.line, start_lc.col, end_lc.line, end_lc.col });
+            try writer.writeAll(",\"severity\":\"");
+            try writer.writeAll(severityName(d.severity));
+            try writer.writeAll("\",\"code\":");
+            try writeJsonString(writer, d.code);
+            try writer.writeAll(",\"message\":");
+            try writeJsonString(writer, d.message);
+            if (d.help) |h| {
+                try writer.writeAll(",\"help\":");
+                try writeJsonString(writer, h);
+            }
+            try writer.writeAll("}\n");
+        }
+    }
+}
+
+// ---------- one diagnostic ----------
+
+fn writeDiagnosticFull(
+    writer: *std.Io.Writer,
+    path: []const u8,
+    source: []const u8,
+    d: Diagnostic,
+    style: Style,
+) !void {
+    const lc = lineColAt(source, d.span.start);
+    try writeHeader(writer, d, style);
+    try writer.print("  {s}-->{s} {s}{s}:{d}:{d}{s}\n", .{
+        style.location, style.reset,
+        style.location, path,
+        lc.line,        lc.col,
+        style.reset,
+    });
+    try writeExcerpt(writer, source, d.span, lc, style);
+    if (d.help) |h| try writeHelp(writer, h, style);
+    try writer.writeByte('\n');
+}
+
+fn writeDiagnosticBody(
+    writer: *std.Io.Writer,
+    path: []const u8,
+    source: []const u8,
+    d: Diagnostic,
+    style: Style,
+) !void {
+    const lc = lineColAt(source, d.span.start);
+    try writer.writeAll("  ");
+    try writeHeader(writer, d, style);
+    try writer.print("    {s}-->{s} {s}{s}:{d}:{d}{s}\n", .{
+        style.location, style.reset,
+        style.location, path,
+        lc.line,        lc.col,
+        style.reset,
+    });
+    try writeExcerpt(writer, source, d.span, lc, style);
+    if (d.help) |h| try writeHelp(writer, h, style);
+    try writer.writeByte('\n');
+}
+
+fn writeHeader(writer: *std.Io.Writer, d: Diagnostic, style: Style) !void {
+    const sev_color: []const u8 = switch (d.severity) {
+        .fatal => style.severity_error,
+        .warning => style.severity_warning,
+        .note => style.severity_note,
+    };
+    try writer.print("{s}{s}{s}: {s} {s}[{s}]{s}\n", .{
+        sev_color,   severityLabel(d.severity), style.reset,
+        d.message,   style.code,                d.code,
+        style.reset,
+    });
+}
+
+fn writeExcerpt(
+    writer: *std.Io.Writer,
+    source: []const u8,
+    span: ast.Span,
+    lc: LineCol,
+    style: Style,
+) !void {
+    const line_slice = lineAt(source, span.start);
+    const gutter_w: usize = digitsOf(lc.line);
+    // Empty gutter line for breathing room.
+    try writePadGutter(writer, gutter_w, style);
+    try writer.writeAll(" |\n");
+    // Source line with right-padded line-number gutter.
+    try writer.writeAll(style.gutter);
+    try writeRightPadInt(writer, lc.line, gutter_w);
+    try writer.print(" |{s} {s}\n", .{ style.reset, line_slice });
+    // Caret line — pad + carets + maybe a trailing label later.
+    try writePadGutter(writer, gutter_w, style);
+    try writer.writeAll(" | ");
+    // Pad with spaces up to the caret column.
+    var i: usize = 1;
+    while (i < lc.col) : (i += 1) try writer.writeByte(' ');
+    try writer.writeAll(style.caret);
+    const caret_len = caretLength(source, span);
+    var c: usize = 0;
+    while (c < caret_len) : (c += 1) try writer.writeByte('^');
+    try writer.writeAll(style.reset);
+    try writer.writeByte('\n');
+}
+
+fn writeHelp(writer: *std.Io.Writer, help_msg: []const u8, style: Style) !void {
+    try writer.print("{s}help:{s} {s}\n", .{ style.help, style.reset, help_msg });
+}
+
+fn writePadGutter(writer: *std.Io.Writer, gutter_w: usize, style: Style) !void {
+    try writer.writeAll(style.gutter);
+    var i: usize = 0;
+    while (i < gutter_w) : (i += 1) try writer.writeByte(' ');
+    try writer.writeAll(style.reset);
+}
+
+/// Write `n` right-padded to `width` ASCII digits (left-padded
+/// with spaces). Zig's runtime format helpers want a comptime
+/// width spec; for a dynamic gutter width we compute by hand.
+fn writeRightPadInt(writer: *std.Io.Writer, n: usize, width: usize) !void {
+    const d = digitsOf(n);
+    var pad: usize = if (width > d) width - d else 0;
+    while (pad > 0) : (pad -= 1) try writer.writeByte(' ');
+    try writer.print("{d}", .{n});
+}
+
+fn writeSummaryHeader(writer: *std.Io.Writer, style: Style, total: usize, files: usize) !void {
+    const err_noun: []const u8 = if (total == 1) "error" else "errors";
+    const file_noun: []const u8 = if (files == 1) "file" else "files";
+    try writer.print("{s}{d} {s}{s} in {d} {s}\n", .{
+        style.code, total, err_noun, style.reset, files, file_noun,
+    });
+}
+
+// ---------- (line, col) + line slice + caret math ----------
+
+/// 1-based `(line, column)` pair, computed from a byte offset
+/// inside a source buffer by `lineColAt`.
+pub const LineCol = struct {
+    line: usize,
+    col: usize,
+};
+
+/// Compute a 1-based `(line, col)` for `byte` inside `source` by
+/// walking the buffer. O(n) — fine for diagnostic rendering where
+/// `n` ≤ a single source file.
+pub fn lineColAt(source: []const u8, byte: u32) LineCol {
+    var line: usize = 1;
+    var col: usize = 1;
+    var i: usize = 0;
+    while (i < source.len and i < byte) : (i += 1) {
+        if (source[i] == '\n') {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    return .{ .line = line, .col = col };
+}
+
+/// Slice the line of source that contains `byte`, without
+/// the trailing newline. Out-of-bounds offsets clamp to the last
+/// line.
+pub fn lineAt(source: []const u8, byte: u32) []const u8 {
+    if (source.len == 0) return source;
+    const idx: usize = if (byte >= source.len) source.len - 1 else @intCast(byte);
+    // Walk back to the previous newline (or start).
+    var start: usize = idx;
+    while (start > 0 and source[start - 1] != '\n') start -= 1;
+    // Walk forward to the next newline (or end).
+    var end: usize = idx;
+    while (end < source.len and source[end] != '\n') end += 1;
+    return source[start..end];
+}
+
+/// Number of caret `^` characters to draw under a span. Clamp to
+/// at least 1 (zero-width spans still need a marker) and to the
+/// remaining bytes on the line (a span that crosses a newline only
+/// gets carets up to the line end).
+fn caretLength(source: []const u8, span: ast.Span) usize {
+    if (span.end <= span.start) return 1;
+    var len: usize = span.end - span.start;
+    var i: usize = span.start;
+    var seen_nl: usize = 0;
+    while (i < span.end and i < source.len) : (i += 1) {
+        if (source[i] == '\n') {
+            seen_nl = i - span.start;
+            break;
+        }
+    }
+    if (seen_nl > 0) len = seen_nl;
+    return @max(len, 1);
+}
+
+fn digitsOf(n: usize) usize {
+    if (n == 0) return 1;
+    var d: usize = 0;
+    var x = n;
+    while (x > 0) : (x /= 10) d += 1;
+    return d;
+}
+
+fn severityLabel(s: Severity) []const u8 {
+    return switch (s) {
+        .fatal => "error",
+        .warning => "warning",
+        .note => "note",
+    };
+}
+
+fn severityName(s: Severity) []const u8 {
+    // JSON variant — same set today.
+    return severityLabel(s);
+}
+
+fn writeJsonString(writer: *std.Io.Writer, s: []const u8) !void {
+    try writer.writeByte('"');
+    for (s) |b| switch (b) {
+        '"' => try writer.writeAll("\\\""),
+        '\\' => try writer.writeAll("\\\\"),
+        '\n' => try writer.writeAll("\\n"),
+        '\r' => try writer.writeAll("\\r"),
+        '\t' => try writer.writeAll("\\t"),
+        // Remaining ASCII control chars (\t, \n, \r already handled above).
+        0...8, 11, 12, 14...0x1f => try writer.print("\\u{x:0>4}", .{b}),
+        else => try writer.writeByte(b),
+    };
+    try writer.writeByte('"');
+}

--- a/src/lang/stmt.zig
+++ b/src/lang/stmt.zig
@@ -22,10 +22,11 @@ const Kind = lexer.Token.Kind;
 /// separator (§4.5) — emit a clear error rather than letting the
 /// inner block consume the loop body silently.
 fn rejectStrandedDo(p: *Parser, context: []const u8) ParserError!void {
+    _ = context; // Was the "expected" prose hint — message body carries it.
     if (p.check(.kw_do)) {
         try p.recordError(
             "`do` is not a loop-head separator — the head ends at the newline (`do…end` is the block form only)",
-            context,
+            "E_SYNTAX_UNEXPECTED_TOKEN",
         );
         return error.ParseFailed;
     }
@@ -419,7 +420,7 @@ pub fn parseDeferStatement(p: *Parser) ParserError!ast.Statement {
         temp.deinit(p.allocator);
         try p.recordError(
             "defer requires exactly one statement (wrap with `do … end` for multi-statement cleanups)",
-            "single statement",
+            "E_SYNTAX_UNEXPECTED_TOKEN",
         );
         return error.ParseFailed;
     }

--- a/src/lang/type_ann.zig
+++ b/src/lang/type_ann.zig
@@ -37,7 +37,7 @@ fn parseTypeBase(p: *Parser) ParserError!*ast.TypeAnn {
         .amp => return try parseReferenceType(p),
         .ident => return try parseNamedOrVecType(p),
         else => {
-            try p.recordError("expected type annotation", "type");
+            try p.recordError("expected type annotation", "E_SYNTAX_MISSING_TOKEN");
             return error.ParseFailed;
         },
     }

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -15,19 +15,20 @@
 /// bake / cast-range / varargs rules and the rendered-diagnostic shape
 /// from `docs/lang-diagnostics.md`.
 const std = @import("std");
-const knit = @import("knit");
-const core = knit.core;
 
 const ast = @import("ast.zig");
 const types = @import("types.zig");
 const scope_mod = @import("scope.zig");
+const diag_mod = @import("diagnostic.zig");
 const Scope = scope_mod.Scope;
+const Diagnostic = diag_mod.Diagnostic;
+const Severity = diag_mod.Severity;
 
 /// Typechecker output. Owns the diagnostics slice and the arena that
 /// allocated every `*Type` plus the scope tree.
 pub const CheckedProgram = struct {
     program: *const ast.Program,
-    diagnostics: []core.ParseError,
+    diagnostics: []Diagnostic,
     type_arena: std.heap.ArenaAllocator,
     allocator: std.mem.Allocator,
 
@@ -54,7 +55,7 @@ pub fn typecheck(
     errdefer arena.deinit();
     const a = arena.allocator();
 
-    var diagnostics: std.ArrayList(core.ParseError) = .empty;
+    var diagnostics: std.ArrayList(Diagnostic) = .empty;
     errdefer diagnostics.deinit(allocator);
 
     var module_scope: Scope = .init(a, null);
@@ -140,7 +141,7 @@ const Checker = struct {
     /// allocator the caller releases the slice with later.
     /// Diagnostic message strings still live in `arena`.
     diag_alloc: std.mem.Allocator,
-    diagnostics: *std.ArrayList(core.ParseError),
+    diagnostics: *std.ArrayList(Diagnostic),
     /// The outermost (module) scope.
     module_scope: *Scope,
     /// The currently-active scope. Walker entry into a function /
@@ -242,19 +243,39 @@ const Checker = struct {
 
     // ---------- diagnostic helpers ----------
 
-    fn emit(
+    /// Emit a diagnostic with full span coverage so the renderer
+    /// can underline the offending source slice rather than a
+    /// single character.
+    fn emitSpan(
         self: *Checker,
         code: []const u8,
-        index: u32,
+        span: ast.Span,
         message: []const u8,
-        actual: ?[]const u8,
     ) WalkError!void {
-        try self.diagnostics.append(self.diag_alloc, core.parseError(
-            "lang_typecheck",
-            index,
-            message,
-            .{ .expected = code, .actual = actual, .kind = .semantic },
-        ));
+        try self.diagnostics.append(self.diag_alloc, .{
+            .severity = .fatal,
+            .code = code,
+            .message = message,
+            .span = span,
+        });
+    }
+
+    /// Same as `emitSpan` plus an optional `help:` block printed
+    /// after the caret snippet.
+    fn emitSpanHelp(
+        self: *Checker,
+        code: []const u8,
+        span: ast.Span,
+        message: []const u8,
+        help: []const u8,
+    ) WalkError!void {
+        try self.diagnostics.append(self.diag_alloc, .{
+            .severity = .fatal,
+            .code = code,
+            .message = message,
+            .span = span,
+            .help = help,
+        });
     }
 
     fn emitMismatch(
@@ -270,7 +291,7 @@ const Checker = struct {
             "type mismatch: expected `{s}`, found `{s}`",
             .{ expected_s, actual_s },
         );
-        try self.emit("E_TYPE_MISMATCH", span.start, msg, null);
+        try self.emitSpan("E_TYPE_MISMATCH", span, msg);
     }
 
     fn lexeme(self: *const Checker, span: ast.Span) []const u8 {
@@ -293,7 +314,7 @@ const Checker = struct {
                     "unknown annotation `@{s}`",
                     .{name},
                 );
-                try self.emit("E_ANN_UNKNOWN", ann.name.start, msg, name);
+                try self.emitSpan("E_ANN_UNKNOWN", ann.name, msg);
                 continue;
             };
             if ((spec.targets & target) == 0) {
@@ -302,7 +323,7 @@ const Checker = struct {
                     "annotation `@{s}` cannot be applied to a {s}",
                     .{ name, targetLabel(target) },
                 );
-                try self.emit("E_ANN_BAD_TARGET", ann.name.start, msg, name);
+                try self.emitSpan("E_ANN_BAD_TARGET", ann.name, msg);
             }
             try self.validateAnnotationArgs(ann, spec);
         }
@@ -320,7 +341,7 @@ const Checker = struct {
                             "annotations `@{s}` and `@{s}` cannot be combined",
                             .{ self.lexeme(a.name), b_name },
                         );
-                        try self.emit("E_ANN_CONFLICT", b.name.start, msg, null);
+                        try self.emitSpan("E_ANN_CONFLICT", b.name, msg);
                     }
                 }
             }
@@ -336,7 +357,7 @@ const Checker = struct {
                         "annotation `@{s}` does not take arguments",
                         .{spec.name},
                     );
-                    try self.emit("E_ANN_BAD_ARG", ann.span.start, msg, null);
+                    try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
                 }
             },
             .int_lit => {
@@ -346,7 +367,7 @@ const Checker = struct {
                         "annotation `@{s}` expects a single integer literal",
                         .{spec.name},
                     );
-                    try self.emit("E_ANN_BAD_ARG", ann.span.start, msg, null);
+                    try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
                 }
             },
             .int_lit_pow2 => {
@@ -356,7 +377,7 @@ const Checker = struct {
                         "annotation `@{s}` expects a single integer literal",
                         .{spec.name},
                     );
-                    try self.emit("E_ANN_BAD_ARG", ann.span.start, msg, null);
+                    try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
                     return;
                 }
                 const v = ann.args[0].int_lit.value;
@@ -366,7 +387,7 @@ const Checker = struct {
                         "annotation `@{s}` requires a power-of-two value, got {d}",
                         .{ spec.name, v },
                     );
-                    try self.emit("E_ANN_BAD_ARG", ann.span.start, msg, null);
+                    try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
                 }
             },
         }
@@ -474,7 +495,7 @@ const Checker = struct {
                     "`{s}` is already defined in this scope",
                     .{name},
                 );
-                try self.emit("E_TYPE_REDEFINED", info.decl_span.start, msg, name);
+                try self.emitSpan("E_TYPE_REDEFINED", info.decl_span, msg);
                 _ = existing;
                 return;
             },
@@ -540,12 +561,7 @@ const Checker = struct {
             .enum_decl => |ed| try self.validateAnnotations(ed.annotations, T.ENUM),
             .use_decl, .local_decl => {},
             .asm_stmt => |as_| if (self.in_bake) {
-                try self.emit(
-                    "E_BAKE_ASM_INSIDE",
-                    as_.span.start,
-                    "`asm` is not allowed inside a `bake` context — compile-time interpretation cannot run host bytecode",
-                    null,
-                );
+                try self.emitSpan("E_BAKE_ASM_INSIDE", as_.span, "`asm` is not allowed inside a `bake` context — compile-time interpretation cannot run host bytecode");
             },
             .defer_stmt => |ds| try self.walkStatement(ds.body.*),
             .unknown => {},
@@ -678,7 +694,7 @@ const Checker = struct {
                 "tuple-destructuring pattern has {d} element{s}, init has {d}",
                 .{ tp.elems.len, suffix, slots.len },
             );
-            try self.emit("E_TYPE_TUPLE_ARITY", tp.span.start, msg, null);
+            try self.emitSpan("E_TYPE_TUPLE_ARITY", tp.span, msg);
             try self.registerPatternBindings(pat);
             return;
         }
@@ -730,12 +746,7 @@ const Checker = struct {
 
     fn checkAssign(self: *Checker, a: ast.AssignStmt) WalkError!void {
         if (!isPlaceExpr(a.target)) {
-            try self.emit(
-                "E_TYPE_MISMATCH",
-                a.target.span().start,
-                "assignment target must be a place expression (ident, field, or index)",
-                null,
-            );
+            try self.emitSpan("E_TYPE_MISMATCH", a.target.span(), "assignment target must be a place expression (ident, field, or index)");
             _ = try self.inferExpr(a.value, null);
             return;
         }
@@ -750,12 +761,7 @@ const Checker = struct {
 
     fn checkIncDec(self: *Checker, id: ast.IncDecStmt) WalkError!void {
         if (!isPlaceExpr(id.target)) {
-            try self.emit(
-                "E_TYPE_MISMATCH",
-                id.target.span().start,
-                "`++` / `--` target must be a place expression (ident, field, or index)",
-                null,
-            );
+            try self.emitSpan("E_TYPE_MISMATCH", id.target.span(), "`++` / `--` target must be a place expression (ident, field, or index)");
             return;
         }
         const tgt_ty = try self.inferExpr(id.target, null);
@@ -767,7 +773,7 @@ const Checker = struct {
                     "`++` / `--` requires an integer type, found `{s}`",
                     .{ty_s},
                 );
-                try self.emit("E_TYPE_MISMATCH", id.target.span().start, msg, null);
+                try self.emitSpan("E_TYPE_MISMATCH", id.target.span(), msg);
             }
         }
     }
@@ -902,12 +908,7 @@ const Checker = struct {
         has_wildcard: *bool,
     ) WalkError!void {
         if (has_wildcard.*) {
-            try self.emit(
-                "E_MATCH_UNREACHABLE_ARM",
-                arm.span.start,
-                "this arm cannot be reached — a wildcard `_` arm above already handles every remaining variant",
-                null,
-            );
+            try self.emitSpan("E_MATCH_UNREACHABLE_ARM", arm.span, "this arm cannot be reached — a wildcard `_` arm above already handles every remaining variant");
         }
         try self.walkArmPattern(arm.pattern, ed, covered, has_wildcard);
     }
@@ -939,7 +940,7 @@ const Checker = struct {
                         "variant `{s}.{s}` is already handled by an earlier arm",
                         .{ self.lexeme(ed.name), split.tail },
                     );
-                    try self.emit("E_MATCH_UNREACHABLE_ARM", pat.span().start, msg, null);
+                    try self.emitSpan("E_MATCH_UNREACHABLE_ARM", pat.span(), msg);
                 }
             },
             .or_pattern => |op| {
@@ -984,7 +985,7 @@ const Checker = struct {
             "non-exhaustive match on enum `{s}` — missing variant{s}: {s}",
             .{ self.lexeme(ed.name), suffix, buf.items },
         );
-        try self.emit("E_MATCH_NON_EXHAUSTIVE", match_span.start, msg, null);
+        try self.emitSpan("E_MATCH_NON_EXHAUSTIVE", match_span, msg);
     }
 
     fn checkReturn(self: *Checker, rs: ast.ReturnStmt) WalkError!void {
@@ -1014,7 +1015,7 @@ const Checker = struct {
             "returning a reference to local binding `{s}` — its storage is freed when the function returns",
             .{name},
         );
-        try self.emit("E_REF_STACK_LIFETIME", v.span().start, msg, null);
+        try self.emitSpan("E_REF_STACK_LIFETIME", v.span(), msg);
     }
 
     fn checkDefDecl(self: *Checker, d: ast.DefDecl) WalkError!void {
@@ -1051,7 +1052,7 @@ const Checker = struct {
                     "`bake def` cannot return `{s}` — only types representable as static data are bakeable",
                     .{ty_s},
                 );
-                try self.emit("E_BAKE_NON_BAKEABLE_VALUE", r.span().start, msg, null);
+                try self.emitSpan("E_BAKE_NON_BAKEABLE_VALUE", r.span(), msg);
             }
         };
 
@@ -1073,7 +1074,7 @@ const Checker = struct {
                 "recursive function `{s}` needs an explicit return type",
                 .{self.lexeme(d.name)},
             );
-            try self.emit("E_TYPE_RECURSIVE_NO_RET", d.name.start, msg, self.lexeme(d.name));
+            try self.emitSpan("E_TYPE_RECURSIVE_NO_RET", d.name, msg);
         }
 
         // Track ret type for `return expr` checking inside the body.
@@ -1207,7 +1208,7 @@ const Checker = struct {
                     "undefined type `{s}`",
                     .{name},
                 );
-                try self.emit("E_TYPE_UNDEFINED", n.name.start, msg, name);
+                try self.emitSpan("E_TYPE_UNDEFINED", n.name, msg);
                 return try types.mkNamed(self.arena, name, n.span);
             },
             .nullable => |n| {
@@ -1219,7 +1220,7 @@ const Checker = struct {
                         "type `{s}?` is invalid — `T?` only applies to pointer-like types (`str`, class, fn-pointer, references)",
                         .{inner_s},
                     );
-                    try self.emit("E_NULL_NON_POINTER", n.span.start, msg, null);
+                    try self.emitSpan("E_NULL_NON_POINTER", n.span, msg);
                 }
                 return try types.mkOptional(self.arena, inner);
             },
@@ -1322,7 +1323,7 @@ const Checker = struct {
                             "binding `{s}` is `@addr`-pinned MMIO — not accessible from a `bake` context",
                             .{name},
                         );
-                        try self.emit("E_BAKE_MMIO_ACCESS", i.span.start, msg, name);
+                        try self.emitSpan("E_BAKE_MMIO_ACCESS", i.span, msg);
                     }
                     // Class names in expression position act as
                     // constructors — synthesize `fn(init.params) ->
@@ -1340,7 +1341,7 @@ const Checker = struct {
                     "undefined symbol `{s}`",
                     .{name},
                 );
-                try self.emit("E_UNDEFINED_SYMBOL", i.span.start, msg, name);
+                try self.emitSpan("E_UNDEFINED_SYMBOL", i.span, msg);
                 return null;
             },
             .self_expr => |se| {
@@ -1354,12 +1355,7 @@ const Checker = struct {
                 if (self.current_class_extends) |ext| {
                     return try types.mkNamed(self.arena, self.lexeme(ext), ext);
                 }
-                try self.emit(
-                    "E_UNDEFINED_SYMBOL",
-                    se.span.start,
-                    "`super` is only valid inside a method of a class that extends a parent",
-                    "super",
-                );
+                try self.emitSpan("E_UNDEFINED_SYMBOL", se.span, "`super` is only valid inside a method of a class that extends a parent");
                 return null;
             },
             .paren => |p| return try self.inferExpr(p.inner, hint),
@@ -1466,30 +1462,20 @@ const Checker = struct {
             "dereferencing nullable `{s}` without a prior nil-check",
             .{ty_s},
         );
-        try self.emit("E_NULL_DEREF", access_span.start, msg, null);
+        try self.emitSpan("E_NULL_DEREF", access_span, msg);
     }
 
     /// `&x` — verify the inner is a place expression and not
     /// already a reference type.
     fn checkRefOf(self: *Checker, r: ast.RefOfExpr) WalkError!?*const types.Type {
         if (!isPlaceExpr(r.inner)) {
-            try self.emit(
-                "E_REF_TEMPORARY",
-                r.span.start,
-                "cannot take a reference to a temporary value (only places — ident, field, or index — have addresses)",
-                null,
-            );
+            try self.emitSpan("E_REF_TEMPORARY", r.span, "cannot take a reference to a temporary value (only places — ident, field, or index — have addresses)");
             _ = try self.inferExpr(r.inner, null);
             return null;
         }
         const inner = try self.inferExpr(r.inner, null) orelse return null;
         if (inner.* == .reference) {
-            try self.emit(
-                "E_REF_DOUBLE",
-                r.span.start,
-                "`&&T` is not a valid type — references do not nest",
-                null,
-            );
+            try self.emitSpan("E_REF_DOUBLE", r.span, "`&&T` is not a valid type — references do not nest");
             return inner;
         }
         return try types.mkReference(self.arena, inner);
@@ -1503,12 +1489,7 @@ const Checker = struct {
                 .optional => return h,
                 .primitive => |p| if (p == .nil_) return try self.primitive(.nil_),
                 .reference => {
-                    try self.emit(
-                        "E_REF_NULLABLE",
-                        lit.span.start,
-                        "`nil` is not a valid reference value — use `T?` for nullable bindings",
-                        null,
-                    );
+                    try self.emitSpan("E_REF_NULLABLE", lit.span, "`nil` is not a valid reference value — use `T?` for nullable bindings");
                     return h;
                 },
                 else => {},
@@ -1519,7 +1500,7 @@ const Checker = struct {
                 "cannot use `nil` where `{s}` is expected",
                 .{ty_s},
             );
-            try self.emit("E_NULL_NIL_TO_NONNULL", lit.span.start, msg, null);
+            try self.emitSpan("E_NULL_NIL_TO_NONNULL", lit.span, msg);
             return h;
         }
         return try self.primitive(.nil_);
@@ -1547,12 +1528,12 @@ const Checker = struct {
                     return try self.resolveType(fld.type_ann);
                 }
             }
-            try self.emitUndefinedField(named_name, field_name, f.field.start);
+            try self.emitUndefinedField(named_name, field_name, f.field);
             return null;
         }
         if (self.class_registry.get(named_name)) |cd| {
             if (try self.lookupClassFieldType(cd, field_name)) |t| return t;
-            try self.emitUndefinedField(named_name, field_name, f.field.start);
+            try self.emitUndefinedField(named_name, field_name, f.field);
             return null;
         }
         return null;
@@ -1577,13 +1558,13 @@ const Checker = struct {
         return null;
     }
 
-    fn emitUndefinedField(self: *Checker, type_name: []const u8, field_name: []const u8, at: u32) WalkError!void {
+    fn emitUndefinedField(self: *Checker, type_name: []const u8, field_name: []const u8, span: ast.Span) WalkError!void {
         const msg = try std.fmt.allocPrint(
             self.arena,
             "type `{s}` has no field `{s}`",
             .{ type_name, field_name },
         );
-        try self.emit("E_TYPE_UNDEFINED_FIELD", at, msg, field_name);
+        try self.emitSpan("E_TYPE_UNDEFINED_FIELD", span, msg);
     }
 
     /// Type-check a method call against the class registry.
@@ -1616,7 +1597,7 @@ const Checker = struct {
                 "class `{s}` has no method `{s}`",
                 .{ named_name, method_name },
             );
-            try self.emit("E_TYPE_UNDEFINED_METHOD", m.method.start, msg, method_name);
+            try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
             for (m.args) |a| _ = try self.inferExpr(a, null);
             return null;
         };
@@ -1633,7 +1614,7 @@ const Checker = struct {
                 "method `{s}.{s}` takes {d} argument{s}, called with {d}",
                 .{ named_name, method_name, sig_params.len, suffix, m.args.len },
             );
-            try self.emit("E_TYPE_ARG_COUNT", m.span.start, msg, null);
+            try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
             for (m.args) |a| _ = try self.inferExpr(a, null);
         } else {
             for (m.args, sig_params) |arg, p| {
@@ -1678,7 +1659,7 @@ const Checker = struct {
             "undefined type `{s}`",
             .{type_name},
         );
-        try self.emit("E_TYPE_UNDEFINED", sl.type_name.start, msg, type_name);
+        try self.emitSpan("E_TYPE_UNDEFINED", sl.type_name, msg);
         for (sl.fields) |f| _ = try self.inferExpr(f.value, null);
         return named_ty;
     }
@@ -1694,7 +1675,7 @@ const Checker = struct {
         for (sl.fields) |lit_field| {
             const field_name = self.lexeme(lit_field.name);
             const decl_field = findStructField(self, decl_fields, field_name) orelse {
-                try self.emitUndefinedField(type_name, field_name, lit_field.name.start);
+                try self.emitUndefinedField(type_name, field_name, lit_field.name);
                 _ = try self.inferExpr(lit_field.value, null);
                 continue;
             };
@@ -1714,7 +1695,7 @@ const Checker = struct {
                     "missing field `{s}` in `{s}` literal",
                     .{ dn, type_name },
                 );
-                try self.emit("E_TYPE_MISSING_FIELD", sl.span.start, msg, dn);
+                try self.emitSpan("E_TYPE_MISSING_FIELD", sl.span, msg);
             }
         }
     }
@@ -1731,7 +1712,7 @@ const Checker = struct {
             // optional-typed, so an untyped field accepts anything.
             const expected_ty: ?*const types.Type = try self.lookupClassFieldType(cd, field_name);
             if (expected_ty == null and findClassField(self, cd, field_name) == null) {
-                try self.emitUndefinedField(type_name, field_name, lit_field.name.start);
+                try self.emitUndefinedField(type_name, field_name, lit_field.name);
                 _ = try self.inferExpr(lit_field.value, null);
                 continue;
             }
@@ -1808,7 +1789,7 @@ const Checker = struct {
                         "literal `{d}` does not fit in `{s}`",
                         .{ lit.value, primitiveName(p) },
                     );
-                    try self.emit("E_TYPE_MISMATCH", lit.span.start, msg, null);
+                    try self.emitSpan("E_TYPE_MISMATCH", lit.span, msg);
                 }
                 return try self.primitive(p);
             }
@@ -1999,7 +1980,7 @@ const Checker = struct {
             "operator {s} requires {s}, found `{s}`",
             .{ op_name, wants, actual_s },
         );
-        try self.emit("E_TYPE_MISMATCH", span.start, msg, null);
+        try self.emitSpan("E_TYPE_MISMATCH", span, msg);
     }
 
     // ---------- cast (`as T`) checking ----------
@@ -2016,7 +1997,7 @@ const Checker = struct {
                     "cannot cast `{s}` to `{s}`",
                     .{ from_s, to_s },
                 );
-                try self.emit("E_CAST_INVALID", c.span.start, msg, null);
+                try self.emitSpan("E_CAST_INVALID", c.span, msg);
             }
         }
         return target_ty;
@@ -2040,7 +2021,7 @@ const Checker = struct {
                 "called value has type `{s}`, expected a function",
                 .{ty_s},
             );
-            try self.emit("E_TYPE_MISMATCH", c.callee.span().start, msg, null);
+            try self.emitSpan("E_TYPE_MISMATCH", c.callee.span(), msg);
             for (c.args) |a| _ = try self.inferExpr(a, null);
             return null;
         }
@@ -2061,7 +2042,7 @@ const Checker = struct {
                 "function takes {d} argument{s}, called with {d}",
                 .{ f.params.len, suffix, c.args.len },
             );
-            try self.emit("E_TYPE_ARG_COUNT", c.span.start, msg, null);
+            try self.emitSpan("E_TYPE_ARG_COUNT", c.span, msg);
             for (c.args) |a| _ = try self.inferExpr(a, null);
             return f.ret;
         }
@@ -2087,12 +2068,7 @@ const Checker = struct {
     fn checkVariadicPosition(self: *Checker, d: ast.DefDecl) WalkError!void {
         for (d.params, 0..) |p, i| {
             if (p.variadic and i != d.params.len - 1) {
-                try self.emit(
-                    "E_VAR_NOT_LAST",
-                    p.span.start,
-                    "variadic parameter must be the last in the parameter list",
-                    null,
-                );
+                try self.emitSpan("E_VAR_NOT_LAST", p.span, "variadic parameter must be the last in the parameter list");
                 return;
             }
         }
@@ -2115,7 +2091,7 @@ const Checker = struct {
                 "variadic function requires at least {d} fixed argument{s}, called with {d}",
                 .{ fixed_count, suffix, c.args.len },
             );
-            try self.emit("E_TYPE_ARG_COUNT", c.span.start, msg, null);
+            try self.emitSpan("E_TYPE_ARG_COUNT", c.span, msg);
             for (c.args) |a| _ = try self.inferExpr(a, null);
             return f.ret;
         }
@@ -2142,7 +2118,7 @@ const Checker = struct {
                         "variadic argument has type `{s}` but earlier variadic arg was `{s}` — all variadic args must share a single type",
                         .{ got_s, exp_s },
                     );
-                    try self.emit("E_VAR_HETEROGENEOUS", arg.span().start, msg, null);
+                    try self.emitSpan("E_VAR_HETEROGENEOUS", arg.span(), msg);
                 }
             } else {
                 pivot = at;
@@ -2162,7 +2138,7 @@ const Checker = struct {
                 "cannot call non-`bake` function `{s}` from inside a `bake` context",
                 .{callee_name},
             );
-            try self.emit("E_BAKE_FORBIDDEN_CALL", c.callee.span().start, msg, callee_name);
+            try self.emitSpan("E_BAKE_FORBIDDEN_CALL", c.callee.span(), msg);
         }
     }
 };

--- a/tests/lang/diagnostic.test.zig
+++ b/tests/lang/diagnostic.test.zig
@@ -1,0 +1,12 @@
+/// Diagnostic module is a simple struct definition — the
+/// real coverage lives in `render.test.zig` (rendering pipeline)
+/// and `typecheck.test.zig` (every diagnostic emitter). This file
+/// pins the mirror-layout rule.
+const std = @import("std");
+const gero = @import("gero");
+
+test "diagnostic module imports cleanly via gero.lang" {
+    _ = std;
+    _ = gero.lang.Diagnostic;
+    _ = gero.lang.Severity;
+}

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -835,6 +835,31 @@ test "parse: match with 3 malformed arms emits multiple diagnostics" {
     try std.testing.expect(tree.errors.len >= 2);
 }
 
+test "parse: error codes flow through expected slot" {
+    var tree = try parseSource("let x: i16 =\n");
+    defer tree.deinit();
+    try std.testing.expect(tree.errors.len > 0);
+    // Parser uses the stable E_SYNTAX_* codes from
+    // `docs/lang-diagnostics.md` in `expected`.
+    try std.testing.expect(tree.errors[0].expected != null);
+    try std.testing.expect(std.mem.startsWith(u8, tree.errors[0].expected.?, "E_SYNTAX_"));
+}
+
+test "parse: hex `0x` prefix emits E_SYNTAX_HEX_PREFIX" {
+    var tree = try parseSource("let x = 0x123\n");
+    defer tree.deinit();
+    var found = false;
+    for (tree.errors) |e| {
+        if (e.expected) |code| {
+            if (std.mem.eql(u8, code, "E_SYNTAX_HEX_PREFIX")) {
+                found = true;
+                break;
+            }
+        }
+    }
+    try std.testing.expect(found);
+}
+
 test "parse: `case PAT then BODY` (legacy) does not parse as a clean arm" {
     // After the syntax patches (#215), `then` is no longer the
     // arm-body separator. Source with the old `then` keyword must

--- a/tests/lang/render.test.zig
+++ b/tests/lang/render.test.zig
@@ -1,0 +1,192 @@
+/// Tests for `gero.lang.render` — the diagnostic-rendering layer.
+const std = @import("std");
+const gero = @import("gero");
+
+const Diagnostic = gero.lang.Diagnostic;
+const FileDiagnostics = gero.lang.render.FileDiagnostics;
+const alloc = std.testing.allocator;
+
+fn renderPretty(file: FileDiagnostics) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    try gero.lang.render.prettyOne(&writer.writer, file, gero.lang.render.Style.none);
+    return writer.toOwnedSlice();
+}
+
+fn renderJson(files: []const FileDiagnostics) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    try gero.lang.render.json(&writer.writer, files);
+    return writer.toOwnedSlice();
+}
+
+test "render: lineColAt computes 1-based (line, col)" {
+    const src = "abc\ndef\nghi";
+    try std.testing.expectEqual(@as(usize, 1), gero.lang.render.lineColAt(src, 0).line);
+    try std.testing.expectEqual(@as(usize, 1), gero.lang.render.lineColAt(src, 0).col);
+    try std.testing.expectEqual(@as(usize, 2), gero.lang.render.lineColAt(src, 5).line);
+    try std.testing.expectEqual(@as(usize, 2), gero.lang.render.lineColAt(src, 5).col);
+}
+
+test "render: lineAt slices the line containing the offset" {
+    const src = "first\nsecond\nthird";
+    try std.testing.expectEqualStrings("first", gero.lang.render.lineAt(src, 2));
+    try std.testing.expectEqualStrings("second", gero.lang.render.lineAt(src, 7));
+    try std.testing.expectEqualStrings("third", gero.lang.render.lineAt(src, 14));
+}
+
+test "render: pretty single diagnostic emits header + excerpt + caret" {
+    const source = "let x: i16 = \"hi\"";
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "type mismatch: expected `i16`, found `str`",
+        .span = .{ .start = 13, .end = 17 },
+    };
+    const file: FileDiagnostics = .{
+        .path = "src/foo.gr",
+        .source = source,
+        .diagnostics = &.{d},
+    };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+    // Header carries severity, message, code.
+    try std.testing.expect(std.mem.indexOf(u8, out, "error:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "[E_TYPE_MISMATCH]") != null);
+    // Location header.
+    try std.testing.expect(std.mem.indexOf(u8, out, "--> src/foo.gr:1:14") != null);
+    // Excerpt + caret line.
+    try std.testing.expect(std.mem.indexOf(u8, out, "let x: i16 = \"hi\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "^^^^") != null);
+}
+
+test "render: pretty includes help block when provided" {
+    const source = "let x: i16 = 0";
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "type mismatch",
+        .span = .{ .start = 13, .end = 14 },
+        .help = "use `let x: u8 = 0` instead",
+    };
+    const file: FileDiagnostics = .{
+        .path = "foo.gr",
+        .source = source,
+        .diagnostics = &.{d},
+    };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "help: use `let x: u8 = 0` instead") != null);
+}
+
+test "render: json emits one object per diagnostic" {
+    const source = "let x: i16 = \"hi\"";
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "type mismatch",
+        .span = .{ .start = 13, .end = 17 },
+    };
+    const file: FileDiagnostics = .{
+        .path = "src/foo.gr",
+        .source = source,
+        .diagnostics = &.{d},
+    };
+    const out = try renderJson(&.{file});
+    defer alloc.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"path\":\"src/foo.gr\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"code\":\"E_TYPE_MISMATCH\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"line\":1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"col\":14") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"severity\":\"error\"") != null);
+}
+
+test "render: severity warning emits `warning:` prefix" {
+    const d = Diagnostic{
+        .severity = .warning,
+        .code = "E_CAST_PRECISION_LOSS",
+        .message = "narrowing without explicit cast",
+        .span = .{ .start = 0, .end = 1 },
+    };
+    const file: FileDiagnostics = .{
+        .path = "x.gr",
+        .source = "x = 1",
+        .diagnostics = &.{d},
+    };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "warning:") != null);
+}
+
+test "render: empty diagnostics list emits nothing" {
+    const file: FileDiagnostics = .{
+        .path = "x.gr",
+        .source = "",
+        .diagnostics = &.{},
+    };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+    try std.testing.expectEqual(@as(usize, 0), out.len);
+}
+
+test "render: pretty multi-file emits summary header + per-file sections" {
+    const d1 = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "boom",
+        .span = .{ .start = 0, .end = 1 },
+    };
+    const d2 = Diagnostic{
+        .severity = .fatal,
+        .code = "E_UNDEFINED_SYMBOL",
+        .message = "missing",
+        .span = .{ .start = 0, .end = 1 },
+    };
+    const file_a: FileDiagnostics = .{ .path = "a.gr", .source = "x", .diagnostics = &.{d1} };
+    const file_b: FileDiagnostics = .{ .path = "b.gr", .source = "y", .diagnostics = &.{d2} };
+
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    try gero.lang.render.pretty(&writer.writer, &.{ file_a, file_b }, gero.lang.render.Style.none);
+    const out = try writer.toOwnedSlice();
+    defer alloc.free(out);
+
+    // Summary header.
+    try std.testing.expect(std.mem.indexOf(u8, out, "2 errors in 2 files") != null);
+    // Both per-file sections present.
+    try std.testing.expect(std.mem.indexOf(u8, out, "a.gr") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "b.gr") != null);
+    // Diagnostic for each.
+    try std.testing.expect(std.mem.indexOf(u8, out, "boom") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "missing") != null);
+}
+
+test "render: pretty skips files with zero diagnostics in multi-file mode" {
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "boom",
+        .span = .{ .start = 0, .end = 1 },
+    };
+    const failing: FileDiagnostics = .{ .path = "fail.gr", .source = "x", .diagnostics = &.{d} };
+    const clean: FileDiagnostics = .{ .path = "clean.gr", .source = "y", .diagnostics = &.{} };
+
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    try gero.lang.render.pretty(&writer.writer, &.{ failing, clean }, gero.lang.render.Style.none);
+    const out = try writer.toOwnedSlice();
+    defer alloc.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "1 error in 1 file") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "fail.gr") != null);
+    // Clean file must not appear in the report.
+    try std.testing.expect(std.mem.indexOf(u8, out, "clean.gr") == null);
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -63,11 +63,11 @@ fn expectCode(source: []const u8, code: []const u8) !void {
     defer checked.deinit();
 
     for (checked.diagnostics) |d| {
-        if (d.expected) |exp| if (std.mem.eql(u8, exp, code)) return;
+        if (std.mem.eql(u8, d.code, code)) return;
     }
     std.debug.print("missing diagnostic code `{s}` for `{s}`; got:\n", .{ code, source });
     for (checked.diagnostics) |d| {
-        std.debug.print("  - {s}: {s}\n", .{ d.expected orelse "?", d.message });
+        std.debug.print("  - {s}: {s}\n", .{ d.code, d.message });
     }
     return error.MissingDiagnosticCode;
 }


### PR DESCRIPTION
## Summary

Eighth (final) slice of the gero-lang typechecker. Lands the diagnostic rendering pipeline documented in \`docs/lang-diagnostics.md\` and wires \`gero check\` to handle \`.gr\` files end-to-end.

### Rich Diagnostic shape

New \`src/lang/diagnostic.zig\` defines the canonical lang Diagnostic carried through the front-end: \`severity\` + \`code\` + \`message\` + \`span\` + optional \`help\`. \`CheckedProgram.diagnostics\` is now \`[]Diagnostic\` (breaking change — element type was \`core.ParseError\`).

The typechecker's legacy \`emit\` helper is gone — every emission goes through \`emitSpan(code, span, msg)\` so the renderer can underline the full offending source slice.

### Rendering

New \`src/lang/render.zig\`:

- \`pretty(writer, []FileDiagnostics, Style)\` — Cargo-style per-file grouped output with summary header, location, line-numbered excerpt, multi-char caret line, optional \`help:\` block.
- \`prettyOne(writer, FileDiagnostics, Style)\` — single-file variant.
- \`json(writer, []FileDiagnostics)\` — line-delimited JSON, one object per diagnostic.
- \`Style.none\` / \`Style.ansi\`.

### \`gero check\` wiring (\`.gr\` end-to-end)

- \`collectGasFiles\` → \`collectSourceFiles\` (picks up \`*.gr\` too).
- Per-file dispatch: \`.gr\` paths route through \`checkOneGr\` which reads + tokenizes + parses + typechecks, folds every parser + typechecker diagnostic into one slice, renders via \`gero.lang.render\`.
- Exit code \`4\` when any diagnostic fires across either pipeline.
- Mixed-extension input handled — asm and lang diagnostics render in separate sections.

### Live demo

\`\`\`
$ gero check /tmp/test_bad.gr
3 errors in 1 file

/tmp/test_bad.gr
  error: type mismatch: expected \\\`i16\\\`, found \\\`str\\\` [E_TYPE_MISMATCH]
    --> /tmp/test_bad.gr:1:14
  |
1 | let x: i16 = \"hello\"
  |              ^^^^^^^

  error: literal \\\`256\\\` does not fit in \\\`u8\\\` [E_TYPE_MISMATCH]
    --> /tmp/test_bad.gr:2:13
  |
2 | let y: u8 = 256
  |             ^^^

  error: undefined symbol \\\`undefined_var\\\` [E_UNDEFINED_SYMBOL]
    --> /tmp/test_bad.gr:3:9
  |
3 | let z = undefined_var
  |         ^^^^^^^^^^^^^
\`\`\`

### Parser-side codes (interim)

Parser still emits prose; CLI converts each to \`Diagnostic\` with \`code = \"E_SYNTAX_GENERIC\"\` at the rendering boundary. Per-error stable codes (\`E_SYNTAX_UNEXPECTED_TOKEN\` etc.) are a follow-up — the rendering pipeline is the load-bearing piece and codes can wire through later without touching the renderer.

## Public surface

- \`gero.lang.Diagnostic\` (struct, new)
- \`gero.lang.Severity\` (enum, new)
- \`gero.lang.render\` (module — \`pretty\`, \`prettyOne\`, \`json\`, \`Style\`, \`FileDiagnostics\`, \`LineCol\`, \`lineColAt\`, \`lineAt\`)
- \`CheckedProgram.diagnostics\` element type changed (\`core.ParseError\` → \`Diagnostic\`). Tests that scanned \`d.expected\` now scan \`d.code\`. Documented in changeset.

## Out of scope (follow-ups)

- Parser-side \`E_SYNTAX_*\` code retrofit.
- Multi-span diagnostics (secondary spans + their own labels).

## Self-review

- ✅ AC: rendering (pretty + JSON), per-file grouping, \`gero check\` wiring all green.
- ⚠️ AC: parser codes deferred — documented above + in changeset.
- ✅ \`zig build verify\` green.
- ✅ 148 typecheck + 9 render + 1 diagnostic mirror tests pass.
- ✅ \`zig build test-modes\` (Debug/ReleaseSafe/Fast/Small) + \`test-all\` (5 targets) green.
- ✅ Public-surface change documented in changeset; \`CheckedProgram.diagnostics\` type change is the only break.
- ✅ Conventional-commit header; no AI attribution.

## Test plan

- [x] \`zig build verify\`
- [x] \`zig build test\` — 1219+ tests pass
- [x] \`zig build test-modes\` — all four modes
- [x] \`zig build test-all\` — all five targets
- [x] Live \`gero check\` smoke against a malformed \`.gr\` (output above)