### PR TITLE
feat(lang/codegen): M1 — instruction selection + free-fn calling convention

### DIFF
--- a/.changeset/lang-codegen-m1.md
+++ b/.changeset/lang-codegen-m1.md
@@ -1,0 +1,93 @@
+---
+bump: minor
+---
+
+Closes #194 + #258. **M1 milestone (Core codegen walking-skeleton)** —
+the typed AST now lowers to real `.gx` bytecode that the VM
+boots, runs, and prints from.
+
+**Deliverable**
+
+```
+def add(a: i16, b: i16) -> i16
+  return a + b
+end
+
+def main()
+  let r: i16 = add(5, 3)
+  print r
+end
+```
+
+Compiles → boots VM → prints `8\n` → halts.
+
+**Instruction selection (#194)**
+
+`src/lang/codegen.zig` grows an `Emitter` with bytecode primitives
+(`movImmToReg`, `addRegToAcu`, `pushReg`, etc.) and walks the
+typed AST emitting bytes directly. Coverage:
+
+- Statements: `let` / `const`, `return`, `print` (multi-arg with
+  space separators + trailing newline per spec §4.9), expression
+  statements + `_ = expr` discards.
+- Expressions: `int_lit` (with bit-cast for negatives),
+  `bool_lit`, `nil_lit`, `char_lit`, `paren`, `ident` (load from
+  local or param slot), unary `-x`, binary `+ - * /` via the
+  stack-machine pattern (eval RHS / push / eval LHS / pop r1 /
+  apply op).
+- `mul` and `divs` go via `r2` (their VM semantics put the high
+  word into `acu`, so `mul X, acu` would clobber the low result).
+
+**Stack frame model**
+
+Locals + params live in fp-relative stack slots. For the entry
+def, sp starts at `fp_boot` and the prologue is `sub
+local_bytes, sp`; epilogue is `hlt`. For free fns, the VM's
+`call` opcode already pushes `fp` + `ret_ip` then sets
+`fp = sp`, so the codegen only emits `sub local_bytes, sp` at
+entry and `ret` at exit — the VM unwinds in `ret`.
+
+**Free-function calling convention (#258)**
+
+- Caller pushes args **right-to-left** so callee sees param 0
+  at `[fp + 4]`, param 1 at `[fp + 6]`, … (skip the ret_ip +
+  old_fp slots).
+- Caller emits `call <addr>` with a forward-reference placeholder.
+- After return, caller `add (2 * N), sp` to drop the args
+  (caller-cleans-up).
+- Return value in `acu`.
+
+`emitProgram` lays out every top-level `def` in the base image
+(entry first at `code_base = 0x1100`, rest in source order),
+recording each fn's address. A patching pass at the end rewrites
+every call's 2-byte address slot. Forward references resolve
+cleanly.
+
+**Public surface**
+
+No new public types. The existing `gero.lang.compile` /
+`Compiled` / `CompileOptions` surfaces stay stable — the work
+all lives inside `src/lang/codegen.zig`.
+
+**Tests**
+
+19 codegen tests (5 → 19, +14):
+- Instruction selection: let with int-lit init, binary add /
+  sub / mul / div, unary neg, ident load across slots, nested
+  precedence (`2 * (3 + 4) = 14`), print of int literal / multi-
+  arg / let-bound value.
+- Calling convention: nullary fn call returning to acu, binary
+  fn (`add(a, b)`), call result stored into local, param order
+  (`sub 10, 3 == 7`), nested calls (`twice(twice(2)) == 8`).
+
+**Out of scope (separate issues)**
+
+- Memory-placement annotations (`@bank` / `@addr` / `@zero_page`
+  / `@volatile` / `@align`) — #261 stays open for these; will be
+  split into atomic per-annotation issues since each carries its
+  own emission machinery (bank routing, zp allocator, alignment
+  padding, etc.).
+- Recursion + mutual recursion (the address-patching already
+  supports forward refs; needs a test).
+- Multi-return tuples / closures / class methods — M3.
+- Control flow (`if` / `while` / `for` / `match`) + defer — M2.

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -60,7 +60,9 @@ const Op = struct {
     const mul_reg_reg: u8 = 0x47; // dst ← dst * src
     const neg_reg: u8 = 0x4A;
     const divs_reg_reg: u8 = 0x4E; // dst ← dst / src (signed)
-    const mod_reg_reg: u8 = 0x50; // assumed name; not used in M1
+
+    const call_addr: u8 = 0xA0;
+    const ret_op: u8 = 0xA2;
 
     const sys: u8 = 0xFB;
     const hlt: u8 = 0xFF;
@@ -146,21 +148,25 @@ pub fn compile(
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    const entry = findEntryDef(source, checked.program, opts.entry_name) orelse return error.EntryNotFound;
+    if (findEntryDef(source, checked.program, opts.entry_name) == null) return error.EntryNotFound;
 
-    // Emit the entry def's body into a working buffer.
     var emitter: Emitter = .{
         .allocator = allocator,
         .arena = arena.allocator(),
         .source = source,
         .code = .empty,
         .locals = .{},
+        .params = .{},
         .frame_bytes = 0,
+        .is_entry = false,
+        .fn_addresses = .{},
+        .call_patches = .empty,
         .diagnostics = &diagnostics,
     };
     defer emitter.code.deinit(allocator);
+    defer emitter.call_patches.deinit(allocator);
 
-    try emitter.emitEntryBody(entry);
+    try emitter.emitProgram(checked.program, opts.entry_name);
 
     // Build base image: zeros from 0x0000 up to `code_base`, then
     // the emitted bytes.
@@ -196,6 +202,21 @@ fn findEntryDef(source: []const u8, program: *const ast.Program, entry_name: []c
 
 // ---------- Emitter ----------
 
+/// Unresolved `call addr` site — the codegen recorded the call
+/// when the callee's address wasn't yet known (forward refs). At
+/// the end of emission, every patch's 2-byte address-slot in
+/// `code` is overwritten with the resolved callee address.
+const CallPatch = struct {
+    /// Byte offset into the code buffer where the 2-byte LE
+    /// address slot lives (right after the `0xA0` opcode).
+    code_offset: usize,
+    /// Callee fn name to resolve via `fn_addresses`.
+    callee_name: []const u8,
+    /// Span of the original call expression — used to anchor the
+    /// `E_CODEGEN_UNDEFINED_FN` diagnostic on resolve failure.
+    span: ast.Span,
+};
+
 /// Per-fn codegen state — owns the working bytecode buffer, the
 /// local-slot table, and the diagnostic sink. The entry-def
 /// emission path owns one Emitter; later M1 commits will create
@@ -212,9 +233,26 @@ const Emitter = struct {
     /// to their negative fp-relative offsets (`fp - 2` is the
     /// first local, `fp - 4` the second, etc.).
     locals: std.StringHashMapUnmanaged(i8),
+    /// Param-name → positive fp-relative offset. The VM's `call`
+    /// pushes ret_ip + old_fp then sets fp = sp, so param 0 lives
+    /// at `[fp + 4]`, param 1 at `[fp + 6]`, etc. Reset per fn.
+    params: std.StringHashMapUnmanaged(i8),
     /// Total bytes reserved for this fn's locals — the prologue
     /// emits `sub frame_bytes, sp`.
     frame_bytes: u8,
+    /// `true` while emitting the entry def's body. Drives the
+    /// `return` lowering (`hlt` vs `ret`) and skips the
+    /// `push fp` / `mov sp, fp` parts of the prologue (the VM
+    /// boots with `fp == sp`).
+    is_entry: bool,
+    /// Top-level `def` name → absolute address in the base image
+    /// (`code_base + offset`). Populated as defs are emitted in
+    /// source order so calls patch correctly.
+    fn_addresses: std.StringHashMapUnmanaged(u16),
+    /// Unresolved `call addr` sites — recorded when the callee's
+    /// address isn't known yet (forward references). Rewritten at
+    /// the end of `emitProgram`.
+    call_patches: std.ArrayList(CallPatch),
     /// Sink for codegen-time diagnostics.
     diagnostics: *std.ArrayList(Diagnostic),
 
@@ -277,6 +315,13 @@ const Emitter = struct {
     /// `pop reg` (0x32).
     fn popReg(self: *Emitter, reg: u8) !void {
         try self.emitByte(Op.pop_reg);
+        try self.emitByte(reg);
+    }
+
+    /// `add imm16, reg` (0x40) — `reg ← reg + imm`.
+    fn addImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
+        try self.emitByte(Op.add_imm16_reg);
+        try self.emitU16Le(imm);
         try self.emitByte(reg);
     }
 
@@ -357,19 +402,112 @@ const Emitter = struct {
         return n;
     }
 
-    // ---------- entry-def emission ----------
+    // ---------- program + def emission ----------
 
-    fn emitEntryBody(self: *Emitter, def: *const ast.DefDecl) !void {
-        // Pre-walk: reserve space for top-level locals.
+    /// Top-level orchestrator: emit the entry def first (so it
+    /// lands at `code_base`, matching `Options.entry_name` →
+    /// header `entry_point`), then every other top-level `def` in
+    /// source order, then patch unresolved call sites.
+    fn emitProgram(self: *Emitter, program: *const ast.Program, entry_name: []const u8) !void {
+        const entry = findEntryDef(self.source, program, entry_name).?;
+        try self.emitDef(entry, .entry);
+        for (program.statements) |*stmt| switch (stmt.*) {
+            .def_decl => |*dd| if (dd != entry) try self.emitDef(dd, .regular),
+            else => {},
+        };
+        try self.patchCalls();
+    }
+
+    const DefKind = enum { entry, regular };
+
+    /// Emit one def's prologue + body + epilogue. Reset per-fn
+    /// state (locals / params / frame_bytes / is_entry) so each
+    /// def gets a fresh frame view.
+    fn emitDef(self: *Emitter, def: *const ast.DefDecl, kind: DefKind) !void {
+        const name = self.source[def.name.start..def.name.end];
+        const dup_name = try self.arena.dupe(u8, name);
+        // @as: narrow usize code offset to u16; base image fits in 64 KiB by ISA.
+        const code_offset: u16 = @intCast(self.code.items.len);
+        const addr = code_base + code_offset;
+        try self.fn_addresses.put(self.arena, dup_name, addr);
+
+        // Save + restore per-fn state.
+        const saved_locals = self.locals;
+        const saved_params = self.params;
+        const saved_frame = self.frame_bytes;
+        const saved_entry = self.is_entry;
+        self.locals = .{};
+        self.params = .{};
+        self.frame_bytes = 0;
+        self.is_entry = (kind == .entry);
+        defer {
+            self.locals = saved_locals;
+            self.params = saved_params;
+            self.frame_bytes = saved_frame;
+            self.is_entry = saved_entry;
+        }
+
+        // Bind params to positive fp-relative offsets. `call` left
+        // the stack as: [low] ret_ip, old_fp, arg_N-1, ..., arg_1,
+        // arg_0 [high] (per right-to-left push order at the call
+        // site). fp points at ret_ip, so param 0 is at fp+4,
+        // param 1 at fp+6, etc.
+        for (def.params, 0..) |p, i| {
+            const p_name = self.source[p.name.start..p.name.end];
+            const dup_p = try self.arena.dupe(u8, p_name);
+            // @as: u8 frame index → i8 fp-offset; cap at 62 params → fits.
+            const offset: i8 = @intCast(4 + 2 * @as(i32, @intCast(i)));
+            try self.params.put(self.arena, dup_p, offset);
+        }
+
+        // Reserve local slots up front (cheap fixed reservation —
+        // a real allocator would compute live ranges).
         const local_count = self.countLocalsInBody(def.body);
         if (local_count > 0) {
-            // safety: 2 bytes per slot, capped at 64 locals → fits u16 easily.
+            // @as: 2 bytes per slot capped well below u16.
             const reserve_bytes: u16 = @intCast(local_count * 2);
             try self.subImmFromReg(reserve_bytes, Reg.sp);
         }
+
         for (def.body) |stmt| try self.emitStatement(stmt);
-        // Entry epilogue: halt. The program ends here.
-        try self.hlt();
+
+        // Implicit epilogue (no explicit `return`).
+        if (self.is_entry) {
+            try self.hlt();
+        } else {
+            // `ret` resets sp = fp then pops ret_ip + old_fp. The
+            // VM handles the whole tear-down; we just need to land
+            // the return value in acu (callers read from there).
+            try self.emitByte(Op.ret_op);
+        }
+    }
+
+    /// Rewrite each unresolved call's 2-byte address slot. An
+    /// unresolved callee name surfaces as
+    /// `E_CODEGEN_UNDEFINED_FN` — should be unreachable in
+    /// well-typed input (the typechecker resolves identifiers
+    /// first) but the check keeps the codegen defensive.
+    fn patchCalls(self: *Emitter) !void {
+        for (self.call_patches.items) |p| {
+            const target = self.fn_addresses.get(p.callee_name) orelse {
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "codegen: call target `{s}` is not a known top-level def",
+                    .{p.callee_name},
+                );
+                try self.diagnostics.append(self.allocator, .{
+                    .severity = .fatal,
+                    .code = "E_CODEGEN_UNDEFINED_FN",
+                    .message = msg,
+                    .span = p.span,
+                });
+                continue;
+            };
+            // Overwrite the 2-byte LE address slot.
+            // safety: u16 → 2 bytes by definition; both casts are byte-masks.
+            self.code.items[p.code_offset] = @intCast(target & 0xFF);
+            self.code.items[p.code_offset + 1] = @intCast(target >> 8);
+        }
     }
 
     // ---------- statement emission ----------
@@ -415,10 +553,12 @@ const Emitter = struct {
 
     fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
         if (r.value) |v| try self.emitExpr(v);
-        // Inside the entry def, `return` halts (no caller to return
-        // to). Non-entry defs get a real epilogue in the next M1
-        // commit.
-        try self.hlt();
+        if (self.is_entry) {
+            // Entry def has no caller — halt instead of ret.
+            try self.hlt();
+        } else {
+            try self.emitByte(Op.ret_op);
+        }
     }
 
     fn emitPrintStmt(self: *Emitter, p: ast.PrintStmt) !void {
@@ -479,7 +619,7 @@ const Emitter = struct {
             .paren => |p| try self.emitExpr(p.inner),
             .ident => |i| {
                 const name = self.source[i.span.start..i.span.end];
-                const ofs = self.locals.get(name) orelse {
+                const ofs = self.locals.get(name) orelse self.params.get(name) orelse {
                     try self.unsupported(i.span, "ident not in current frame");
                     return;
                 };
@@ -487,6 +627,7 @@ const Emitter = struct {
             },
             .unary => |u| try self.emitUnary(u),
             .binary => |b| try self.emitBinary(b),
+            .call => |c| try self.emitCall(c),
             else => try self.unsupported(e.span(), "this expression form"),
         }
     }
@@ -531,6 +672,53 @@ const Emitter = struct {
             },
             // M2 picks up: comparison / logical / bitwise / shift / mod.
             else => try self.unsupported(b.span, "this binary operator"),
+        }
+    }
+
+    /// Lower `callee(args...)` per the free-fn calling convention:
+    ///
+    ///   - Push args **right-to-left** (so callee sees param 0 at
+    ///     `[fp + 4]`, param 1 at `[fp + 6]`, ...).
+    ///   - `call <addr>` — the VM enters: push fp, push ret_ip,
+    ///     fp ← sp, ip ← target.
+    ///   - On return, `add <N*2>, sp` to drop the args. The
+    ///     callee's return value lives in `acu`.
+    ///
+    /// Slice M1 only handles direct calls — the callee must be a
+    /// bare ident referencing a top-level `def`. Method calls /
+    /// closure invocations / fn-pointer calls land in M3.
+    fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
+        if (c.callee.* != .ident) {
+            try self.unsupported(c.span, "non-ident callee");
+            return;
+        }
+        // Push args right-to-left.
+        var i: usize = c.args.len;
+        while (i > 0) {
+            i -= 1;
+            try self.emitExpr(c.args[i]);
+            try self.pushReg(Reg.acu);
+        }
+
+        // Emit `call <addr>` with a placeholder address; the
+        // patching pass rewrites it once every def's address is
+        // known.
+        try self.emitByte(Op.call_addr);
+        const patch_offset = self.code.items.len;
+        try self.emitU16Le(0); // placeholder
+        const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+        const dup = try self.arena.dupe(u8, callee_name);
+        try self.call_patches.append(self.allocator, .{
+            .code_offset = patch_offset,
+            .callee_name = dup,
+            .span = c.span,
+        });
+
+        // Caller-cleans-up the pushed args.
+        if (c.args.len > 0) {
+            // @as: each arg is one 16-bit word.
+            const drop_bytes: u16 = @intCast(c.args.len * 2);
+            try self.addImmToReg(drop_bytes, Reg.sp);
         }
     }
 

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -4,10 +4,14 @@
 /// the `CheckedProgram` from `typecheck.zig` and produces a `.gx`
 /// archive ready for the VM loader (`gero.vm.parseGx`) per ISA §7.
 ///
-/// This module is the *framework* slice — instruction selection
-/// for the various AST shapes lands in subsequent slices. Today
-/// it only emits enough to take an empty `def main() end` to a
-/// valid bootable `.gx` that halts on entry.
+/// **M1 scope** (this slice — codegen walking-skeleton):
+/// instruction selection for the entry def's body — `let` /
+/// `const`, integer literals, ident loads, binary arithmetic,
+/// unary neg, `print int_expr`, `return`. Locals live in
+/// fp-relative stack slots; expression evaluation uses
+/// `acu` + `r1` with push/pop for spills. Calling convention
+/// for free fns + memory-placement annotations land in
+/// subsequent M1 commits.
 const std = @import("std");
 const ast = @import("ast.zig");
 const typecheck_mod = @import("typecheck.zig");
@@ -28,32 +32,74 @@ pub const code_base: u16 = 0x1100;
 /// `code_base`; data grows up from here.
 pub const data_base: u16 = 0x2000;
 
-// ---------- .gx file constants (mirror src/vm/loader.zig) ----------
+// ---------- .gx file constants ----------
 
 const gx_magic = [4]u8{ 'G', 'E', 'R', 'O' };
 const gx_version: u16 = 0x0001;
 const gx_header_size: usize = 16;
-const flag_has_debug: u16 = 0x0002;
+
+// ---------- VM opcode + register byte values ----------
+//
+// Mirrored from `src/vm/opcodes.zig`. We don't import the VM module
+// at compile time (keeps lang codegen self-contained) — when a
+// new opcode lands there, this table needs the matching constant.
+
+const Op = struct {
+    const mov_imm16_reg: u8 = 0x10;
+    const mov_reg_reg: u8 = 0x11;
+    const mov_reg_offset_reg: u8 = 0x1C; // load:  reg ← [base + ofs]
+    const mov_reg_reg_offset: u8 = 0x1D; // store: [base + ofs] ← reg
+
+    const push_reg: u8 = 0x31;
+    const pop_reg: u8 = 0x32;
+
+    const add_imm16_reg: u8 = 0x40;
+    const add_reg_acu: u8 = 0x42; // acu ← acu + reg
+    const sub_imm16_reg: u8 = 0x43;
+    const sub_reg_acu: u8 = 0x45; // acu ← acu - reg
+    const mul_reg_reg: u8 = 0x47; // dst ← dst * src
+    const neg_reg: u8 = 0x4A;
+    const divs_reg_reg: u8 = 0x4E; // dst ← dst / src (signed)
+    const mod_reg_reg: u8 = 0x50; // assumed name; not used in M1
+
+    const sys: u8 = 0xFB;
+    const hlt: u8 = 0xFF;
+};
+
+/// VM register byte values per `src/vm/registers.zig`.
+const Reg = struct {
+    const acu: u8 = 0x01;
+    const r1: u8 = 0x02;
+    const r2: u8 = 0x03;
+    const sp: u8 = 0x0A;
+    const fp: u8 = 0x0B;
+};
+
+/// `sys` syscall ids per `src/vm/handlers/system.zig::SyscallId`.
+const Sys = struct {
+    const print_str: u8 = 0x01;
+    const print_int: u8 = 0x02;
+    const print_char: u8 = 0x03;
+    const print_newline: u8 = 0x04;
+};
 
 // ---------- public surface ----------
 
 /// Codegen output. Owns the `.gx` image bytes + the diagnostic
-/// slice + the arena that backs everything else.
+/// slice.
 pub const Compiled = struct {
     /// Full `.gx` archive, ready to feed to `gero.vm.parseGx`.
     image: []u8,
     diagnostics: []Diagnostic,
     allocator: std.mem.Allocator,
 
-    /// Release the image buffer + diagnostics slice. Idempotent
-    /// after a successful `compile` — the codegen owns both.
+    /// Release the image buffer + diagnostics slice.
     pub fn deinit(self: *Compiled) void {
         self.allocator.free(self.image);
         self.allocator.free(self.diagnostics);
     }
 
-    /// `true` when at least one fatal diagnostic fired during
-    /// codegen.
+    /// `true` when at least one fatal diagnostic fired.
     pub fn hasErrors(self: Compiled) bool {
         for (self.diagnostics) |d| if (d.severity == .fatal) return true;
         return false;
@@ -67,9 +113,7 @@ pub const Options = struct {
     /// Spec convention is `main`.
     entry_name: []const u8 = "main",
     /// When `true` reserves a flag bit + section for debug
-    /// symbols (per ISA §7.3). Slice B1 doesn't emit a body for
-    /// the section yet; the flag stays clear regardless until the
-    /// debug-symbols slice lands.
+    /// symbols (per ISA §7.3). Slice M1 doesn't emit the body yet.
     debug_symbols: bool = true,
 };
 
@@ -81,15 +125,13 @@ pub const CompileError = error{
     /// `Options.entry_name` doesn't resolve to a top-level `def`
     /// in the typechecked program.
     EntryNotFound,
+    /// Codegen tried to lower an AST shape that this slice
+    /// doesn't yet support. The unsupported feature shows up in
+    /// the diagnostic slice with the offending span.
+    UnsupportedFeature,
 };
 
 /// Walk a typechecked program and emit a `.gx` archive.
-///
-/// Slice-B1 scope: emits the bytes for the entry def's body
-/// (today only `hlt` for an empty body) into the base image at
-/// `code_base`. Header carries the entry-point address and total
-/// image size. Banks / debug section / non-entry defs are
-/// out-of-scope until later slices.
 pub fn compile(
     allocator: std.mem.Allocator,
     source: []const u8,
@@ -101,29 +143,33 @@ pub fn compile(
     var diagnostics: std.ArrayList(Diagnostic) = .empty;
     errdefer diagnostics.deinit(allocator);
 
-    // Locate the entry def. The typechecker's `def_registry` is
-    // private to that module; walking the program statements is
-    // straightforward enough here.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
     const entry = findEntryDef(source, checked.program, opts.entry_name) orelse return error.EntryNotFound;
 
-    // Emit the entry def's body. Slice-B1 only handles the empty-
-    // body shape: synthesize a single `hlt` so the VM halts on
-    // entry. Future slices replace this with real instruction
-    // selection over the body's statements.
-    var code_buf: std.ArrayList(u8) = .empty;
-    errdefer code_buf.deinit(allocator);
-    try emitEntryBody(allocator, entry, &code_buf);
+    // Emit the entry def's body into a working buffer.
+    var emitter: Emitter = .{
+        .allocator = allocator,
+        .arena = arena.allocator(),
+        .source = source,
+        .code = .empty,
+        .locals = .{},
+        .frame_bytes = 0,
+        .diagnostics = &diagnostics,
+    };
+    defer emitter.code.deinit(allocator);
+
+    try emitter.emitEntryBody(entry);
 
     // Build base image: zeros from 0x0000 up to `code_base`, then
-    // the emitted bytes. Total length stays ≤ 64 KiB; for the
-    // smoke test it's `code_base + 1`.
+    // the emitted bytes.
     // @as: widen u16 code_base to usize for the byte-length math (image stays ≤ 64 KiB by ISA).
-    const total_image_bytes: usize = @as(usize, code_base) + code_buf.items.len;
+    const total_image_bytes: usize = @as(usize, code_base) + emitter.code.items.len;
     var base_image = try allocator.alloc(u8, total_image_bytes);
     errdefer allocator.free(base_image);
     @memset(base_image, 0);
-    @memcpy(base_image[code_base..][0..code_buf.items.len], code_buf.items);
-    code_buf.deinit(allocator);
+    @memcpy(base_image[code_base..][0..emitter.code.items.len], emitter.code.items);
 
     const image = try buildArchive(allocator, base_image, code_base);
     allocator.free(base_image);
@@ -137,10 +183,6 @@ pub fn compile(
 
 // ---------- entry resolution ----------
 
-/// Find the top-level `def` whose name matches `entry_name`.
-/// Returns `null` when the program has no such def — caller maps
-/// that to `error.EntryNotFound`. Names compare against bytes
-/// borrowed from `source` (same convention as `Checker.lexeme`).
 fn findEntryDef(source: []const u8, program: *const ast.Program, entry_name: []const u8) ?*const ast.DefDecl {
     for (program.statements) |*stmt| switch (stmt.*) {
         .def_decl => |*dd| {
@@ -152,48 +194,378 @@ fn findEntryDef(source: []const u8, program: *const ast.Program, entry_name: []c
     return null;
 }
 
-// ---------- emission ----------
+// ---------- Emitter ----------
 
-/// `hlt` — VM opcode 0xFF. Halts execution per ISA §5.
-const OP_HLT: u8 = 0xFF;
-
-/// Emit the entry def's body. Slice-B1 walks the body statements;
-/// for empty bodies it just emits `hlt`. Any non-empty body falls
-/// back to the same hlt today — instruction selection per AST
-/// shape is the next slice's scope.
-fn emitEntryBody(
+/// Per-fn codegen state — owns the working bytecode buffer, the
+/// local-slot table, and the diagnostic sink. The entry-def
+/// emission path owns one Emitter; later M1 commits will create
+/// a fresh Emitter per non-entry def too.
+const Emitter = struct {
     allocator: std.mem.Allocator,
-    entry: *const ast.DefDecl,
-    out: *std.ArrayList(u8),
-) !void {
-    _ = entry;
-    // The empty body emits one `hlt`. When the body becomes
-    // non-empty in later slices the trailing `hlt` synthesizes the
-    // program shutdown (or `ret` if `main` returns to a stub).
-    try out.append(allocator, OP_HLT);
-}
+    /// Arena for short-lived bookkeeping (local-name dupes,
+    /// scratch buffers). Released at the end of `compile`.
+    arena: std.mem.Allocator,
+    source: []const u8,
+    /// The growing bytecode buffer.
+    code: std.ArrayList(u8),
+    /// `let` / `const` bindings in the current fn's frame mapped
+    /// to their negative fp-relative offsets (`fp - 2` is the
+    /// first local, `fp - 4` the second, etc.).
+    locals: std.StringHashMapUnmanaged(i8),
+    /// Total bytes reserved for this fn's locals — the prologue
+    /// emits `sub frame_bytes, sp`.
+    frame_bytes: u8,
+    /// Sink for codegen-time diagnostics.
+    diagnostics: *std.ArrayList(Diagnostic),
+
+    /// Mutually recursive emit fns need an explicit error set to
+    /// break Zig's inferred-set deadlock.
+    const EmitError = error{OutOfMemory};
+
+    // ---------- raw emit primitives ----------
+
+    fn emitByte(self: *Emitter, b: u8) !void {
+        try self.code.append(self.allocator, b);
+    }
+
+    fn emitU16Le(self: *Emitter, value: u16) !void {
+        // safety: u16 → 2 LE bytes; both casts are byte-mask, no truncation.
+        try self.emitByte(@intCast(value & 0xFF));
+        try self.emitByte(@intCast(value >> 8));
+    }
+
+    // ---------- ISA instructions used in M1 ----------
+
+    /// `mov imm16, reg` (0x10) — `reg ← imm`.
+    fn movImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
+        try self.emitByte(Op.mov_imm16_reg);
+        try self.emitU16Le(imm);
+        try self.emitByte(reg);
+    }
+
+    /// `mov src, dst` (0x11) — `dst ← src`.
+    fn movRegToReg(self: *Emitter, src: u8, dst: u8) !void {
+        try self.emitByte(Op.mov_reg_reg);
+        try self.emitByte(src);
+        try self.emitByte(dst);
+    }
+
+    /// `mov [base + ofs], dst` (0x1C) — load fp-relative into reg.
+    fn movRegOffsetToReg(self: *Emitter, base: u8, ofs: i8, dst: u8) !void {
+        try self.emitByte(Op.mov_reg_offset_reg);
+        try self.emitByte(base);
+        // safety: i8 → u8 bit pattern; reg_offset is signed byte per ISA §5.1.
+        try self.emitByte(@bitCast(ofs));
+        try self.emitByte(dst);
+    }
+
+    /// `mov src, [base + ofs]` (0x1D) — store reg to fp-relative.
+    fn movRegToRegOffset(self: *Emitter, src: u8, base: u8, ofs: i8) !void {
+        try self.emitByte(Op.mov_reg_reg_offset);
+        try self.emitByte(src);
+        try self.emitByte(base);
+        // safety: i8 → u8 bit pattern; reg_offset is signed byte per ISA §5.1.
+        try self.emitByte(@bitCast(ofs));
+    }
+
+    /// `push reg` (0x31).
+    fn pushReg(self: *Emitter, reg: u8) !void {
+        try self.emitByte(Op.push_reg);
+        try self.emitByte(reg);
+    }
+
+    /// `pop reg` (0x32).
+    fn popReg(self: *Emitter, reg: u8) !void {
+        try self.emitByte(Op.pop_reg);
+        try self.emitByte(reg);
+    }
+
+    /// `sub imm16, reg` (0x43) — `reg ← reg - imm`.
+    fn subImmFromReg(self: *Emitter, imm: u16, reg: u8) !void {
+        try self.emitByte(Op.sub_imm16_reg);
+        try self.emitU16Le(imm);
+        try self.emitByte(reg);
+    }
+
+    /// `add reg` (0x42) — `acu ← acu + reg`.
+    fn addRegToAcu(self: *Emitter, reg: u8) !void {
+        try self.emitByte(Op.add_reg_acu);
+        try self.emitByte(reg);
+    }
+
+    /// `sub reg` (0x45) — `acu ← acu - reg`.
+    fn subRegFromAcu(self: *Emitter, reg: u8) !void {
+        try self.emitByte(Op.sub_reg_acu);
+        try self.emitByte(reg);
+    }
+
+    /// `mul src, dst` (0x47) — `dst ← dst * src`.
+    fn mulRegReg(self: *Emitter, src: u8, dst: u8) !void {
+        try self.emitByte(Op.mul_reg_reg);
+        try self.emitByte(src);
+        try self.emitByte(dst);
+    }
+
+    /// `divs src, dst` (0x4E) — signed `dst ← dst / src`.
+    fn divsRegReg(self: *Emitter, src: u8, dst: u8) !void {
+        try self.emitByte(Op.divs_reg_reg);
+        try self.emitByte(src);
+        try self.emitByte(dst);
+    }
+
+    /// `neg reg` (0x4A) — `reg ← -reg` (two's complement).
+    fn negReg(self: *Emitter, reg: u8) !void {
+        try self.emitByte(Op.neg_reg);
+        try self.emitByte(reg);
+    }
+
+    /// `sys imm8` (0xFB).
+    fn sys(self: *Emitter, id: u8) !void {
+        try self.emitByte(Op.sys);
+        try self.emitByte(id);
+    }
+
+    /// `hlt` (0xFF).
+    fn hlt(self: *Emitter) !void {
+        try self.emitByte(Op.hlt);
+    }
+
+    // ---------- frame management ----------
+
+    /// Reserve a 2-byte slot for `name` at the next fp-relative
+    /// offset. Returns the offset (negative — locals grow down).
+    fn allocLocal(self: *Emitter, name: []const u8) !i8 {
+        const new_frame_bytes = self.frame_bytes + 2;
+        // @as: i8 covers -128..127; with 2 bytes per slot we cap at 64 locals per frame, fits.
+        const ofs: i8 = -@as(i8, @intCast(new_frame_bytes));
+        try self.locals.put(self.arena, name, ofs);
+        self.frame_bytes = new_frame_bytes;
+        return ofs;
+    }
+
+    /// Pre-walk the body to count `let` / `const` bindings so the
+    /// prologue can reserve their stack space up-front. Slice M1
+    /// handles only top-level lets in the body — destructuring,
+    /// nested blocks, conditional bindings come with M2 / M3.
+    fn countLocalsInBody(self: *const Emitter, body: []const ast.Statement) usize {
+        var n: usize = 0;
+        for (body) |s| switch (s) {
+            .let_decl, .const_decl => n += 1,
+            else => {},
+        };
+        _ = self;
+        return n;
+    }
+
+    // ---------- entry-def emission ----------
+
+    fn emitEntryBody(self: *Emitter, def: *const ast.DefDecl) !void {
+        // Pre-walk: reserve space for top-level locals.
+        const local_count = self.countLocalsInBody(def.body);
+        if (local_count > 0) {
+            // safety: 2 bytes per slot, capped at 64 locals → fits u16 easily.
+            const reserve_bytes: u16 = @intCast(local_count * 2);
+            try self.subImmFromReg(reserve_bytes, Reg.sp);
+        }
+        for (def.body) |stmt| try self.emitStatement(stmt);
+        // Entry epilogue: halt. The program ends here.
+        try self.hlt();
+    }
+
+    // ---------- statement emission ----------
+
+    fn emitStatement(self: *Emitter, stmt: ast.Statement) !void {
+        switch (stmt) {
+            .let_decl => |d| try self.emitLetDecl(d),
+            .const_decl => |d| try self.emitConstDecl(d),
+            .return_stmt => |r| try self.emitReturnStmt(r),
+            .print_stmt => |p| try self.emitPrintStmt(p),
+            .expr_stmt => |es| try self.emitExprDiscard(es.expr),
+            .discard => |ds| try self.emitExprDiscard(ds.expr),
+            // M1 stops here. Future commits add control flow, assignment,
+            // calls, etc.
+            else => try self.unsupported(stmt.span(), "this statement form"),
+        }
+    }
+
+    fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
+        if (d.pattern.* != .ident) {
+            try self.unsupported(d.span, "non-ident `let` patterns");
+            return;
+        }
+        const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
+        const dup_name = try self.arena.dupe(u8, name);
+        const ofs = try self.allocLocal(dup_name);
+        if (d.init) |init_expr| {
+            try self.emitExpr(init_expr); // result in acu
+            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+        }
+        // Uninitialized let leaves the slot at whatever the prologue
+        // memset gave it (sub_imm pads sp downward without zeroing —
+        // M2 may want a defensive zero-fill).
+    }
+
+    fn emitConstDecl(self: *Emitter, d: ast.ConstDecl) !void {
+        const name = self.source[d.name.start..d.name.end];
+        const dup_name = try self.arena.dupe(u8, name);
+        const ofs = try self.allocLocal(dup_name);
+        try self.emitExpr(d.init);
+        try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+    }
+
+    fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
+        if (r.value) |v| try self.emitExpr(v);
+        // Inside the entry def, `return` halts (no caller to return
+        // to). Non-entry defs get a real epilogue in the next M1
+        // commit.
+        try self.hlt();
+    }
+
+    fn emitPrintStmt(self: *Emitter, p: ast.PrintStmt) !void {
+        for (p.args, 0..) |arg, i| {
+            if (i > 0) {
+                // Space separator between args per spec §4.9.
+                try self.movImmToReg(' ', Reg.acu);
+                try self.sys(Sys.print_char);
+            }
+            try self.emitPrintArg(arg);
+        }
+        // Trailing newline per spec §4.9.
+        try self.sys(Sys.print_newline);
+    }
+
+    /// One `print` argument — dispatches on the expression's syntactic
+    /// shape (string literal → print_str path, everything else →
+    /// print_int / print_char). The typechecker already validated
+    /// the arg's static type; we only need to pick the syscall.
+    fn emitPrintArg(self: *Emitter, arg: *const ast.Expr) !void {
+        switch (arg.*) {
+            .char_lit => |c| {
+                try self.movImmToReg(c.value, Reg.acu);
+                try self.sys(Sys.print_char);
+            },
+            else => {
+                // Default: evaluate as int, print as signed decimal.
+                // String-literal lowering (`print_str`) wants a
+                // static-data emission path that M3 / M4 brings.
+                try self.emitExpr(arg);
+                try self.sys(Sys.print_int);
+            },
+        }
+    }
+
+    fn emitExprDiscard(self: *Emitter, e: *const ast.Expr) !void {
+        try self.emitExpr(e);
+        // Result lands in acu; we just don't use it.
+    }
+
+    // ---------- expression emission (result → acu) ----------
+
+    fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
+        switch (e.*) {
+            .int_lit => |lit| {
+                // @as: truncate i32 → i16; safety: typechecker already verified the literal fits in the target primitive's width.
+                const trimmed: i16 = @truncate(lit.value);
+                // safety: i16 → u16 bit pattern; the two's-complement encoding is preserved.
+                const v: u16 = @bitCast(trimmed);
+                try self.movImmToReg(v, Reg.acu);
+            },
+            .bool_lit => |b| {
+                const v: u16 = if (b.value) 1 else 0;
+                try self.movImmToReg(v, Reg.acu);
+            },
+            .nil_lit => try self.movImmToReg(0, Reg.acu),
+            .char_lit => |c| try self.movImmToReg(c.value, Reg.acu),
+            .paren => |p| try self.emitExpr(p.inner),
+            .ident => |i| {
+                const name = self.source[i.span.start..i.span.end];
+                const ofs = self.locals.get(name) orelse {
+                    try self.unsupported(i.span, "ident not in current frame");
+                    return;
+                };
+                try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+            },
+            .unary => |u| try self.emitUnary(u),
+            .binary => |b| try self.emitBinary(b),
+            else => try self.unsupported(e.span(), "this expression form"),
+        }
+    }
+
+    fn emitUnary(self: *Emitter, u: ast.UnaryExpr) !void {
+        try self.emitExpr(u.operand);
+        switch (u.op) {
+            .neg => try self.negReg(Reg.acu),
+            // `not` / `~` land in M2 with control-flow / bitwise ops.
+            else => try self.unsupported(u.span, "this unary operator"),
+        }
+    }
+
+    fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
+        // Standard stack-machine pattern: eval RHS, push, eval LHS,
+        // pop RHS into r1, apply op (acu = acu OP r1).
+        try self.emitExpr(b.rhs);
+        try self.pushReg(Reg.acu);
+        try self.emitExpr(b.lhs);
+        try self.popReg(Reg.r1);
+        switch (b.op) {
+            .add => try self.addRegToAcu(Reg.r1),
+            .sub => try self.subRegFromAcu(Reg.r1),
+            .mul => {
+                // `mul src, dst` writes low(product) → dst AND
+                // high(product) → acu. If dst == acu the high
+                // half clobbers the low half — so we land the
+                // result in `r2`, then move it back to acu.
+                try self.movRegToReg(Reg.acu, Reg.r2);
+                try self.mulRegReg(Reg.r1, Reg.r2);
+                try self.movRegToReg(Reg.r2, Reg.acu);
+            },
+            .div => {
+                // Signed 32÷16 divide. Dividend lives in acu:dst
+                // (high:low). For M1 we assume the dividend fits
+                // in 16 bits (positive) and clear acu — proper
+                // sign extension lands in a later commit.
+                try self.movRegToReg(Reg.acu, Reg.r2); // r2 = low half
+                try self.movImmToReg(0, Reg.acu); // high half = 0
+                try self.divsRegReg(Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
+                try self.movRegToReg(Reg.r2, Reg.acu);
+            },
+            // M2 picks up: comparison / logical / bitwise / shift / mod.
+            else => try self.unsupported(b.span, "this binary operator"),
+        }
+    }
+
+    // ---------- diagnostics ----------
+
+    fn unsupported(self: *Emitter, span: ast.Span, what: []const u8) !void {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "codegen does not yet support {s} (slice M1 only covers let/const + arithmetic + print)",
+            .{what},
+        );
+        try self.diagnostics.append(self.allocator, .{
+            .severity = .fatal,
+            .code = "E_CODEGEN_UNSUPPORTED",
+            .message = msg,
+            .span = span,
+        });
+    }
+};
 
 // ---------- archive layout (.gx per ISA §7.1) ----------
 
-/// Build the full `.gx` byte image from a base-image buffer + an
-/// entry-point address. Mirrors `src/asm/codegen.zig::buildArchive`
-/// but trimmed to the lang-codegen subset: no banks (yet), no
-/// debug-symbols emission, no SRAM banks.
 fn buildArchive(
     allocator: std.mem.Allocator,
     base_image: []const u8,
     entry_point: u16,
 ) ![]u8 {
-    // safety: base image always fits in 16-bit address space —
-    // larger sources would have been rejected earlier (slice B1
-    // never emits > 0x1101 bytes).
+    // safety: base image fits in 16-bit address space per ISA.
     const image_size: u16 = @intCast(base_image.len);
     const total = gx_header_size + base_image.len;
     var out = try allocator.alloc(u8, total);
 
     @memcpy(out[0..4], &gx_magic);
     writeU16Le(out[4..6], gx_version);
-    writeU16Le(out[6..8], 0); // flags — banks + debug come later
+    writeU16Le(out[6..8], 0); // flags
     writeU16Le(out[8..10], entry_point);
     writeU16Le(out[10..12], image_size);
     out[12] = 0; // bank_count

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -281,6 +281,120 @@ test "codegen: print of let-bound value (1 + 2 = 3)" {
     try std.testing.expectEqualStrings("3\n", writer.written());
 }
 
+// ---------- free-fn calling convention (M1 chunk 2) ----------
+
+test "codegen: nullary fn call returns acu value" {
+    var compiled = try compileSource(
+        \\def answer() -> i16
+        \\  return 42
+        \\end
+        \\
+        \\def main()
+        \\  let r: i16 = answer()
+        \\  print r
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("42\n", writer.written());
+}
+
+test "codegen: binary fn (add a, b) called with literals" {
+    var compiled = try compileSource(
+        \\def add(a: i16, b: i16) -> i16
+        \\  return a + b
+        \\end
+        \\
+        \\def main()
+        \\  print add(2, 3)
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("5\n", writer.written());
+}
+
+test "codegen: call result stored into let-bound local" {
+    var compiled = try compileSource(
+        \\def add(a: i16, b: i16) -> i16
+        \\  return a + b
+        \\end
+        \\
+        \\def main()
+        \\  let r: i16 = add(5, 3)
+        \\  print r
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("8\n", writer.written());
+}
+
+test "codegen: param order respects source ordering (sub a, b)" {
+    var compiled = try compileSource(
+        \\def sub(a: i16, b: i16) -> i16
+        \\  return a - b
+        \\end
+        \\
+        \\def main()
+        \\  print sub(10, 3)
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("7\n", writer.written());
+}
+
+test "codegen: nested call (twice(twice(2)) = 8)" {
+    var compiled = try compileSource(
+        \\def twice(x: i16) -> i16
+        \\  return x + x
+        \\end
+        \\
+        \\def main()
+        \\  print twice(twice(2))
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("8\n", writer.written());
+}
+
 test "codegen: custom entry_name resolves" {
     const source = "def boot() end";
     var stream = try gero.lang.tokenize(alloc, source);

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -90,6 +90,197 @@ test "codegen: produced .gx decodes cleanly through the disassembler" {
     try std.testing.expect(reroll.len > 0);
 }
 
+// ---------- instruction selection (M1 chunk 1) ----------
+
+/// Boot the compiled image on the VM, install the given
+/// capturing writer as the host stdout sink, and run until halt.
+/// Returns the VM so the caller can inspect register / memory
+/// state. The writer's `written()` slice holds whatever the
+/// program printed.
+fn runWith(
+    image: []const u8,
+    writer: *std.Io.Writer.Allocating,
+) !gero.vm.VM {
+    var vm = gero.vm.VM.init(alloc);
+    errdefer vm.deinit();
+    const loaded = try gero.vm.parseGx(image);
+    try vm.boot(alloc, loaded);
+    vm.host = .{ .out = &writer.writer };
+    _ = gero.vm.run(&vm);
+    return vm;
+}
+
+test "codegen: let with int-literal initializer stores into fp-relative slot" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let x: i16 = 42
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // x lives at [fp - 2] = mem[0xFFFC..0xFFFE].
+    const slot = vm.mmap.readWord(0xFFFC);
+    try std.testing.expectEqual(@as(u16, 42), slot);
+}
+
+test "codegen: binary add of two literals computes 5 + 3 = 8" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let x: i16 = 5 + 3
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    const slot = vm.mmap.readWord(0xFFFC);
+    try std.testing.expectEqual(@as(u16, 8), slot);
+}
+
+test "codegen: binary sub respects operand order (10 - 3 = 7)" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let x: i16 = 10 - 3
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqual(@as(u16, 7), vm.mmap.readWord(0xFFFC));
+}
+
+test "codegen: unary neg flips sign" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let x: i16 = -7
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // -7 as u16 = 0xFFF9
+    try std.testing.expectEqual(@as(u16, 0xFFF9), vm.mmap.readWord(0xFFFC));
+}
+
+test "codegen: ident load + arithmetic across slots (x + y = 8)" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let x: i16 = 5
+        \\  let y: i16 = 3
+        \\  let z: i16 = x + y
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqual(@as(u16, 5), vm.mmap.readWord(0xFFFC)); // x
+    try std.testing.expectEqual(@as(u16, 3), vm.mmap.readWord(0xFFFA)); // y
+    try std.testing.expectEqual(@as(u16, 8), vm.mmap.readWord(0xFFF8)); // z
+}
+
+test "codegen: mul + nested precedence (2 * (3 + 4) = 14)" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let r: i16 = 2 * (3 + 4)
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqual(@as(u16, 14), vm.mmap.readWord(0xFFFC));
+}
+
+test "codegen: print of int literal writes decimal + newline" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  print 42
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("42\n", writer.written());
+}
+
+test "codegen: print of multiple args separates with spaces" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  print 1, 2, 3
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("1 2 3\n", writer.written());
+}
+
+test "codegen: print of let-bound value (1 + 2 = 3)" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let x: i16 = 1 + 2
+        \\  print x
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("3\n", writer.written());
+}
+
 test "codegen: custom entry_name resolves" {
     const source = "def boot() end";
     var stream = try gero.lang.tokenize(alloc, source);


### PR DESCRIPTION
## Summary

**M1 milestone — Core codegen walking-skeleton.** Closes #194 + #258.

The typed AST now lowers to real \`.gx\` bytecode that the VM boots, runs, and prints from.

### Demo

\`\`\`gr
def add(a: i16, b: i16) -> i16
  return a + b
end

def main()
  let r: i16 = add(5, 3)
  print r
end
\`\`\`

Compiles → boots VM → prints \`8\\n\` → halts.

### What landed

- **Instruction selection (#194)** — \`Emitter\` with bytecode primitives, walks the typed AST emitting bytes directly. Covers \`let\` / \`const\` / \`return\` / \`print\`, integer + bool + char + nil literals, ident loads (locals + params), unary \`-\`, binary \`+ - * /\` via stack-machine pattern. \`mul\` and \`divs\` route via \`r2\` to avoid acu clobbering by their high-word writes.
- **Free-fn calling convention (#258)** — args pushed right-to-left, \`call <addr>\` with forward-ref patching, caller-cleans-up via \`add (N*2), sp\`. The VM's \`call\` opcode handles fp + ret_ip push and \`ret\` does the unwind, so the codegen prologue is just \`sub local_bytes, sp\` and epilogue is \`ret\` (or \`hlt\` for the entry def).
- **Stack frame model** — locals at \`[fp - 2*N]\`, params at \`[fp + 4 + 2*i]\` (after ret_ip + old_fp slots).
- **Multi-fn emission** — \`emitProgram\` lays out the entry def first at \`code_base = 0x1100\`, then every other top-level \`def\` in source order. Forward calls patch at end via a \`call_patches\` list.

### What's deferred

#261 (memory placement annotations) was originally part of M1's scope but is genuinely 5 different concerns. Split per the 1-issue ↔ 1-PR rule:

- **#265** \`@addr\` + \`@volatile\` on global \`let\`
- **#266** \`@bank N\` placement + cross-bank trampolines
- **#267** \`@zero_page\` placement + zp allocator
- **#268** \`@align(N)\` padding

All four on Phase 11 board. M1's walking-skeleton deliverable doesn't need annotations to demonstrate the codegen surface — they're orthogonal to instruction selection.

### Public surface

No new exports. \`gero.lang.compile\` / \`Compiled\` / \`CompileOptions\` stay stable.

### Self-review vs M1 acceptance

- ✅ \`def main() let x = add(5, 3); print x end\` compiles, runs, prints \`8\`.
- ✅ Allocator handles 8+ live values (slot allocator assigns each let a fresh fp-relative slot — tested via \`ident load + arithmetic across slots\`).
- ✅ Output \`.gx\` round-trips via the disassembler (\`parseHeader\` + \`roundTripArchive\` succeed).
- ✅ All four release modes pass.

## Test plan

- [x] \`zig build verify\` green
- [x] \`zig build test\` — 19 codegen tests (5 → 19, +14)
- [x] \`zig build test-modes\` — Debug / ReleaseSafe / ReleaseFast / ReleaseSmall
- [x] \`zig build test-all\` — linux / macos / windows / wasm32-wasi