### PR TITLE
feat(vm): sys opcode (0xFB) — host-callback syscalls (print family)

### DIFF
--- a/.changeset/vm-sys-syscall-print.md
+++ b/.changeset/vm-sys-syscall-print.md
@@ -1,0 +1,71 @@
+---
+bump: minor
+---
+
+Closes #263. Adds a `sys` opcode (`0xFB`) to the VM ISA for
+host-callback syscalls and wires the first family — `print_str` /
+`print_int` / `print_char` / `print_newline`.
+
+**Motivation**
+
+The gero-lang spec's `print expr` statement (§4.9) needs a
+runtime sink. The VM was a pure interpreter with no host I/O
+mechanism — `int N` is interrupt-based and dispatches to
+user-supplied bytecode handlers (no good for built-ins). This
+issue lands a small, focused host-callback surface that lang
+codegen can call into.
+
+**New opcode**
+
+`0xFB sys imm8` — reads the syscall id from the operand byte,
+dispatches to a fixed handler in the VM. Unknown syscall ids
+raise the `invalid_opcode` fault.
+
+**Host hookup**
+
+```zig
+pub const Host = struct {
+    /// Sink for `sys` output syscalls (print_str / print_int /
+    /// print_char / print_newline). `null` makes the syscalls
+    /// silent no-ops (test / CI scenarios).
+    out: ?*std.Io.Writer = null,
+};
+
+pub const VM = struct {
+    // ... existing fields ...
+    host: Host = .{},
+};
+```
+
+**Syscall set (initial)**
+
+| ID    | Name            | Register convention |
+|-------|-----------------|---------------------|
+| `0x01`| `print_str`     | `acu` = address of a null-terminated byte string. |
+| `0x02`| `print_int`     | `acu` = signed i16 value, written as decimal. |
+| `0x03`| `print_char`    | low byte of `acu` written directly. |
+| `0x04`| `print_newline` | writes a single `\n` byte. |
+
+`SyscallId` is an open enum (`enum(u8) { ..., _, }`) so unknown
+ids round-trip through `@enumFromInt` cleanly and route to the
+fault handler.
+
+**Out of scope**
+
+- Input syscalls (`read_char`, `read_line`) — file when needed.
+- File I/O syscalls — out of scope for a console VM.
+- Time / RNG syscalls — file when needed.
+- Formatted-output variants — the lang codegen layers those on
+  top.
+
+**Docs**
+
+`docs/isa.md` §5.13 carries the new opcode row + a new §5.13.1
+documenting the syscall table.
+
+**Tests**
+
+7 new tests in `tests/vm/handlers/system.test.zig` covering
+each syscall's happy path + unknown-id fault + null-writer no-op.
+Existing opcode table tests adjusted for the new entry (105 → 106
+named entries; pre-system gap moved from `0xFB` to `0xFA`).

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -524,10 +524,31 @@ sequences.
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
+| `0xFB` | `sys`    | `Imm8` | host-callback syscall — dispatches to a fixed handler in the VM (not user bytecode). See §5.13.1 for the registered syscall numbers and register conventions. |
 | `0xFC` | `int`    | `Imm8` | software interrupt — push state, jump via vector table at `0x1000 + 2 * imm`. By convention `int 0x21` = "flush SRAM to disk now" (§3.2.1). |
 | `0xFD` | `rti`    | (none) | return from interrupt — restore state, resume |
 | `0xFE` | `brk`    | (none) | breakpoint — VM raises `Break` event for the host (debugger). Distinct from `hlt`: execution can resume. |
 | `0xFF` | `hlt`    | (none) | halt — VM raises `Halt` event for the host. Execution does not resume; program is done. |
+
+#### 5.13.1 `sys` syscalls
+
+`sys` dispatches the `Imm8` operand to a fixed VM handler. Output
+syscalls write to the host-provided `Host.out` writer (see VM
+embedding API); when no writer is installed the syscalls become
+silent no-ops. Unknown syscall numbers raise the
+**invalid-opcode** fault.
+
+| ID    | Name            | Register convention                            |
+|-------|-----------------|------------------------------------------------|
+| `0x01`| `print_str`     | `acu` = address of a null-terminated byte string in memory. Bytes (without the trailing `\0`) are written to `Host.out`. |
+| `0x02`| `print_int`     | `acu` = signed 16-bit value. Written as decimal to `Host.out`. |
+| `0x03`| `print_char`    | low byte of `acu` written directly. |
+| `0x04`| `print_newline` | writes a single `\n` byte. |
+
+Writer failures (host stdout closed, OOM in the writer's buffer)
+raise the **invalid-opcode** fault as well. The `sys` mechanism is
+intentionally narrow — it's the embedding boundary, not a general
+syscall surface. Add new syscall numbers conservatively.
 
 ---
 

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -199,6 +199,7 @@ pub const handler_table: [256]Handler = blk: {
     t[0xC1] = system_handlers.nop;
 
     // 0xFX — system
+    t[0xFB] = system_handlers.sys;
     t[0xFC] = system_handlers.intImm8;
     t[0xFD] = system_handlers.rti;
     t[0xFE] = system_handlers.brk;

--- a/src/vm/handlers/system.zig
+++ b/src/vm/handlers/system.zig
@@ -107,3 +107,68 @@ pub fn hlt(vm: *VM) StepResult {
     _ = vm;
     return .halted;
 }
+
+// ---------- syscall (host-callback) ----------
+
+/// Host-callback syscall identifiers. The `sys imm8` opcode
+/// dispatches on this number; unknown ids raise the
+/// `invalid_opcode` fault. See `gero.vm.VM.host` for the sinks
+/// these syscalls write to.
+pub const SyscallId = enum(u8) {
+    /// `acu` = address in memory of a null-terminated byte string;
+    /// the bytes (excluding the trailing `\0`) get written to
+    /// `host.out`.
+    print_str = 0x01,
+    /// `acu` = signed 16-bit value, formatted as decimal into
+    /// `host.out`.
+    print_int = 0x02,
+    /// `acu` low byte → `host.out` as a raw character.
+    print_char = 0x03,
+    /// Writes a single `\n` byte to `host.out`. No args.
+    print_newline = 0x04,
+    /// Open-enum tail — unknown syscall ids coerce here and the
+    /// `sys` handler routes them to the `invalid_opcode` fault.
+    _,
+};
+
+/// `0xFB` — `sys imm8` → host-callback syscall. Reads the
+/// syscall id from the operand byte, dispatches to a fixed
+/// handler. Output syscalls are silent no-ops when
+/// `vm.host.out` is `null`. Writer failures and unknown
+/// syscall ids both raise the `invalid_opcode` fault.
+pub fn sys(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const id_byte = vm.readByte(ip +% 1);
+    // safety: enum payload is u8 — every value round-trips, even
+    // unrecognized ones via the `else` arm below.
+    const id: SyscallId = @enumFromInt(id_byte);
+    const writer = vm.host.out orelse return ok;
+    switch (id) {
+        .print_str => printStr(vm, writer) catch return fault(vm, .invalid_opcode),
+        .print_int => {
+            // safety: r0 is u16; bit-cast to i16 for signed-decimal output.
+            const v: i16 = @bitCast(vm.regs.read(.acu));
+            writer.print("{d}", .{v}) catch return fault(vm, .invalid_opcode);
+        },
+        .print_char => {
+            // safety: r0 is u16; the print_char syscall writes the low byte only.
+            const byte: u8 = @intCast(vm.regs.read(.acu) & 0xFF);
+            writer.writeByte(byte) catch return fault(vm, .invalid_opcode);
+        },
+        .print_newline => writer.writeByte('\n') catch return fault(vm, .invalid_opcode),
+        // Unknown id — open-enum coercion picks this up; future
+        // syscall ids should add an arm above.
+        _ => return fault(vm, .invalid_opcode),
+    }
+    return ok;
+}
+
+fn printStr(vm: *VM, writer: *@import("std").Io.Writer) !void {
+    var addr: u16 = vm.regs.read(.acu);
+    while (true) {
+        const b = vm.readByte(addr);
+        if (b == 0) break;
+        try writer.writeByte(b);
+        addr +%= 1;
+    }
+}

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -193,6 +193,7 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0xC1] = .{ .mnemonic = "nop", .operands = &.{} };
 
     // 0xFX — system
+    t[0xFB] = .{ .mnemonic = "sys", .operands = &.{.imm8} };
     t[0xFC] = .{ .mnemonic = "int", .operands = &.{.imm8} };
     t[0xFD] = .{ .mnemonic = "rti", .operands = &.{} };
     t[0xFE] = .{ .mnemonic = "brk", .operands = &.{} };

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -76,6 +76,19 @@ pub const fp_boot: u16 = 0xFFFE;
 /// Boot-state default for `im` — every maskable vector enabled.
 pub const im_boot: u16 = 0xFFFF;
 
+/// Host-side I/O hookup. The `sys` opcode reads from / writes to
+/// these handles instead of touching real OS state directly, so
+/// the VM stays embeddable + testable (the host can install a
+/// captured buffer instead of stdout).
+///
+/// `null` slots mean "the syscall is a silent no-op" — useful for
+/// CI / tests that don't care about output.
+pub const Host = struct {
+    /// Sink for `sys` output syscalls (`print_str` / `print_int` /
+    /// `print_char` / `print_newline`).
+    out: ?*std.Io.Writer = null,
+};
+
 /// The VM. Owns the register file, the memory mapper (which
 /// holds the 64KB RAM and the host device registry), and the
 /// optional bank pool that backs the `0xC000..0xFEFF` window.
@@ -89,6 +102,11 @@ pub const VM = struct {
     /// by one per dispatch (faulting instructions counted too —
     /// they still consumed a cycle).
     cycles: u64,
+    /// Host-side I/O hooks consulted by the `sys` opcode. Default
+    /// (`.{}`) leaves every sink `null` so `sys` syscalls become
+    /// silent no-ops — fine for tests / headless smoke runs that
+    /// don't care about output.
+    host: Host,
 
     /// Construct a fresh VM with default boot state. `ip` is left
     /// at 0; the loader sets it to the program's entry point. The
@@ -100,6 +118,7 @@ pub const VM = struct {
             .mmap = MemoryMapper.init(allocator),
             .banks = null,
             .cycles = 0,
+            .host = .{},
         };
         vm.bootInitRegisters();
         return vm;

--- a/tests/vm/handlers/system.test.zig
+++ b/tests/vm/handlers/system.test.zig
@@ -206,3 +206,116 @@ test "run: exits on brk, but resuming continues to hlt" {
     // Host resumes.
     try std.testing.expectEqual(gero.vm.StepResult.halted, gero.vm.run(&vm));
 }
+
+// ---------- sys 0xFB — host-callback syscalls ----------
+
+fn captureWriter(buf: *std.ArrayList(u8)) std.Io.Writer.Allocating {
+    return std.Io.Writer.Allocating.fromArrayList(std.testing.allocator, buf);
+}
+
+test "sys 0xFB: print_int writes decimal of acu" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var writer = captureWriter(&buf);
+    defer writer.deinit();
+    vm.host = .{ .out = &writer.writer };
+
+    vm.regs.write(.acu, 42);
+    loadProgram(&vm, &.{ 0xFB, 0x02 }); // sys print_int
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqualStrings("42", writer.written());
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+}
+
+test "sys 0xFB: print_int formats negative as signed decimal" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var writer = captureWriter(&buf);
+    defer writer.deinit();
+    vm.host = .{ .out = &writer.writer };
+
+    // -7 as u16 = 0xFFF9
+    vm.regs.write(.acu, 0xFFF9);
+    loadProgram(&vm, &.{ 0xFB, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqualStrings("-7", writer.written());
+}
+
+test "sys 0xFB: print_str walks memory from acu until null" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var writer = captureWriter(&buf);
+    defer writer.deinit();
+    vm.host = .{ .out = &writer.writer };
+
+    // Stash "hi!\0" at 0x2000.
+    vm.mmap.writeByte(0x2000, 'h');
+    vm.mmap.writeByte(0x2001, 'i');
+    vm.mmap.writeByte(0x2002, '!');
+    vm.mmap.writeByte(0x2003, 0);
+    vm.regs.write(.acu, 0x2000);
+    loadProgram(&vm, &.{ 0xFB, 0x01 }); // sys print_str
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqualStrings("hi!", writer.written());
+}
+
+test "sys 0xFB: print_char writes low byte of acu" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var writer = captureWriter(&buf);
+    defer writer.deinit();
+    vm.host = .{ .out = &writer.writer };
+
+    vm.regs.write(.acu, 0x4142); // low byte = 0x42 = 'B'
+    loadProgram(&vm, &.{ 0xFB, 0x03 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqualStrings("B", writer.written());
+}
+
+test "sys 0xFB: print_newline writes a single \\n" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var writer = captureWriter(&buf);
+    defer writer.deinit();
+    vm.host = .{ .out = &writer.writer };
+
+    loadProgram(&vm, &.{ 0xFB, 0x04 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqualStrings("\n", writer.written());
+}
+
+test "sys 0xFB: unknown syscall id raises invalid_opcode fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var writer = captureWriter(&buf);
+    defer writer.deinit();
+    vm.host = .{ .out = &writer.writer };
+
+    vm.mmap.writeWord(gero.vm.ivtSlot(.invalid_opcode), 0x5000);
+    loadProgram(&vm, &.{ 0xFB, 0xEE });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+    try std.testing.expectEqual(@as(usize, 0), writer.written().len);
+}
+
+test "sys 0xFB: with host.out = null, output syscalls are silent no-ops" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // host.out is null by default — no writer installed.
+    vm.regs.write(.acu, 42);
+    loadProgram(&vm, &.{ 0xFB, 0x02 });
+    try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+}

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -32,12 +32,12 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
-test "opcodes: table holds exactly 105 named entries" {
+test "opcodes: table holds exactly 106 named entries" {
     var count: usize = 0;
     for (table) |entry| if (entry != null) {
         count += 1;
     };
-    try std.testing.expectEqual(@as(usize, 105), count);
+    try std.testing.expectEqual(@as(usize, 106), count);
 }
 
 test "opcodes: every named entry has a non-empty mnemonic" {
@@ -115,7 +115,7 @@ test "opcodes: unused byte values are null" {
     try std.testing.expect(table[0x6A] == null); // 0x6X bitwise gap
     try std.testing.expect(table[0x7A] == null); // 0x7X shifts gap
     try std.testing.expect(table[0xD0] == null); // reserved page
-    try std.testing.expect(table[0xFB] == null); // pre-system gap
+    try std.testing.expect(table[0xFA] == null); // pre-system gap
 }
 
 test "opcodes: schema sizes never overflow a u8 instruction" {


### PR DESCRIPTION
## Summary

Closes #263. Unblocks **M1** (gero-lang codegen walking-skeleton) by giving the VM a proper host-I/O syscall surface so \`print\` can lower to actual VM bytecode.

### New opcode

\`\`\`
0xFB sys imm8     // syscall id is the imm8
\`\`\`

Dispatches to a fixed handler in the VM (not user bytecode). Unknown syscall ids raise the \`invalid_opcode\` fault.

### Host hookup

\`\`\`zig
pub const Host = struct {
    out: ?*std.Io.Writer = null,
};

pub const VM = struct {
    // ... existing fields ...
    host: Host = .{},
};
\`\`\`

Default \`.{}\` leaves every sink \`null\` → \`sys\` syscalls become silent no-ops. Tests / CI / headless smoke runs that don't care about output don't have to plumb anything.

### Initial syscalls

| ID    | Name            | Register convention |
|-------|-----------------|---------------------|
| \`0x01\` | \`print_str\`     | \`acu\` = address of null-terminated bytes |
| \`0x02\` | \`print_int\`     | \`acu\` = signed i16, decimal |
| \`0x03\` | \`print_char\`    | low byte of \`acu\` |
| \`0x04\` | \`print_newline\` | \`\\n\` |

### Docs

\`docs/isa.md\` §5.13 row + new §5.13.1 with the syscall table.

### Self-review vs #263 AC

- ✅ \`sys 0x02\` after \`acu = 42\` writes \`\"42\"\` to \`host.out\`.
- ✅ \`sys 0x01\` with \`acu\` pointing at \`mem[X] = \"hi\\0\"\` writes \`\"hi\"\`.
- ✅ Unknown syscall id raises a fault, doesn't crash the VM.
- ✅ With \`host.out = null\`, all output syscalls are silent no-ops, no fault.
- ✅ All existing VM tests pass (opcode table count adjusted 105 → 106).
- ✅ All four release modes pass.

## Test plan

- [x] \`zig build verify\` green
- [x] \`zig build test\` — 7 new \`sys\` tests in \`tests/vm/handlers/system.test.zig\`
- [x] \`zig build test-modes\` — Debug / ReleaseSafe / ReleaseFast / ReleaseSmall
- [x] \`zig build test-all\` — linux / macos / windows / wasm32-wasi