### PR TITLE
feat(lang): @no_capture enforcement + close stale Phase 11 front-end issues

### DIFF
--- a/.changeset/lang-typecheck-no-capture.md
+++ b/.changeset/lang-typecheck-no-capture.md
@@ -1,0 +1,44 @@
+---
+bump: patch
+---
+
+Closes #220. Implements `@no_capture` enforcement in the
+typechecker per `docs/gero-lang.md` §3.7.2.
+
+When a `def` is annotated `@no_capture`, the typechecker walks
+its body and tracks lambdas it contains. Inside each lambda body,
+any assignment / compound `op=` / `++` / `--` target that
+resolves to a name *not* declared locally in the lambda
+(parameter or `let` inside the lambda body) is treated as a
+capture-and-mutate and emits `E_ANN_CAPTURE_VIOLATION`. Read-only
+captures stay accepted (they don't trigger heap promotion per
+§4.7.2). Without `@no_capture`, the same code compiles.
+
+**Implementation**
+
+Two new fields on `Checker`:
+
+- `in_no_capture: bool` — true when walking the body of a
+  `@no_capture` def (nested defs inherit).
+- `lambda_locals: ?StringHashMapUnmanaged(void)` — non-null when
+  inside a lambda body that's being capture-checked. Populated
+  via `registerName` for every param and local `let`.
+
+`checkAssign` and `checkIncDec` call a new
+`checkNoCaptureMutation(target)` helper that bails fast outside
+the no-capture context and emits the diagnostic otherwise.
+
+**Public surface**
+
+No new public types or functions. The diagnostic code
+`E_ANN_CAPTURE_VIOLATION` is already documented in
+`docs/lang-diagnostics.md`.
+
+**Tests**
+
+7 new tests in `tests/lang/typecheck.test.zig` (155 total):
+- Captured-mutation rejected (`=`, `+=`, `++`).
+- Read-only capture accepted.
+- No-capture lambda accepted.
+- Mutation of lambda-local accepted.
+- Without `@no_capture`, capture-mutation compiles.

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -81,6 +81,8 @@ pub fn typecheck(
         .fn_locals = null,
         .tuple_correlations = .{},
         .in_bake = false,
+        .in_no_capture = false,
+        .lambda_locals = null,
     };
 
     // Pre-pass: capture stable enum / struct / class / def decl
@@ -187,6 +189,15 @@ const Checker = struct {
     /// Bake-context restrictions (no asm, no MMIO, no non-bake
     /// calls) gate on this flag.
     in_bake: bool,
+    /// `true` when walking the body of a `@no_capture` def. Inner
+    /// lambdas that mutate a captured binding emit
+    /// `E_ANN_CAPTURE_VIOLATION` per spec §3.7.2.
+    in_no_capture: bool,
+    /// Names declared inside the currently-walked lambda body
+    /// (params + nested `let` / `const`). `null` outside a
+    /// `@no_capture`-tracked lambda. Drives the capture-mutation
+    /// check on assignments and `++` / `--`.
+    lambda_locals: ?std.StringHashMapUnmanaged(void),
     /// Names declared inside the currently-walked function body
     /// (parameters + nested `let` / `const` / `def`). `null` at
     /// module scope. Drives `return &local` stack-lifetime checks.
@@ -506,6 +517,11 @@ const Checker = struct {
         if (self.fn_locals) |*set| {
             _ = try set.put(self.arena, name, {});
         }
+        // Track lambda-body locals for the `@no_capture`
+        // capture-mutation check. `null` outside a tracked lambda.
+        if (self.lambda_locals) |*set| {
+            _ = try set.put(self.arena, name, {});
+        }
     }
 
     /// Build the function-pointer type for a `def` from its
@@ -750,6 +766,7 @@ const Checker = struct {
             _ = try self.inferExpr(a.value, null);
             return;
         }
+        try self.checkNoCaptureMutation(a.target);
         const tgt_ty = try self.inferExpr(a.target, null);
         // Compound `op=` is sugar for `target = target op value`; the
         // target's type is the hint for the rhs in either form.
@@ -764,6 +781,7 @@ const Checker = struct {
             try self.emitSpan("E_TYPE_MISMATCH", id.target.span(), "`++` / `--` target must be a place expression (ident, field, or index)");
             return;
         }
+        try self.checkNoCaptureMutation(id.target);
         const tgt_ty = try self.inferExpr(id.target, null);
         if (tgt_ty) |t| {
             if (!isIntegerType(t.*)) {
@@ -776,6 +794,23 @@ const Checker = struct {
                 try self.emitSpan("E_TYPE_MISMATCH", id.target.span(), msg);
             }
         }
+    }
+
+    /// `@no_capture` enforcement (§3.7.2): when the walker is
+    /// inside a lambda body of a `@no_capture` def, mutating a
+    /// binding that wasn't declared locally (param or `let` inside
+    /// this lambda) is `E_ANN_CAPTURE_VIOLATION`.
+    fn checkNoCaptureMutation(self: *Checker, target: *const ast.Expr) WalkError!void {
+        if (!self.in_no_capture) return;
+        const locals = self.lambda_locals orelse return;
+        const name = identName(self, target) orelse return;
+        if (locals.contains(name)) return;
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "closure mutates captured binding `{s}` — forbidden by `@no_capture` on the enclosing function (§3.7.2)",
+            .{name},
+        );
+        try self.emitSpan("E_ANN_CAPTURE_VIOLATION", target.span(), msg);
     }
 
     fn checkIfChain(
@@ -1040,6 +1075,13 @@ const Checker = struct {
         const saved_bake = self.in_bake;
         self.in_bake = d.is_bake;
         defer self.in_bake = saved_bake;
+
+        // `@no_capture` context: inner lambdas in this fn's body
+        // must not mutate captured bindings. Nested `def`s inherit
+        // the flag so a closure two levels deep still flags.
+        const saved_nc = self.in_no_capture;
+        self.in_no_capture = saved_nc or defHasNoCapture(self, d);
+        defer self.in_no_capture = saved_nc;
 
         // Bake fn return type must be bakeable. `Vec(T)` and `&T`
         // are runtime-only.
@@ -1395,6 +1437,15 @@ const Checker = struct {
                 var lambda_scope: Scope = .init(self.arena, saved);
                 self.current_scope = &lambda_scope;
                 defer self.current_scope = saved;
+
+                // `@no_capture` tracking: when the enclosing fn is
+                // marked, collect THIS lambda's local names so
+                // `checkAssign` / `checkIncDec` can flag captured-
+                // and-mutated bindings.
+                const saved_locals = self.lambda_locals;
+                if (self.in_no_capture) self.lambda_locals = .{};
+                defer self.lambda_locals = saved_locals;
+
                 for (l.params) |p| {
                     const pt: ?*const types.Type = if (p.type_ann) |t|
                         try self.resolveType(t)
@@ -2297,6 +2348,14 @@ fn isStrType(t: types.Type) bool {
         .primitive => |p| p == .str,
         else => false,
     };
+}
+
+/// `true` when `d` carries a `@no_capture` annotation.
+fn defHasNoCapture(c: *const Checker, d: ast.DefDecl) bool {
+    for (d.annotations) |ann| {
+        if (std.mem.eql(u8, c.lexeme(ann.name), "no_capture")) return true;
+    }
+    return false;
 }
 
 fn isNilType(t: types.Type) bool {

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -1227,6 +1227,86 @@ test "typecheck: multi-return bail propagates non-nil to sibling slot" {
     );
 }
 
+// ---------- @no_capture enforcement (§3.7.2) ----------
+
+test "typecheck: @no_capture rejects closure that mutates captured binding" {
+    try expectCode(
+        \\@no_capture
+        \\def f()
+        \\  let n: i16 = 0
+        \\  let inc = lambda ()
+        \\    n = n + 1
+        \\  end
+        \\end
+    , "E_ANN_CAPTURE_VIOLATION");
+}
+
+test "typecheck: @no_capture accepts closure with read-only capture" {
+    try expectClean(
+        \\@no_capture
+        \\def f()
+        \\  let n: i16 = 0
+        \\  let read = || n
+        \\end
+    );
+}
+
+test "typecheck: @no_capture accepts closure with no capture at all" {
+    try expectClean(
+        \\@no_capture
+        \\def f()
+        \\  let g = || 42
+        \\end
+    );
+}
+
+test "typecheck: @no_capture rejects compound op= on captured binding" {
+    try expectCode(
+        \\@no_capture
+        \\def f()
+        \\  let n: i16 = 0
+        \\  let bump = lambda ()
+        \\    n += 1
+        \\  end
+        \\end
+    , "E_ANN_CAPTURE_VIOLATION");
+}
+
+test "typecheck: @no_capture rejects `++` on captured binding" {
+    try expectCode(
+        \\@no_capture
+        \\def f()
+        \\  let n: i16 = 0
+        \\  let tick = lambda ()
+        \\    n++
+        \\  end
+        \\end
+    , "E_ANN_CAPTURE_VIOLATION");
+}
+
+test "typecheck: closure mutating its own local accepts" {
+    try expectClean(
+        \\@no_capture
+        \\def f()
+        \\  let g = lambda ()
+        \\    let inner: i16 = 0
+        \\    inner = inner + 1
+        \\  end
+        \\end
+    );
+}
+
+test "typecheck: without @no_capture, mutating capture compiles" {
+    try expectClean(
+        \\def f()
+        \\  let n: i16 = 0
+        \\  let inc = lambda ()
+        \\    n = n + 1
+        \\  end
+        \\end
+    );
+}
+
 // ---------- char literal typing ----------
 
 test "typecheck: char literal infers as `char` primitive" {


### PR DESCRIPTION
## Summary

Solde le résidu front-end de Phase 11 :

- **#220 — @no_capture enforcement** : implémentation complète (this PR). Typechecker rejette assignment / compound `op=` / `++` / `--` sur une binding capturée à l'intérieur d'un lambda contenu dans un \`def @no_capture\`.
- **#221 — user-defined variadic params** : à fermer (front-end terminé en slice 7, codegen partie de #194).
- **#226 — docs/lang-diagnostics.md** : à fermer (doc shipped en PR #230, renderer en PR #251, codes émis par les passes typecheck + lexer + parser ; \`--werror\` reste pour quand on aura des warnings).

### Implementation (#220)

Deux nouveaux flags sur \`Checker\` :

- \`in_no_capture: bool\` — vrai pendant le walk d'un \`def @no_capture\` body (les nested defs héritent).
- \`lambda_locals: ?StringHashMapUnmanaged(void)\` — non-null à l'intérieur d'un lambda capture-checked. Peuplé via \`registerName\` à chaque param + local \`let\`.

\`checkAssign\` et \`checkIncDec\` appellent \`checkNoCaptureMutation(target)\` qui bail fast hors no-capture context, sinon vérifie que le nom cible est local au lambda. Si non → \`E_ANN_CAPTURE_VIOLATION\`.

### Public surface

Pas de nouvel export. \`E_ANN_CAPTURE_VIOLATION\` déjà documenté dans \`docs/lang-diagnostics.md\`.

## Test plan

- [x] \`zig build verify\` green
- [x] \`zig build test\` — 155/155 typecheck tests (7 new)
- [x] \`zig build test-modes\` + \`test-all\` green

## Self-review

- ✅ AC #220 : tous les 6 ACs couverts par tests (mutate=fail, read-only=ok, no-capture=ok, sans annotation=ok, names binding, lambda-local mutation=ok).
- ✅ \`zig build verify\` / test-modes / test-all green.
- ✅ Changeset présent (patch — bug fix + enforcement nouveau).
- ✅ Pas de \`std.debug.print\`, pas d'AI attribution.