### PR TITLE
feat(lang/codegen): cross-bank trampoline + movl byte-store (closes out the M1-annotations limitations)

### DIFF
--- a/.changeset/lang-codegen-memory-annotations.md
+++ b/.changeset/lang-codegen-memory-annotations.md
@@ -33,9 +33,31 @@ on top-level `let` / `const` / `def`.
 - **`@bank N`** — routes the annotated `def`'s bytecode into a
   per-bank emit buffer. The `.gx` archive layout grows: header
   declares `bank_count = max_bank + 1` with the `banked` flag bit
-  set, and each bank's 16 KiB buffer follows the base image (zero-
-  padded for banks the user didn't touch). Call patches that live
-  in a bank get their address slot rewritten in the right buffer.
+  set, and each bank's 16 KiB buffer follows the base image
+  (zero-padded for banks the user didn't touch). Cross-bank calls
+  route through a `__call_bank` trampoline that the codegen emits
+  at the end of the base image when needed:
+  ```
+  __call_bank:
+    push mb         ; save caller's bank
+    mov r2, mb      ; switch to target bank
+    call r1         ; jump to target
+    pop mb          ; restore caller's bank
+    ret
+  ```
+  Same-bank calls keep the direct-call shape (3 bytes vs the
+  trampoline's 11). Pre-pass over `program.statements` populates
+  `fn_banks` so `emitCall` decides direct vs trampoline without
+  needing the target's address yet (forward-ref-safe).
+
+**Byte-width global stores use `movl`**
+
+A `@addr`-pinned `let DISPCTL: u8 = 0; DISPCTL = 1` lowers to
+`movl acu, $FE40` (0x27) — a 1-byte store that leaves the
+neighboring byte untouched. Critical for MMIO where adjacent
+addresses are independent registers. Word-width globals keep the
+`mov reg, addr` (0x12) shape. The `mov_reg_to_zp` companion
+(`movl reg, zp`, 0x2B) covers zero-page byte stores symmetrically.
 
 **Assignment statement lowering**
 
@@ -44,20 +66,6 @@ targets resolving to a local, param, or global. Compound `op=`
 forms (`+=`, etc.) stay on the unsupported path — they're sugar
 that lowers via the binary-op chain and lands in M2 alongside the
 rest of control flow.
-
-**Limitations carried forward** (documented, not regressions):
-
-- `@bank N` routes bytes correctly but **does NOT** emit
-  cross-bank trampolines. Cross-bank calls require the user to
-  set `mb` to the target bank before the call; otherwise the call
-  faults at runtime. Auto-trampoline emission lands when codegen
-  has the calling-convention surface for it (M3 alongside class
-  vtables).
-- `@addr` byte stores go through the 16-bit `mov reg, addr`
-  opcode (clobbers the trailing byte). M1 doesn't need a 1-byte
-  store path because adjacent globals are placement-disjoint
-  (each binding owns its bytes); cleaner emit lands when struct
-  layout needs it.
 
 **Public surface**
 
@@ -70,7 +78,7 @@ flows them.
 
 **Tests**
 
-8 new codegen tests (19 → 27, +8):
+10 new codegen tests (19 → 29, +10):
 
 - `@addr` read + write + read-modify-write (MMIO loop).
 - `@volatile` accepted as no-op.
@@ -79,3 +87,7 @@ flows them.
 - `@align(16)` pads placement to a 16-byte boundary.
 - `@bank N` routes bytecode into bank N (verified via .gx header
   flags + the bank buffer's first bytes).
+- Cross-bank call through `__call_bank` trampoline executes end
+  to end and returns the right value.
+- Byte-store through `@addr` (via `movl`) leaves the neighboring
+  byte untouched (sentinel-check on adjacent address).

--- a/.changeset/lang-codegen-memory-annotations.md
+++ b/.changeset/lang-codegen-memory-annotations.md
@@ -33,31 +33,9 @@ on top-level `let` / `const` / `def`.
 - **`@bank N`** — routes the annotated `def`'s bytecode into a
   per-bank emit buffer. The `.gx` archive layout grows: header
   declares `bank_count = max_bank + 1` with the `banked` flag bit
-  set, and each bank's 16 KiB buffer follows the base image
-  (zero-padded for banks the user didn't touch). Cross-bank calls
-  route through a `__call_bank` trampoline that the codegen emits
-  at the end of the base image when needed:
-  ```
-  __call_bank:
-    push mb         ; save caller's bank
-    mov r2, mb      ; switch to target bank
-    call r1         ; jump to target
-    pop mb          ; restore caller's bank
-    ret
-  ```
-  Same-bank calls keep the direct-call shape (3 bytes vs the
-  trampoline's 11). Pre-pass over `program.statements` populates
-  `fn_banks` so `emitCall` decides direct vs trampoline without
-  needing the target's address yet (forward-ref-safe).
-
-**Byte-width global stores use `movl`**
-
-A `@addr`-pinned `let DISPCTL: u8 = 0; DISPCTL = 1` lowers to
-`movl acu, $FE40` (0x27) — a 1-byte store that leaves the
-neighboring byte untouched. Critical for MMIO where adjacent
-addresses are independent registers. Word-width globals keep the
-`mov reg, addr` (0x12) shape. The `mov_reg_to_zp` companion
-(`movl reg, zp`, 0x2B) covers zero-page byte stores symmetrically.
+  set, and each bank's 16 KiB buffer follows the base image (zero-
+  padded for banks the user didn't touch). Call patches that live
+  in a bank get their address slot rewritten in the right buffer.
 
 **Assignment statement lowering**
 
@@ -66,6 +44,20 @@ targets resolving to a local, param, or global. Compound `op=`
 forms (`+=`, etc.) stay on the unsupported path — they're sugar
 that lowers via the binary-op chain and lands in M2 alongside the
 rest of control flow.
+
+**Limitations carried forward** (documented, not regressions):
+
+- `@bank N` routes bytes correctly but **does NOT** emit
+  cross-bank trampolines. Cross-bank calls require the user to
+  set `mb` to the target bank before the call; otherwise the call
+  faults at runtime. Auto-trampoline emission lands when codegen
+  has the calling-convention surface for it (M3 alongside class
+  vtables).
+- `@addr` byte stores go through the 16-bit `mov reg, addr`
+  opcode (clobbers the trailing byte). M1 doesn't need a 1-byte
+  store path because adjacent globals are placement-disjoint
+  (each binding owns its bytes); cleaner emit lands when struct
+  layout needs it.
 
 **Public surface**
 
@@ -78,7 +70,7 @@ flows them.
 
 **Tests**
 
-10 new codegen tests (19 → 29, +10):
+8 new codegen tests (19 → 27, +8):
 
 - `@addr` read + write + read-modify-write (MMIO loop).
 - `@volatile` accepted as no-op.
@@ -87,7 +79,3 @@ flows them.
 - `@align(16)` pads placement to a 16-byte boundary.
 - `@bank N` routes bytecode into bank N (verified via .gx header
   flags + the bank buffer's first bytes).
-- Cross-bank call through `__call_bank` trampoline executes end
-  to end and returns the right value.
-- Byte-store through `@addr` (via `movl`) leaves the neighboring
-  byte untouched (sentinel-check on adjacent address).

--- a/.changeset/lang-codegen-trampoline-bytestore.md
+++ b/.changeset/lang-codegen-trampoline-bytestore.md
@@ -1,0 +1,77 @@
+---
+bump: minor
+---
+
+**Closes out the two limitations carried forward from the memory-
+placement annotation PR** — cross-bank calls now auto-route through
+a `__call_bank` trampoline, and byte-width global stores lower to
+`movl` so MMIO writes no longer clobber the neighboring byte.
+
+**Cross-bank call trampoline**
+
+A pre-pass over `program.statements` populates `fn_banks: StringHash
+MapUnmanaged([]const u8, ?u8)` so `emitCall` can decide direct vs
+trampoline without needing the target's address yet (forward-ref-
+safe). When the caller's bank differs from the callee's, the codegen
+emits the call sequence:
+
+```
+mov target_addr, r1   ; address of target fn
+mov target_bank, r2   ; target bank
+call __call_bank
+```
+
+and `__call_bank` (11 bytes, emitted once at the end of the base
+image when at least one cross-bank call exists) saves the caller's
+bank, switches `mb`, calls the target, and restores `mb` on return:
+
+```
+__call_bank:
+  push mb         ; save caller's bank
+  mov r2, mb      ; switch to target bank
+  call r1         ; jump to target
+  pop mb          ; restore caller's bank
+  ret
+```
+
+Same-bank calls keep the direct-call shape (3 bytes vs the
+trampoline path's setup overhead). The `CallPatch.target` union grows
+a `.trampoline` variant so the address-patching pass at the end of
+codegen resolves trampoline call sites against the `__call_bank`
+emit address.
+
+**Byte-width global stores via `movl`**
+
+`@addr`-pinned bindings of byte-width types (`u8` / `i8` / `bool` /
+`char`) now lower assignment stores to `movl acu, $XXXX` (0x27) — a
+1-byte store that leaves the neighboring byte untouched. The mirror
+case `movl reg, zp` (0x2B) covers `@zero_page` byte stores. Word-
+width globals keep the `mov reg, addr` (0x12) shape unchanged.
+
+This matters for MMIO: a `let DISPCTL: u8 = 0 @addr $FE40 @volatile;
+DISPCTL = 1` lowering used to write a 16-bit word starting at
+`$FE40`, clobbering `$FE41`. Adjacent MMIO addresses are usually
+independent registers, so the clobber would corrupt a sibling
+register on every write.
+
+**Stop-and-ask, no half-features**
+
+CLAUDE.md grows two new design-principle sections:
+
+- **No half-features, no "David GoodEnough"** — forbids "it mostly
+  works but doesn't handle case X — that's a follow-up" and "the VM
+  has a gap, so I emit suboptimal bytecode. Documented." Either the
+  feature ships complete, or it's explicitly out of scope.
+- **Stop and ask, don't assume** — forbids silently working around a
+  perceived VM gap or deferring a caveat to a follow-up. When a
+  trade-off appears, surface it: "I see two ways to do X: A or B. A
+  costs N lines, B costs M. Which one?"
+
+**Tests**
+
+2 new codegen tests (27 → 29, +2):
+
+- Cross-bank call through `__call_bank` trampoline executes end to
+  end and returns the right value.
+- Byte-store through `@addr` (via `movl`) leaves the neighboring
+  byte untouched (sentinel-check on adjacent address).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,52 @@ points, failure semantics: all decided up front.
 Implementation can stage across PRs; the **spec** describes the
 final shape from day one.
 
+### No half-features, no "David GoodEnough"
+
+When an issue is scoped, **finish it.** A feature is either fully
+implemented or explicitly cut from scope at the start — not half-
+implemented and shipped under a "Limitations carried forward"
+section in the changeset / PR.
+
+Specifically forbidden:
+
+- ❌ "It mostly works but doesn't handle case X — that's a follow-
+  up." If case X is in the issue's AC, do it. If it shouldn't be,
+  argue for cutting it from the AC before starting work.
+- ❌ "There's a VM gap, so I emit suboptimal bytecode. Documented."
+  If the VM gap blocks a clean implementation, extend the VM in
+  the same PR (or split honestly with the user's go-ahead).
+- ❌ "Trampolines are complex — the user can manually set
+  the register before calling." If the spec promises automatic
+  behavior, deliver it.
+
+The instinct to ship something almost-complete is paved with the
+phrase "good enough." It isn't. Ship complete or scope down
+honestly with explicit user approval.
+
+### Stop and ask, don't assume
+
+When you hit an open question — scope, design choice, whether a
+limitation is acceptable, whether to defer something — **stop and
+ask.** Do not silently choose the path of least effort and ship a
+half-feature.
+
+- ❌ "I'll just defer this caveat to a follow-up and document it
+  in the changeset." That's unilateral scope reduction without
+  permission.
+- ❌ "The VM doesn't have this opcode, so I'll work around it."
+  Surface the gap, ask whether to extend the VM.
+- ❌ Pretending a half-fix is complete in the PR description while
+  burying the limitation in a "carried forward" footnote.
+- ✅ "I see two ways to do X: A or B. A costs N lines, B costs M.
+  Which one?"
+- ✅ "Issue says Y, but the VM lacks the primitive for Y. Do I
+  extend the VM in this PR or scope Y out?"
+
+The cost of a 30-second clarifying question is much smaller than
+the cost of an architecturally-wrong implementation that ships and
+has to be unwound later.
+
 ## Imports
 
 - **Single-level relative imports** — `../foo.zig` or `./foo.zig`.

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -4,14 +4,21 @@
 /// the `CheckedProgram` from `typecheck.zig` and produces a `.gx`
 /// archive ready for the VM loader (`gero.vm.parseGx`) per ISA §7.
 ///
-/// **M1 scope** (this slice — codegen walking-skeleton):
-/// instruction selection for the entry def's body — `let` /
-/// `const`, integer literals, ident loads, binary arithmetic,
-/// unary neg, `print int_expr`, `return`. Locals live in
-/// fp-relative stack slots; expression evaluation uses
-/// `acu` + `r1` with push/pop for spills. Calling convention
-/// for free fns + memory-placement annotations land in
-/// subsequent M1 commits.
+/// **M1 surface** (instruction selection + free-fn calling
+/// convention + memory-placement annotations):
+///   - Statements: `let` / `const` / `return` / `print` /
+///     `target = value` / discard / expression statements.
+///   - Expressions: literals, idents (local + param + global),
+///     unary neg, binary `+ - * /`, direct calls.
+///   - Stack frames: locals at `[fp - 2*N]`, params at
+///     `[fp + 4 + 2*i]`; the VM's `call` / `ret` handle the
+///     ret_ip + fp push / pop.
+///   - Globals: top-level `let` / `const` with optional
+///     `@addr` / `@volatile` / `@zero_page` / `@align(N)`
+///     placement annotations. Byte-width globals use `movl`.
+///   - Banks: `@bank N` routes defs into per-bank buffers;
+///     cross-bank calls go through a `__call_bank` trampoline
+///     in the base image.
 const std = @import("std");
 const ast = @import("ast.zig");
 const typecheck_mod = @import("typecheck.zig");

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -64,8 +64,8 @@ const Op = struct {
     const mov_zp_to_reg: u8 = 0x1A; // load:  reg ← [zp] (word)
     const mov8_addr_to_reg: u8 = 0x22; // load:  reg ← byte [addr]
     const mov8_zp_to_reg: u8 = 0x29; // load:  reg ← byte [zp]
-    const mov8_imm_to_zp: u8 = 0x28; // store: byte at [zp] ← imm
-    const mov8_imm_to_addr: u8 = 0x20; // store: byte at [addr] ← imm
+    const movl_reg_to_addr: u8 = 0x27; // store: [addr] ← reg.lo  (byte store)
+    const movl_reg_to_zp: u8 = 0x2B; // store: [zp]   ← reg.lo  (byte store)
 
     const push_reg: u8 = 0x31;
     const pop_reg: u8 = 0x32;
@@ -79,6 +79,7 @@ const Op = struct {
     const divs_reg_reg: u8 = 0x4E; // dst ← dst / src (signed)
 
     const call_addr: u8 = 0xA0;
+    const call_reg: u8 = 0xA1;
     const ret_op: u8 = 0xA2;
 
     const sys: u8 = 0xFB;
@@ -92,6 +93,7 @@ const Reg = struct {
     const r2: u8 = 0x03;
     const sp: u8 = 0x0A;
     const fp: u8 = 0x0B;
+    const mb: u8 = 0x0C;
 };
 
 /// `sys` syscall ids per `src/vm/handlers/system.zig::SyscallId`.
@@ -177,6 +179,8 @@ pub fn compile(
         .frame_bytes = 0,
         .is_entry = false,
         .fn_addresses = .{},
+        .fn_banks = .{},
+        .trampoline_addr = null,
         .call_patches = .empty,
         .globals = .{},
         .data_cursor = data_base,
@@ -235,17 +239,25 @@ fn findEntryDef(source: []const u8, program: *const ast.Program, entry_name: []c
 /// `code` is overwritten with the resolved callee address.
 const CallPatch = struct {
     /// Which buffer the patch lives in — `null` = base code,
-    /// non-null = bank N's buffer. The patcher uses this to
-    /// find the right ArrayList.
+    /// non-null = bank N's buffer.
     bank: ?u8,
     /// Byte offset into the resolved buffer where the 2-byte LE
-    /// address slot lives (right after the `0xA0` opcode).
+    /// address slot lives.
     code_offset: usize,
-    /// Callee fn name to resolve via `fn_addresses`.
-    callee_name: []const u8,
+    /// What address to write into the slot at patch time.
+    target: Target,
     /// Span of the original call expression — used to anchor the
     /// `E_CODEGEN_UNDEFINED_FN` diagnostic on resolve failure.
     span: ast.Span,
+
+    /// Patch-target kinds:
+    /// - `fn_name`: resolve via the codegen's `fn_addresses` map.
+    /// - `trampoline`: resolve to the `__call_bank` trampoline's
+    ///   address, recorded after the trampoline emits.
+    const Target = union(enum) {
+        fn_name: []const u8,
+        trampoline,
+    };
 };
 
 /// One top-level `let` / `const` global. Address is decided during
@@ -294,10 +306,21 @@ const Emitter = struct {
     /// `push fp` / `mov sp, fp` parts of the prologue (the VM
     /// boots with `fp == sp`).
     is_entry: bool,
-    /// Top-level `def` name → absolute address in the base image
-    /// (`code_base + offset`). Populated as defs are emitted in
-    /// source order so calls patch correctly.
+    /// Top-level `def` name → absolute address. Populated as defs
+    /// are emitted in source order so calls patch correctly. For
+    /// banked defs, the recorded address sits in the bank window
+    /// (`bank_window_base + offset`); for un-banked defs, it sits
+    /// in the base image (`code_base + offset`).
     fn_addresses: std.StringHashMapUnmanaged(u16),
+    /// Top-level `def` name → the bank it lives in (or `null`
+    /// for the base image). Populated in a pre-pass over
+    /// `program.statements` BEFORE emission, so `emitCall` knows
+    /// the target's bank when deciding direct-call vs trampoline.
+    fn_banks: std.StringHashMapUnmanaged(?u8),
+    /// Address of the `__call_bank` trampoline in the base image
+    /// after emission. `null` until the trampoline is emitted —
+    /// trampoline-target call patches resolve against this.
+    trampoline_addr: ?u16,
     /// Unresolved `call addr` sites — recorded when the callee's
     /// address isn't known yet (forward references). Rewritten at
     /// the end of `emitProgram`.
@@ -437,6 +460,22 @@ const Emitter = struct {
         try self.emitByte(dst);
     }
 
+    /// `movl reg, [addr]` (0x27) — store reg's low byte to addr.
+    /// Used for 1-byte global stores so neighboring bytes stay
+    /// untouched (critical for MMIO).
+    fn movlRegToAddr(self: *Emitter, src: u8, addr: u16) !void {
+        try self.emitByte(Op.movl_reg_to_addr);
+        try self.emitByte(src);
+        try self.emitU16Le(addr);
+    }
+
+    /// `movl reg, [zp]` (0x2B) — store reg's low byte to zp slot.
+    fn movlRegToZp(self: *Emitter, src: u8, zp: u8) !void {
+        try self.emitByte(Op.movl_reg_to_zp);
+        try self.emitByte(src);
+        try self.emitByte(zp);
+    }
+
     /// `push reg` (0x31).
     fn pushReg(self: *Emitter, reg: u8) !void {
         try self.emitByte(Op.push_reg);
@@ -540,11 +579,12 @@ const Emitter = struct {
     /// header `entry_point`), then every other top-level `def` in
     /// source order, then patch unresolved call sites.
     fn emitProgram(self: *Emitter, program: *const ast.Program, entry_name: []const u8) !void {
-        // Pre-pass: register every top-level `let` / `const` with
-        // its resolved address. `@addr` literal wins, then
-        // `@zero_page` (bumps `zp_cursor`), else dynamic data
-        // region (bumps `data_cursor`).
+        // Pre-pass 1: register globals (top-level let/const).
         try self.registerGlobals(program);
+        // Pre-pass 2: collect each def's bank so `emitCall` can
+        // decide direct-call vs trampoline without needing the
+        // target's address yet.
+        try self.collectDefBanks(program);
 
         const entry = findEntryDef(self.source, program, entry_name).?;
         try self.emitDef(entry, .entry);
@@ -552,7 +592,85 @@ const Emitter = struct {
             .def_decl => |*dd| if (dd != entry) try self.emitDef(dd, .regular),
             else => {},
         };
+
+        // Emit the `__call_bank` trampoline only if at least one
+        // cross-bank call site asked for it (saves 10 bytes when
+        // the program is entirely un-banked or single-bank).
+        if (self.needsTrampoline()) try self.emitCallBankTrampoline();
+
         try self.patchCalls();
+    }
+
+    /// Scan top-level `def`s, recording each name → its `@bank N`
+    /// annotation (or `null` for base-image defs).
+    fn collectDefBanks(self: *Emitter, program: *const ast.Program) !void {
+        for (program.statements) |*stmt| switch (stmt.*) {
+            .def_decl => |*dd| {
+                const name = self.source[dd.name.start..dd.name.end];
+                const dup = try self.arena.dupe(u8, name);
+                var bank: ?u8 = null;
+                for (dd.annotations) |ann| {
+                    const ann_name = self.source[ann.name.start..ann.name.end];
+                    if (std.mem.eql(u8, ann_name, "bank") and ann.args.len == 1 and ann.args[0].* == .int_lit) {
+                        // @as: typechecker enforces u8 range on `@bank N`.
+                        bank = @intCast(ann.args[0].int_lit.value & 0xFF);
+                    }
+                }
+                try self.fn_banks.put(self.arena, dup, bank);
+            },
+            else => {},
+        };
+    }
+
+    /// `true` when any unresolved call patch targets the
+    /// trampoline. We only emit the trampoline body when at least
+    /// one call site needs it — keeps single-bank programs lean.
+    fn needsTrampoline(self: *const Emitter) bool {
+        for (self.call_patches.items) |p| switch (p.target) {
+            .trampoline => return true,
+            else => {},
+        };
+        return false;
+    }
+
+    /// Emit the `__call_bank` trampoline at the current base-
+    /// image cursor. Caller sets up `r1 = target_addr`,
+    /// `r2 = target_bank`, then `call __call_bank`. The trampoline
+    /// saves the caller's `mb`, switches to the target bank, calls
+    /// through `r1`, restores `mb`, and `ret`s back.
+    ///
+    /// Layout (10 bytes):
+    ///   push mb         ; 31 0C
+    ///   mov r2, mb      ; 11 03 0C
+    ///   call r1         ; A1 02
+    ///   pop mb          ; 32 0C
+    ///   ret             ; A2
+    fn emitCallBankTrampoline(self: *Emitter) !void {
+        // The trampoline must live in the base image (always
+        // reachable regardless of `mb`). Save / restore the
+        // bank-routing state explicitly even though we expect the
+        // caller to be in the base buffer already.
+        const saved_bank = self.current_bank;
+        self.current_bank = null;
+        defer self.current_bank = saved_bank;
+
+        // @as: narrow usize → u16; base image fits in 64 KiB.
+        const tramp_offset: u16 = @intCast(self.code.items.len);
+        self.trampoline_addr = code_base + tramp_offset;
+
+        // push mb
+        try self.emitByte(Op.push_reg);
+        try self.emitByte(Reg.mb);
+        // mov r2, mb
+        try self.movRegToReg(Reg.r2, Reg.mb);
+        // call r1
+        try self.emitByte(Op.call_reg);
+        try self.emitByte(Reg.r1);
+        // pop mb
+        try self.emitByte(Op.pop_reg);
+        try self.emitByte(Reg.mb);
+        // ret
+        try self.emitByte(Op.ret_op);
     }
 
     /// Pre-pass over top-level statements that registers every
@@ -695,19 +813,27 @@ const Emitter = struct {
         }
     }
 
-    /// Emit a store of `src` reg's value into `g`'s slot. Only the
-    /// 16-bit `mov` opcodes are exposed today; 1-byte stores fall
-    /// back to the 16-bit form which clobbers the trailing byte —
-    /// acceptable for slice M1 since the byte's neighbor is also
-    /// part of `g`'s slot (the allocator places adjacent bindings
-    /// with their own widths).
+    /// Emit a store of `src` reg's value into `g`'s slot. Byte-
+    /// width globals use `movl` (low-byte store) so the
+    /// neighboring byte stays untouched — critical for MMIO where
+    /// adjacent addresses are distinct registers.
     fn emitGlobalStore(self: *Emitter, src: u8, g: Global) !void {
         switch (g.placement) {
-            .addr, .data => try self.movRegToAddr(src, g.address),
+            .addr, .data => {
+                if (g.width == 1) {
+                    try self.movlRegToAddr(src, g.address);
+                } else {
+                    try self.movRegToAddr(src, g.address);
+                }
+            },
             .zero_page => {
                 // @as: zero-page address fits in u8; placement.zero_page guarantees address ≤ 0xFF.
                 const zp: u8 = @intCast(g.address);
-                try self.movRegToZp(src, zp);
+                if (g.width == 1) {
+                    try self.movlRegToZp(src, zp);
+                } else {
+                    try self.movRegToZp(src, zp);
+                }
             },
         }
     }
@@ -817,19 +943,22 @@ const Emitter = struct {
     /// first) but the check keeps the codegen defensive.
     fn patchCalls(self: *Emitter) !void {
         for (self.call_patches.items) |p| {
-            const target = self.fn_addresses.get(p.callee_name) orelse {
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "codegen: call target `{s}` is not a known top-level def",
-                    .{p.callee_name},
-                );
-                try self.diagnostics.append(self.allocator, .{
-                    .severity = .fatal,
-                    .code = "E_CODEGEN_UNDEFINED_FN",
-                    .message = msg,
-                    .span = p.span,
-                });
-                continue;
+            const target_addr: u16 = switch (p.target) {
+                .fn_name => |name| self.fn_addresses.get(name) orelse {
+                    const msg = try std.fmt.allocPrint(
+                        self.arena,
+                        "codegen: call target `{s}` is not a known top-level def",
+                        .{name},
+                    );
+                    try self.diagnostics.append(self.allocator, .{
+                        .severity = .fatal,
+                        .code = "E_CODEGEN_UNDEFINED_FN",
+                        .message = msg,
+                        .span = p.span,
+                    });
+                    continue;
+                },
+                .trampoline => self.trampoline_addr orelse continue,
             };
             // Resolve which buffer holds this patch — base or
             // one of the bank ArrayLists.
@@ -839,8 +968,8 @@ const Emitter = struct {
                 self.code.items;
             // Overwrite the 2-byte LE address slot.
             // safety: u16 → 2 bytes by definition; both casts are byte-masks.
-            buf[p.code_offset] = @intCast(target & 0xFF);
-            buf[p.code_offset + 1] = @intCast(target >> 8);
+            buf[p.code_offset] = @intCast(target_addr & 0xFF);
+            buf[p.code_offset + 1] = @intCast(target_addr >> 8);
         }
     }
 
@@ -1064,7 +1193,16 @@ const Emitter = struct {
             try self.unsupported(c.span, "non-ident callee");
             return;
         }
-        // Push args right-to-left.
+        const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+        const dup = try self.arena.dupe(u8, callee_name);
+
+        // Decide direct call vs trampoline by comparing the
+        // caller's bank with the target's. The pre-pass populated
+        // `fn_banks` so this resolves without needing the address.
+        const target_bank: ?u8 = self.fn_banks.get(callee_name) orelse null;
+        const cross_bank = !banksEqual(self.current_bank, target_bank);
+
+        // Push args right-to-left (caller-cleans-up).
         var i: usize = c.args.len;
         while (i > 0) {
             i -= 1;
@@ -1072,24 +1210,50 @@ const Emitter = struct {
             try self.pushReg(Reg.acu);
         }
 
-        // Emit `call <addr>` with a placeholder address; the
-        // patching pass rewrites it once every def's address is
-        // known.
-        try self.emitByte(Op.call_addr);
-        const patch_offset = try self.currentOffset();
-        try self.emitU16Le(0); // placeholder
-        const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
-        const dup = try self.arena.dupe(u8, callee_name);
-        try self.call_patches.append(self.allocator, .{
-            .bank = self.current_bank,
-            .code_offset = patch_offset,
-            .callee_name = dup,
-            .span = c.span,
-        });
+        if (cross_bank) {
+            // Trampoline path:
+            //   mov <target_addr>, r1   ; patched at end
+            //   mov <target_bank>,  r2  ; literal at emit time
+            //   call __call_bank        ; patched at end
+            try self.emitByte(Op.mov_imm16_reg);
+            const addr_patch_offset = try self.currentOffset();
+            try self.emitU16Le(0); // placeholder
+            try self.emitByte(Reg.r1);
+            // mov <bank>, r2  — bank known at emit time (null → 0).
+            const target_bank_byte: u8 = target_bank orelse 0;
+            try self.movImmToReg(target_bank_byte, Reg.r2);
+            // call __call_bank  (patched at end)
+            try self.emitByte(Op.call_addr);
+            const tramp_patch_offset = try self.currentOffset();
+            try self.emitU16Le(0);
 
-        // Caller-cleans-up the pushed args.
+            try self.call_patches.append(self.allocator, .{
+                .bank = self.current_bank,
+                .code_offset = addr_patch_offset,
+                .target = .{ .fn_name = dup },
+                .span = c.span,
+            });
+            try self.call_patches.append(self.allocator, .{
+                .bank = self.current_bank,
+                .code_offset = tramp_patch_offset,
+                .target = .trampoline,
+                .span = c.span,
+            });
+        } else {
+            // Direct same-bank call.
+            try self.emitByte(Op.call_addr);
+            const patch_offset = try self.currentOffset();
+            try self.emitU16Le(0); // placeholder
+            try self.call_patches.append(self.allocator, .{
+                .bank = self.current_bank,
+                .code_offset = patch_offset,
+                .target = .{ .fn_name = dup },
+                .span = c.span,
+            });
+        }
+
         if (c.args.len > 0) {
-            // @as: each arg is one 16-bit word.
+            // @as: each arg is one 16-bit word; arg count capped by parser.
             const drop_bytes: u16 = @intCast(c.args.len * 2);
             try self.addImmToReg(drop_bytes, Reg.sp);
         }
@@ -1198,4 +1362,13 @@ fn alignUpU16(value: u16, align_n: u16) u16 {
     if (align_n <= 1) return value;
     const mask: u16 = align_n - 1;
     return (value + mask) & ~mask;
+}
+
+/// `true` when two optional bank tags refer to the same code
+/// location — both `null` (base image) or both wrapping the same
+/// bank index.
+fn banksEqual(a: ?u8, b: ?u8) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return a.? == b.?;
 }

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -598,6 +598,64 @@ test "codegen: @bank N routes a def's bytecode into bank N's buffer" {
     try std.testing.expectEqual(@as(u8, 0), bank2[2]); // high byte
 }
 
+test "codegen: cross-bank call goes through __call_bank trampoline + executes correctly" {
+    var compiled = try compileSource(
+        \\@bank 2
+        \\def town() -> i16
+        \\  return 42
+        \\end
+        \\
+        \\def main()
+        \\  let r: i16 = town()
+        \\  print r
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    // The full pipeline must boot, switch into bank 2 via the
+    // trampoline, fetch the literal, return to main, and print
+    // `42\n`.
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("42\n", writer.written());
+}
+
+test "codegen: byte-store to @addr global uses movl (does not clobber adjacent byte)" {
+    var compiled = try compileSource(
+        \\@addr $FE40
+        \\let DISPCTL: u8 = 0
+        \\
+        \\def main()
+        \\  DISPCTL = 1
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+
+    var vm = gero.vm.VM.init(alloc);
+    defer vm.deinit();
+    const loaded = try gero.vm.parseGx(compiled.image);
+    try vm.boot(alloc, loaded);
+    vm.host = .{ .out = &writer.writer };
+    // Pre-seed $FE41 with a sentinel — the byte store must NOT
+    // overwrite it (that would mean we emitted the 16-bit mov).
+    vm.mmap.writeByte(0xFE41, 0xAB);
+    _ = gero.vm.run(&vm);
+
+    try std.testing.expectEqual(@as(u8, 1), vm.mmap.readByte(0xFE40));
+    try std.testing.expectEqual(@as(u8, 0xAB), vm.mmap.readByte(0xFE41));
+}
+
 test "codegen: custom entry_name resolves" {
     const source = "def boot() end";
     var stream = try gero.lang.tokenize(alloc, source);


### PR DESCRIPTION
## Summary

Closes out the two limitations carried forward from PR #270
(memory-placement annotations). PR #270 merged before these
landed, so this is the follow-up that completes M1 honestly —
no more "Limitations carried forward" section.

## What lands

**Cross-bank call trampoline** — a pre-pass over `program.statements`
populates `fn_banks: StringHashMapUnmanaged([]const u8, ?u8)` so
`emitCall` can decide direct vs trampoline without needing the
target's address yet (forward-ref-safe). When the caller's bank
differs from the callee's, codegen emits the call sequence:

```
mov target_addr, r1
mov target_bank, r2
call __call_bank
```

and `__call_bank` (11 bytes, emitted once at the end of the base
image when at least one cross-bank call exists) saves `mb`,
switches it, calls the target, and restores `mb` on return:

```
__call_bank:
  push mb
  mov r2, mb
  call r1
  pop mb
  ret
```

Same-bank calls keep the direct-call shape. The `CallPatch.target`
union grows a `.trampoline` variant so the address-patching pass
resolves trampoline call sites against `__call_bank`'s emit
address.

**Byte-width global stores via `movl`** — `@addr`-pinned bindings
of byte-width types (`u8` / `i8` / `bool` / `char`) lower
assignment stores to `movl acu, $XXXX` (0x27) — a 1-byte store
that leaves the neighboring byte untouched. The mirror case
`movl reg, zp` (0x2B) covers `@zero_page` byte stores. Word-width
globals keep the `mov reg, addr` (0x12) shape unchanged. This
matters for MMIO: adjacent MMIO addresses are usually independent
registers, so a 16-bit store at `$FE40` would silently corrupt
`$FE41`.

**CLAUDE.md — two new design principles** under "Complete designs,
no deferral":

- **No half-features, no "David GoodEnough"** — forbids "it
  mostly works but doesn't handle case X — that's a follow-up"
  and "VM has a gap, so I emit suboptimal bytecode. Documented."
- **Stop and ask, don't assume** — forbids silently working around
  a perceived VM gap or deferring a caveat to a follow-up.
  Surface the trade-off, ask for direction.

## Tests

2 new codegen tests (27 → 29, +2):

- Cross-bank call through `__call_bank` trampoline executes end
  to end and returns the right value.
- Byte-store through `@addr` (via `movl`) leaves the neighboring
  byte untouched (sentinel-check on adjacent address).

## Test plan

- [x] `zig build verify` green
- [x] `zig build test-modes` green (Debug / ReleaseSafe / Fast / Small)
- [x] `zig build test-all` green (linux / macos / windows / wasi)
- [x] New changeset present (`lang-codegen-trampoline-bytestore.md`)
- [x] No AI attribution in commits