### PR TITLE
feat(lang): M3a foundations — nullary enums + mem stdlib + &T reference codegen

### DIFF
--- a/.changeset/lang-codegen-m3a.md
+++ b/.changeset/lang-codegen-m3a.md
@@ -1,0 +1,115 @@
+---
+bump: minor
+---
+
+Closes #222 + nullary half of #195. Advances #216. **M3a
+milestone (codegen foundations)** — adds enum codegen for
+nullary variants, the `mem.*` stdlib (typed peek/poke +
+memcpy/memset + addr_of), and the typed-reference (`&T`)
+codegen. The class-vtable + closure pieces ride in M3b
+alongside the shared heap allocator.
+
+**Enum codegen (nullary variants — full payload variants are
+M3b)**
+
+- Typecheck: `resolveEnumVariant` recognizes `EnumName.Variant`
+  field expressions on receivers matching a registered enum.
+  Nullary variants resolve directly to the enum's `Named` type;
+  payload-bearing variants synthesize a `fn(payload) -> Enum`
+  signature for the wrapping `CallExpr`. Unknown variant names
+  emit `E_TYPE_UNDEFINED_VARIANT`.
+- Codegen: `collectEnumDecls` pre-pass indexes every top-level
+  enum by name. `variantTag` resolves names to their
+  declaration-order tag index (matches spec §3.6 — `Sword=0,
+  Potion=1, Key=2`). `emitFieldExpr` lowers a nullary
+  `EnumName.Variant` to `mov tag, acu`. `emitIsTest` lowers
+  `expr is EnumName.Variant` to evaluate-LHS + `cmp` +
+  materialize-bool. `emitPatternTest` grows a `.variant_pattern`
+  arm — `cmp acu, tag; jne skip` per arm. Composes with the
+  existing OR-dedup / range / guard machinery.
+
+**`mem` stdlib (#222 — every typed read/write + memcpy/memset
++ addr_of + peek/poke)**
+
+- Typecheck: `mem` is a compiler-recognized module rather than
+  a source module. The receiver-`mem` shape on field
+  expressions + method calls dispatches through
+  `resolveMemBuiltin` / `checkMemMethodCall`, which validates
+  arity + per-arg types against the builtin's declared
+  signature and synthesizes a function type so the wrapping
+  call flows through the regular type-check path.
+- Codegen: `emitMethodCall` intercepts `mem.X(args)` shapes and
+  dispatches per builtin:
+  - `read_u8`, `peek` → `mov8 [r1], acu` (zero-extend byte
+    load).
+  - `read_u16`, `read_i16` → `mov [r1], acu` (word load).
+  - `read_i8` → `mov8 [r1], acu; shl 8 acu; asr 8 acu` (sign-
+    extend byte to i16).
+  - `write_u8`, `write_i8`, `poke` → `mov8 acu, [r1]` (byte
+    store).
+  - `write_u16`, `write_i16` → `mov [r1], acu` (word store).
+  - `memcpy(dst, src, n)` → `bcpy r1, r2, r3` (opcode 0x2C).
+  - `memset(dst, v, n)` → `bfill r1, r3, r2` (opcode 0x2D).
+  - `addr_of(x)` → ident-only for M3a; emits `mov fp, acu`
+    + `add/sub ofs, acu` for locals / params, `mov global_addr,
+    acu` for static-data bindings.
+
+**Reference codegen (#216 — `&x` expression, type tracking)**
+
+- `&local` / `&param` / `&global` lowers to the address-
+  computation the codegen reuses for `mem.addr_of(x)`. The
+  reference's runtime representation is a 16-bit address.
+- Type-level: `checkRefOf` already rejects `&temp`, `&(a+b)`,
+  `&&T`, and `return &local`. M3a doesn't add new typecheck
+  rules — it wires up the codegen path.
+- Auto-deref on field / method access lands with M3b's
+  struct + class layout. M3a's references are useful for
+  passing addresses around (paired with `mem.write_*` /
+  `mem.read_*`); compound-type field access waits.
+
+**Codegen surface cleanups**
+
+- `MethodCallExpr` (parser shape for `recv.method(args)`) now
+  has a codegen arm — previously fell through to
+  "unsupported expression form". M3a only handles the
+  `mem.X` receiver; class methods land in M3b.
+- `CastExpr` (`x as T`) lowers as a no-op for same-width
+  primitives (the bit pattern is identical between the
+  primitive width set M3a supports). Narrowing / fixed-point
+  conversions stay typecheck-only until ISA-level widening
+  ops land.
+- `Compiled.diag_arena` — codegen diagnostics now allocate
+  their message strings on an arena that lives past the
+  `compile` call. Pre-existing dangling-pointer bug;
+  surfaced by the new tests that print diagnostic messages.
+
+**Tests**
+
+15 new codegen tests (71 → 86, +15):
+
+- Nullary enum constructor stores tag byte.
+- `is` test fires on the matching variant.
+- 3-arm match on nullary enum dispatches by tag.
+- `mem.write_u8` + `mem.read_u8` round-trip.
+- `mem.write_u16` + `mem.read_u16` preserve little-endian
+  byte order.
+- `mem.read_i8` sign-extends `255` to `-1`.
+- `mem.poke` + `mem.peek` aliases work identically.
+- `mem.memcpy` copies 3 bytes between data slots.
+- `mem.memset` fills 3 bytes with one value.
+- `mem.addr_of(local)` returns the stack-slot address.
+- `mem.addr_of(global)` returns the static address.
+- `&x` produces the same address as `mem.addr_of(x)`.
+- `&(a + b)` is rejected by typecheck.
+- Undefined `mem.X` surfaces `E_TYPE_UNDEFINED_METHOD`.
+- Undefined enum variant in `is` rhs surfaces
+  `E_CODEGEN_UNDEFINED_VARIANT`.
+
+**Out of scope (M3b follow-up PR)**
+
+- Enum payload variants + payload destructuring in `match`.
+- Class vtables, virtual dispatch, `self` / `super`.
+- Closures + capture analysis + heap-promoted cells.
+- VM bump allocator (shared by classes + closures).
+- Auto-deref on `r.field` / `r.method()` (rides with struct
+  + class field codegen).

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -42,6 +42,10 @@ pub const scope = scope_mod;
 pub const CheckedProgram = typecheck_mod.CheckedProgram;
 /// Re-export: walk an `ast.Program` through the typechecker.
 pub const typecheck = typecheck_mod.typecheck;
+/// Re-export: typechecker module barrel — `gero.lang.typecheck`
+/// already names the entry-point function so sub-module access
+/// goes through this alias.
+pub const typechecker = typecheck_mod;
 
 /// Re-export: rich diagnostic shape carried by `CheckedProgram`.
 pub const Diagnostic = diag_mod.Diagnostic;

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -56,6 +56,10 @@ pub const archive = @import("codegen/archive.zig");
 /// `mem.*` stdlib builtin lowering — typed peek / poke,
 /// memcpy / memset, addr-of.
 pub const mem_builtin = @import("codegen/mem_builtin.zig");
+/// String literal pool + interpolation lowering — `InternedString`,
+/// `StringPatch`, the interp buffer reservation, and the per-part
+/// fill helpers.
+pub const strings = @import("codegen/strings.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const CheckedProgram = typecheck_mod.CheckedProgram;
@@ -80,13 +84,8 @@ pub const data_base: u16 = 0x2000;
 
 const bank_window_base = archive.bank_window_base;
 
-/// Bytes reserved per interpolated-string buffer in the data
-/// region. Sized for the worst common case (a few interp values
-/// + surrounding literal text). Programs that need larger
-/// interpolations should compose with explicit concatenation —
-/// the codegen rejects the formatted result at runtime if it
-/// overflows (the VM doesn't bounds-check the buffer writes).
-const interp_buffer_size: u16 = 64;
+const InternedString = strings.InternedString;
+const StringPatch = strings.StringPatch;
 
 // ---------- public surface ----------
 
@@ -269,25 +268,6 @@ const CallPatch = struct {
     };
 };
 
-/// One interned string literal — emitted as a null-terminated byte
-/// run at the end of the base image. Multiple call sites that
-/// reference the same byte content share one entry; the `address`
-/// field carries the resolved RAM address after the pool emits.
-const InternedString = struct {
-    bytes: []const u8,
-    address: u16,
-};
-
-/// Forward reference to a string literal — recorded when an emit
-/// site needs to load the string's address into a register but the
-/// pool hasn't been laid out yet. The `code_offset` is the 2-byte
-/// `mov imm16, reg` operand slot waiting for the resolved address.
-const StringPatch = struct {
-    bank: ?u8,
-    code_offset: usize,
-    string_id: usize,
-};
-
 /// One lexical block tracked at codegen time. Owns the LIFO list of
 /// `defer` statements registered within the block so the codegen can
 /// re-emit them at every exit path (fall-through, `return`, `break`,
@@ -459,7 +439,9 @@ pub const Emitter = struct {
     /// Byte offset of the next emission within the current code
     /// buffer. Used to record `fn_addresses` + `call_patches` at
     /// the right position.
-    fn currentOffset(self: *Emitter) !usize {
+    /// Current byte cursor inside the active code buffer — used
+    /// by sub-modules to record patch sites.
+    pub fn currentOffset(self: *Emitter) !usize {
         const buf = try self.currentCode();
         return buf.items.len;
     }
@@ -747,7 +729,9 @@ pub const Emitter = struct {
     }
 
     /// `sys imm8` (0xFB).
-    fn sys(self: *Emitter, id: u8) !void {
+    /// `sys imm8` (0xFB) — host-callback syscall, identifier in
+    /// the immediate operand byte.
+    pub fn sys(self: *Emitter, id: u8) !void {
         try self.emitByte(Op.sys);
         try self.emitByte(id);
     }
@@ -866,69 +850,24 @@ pub const Emitter = struct {
         try self.patchStrings();
     }
 
-    /// Lay out every interned string at the end of the base buffer.
-    /// Each entry gets its bytes plus a trailing null terminator (the
-    /// VM's `print_str` syscall reads until `\0`). Records the
-    /// resolved address into the pool entry.
+    /// Delegated to `codegen/strings.zig`.
     fn emitStringPool(self: *Emitter) !void {
-        // Strings live in the base image so banked code can still
-        // address them (banks only cover `0xC000..0xFEFF`). Save +
-        // restore the buffer-routing so callers in a banked def
-        // still emit into the base buffer here.
-        const saved_bank = self.current_bank;
-        self.current_bank = null;
-        defer self.current_bank = saved_bank;
-
-        for (self.strings.items) |*s| {
-            // @as: usize → u16; base image fits in 16-bit address space.
-            const offset: u16 = @intCast(try self.currentOffset());
-            s.address = code_base +% offset;
-            for (s.bytes) |b| try self.emitByte(b);
-            try self.emitByte(0);
-        }
+        return strings.emitStringPool(self);
     }
 
-    /// Rewrite each `StringPatch`'s 2-byte LE address slot with the
-    /// resolved string address.
+    /// Delegated to `codegen/strings.zig`.
     fn patchStrings(self: *Emitter) !void {
-        for (self.string_patches.items) |p| {
-            const addr = self.strings.items[p.string_id].address;
-            const buf: []u8 = if (p.bank) |b|
-                if (self.banks.getPtr(b)) |bl| bl.items else continue
-            else
-                self.code.items;
-            // safety: u16 → 2 bytes by definition; byte-mask casts.
-            buf[p.code_offset] = @intCast(addr & 0xFF);
-            buf[p.code_offset + 1] = @intCast(addr >> 8);
-        }
+        return strings.patchStrings(self);
     }
 
-    /// Intern a byte string by content. Returns the index into
-    /// `strings`. Callers that need the address use a `StringPatch`
-    /// since the pool isn't laid out until the end of `emitProgram`.
+    /// Delegated to `codegen/strings.zig`.
     fn internString(self: *Emitter, bytes: []const u8) !usize {
-        for (self.strings.items, 0..) |s, i| {
-            if (std.mem.eql(u8, s.bytes, bytes)) return i;
-        }
-        const owned = try self.arena.dupe(u8, bytes);
-        try self.strings.append(self.allocator, .{ .bytes = owned, .address = 0 });
-        return self.strings.items.len - 1;
+        return strings.internString(self, bytes);
     }
 
-    /// Emit a `mov imm16, reg` whose imm is the resolved address of
-    /// the interned string with index `string_id`. The imm slot is
-    /// recorded as a `StringPatch` and back-patched after the pool
-    /// lays out.
+    /// Delegated to `codegen/strings.zig`.
     fn emitMovStringAddrToReg(self: *Emitter, string_id: usize, reg: u8) !void {
-        try self.emitByte(Op.mov_imm16_reg);
-        const slot = try self.currentOffset();
-        try self.emitU16Le(0); // placeholder
-        try self.emitByte(reg);
-        try self.string_patches.append(self.allocator, .{
-            .bank = self.current_bank,
-            .code_offset = slot,
-            .string_id = string_id,
-        });
+        return strings.emitMovStringAddrToReg(self, string_id, reg);
     }
 
     /// Look up the typechecker's inferred type for an expression.
@@ -940,7 +879,9 @@ pub const Emitter = struct {
 
     /// `true` when the expression's inferred type is the named
     /// primitive `p`. Returns `false` for missing types.
-    fn isPrimitiveType(self: *const Emitter, e: *const ast.Expr, p: types_mod.Primitive) bool {
+    /// `true` when the expression's inferred type is the named
+    /// primitive `p`. Returns `false` for missing types.
+    pub fn isPrimitiveType(self: *const Emitter, e: *const ast.Expr, p: types_mod.Primitive) bool {
         const t = self.typeOf(e) orelse return false;
         return t.* == .primitive and t.primitive == p;
     }
@@ -2188,135 +2129,14 @@ pub const Emitter = struct {
         try self.sys(Sys.print_int);
     }
 
-    /// Lower a `str_lit` at expression position. Single-literal
-    /// strings load the pooled address directly into `acu`.
-    /// Interpolated strings allocate a fixed-size buffer in the
-    /// data region (per-site, lives for the program's lifetime
-    /// per spec §3.2.2 "single-buffer allocation") and emit the
-    /// `format_*_to_buf` syscall sequence that fills it. The
-    /// buffer's base address lands in `acu` as the string value.
+    /// Delegated to `codegen/strings.zig`.
     fn emitStrLitExpr(self: *Emitter, sl: ast.StrLitExpr) !void {
-        if (sl.parts.len == 1 and sl.parts[0] == .lit) {
-            const span = sl.parts[0].lit.span;
-            const raw = self.source[span.start..span.end];
-            const decoded = try decodeStringEscapes(self.arena, raw);
-            const id = try self.internString(decoded);
-            try self.emitMovStringAddrToReg(id, Reg.acu);
-            return;
-        }
-
-        const buf_addr = self.reserveInterpBuffer(sl.span) orelse {
-            // Diagnostic already emitted; produce a valid placeholder
-            // so downstream codegen doesn't see a bad acu shape.
-            try self.movImmToReg(0, Reg.acu);
-            return;
-        };
-
-        // r1 holds the moving write cursor. Initialize it to the
-        // buffer's base address.
-        try self.movImmToReg(buf_addr, Reg.r1);
-        try self.emitInterpFill(sl);
-        try self.sys(Sys.format_terminate_buf);
-        try self.movImmToReg(buf_addr, Reg.acu);
+        return strings.emitStrLitExpr(self, sl);
     }
 
-    /// Reserve `interp_buffer_size` bytes at the top of the data
-    /// region for one interpolated-string site. Returns the
-    /// buffer's base address. Emits `E_CODEGEN_DATA_OVERFLOW` and
-    /// `null` when the data region (capped at the MMIO line) would
-    /// overflow.
-    fn reserveInterpBuffer(self: *Emitter, site_span: ast.Span) ?u16 {
-        const base = self.data_cursor;
-        // @as: widen u16 → u32 so the overflow check doesn't itself wrap.
-        const next: u32 = @as(u32, self.data_cursor) + interp_buffer_size;
-        if (next > 0xFE40) {
-            self.diagFatal(site_span, "E_CODEGEN_DATA_OVERFLOW", "static-data region exhausted — too many interpolated string sites") catch return null;
-            return null;
-        }
-        // @as: bounded by the > 0xFE40 check above; result fits u16.
-        self.data_cursor = @intCast(next);
-        return base;
-    }
-
-    /// Emit one `format_*_to_buf` syscall per `sl.parts` entry —
-    /// shared between non-print interpolation and the buffered
-    /// equivalent. `r1` must hold the buffer cursor on entry and
-    /// holds the post-write cursor on exit. Saves / restores `r1`
-    /// around interp-expression evaluation so the stack-machine
-    /// pattern's scratch use of `r1` doesn't trash the cursor.
-    fn emitInterpFill(self: *Emitter, sl: ast.StrLitExpr) !void {
-        for (sl.parts) |part| switch (part) {
-            .lit => |lp| {
-                const raw = self.source[lp.span.start..lp.span.end];
-                if (raw.len == 0) continue;
-                const decoded = try decodeStringEscapes(self.arena, raw);
-                const id = try self.internString(decoded);
-                // Save cursor across the lit-address load (the
-                // `mov imm16, acu` itself only touches acu, but
-                // emitting it via the patching helper is cleaner if
-                // we treat `r1` as untouched here).
-                try self.emitMovStringAddrToReg(id, Reg.acu);
-                try self.sys(Sys.format_str_to_buf);
-            },
-            .interp => |ip| {
-                if (ip.format_spec != null) {
-                    try self.unsupported(ip.span, "`$(expr:fmt)` format specs");
-                    return;
-                }
-                // Save the cursor — the interp-expression eval may
-                // pop into r1 as scratch.
-                try self.pushReg(Reg.r1);
-                try self.emitExpr(ip.expr);
-                try self.popReg(Reg.r1);
-
-                if (self.isPrimitiveType(ip.expr, .char)) {
-                    try self.sys(Sys.format_char_to_buf);
-                } else if (self.isPrimitiveType(ip.expr, .fixed)) {
-                    try self.sys(Sys.format_fixed_to_buf);
-                } else if (self.isPrimitiveType(ip.expr, .str)) {
-                    try self.sys(Sys.format_str_to_buf);
-                } else {
-                    try self.sys(Sys.format_int_to_buf);
-                }
-            },
-        };
-    }
-
-    /// Walk a string literal's parts inside `print`, emitting the
-    /// per-part syscall for each. Zero-alloc per spec §4.9: no
-    /// runtime buffer materializes — each part writes to `host.out`
-    /// directly. The interpolated value's type drives the syscall
-    /// pick (same dispatch as `emitPrintArg` for non-literal args).
+    /// Delegated to `codegen/strings.zig`.
     fn emitPrintStrLit(self: *Emitter, sl: ast.StrLitExpr) !void {
-        for (sl.parts) |part| switch (part) {
-            .lit => |lp| {
-                const raw = self.source[lp.span.start..lp.span.end];
-                if (raw.len == 0) continue;
-                const decoded = try decodeStringEscapes(self.arena, raw);
-                const id = try self.internString(decoded);
-                try self.emitMovStringAddrToReg(id, Reg.acu);
-                try self.sys(Sys.print_str);
-            },
-            .interp => |ip| {
-                if (ip.format_spec != null) {
-                    try self.unsupported(ip.span, "`$(expr:fmt)` format specs");
-                    return;
-                }
-                if (self.isPrimitiveType(ip.expr, .char)) {
-                    try self.emitExpr(ip.expr);
-                    try self.sys(Sys.print_char);
-                } else if (self.isPrimitiveType(ip.expr, .fixed)) {
-                    try self.emitExpr(ip.expr);
-                    try self.sys(Sys.print_fixed);
-                } else if (self.isPrimitiveType(ip.expr, .str)) {
-                    try self.emitExpr(ip.expr);
-                    try self.sys(Sys.print_str);
-                } else {
-                    try self.emitExpr(ip.expr);
-                    try self.sys(Sys.print_int);
-                }
-            },
-        };
+        return strings.emitPrintStrLit(self, sl);
     }
 
     fn emitExprDiscard(self: *Emitter, e: *const ast.Expr) !void {

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -47,10 +47,22 @@ const ast = @import("ast.zig");
 const types_mod = @import("types.zig");
 const typecheck_mod = @import("typecheck.zig");
 const diag_mod = @import("diagnostic.zig");
+/// Re-exported codegen sub-modules — tests reach internal files
+/// through the public barrel so the lint mirror rule resolves.
+pub const opcodes = @import("codegen/opcodes.zig");
+/// `.gx` archive layout + small pure helpers (escape decode,
+/// power-of-two alignment, bank-tag comparison).
+pub const archive = @import("codegen/archive.zig");
+/// `mem.*` stdlib builtin lowering — typed peek / poke,
+/// memcpy / memset, addr-of.
+pub const mem_builtin = @import("codegen/mem_builtin.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const CheckedProgram = typecheck_mod.CheckedProgram;
 const Type = types_mod.Type;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Sys = opcodes.Sys;
 
 // ---------- public constants (boot layout per ISA §7) ----------
 
@@ -64,114 +76,9 @@ pub const code_base: u16 = 0x1100;
 /// `code_base`; data grows up from here.
 pub const data_base: u16 = 0x2000;
 
-// ---------- .gx file constants ----------
+// ---------- .gx file constants (re-exported from archive) ----------
 
-const gx_magic = [4]u8{ 'G', 'E', 'R', 'O' };
-const gx_version: u16 = 0x0001;
-const gx_header_size: usize = 16;
-/// Per-bank disk size — 16 KiB, the size of the `0xC000..0xFEFF`
-/// window in the address space. Each bank stored in the .gx
-/// archive consumes exactly this many bytes (zero-padded).
-const bank_disk_size: usize = 0x4000;
-/// Window base address — every banked address resolves to
-/// `window_base + offset_within_bank`.
-const bank_window_base: u16 = 0xC000;
-/// Banked flag bit in the .gx header per ISA §7.1.
-const flag_banked: u16 = 0x0001;
-
-// ---------- VM opcode + register byte values ----------
-//
-// Mirrored from `src/vm/opcodes.zig`. We don't import the VM module
-// at compile time (keeps lang codegen self-contained) — when a
-// new opcode lands there, this table needs the matching constant.
-
-const Op = struct {
-    const mov_imm16_reg: u8 = 0x10;
-    const mov_reg_reg: u8 = 0x11;
-    const mov_reg_offset_reg: u8 = 0x1C; // load:  reg ← [base + ofs]
-    const mov_reg_reg_offset: u8 = 0x1D; // store: [base + ofs] ← reg
-    const mov_reg_to_addr: u8 = 0x12; // store: [addr] ← reg (word)
-    const mov_addr_to_reg: u8 = 0x13; // load:  reg ← [addr] (word)
-    const mov_reg_to_zp: u8 = 0x19; // store: [zp] ← reg (word)
-    const mov_zp_to_reg: u8 = 0x1A; // load:  reg ← [zp] (word)
-    const mov_ptr_to_reg: u8 = 0x15; // load:  reg ← [ptr_reg] (word)
-    const mov_reg_to_ptr: u8 = 0x16; // store: [ptr_reg] ← reg (word)
-    const mov8_addr_to_reg: u8 = 0x22; // load:  reg ← byte [addr]
-    const mov8_reg_to_ptr: u8 = 0x23; // store: [ptr_reg] ← reg.lo (byte)
-    const mov8_ptr_to_reg: u8 = 0x24; // load:  reg ← byte [ptr_reg]
-    const mov8_zp_to_reg: u8 = 0x29; // load:  reg ← byte [zp]
-    const movl_reg_to_addr: u8 = 0x27; // store: [addr] ← reg.lo  (byte store)
-    const movl_reg_to_zp: u8 = 0x2B; // store: [zp]   ← reg.lo  (byte store)
-
-    const push_reg: u8 = 0x31;
-    const pop_reg: u8 = 0x32;
-
-    const add_imm16_reg: u8 = 0x40;
-    const add_reg_acu: u8 = 0x42; // acu ← acu + reg
-    const sub_imm16_reg: u8 = 0x43;
-    const sub_reg_acu: u8 = 0x45; // acu ← acu - reg
-    const mul_reg_reg: u8 = 0x47; // dst ← dst * src
-    const neg_reg: u8 = 0x4A;
-    const divs_reg_reg: u8 = 0x4E; // dst ← dst / src (signed)
-
-    const and_reg_reg: u8 = 0x61; // dst ← dst & src
-    const or_reg_reg: u8 = 0x63; // dst ← dst | src
-    const xor_reg_reg: u8 = 0x65; // dst ← dst ^ src
-    const not_reg: u8 = 0x66; // reg ← ~reg
-    const shl_reg_reg: u8 = 0x71; // dst ← dst << src
-    const shr_reg_reg: u8 = 0x73; // dst ← dst >> src
-
-    const shl_reg_imm8: u8 = 0x70; // reg ← reg << imm
-    const shr_reg_imm8: u8 = 0x72; // reg ← reg >> imm (logical / unsigned)
-    const asr_reg_imm8: u8 = 0x74; // reg ← reg >>a imm (arithmetic / signed)
-
-    const cmp_reg_imm16: u8 = 0x80; // flags ← reg - imm
-    const cmp_reg_reg: u8 = 0x81; // flags ← dst - src
-
-    const jmp_addr: u8 = 0x90; // unconditional
-    const jeq_addr: u8 = 0x92; // Z = 1
-    const jne_addr: u8 = 0x93; // Z = 0
-    const jlt_addr: u8 = 0x94; // signed less
-    const jle_addr: u8 = 0x95; // signed ≤
-    const jgt_addr: u8 = 0x96; // signed >
-    const jge_addr: u8 = 0x97; // signed ≥
-
-    const bcpy: u8 = 0x2C; // bcpy dst, src, len — memcpy via 3 regs
-    const bfill: u8 = 0x2D; // bfill addr, len, val — memset via 3 regs
-
-    const call_addr: u8 = 0xA0;
-    const call_reg: u8 = 0xA1;
-    const ret_op: u8 = 0xA2;
-
-    const sys: u8 = 0xFB;
-    const hlt: u8 = 0xFF;
-};
-
-/// VM register byte values per `src/vm/registers.zig`.
-const Reg = struct {
-    const acu: u8 = 0x01;
-    const r1: u8 = 0x02;
-    const r2: u8 = 0x03;
-    const r3: u8 = 0x04;
-    const sp: u8 = 0x0A;
-    const fp: u8 = 0x0B;
-    const mb: u8 = 0x0C;
-};
-
-/// `sys` syscall ids per `src/vm/handlers/system.zig::SyscallId`.
-const Sys = struct {
-    const print_str: u8 = 0x01;
-    const print_int: u8 = 0x02;
-    const print_char: u8 = 0x03;
-    const print_newline: u8 = 0x04;
-    const print_fixed: u8 = 0x05;
-
-    const format_str_to_buf: u8 = 0x10;
-    const format_int_to_buf: u8 = 0x11;
-    const format_char_to_buf: u8 = 0x12;
-    const format_fixed_to_buf: u8 = 0x13;
-    const format_terminate_buf: u8 = 0x14;
-};
+const bank_window_base = archive.bank_window_base;
 
 /// Bytes reserved per interpolated-string buffer in the data
 /// region. Sized for the worst common case (a few interp values
@@ -437,7 +344,7 @@ const Global = struct {
 /// local-slot table, and the diagnostic sink. The entry-def
 /// emission path owns one Emitter; later M1 commits will create
 /// a fresh Emitter per non-entry def too.
-const Emitter = struct {
+pub const Emitter = struct {
     allocator: std.mem.Allocator,
     /// Arena for short-lived bookkeeping (local-name dupes,
     /// scratch buffers). Released at the end of `compile`.
@@ -557,12 +464,15 @@ const Emitter = struct {
         return buf.items.len;
     }
 
-    fn emitByte(self: *Emitter, b: u8) !void {
+    /// Append one raw byte to the currently-active code buffer
+    /// (base image or per-bank window).
+    pub fn emitByte(self: *Emitter, b: u8) !void {
         const buf = try self.currentCode();
         try buf.append(self.allocator, b);
     }
 
-    fn emitU16Le(self: *Emitter, value: u16) !void {
+    /// Append a 16-bit value in little-endian byte order.
+    pub fn emitU16Le(self: *Emitter, value: u16) !void {
         // safety: u16 → 2 LE bytes; both casts are byte-mask, no truncation.
         try self.emitByte(@intCast(value & 0xFF));
         try self.emitByte(@intCast(value >> 8));
@@ -571,14 +481,14 @@ const Emitter = struct {
     // ---------- ISA instructions used in M1 ----------
 
     /// `mov imm16, reg` (0x10) — `reg ← imm`.
-    fn movImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
+    pub fn movImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
         try self.emitByte(Op.mov_imm16_reg);
         try self.emitU16Le(imm);
         try self.emitByte(reg);
     }
 
     /// `mov src, dst` (0x11) — `dst ← src`.
-    fn movRegToReg(self: *Emitter, src: u8, dst: u8) !void {
+    pub fn movRegToReg(self: *Emitter, src: u8, dst: u8) !void {
         try self.emitByte(Op.mov_reg_reg);
         try self.emitByte(src);
         try self.emitByte(dst);
@@ -662,26 +572,26 @@ const Emitter = struct {
     }
 
     /// `push reg` (0x31).
-    fn pushReg(self: *Emitter, reg: u8) !void {
+    pub fn pushReg(self: *Emitter, reg: u8) !void {
         try self.emitByte(Op.push_reg);
         try self.emitByte(reg);
     }
 
     /// `pop reg` (0x32).
-    fn popReg(self: *Emitter, reg: u8) !void {
+    pub fn popReg(self: *Emitter, reg: u8) !void {
         try self.emitByte(Op.pop_reg);
         try self.emitByte(reg);
     }
 
     /// `add imm16, reg` (0x40) — `reg ← reg + imm`.
-    fn addImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
+    pub fn addImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
         try self.emitByte(Op.add_imm16_reg);
         try self.emitU16Le(imm);
         try self.emitByte(reg);
     }
 
     /// `sub imm16, reg` (0x43) — `reg ← reg - imm`.
-    fn subImmFromReg(self: *Emitter, imm: u16, reg: u8) !void {
+    pub fn subImmFromReg(self: *Emitter, imm: u16, reg: u8) !void {
         try self.emitByte(Op.sub_imm16_reg);
         try self.emitU16Le(imm);
         try self.emitByte(reg);
@@ -776,7 +686,7 @@ const Emitter = struct {
     }
 
     /// `shl reg, imm8` (0x70) — `reg ← reg << imm`.
-    fn shlRegImm(self: *Emitter, reg: u8, imm: u8) !void {
+    pub fn shlRegImm(self: *Emitter, reg: u8, imm: u8) !void {
         try self.emitByte(Op.shl_reg_imm8);
         try self.emitByte(reg);
         try self.emitByte(imm);
@@ -790,7 +700,7 @@ const Emitter = struct {
     }
 
     /// `asr reg, imm8` (0x74) — `reg ← reg >>arith imm` (sign-fill).
-    fn asrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
+    pub fn asrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
         try self.emitByte(Op.asr_reg_imm8);
         try self.emitByte(reg);
         try self.emitByte(imm);
@@ -2416,7 +2326,10 @@ const Emitter = struct {
 
     // ---------- expression emission (result → acu) ----------
 
-    fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
+    /// Lower one expression — result lands in `acu`. Branches on
+    /// the AST variant; sub-modules (`mem_builtin`, etc.) call
+    /// back into this through the method dispatch.
+    pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         switch (e.*) {
             .int_lit => |lit| {
                 // @as: truncate i32 → i16; safety: typechecker already verified the literal fits in the target primitive's width.
@@ -2849,192 +2762,27 @@ const Emitter = struct {
         try self.unsupported(e.span(), "method calls on non-stdlib receivers");
     }
 
-    // ---------- mem stdlib builtins ----------
+    // ---------- mem stdlib builtins (delegated) ----------
 
-    /// Lower a `mem.X(args)` call. Each builtin maps to a specific
-    /// opcode sequence — see the per-arm comments for the exact
-    /// shape. Unknown `mem.X` calls fall through to a defensive
-    /// diagnostic (the typechecker already rejects bad names with
-    /// `E_TYPE_UNDEFINED_METHOD`).
+    /// Dispatch a `mem.X(args)` call to the matching emitter in
+    /// `codegen/mem_builtin.zig`.
     fn emitMemCall(self: *Emitter, fe: ast.FieldExpr, c: ast.CallExpr) !void {
-        const fn_name = self.source[fe.field.start..fe.field.end];
-        if (std.mem.eql(u8, fn_name, "read_u8") or std.mem.eql(u8, fn_name, "peek")) {
-            try self.emitMemRead1Arg(c, .byte_zext);
-        } else if (std.mem.eql(u8, fn_name, "read_u16") or std.mem.eql(u8, fn_name, "read_i16")) {
-            try self.emitMemRead1Arg(c, .word);
-        } else if (std.mem.eql(u8, fn_name, "read_i8")) {
-            try self.emitMemRead1Arg(c, .byte_sext);
-        } else if (std.mem.eql(u8, fn_name, "write_u8") or std.mem.eql(u8, fn_name, "write_i8") or std.mem.eql(u8, fn_name, "poke")) {
-            try self.emitMemWrite2Args(c, .byte);
-        } else if (std.mem.eql(u8, fn_name, "write_u16") or std.mem.eql(u8, fn_name, "write_i16")) {
-            try self.emitMemWrite2Args(c, .word);
-        } else if (std.mem.eql(u8, fn_name, "memcpy")) {
-            try self.emitMemCopy(c);
-        } else if (std.mem.eql(u8, fn_name, "memset")) {
-            try self.emitMemFill(c);
-        } else if (std.mem.eql(u8, fn_name, "addr_of")) {
-            if (c.args.len != 1) {
-                try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.addr_of` takes exactly one argument");
-                return;
-            }
-            try self.emitAddrOf(c.args[0]);
-        } else {
-            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `mem` builtin");
-        }
+        return mem_builtin.emitMemCall(self, fe, c);
     }
 
-    const MemReadKind = enum { byte_zext, byte_sext, word };
-    const MemWriteKind = enum { byte, word };
-
-    /// Common shape: `mem.read_*(addr)` — one arg, returns a value
-    /// in `acu`. The width / sign-extension choice picks the load
-    /// opcode (and an optional sign-extension tail for `read_i8`).
-    fn emitMemRead1Arg(self: *Emitter, c: ast.CallExpr, kind: MemReadKind) !void {
-        if (c.args.len != 1) {
-            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.read_*` takes exactly one argument");
-            return;
-        }
-        try self.emitExpr(c.args[0]); // acu = addr
-        try self.movRegToReg(Reg.acu, Reg.r1); // r1 = addr
-        switch (kind) {
-            .word => {
-                try self.emitByte(Op.mov_ptr_to_reg);
-                try self.emitByte(Reg.acu); // dst
-                try self.emitByte(Reg.r1); // ptr
-            },
-            .byte_zext => {
-                try self.emitByte(Op.mov8_ptr_to_reg);
-                try self.emitByte(Reg.r1); // ptr
-                try self.emitByte(Reg.acu); // dst
-            },
-            .byte_sext => {
-                try self.emitByte(Op.mov8_ptr_to_reg);
-                try self.emitByte(Reg.r1);
-                try self.emitByte(Reg.acu);
-                // Sign-extend 8 → 16: `shl 8 ; asr 8`. The byte
-                // sits in `acu.lo`; shifting it into the top byte
-                // and back arithmetic-shift-right preserves the
-                // sign bit through the high half.
-                try self.shlRegImm(Reg.acu, 8);
-                try self.asrRegImm(Reg.acu, 8);
-            },
-        }
-    }
-
-    /// Common shape: `mem.write_*(addr, v)` — two args, no return.
-    /// Args eval left-to-right via push/pop so `addr` and `v` can
-    /// be arbitrary subexpressions.
-    fn emitMemWrite2Args(self: *Emitter, c: ast.CallExpr, kind: MemWriteKind) !void {
-        if (c.args.len != 2) {
-            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.write_*` takes exactly two arguments");
-            return;
-        }
-        try self.emitExpr(c.args[0]); // acu = addr
-        try self.pushReg(Reg.acu);
-        try self.emitExpr(c.args[1]); // acu = value
-        try self.popReg(Reg.r1); // r1 = addr
-        switch (kind) {
-            .word => {
-                try self.emitByte(Op.mov_reg_to_ptr);
-                try self.emitByte(Reg.r1); // ptr
-                try self.emitByte(Reg.acu); // src
-            },
-            .byte => {
-                try self.emitByte(Op.mov8_reg_to_ptr);
-                try self.emitByte(Reg.acu); // src (low byte)
-                try self.emitByte(Reg.r1); // ptr
-            },
-        }
-    }
-
-    /// `mem.memcpy(dst, src, n)` — eval each arg left-to-right
-    /// into a dedicated register, then emit `bcpy dst, src, len`
-    /// (opcode 0x2C).
-    fn emitMemCopy(self: *Emitter, c: ast.CallExpr) !void {
-        if (c.args.len != 3) {
-            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.memcpy` takes exactly three arguments");
-            return;
-        }
-        try self.emitExpr(c.args[0]); // dst
-        try self.pushReg(Reg.acu);
-        try self.emitExpr(c.args[1]); // src
-        try self.pushReg(Reg.acu);
-        try self.emitExpr(c.args[2]); // n → acu
-        try self.movRegToReg(Reg.acu, Reg.r3); // r3 = len
-        try self.popReg(Reg.r2); // r2 = src
-        try self.popReg(Reg.r1); // r1 = dst
-        try self.emitByte(Op.bcpy);
-        try self.emitByte(Reg.r1); // dst
-        try self.emitByte(Reg.r2); // src
-        try self.emitByte(Reg.r3); // len
-    }
-
-    /// `mem.memset(dst, v, n)` — eval args into dedicated regs and
-    /// emit `bfill addr, len, val` (opcode 0x2D). Note the operand
-    /// order: the VM reads bytes as `dst, len, val`.
-    fn emitMemFill(self: *Emitter, c: ast.CallExpr) !void {
-        if (c.args.len != 3) {
-            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.memset` takes exactly three arguments");
-            return;
-        }
-        try self.emitExpr(c.args[0]); // dst
-        try self.pushReg(Reg.acu);
-        try self.emitExpr(c.args[1]); // v
-        try self.pushReg(Reg.acu);
-        try self.emitExpr(c.args[2]); // n → acu
-        try self.movRegToReg(Reg.acu, Reg.r3); // r3 = len
-        try self.popReg(Reg.r2); // r2 = val
-        try self.popReg(Reg.r1); // r1 = dst
-        try self.emitByte(Op.bfill);
-        try self.emitByte(Reg.r1); // dst
-        try self.emitByte(Reg.r3); // len
-        try self.emitByte(Reg.r2); // val
-    }
-
-    /// Compute the address of an addressable expression and leave
-    /// it in `acu`. Backs `mem.addr_of(x)` and the typed `&x`
-    /// reference operator. Plain idents (locals, params, globals)
-    /// are supported; field / index targets are not yet supported.
+    /// Compute the address of an addressable expression into
+    /// `acu`. Backs `mem.addr_of(x)` and the `&x` reference
+    /// operator.
     fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
-        if (e.* != .ident) {
-            try self.unsupported(e.span(), "`addr_of` on non-ident expression");
-            return;
-        }
-        const name = self.source[e.ident.span.start..e.ident.span.end];
-        if (self.locals.get(name)) |ofs| {
-            // Local: address = fp + ofs (ofs is negative).
-            try self.movRegToReg(Reg.fp, Reg.acu);
-            if (ofs < 0) {
-                // @as: widen i8 → i16 so the negate doesn't trip on the minimum value.
-                const widened: i16 = ofs;
-                // @as: |ofs| ≤ 128 by allocLocal cap; result fits a u16.
-                const neg: u16 = @intCast(-widened);
-                try self.subImmFromReg(neg, Reg.acu);
-            } else if (ofs > 0) {
-                // @as: positive i8 → u16; cap by allocLocal layout.
-                const pos: u16 = @intCast(ofs);
-                try self.addImmToReg(pos, Reg.acu);
-            }
-            return;
-        }
-        if (self.params.get(name)) |ofs| {
-            // Param: address = fp + ofs (ofs is positive).
-            try self.movRegToReg(Reg.fp, Reg.acu);
-            // @as: positive i8 → u16.
-            const pos: u16 = @intCast(ofs);
-            try self.addImmToReg(pos, Reg.acu);
-            return;
-        }
-        if (self.globals.get(name)) |g| {
-            try self.movImmToReg(g.address, Reg.acu);
-            return;
-        }
-        try self.unsupported(e.span(), "`addr_of` target not in scope");
+        return mem_builtin.emitAddrOf(self, e);
     }
 
     // ---------- diagnostics ----------
 
-    fn diagFatal(self: *Emitter, span: ast.Span, code: []const u8, message: []const u8) !void {
+    /// Append a fatal `Diagnostic` with the given code + literal
+    /// message. The message string isn't duplicated — callers
+    /// either pass a string literal or allocate on `diag_arena`.
+    pub fn diagFatal(self: *Emitter, span: ast.Span, code: []const u8, message: []const u8) !void {
         try self.diagnostics.append(self.allocator, .{
             .severity = .fatal,
             .code = code,
@@ -3043,7 +2791,11 @@ const Emitter = struct {
         });
     }
 
-    fn unsupported(self: *Emitter, span: ast.Span, what: []const u8) !void {
+    /// Emit `E_CODEGEN_UNSUPPORTED` with a message describing the
+    /// shape that wasn't lowered. `what` is interpolated into the
+    /// formatted message and the formatted string lives on
+    /// `diag_arena`.
+    pub fn unsupported(self: *Emitter, span: ast.Span, what: []const u8) !void {
         const msg = try std.fmt.allocPrint(
             self.diag_arena,
             "codegen does not yet support {s}",
@@ -3060,116 +2812,7 @@ const Emitter = struct {
 
 // ---------- archive layout (.gx per ISA §7.1) ----------
 
-fn buildArchive(
-    allocator: std.mem.Allocator,
-    base_image: []const u8,
-    entry_point: u16,
-    banks: *const std.AutoHashMapUnmanaged(u8, std.ArrayList(u8)),
-) ![]u8 {
-    // Bank count = max bank index + 1 (banks are 0-indexed). 0 if
-    // no banks declared.
-    var max_bank: ?u8 = null;
-    var it = banks.keyIterator();
-    while (it.next()) |b| {
-        if (max_bank) |m| max_bank = @max(m, b.*) else max_bank = b.*;
-    }
-    // @as: widen u8 max_bank to u16 so `+ 1` doesn't overflow when max_bank == 255.
-    const bank_count: u16 = if (max_bank) |m| @as(u16, m) + 1 else 0;
-    // @as: bank_count ≤ 256 by u8 input; the byte total fits usize.
-    const banked_bytes: usize = @as(usize, bank_count) * bank_disk_size;
-
-    // safety: base image fits in 16-bit address space per ISA.
-    const image_size: u16 = @intCast(base_image.len);
-    const total = gx_header_size + base_image.len + banked_bytes;
-    var out = try allocator.alloc(u8, total);
-    @memset(out, 0);
-
-    var flags: u16 = 0;
-    if (bank_count > 0) flags |= flag_banked;
-
-    @memcpy(out[0..4], &gx_magic);
-    writeU16Le(out[4..6], gx_version);
-    writeU16Le(out[6..8], flags);
-    writeU16Le(out[8..10], entry_point);
-    writeU16Le(out[10..12], image_size);
-    // safety: bank_count ≤ 256 by construction.
-    out[12] = @intCast(bank_count);
-    out[13] = 0; // sram_bank_count
-    writeU16Le(out[14..16], 0); // reserved
-
-    @memcpy(out[gx_header_size..][0..base_image.len], base_image);
-
-    // Bank buffers: each occupies `bank_disk_size` bytes (zero-
-    // padded). Banks the user didn't touch stay all zeros.
-    var cursor: usize = gx_header_size + base_image.len;
-    var b: u16 = 0;
-    while (b < bank_count) : (b += 1) {
-        const dst = out[cursor..][0..bank_disk_size];
-        // safety: b < bank_count ≤ 256, fits u8.
-        if (banks.get(@intCast(b))) |bank_buf| {
-            const n = @min(bank_buf.items.len, bank_disk_size);
-            @memcpy(dst[0..n], bank_buf.items[0..n]);
-        }
-        cursor += bank_disk_size;
-    }
-
-    return out;
-}
-
-fn writeU16Le(dst: *[2]u8, value: u16) void {
-    // safety: u16 → 2 bytes by definition; no truncation possible.
-    dst[0] = @intCast(value & 0xFF);
-    dst[1] = @intCast(value >> 8);
-}
-
-/// Decode the standard backslash escapes (`\n`, `\r`, `\t`, `\\`,
-/// `\"`, `\0`) into raw bytes. The source slice is the part between
-/// the surrounding `"` delimiters with escapes still encoded; the
-/// returned slice owns its bytes (caller's allocator). Unknown
-/// escape sequences pass through as the bare character following
-/// the backslash — matches the lexer's leniency until a spec-
-/// committed escape table lands.
-fn decodeStringEscapes(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-    var i: usize = 0;
-    while (i < raw.len) {
-        const c = raw[i];
-        if (c == '\\' and i + 1 < raw.len) {
-            const next = raw[i + 1];
-            const decoded: u8 = switch (next) {
-                'n' => '\n',
-                'r' => '\r',
-                't' => '\t',
-                '\\' => '\\',
-                '"' => '"',
-                '0' => 0,
-                else => next,
-            };
-            try out.append(allocator, decoded);
-            i += 2;
-            continue;
-        }
-        try out.append(allocator, c);
-        i += 1;
-    }
-    return out.toOwnedSlice(allocator);
-}
-
-/// Round `value` up to the next multiple of `align_n` (which must
-/// be a power of two — typechecker enforces). `align_n == 1`
-/// passes through.
-fn alignUpU16(value: u16, align_n: u16) u16 {
-    if (align_n <= 1) return value;
-    const mask: u16 = align_n - 1;
-    return (value + mask) & ~mask;
-}
-
-/// `true` when two optional bank tags refer to the same code
-/// location — both `null` (base image) or both wrapping the same
-/// bank index.
-fn banksEqual(a: ?u8, b: ?u8) bool {
-    if (a == null and b == null) return true;
-    if (a == null or b == null) return false;
-    return a.? == b.?;
-}
+const buildArchive = archive.buildArchive;
+const decodeStringEscapes = archive.decodeStringEscapes;
+const alignUpU16 = archive.alignUpU16;
+const banksEqual = archive.banksEqual;

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -4,45 +4,44 @@
 /// the `CheckedProgram` from `typecheck.zig` and produces a `.gx`
 /// archive ready for the VM loader (`gero.vm.parseGx`) per ISA §7.
 ///
-/// **M1 surface** (instruction selection + free-fn calling
-/// convention + memory-placement annotations):
-///   - Statements: `let` / `const` / `return` / `print` /
-///     `target = value` / discard / expression statements.
-///   - Expressions: literals, idents (local + param + global),
-///     unary neg, binary `+ - * /`, direct calls.
-///   - Stack frames: locals at `[fp - 2*N]`, params at
-///     `[fp + 4 + 2*i]`; the VM's `call` / `ret` handle the
-///     ret_ip + fp push / pop.
-///   - Globals: top-level `let` / `const` with optional
-///     `@addr` / `@volatile` / `@zero_page` / `@align(N)`
-///     placement annotations. Byte-width globals use `movl`.
-///   - Banks: `@bank N` routes defs into per-bank buffers;
-///     cross-bank calls go through a `__call_bank` trampoline
-///     in the base image.
+/// **Statements** — `let` / `const` / `return` / `print` /
+/// `target = value` / discard / expression statements; `do…end`
+/// blocks; `if` / `else if` / `else` (incl. `if let` ident-binder
+/// form); `while` (incl. `while let`); `for x in start..end
+/// [step N]`; `repeat body until cond`; `match`; `break [:label]`;
+/// `continue [:label]`; `defer stmt`.
 ///
-/// **M2 surface** (control flow + match + defer):
-///   - Statements: `do…end` blocks, `if / else if / else`
-///     (incl. `if let` ident-binder form), `while` (incl.
-///     `while let`), `for x in start..end [step N]`, `repeat
-///     body until cond`, `match`, `break [:label]`,
-///     `continue [:label]`, `defer stmt`.
-///   - Expressions: comparison ops (`== != < <= > >=`), logical
-///     `and` / `or` (short-circuit), `not`, bitwise `& | ^ ~`,
-///     shifts `<< >>`, `%` (mod via `divs` remainder).
-///   - Flag-driven lowering: `cmp` + `jeq/jne/jlt/jle/jgt/jge`
-///     for comparisons; condition fast-path skips the 0/1
-///     materialization when the cmp drives a branch directly.
-///   - Loop frames carry per-loop break / continue patch lists
-///     so labeled jumps resolve at loop teardown.
-///   - Match: sequential cmp+branch decision tree. OR-patterns
-///     collapse onto one shared body label; range patterns emit
-///     a single low+high cmp pair; `when` guards run after the
-///     pattern bind. Enum-variant patterns + jump-table
-///     dispatch wait on M3's enum tag codegen.
-///   - Defer: per-block LIFO list of statements; cleanup emits
-///     inline at every exit path (normal block end, `return`,
-///     `break`, `continue`). `acu` is preserved across the
-///     cleanup so the caller's return value survives.
+/// **Expressions** — literals (int / fixed / bool / nil / char /
+/// string with single-literal + multi-part interpolation); idents
+/// (local + param + global); unary `- / not / ~`; binary `+ - *
+/// / % == != < <= > >= and or & | ^ << >>`; direct calls; nullary
+/// enum variant constructors (`EnumName.Variant`); `is`
+/// tag-tests; `&x` reference taking; `as` cast (no-op for
+/// same-width primitives); `mem.*` stdlib builtins.
+///
+/// **Stack frames** — locals at `[fp - 2*N]`, params at
+/// `[fp + 4 + 2*i]`; the VM's `call` / `ret` handle the
+/// `ret_ip` + `fp` push / pop. `countLocalsInBody` reserves the
+/// frame up front.
+///
+/// **Globals + placement annotations** — top-level `let` /
+/// `const` with optional `@addr` / `@volatile` / `@zero_page` /
+/// `@align(N)`. Byte-width globals use `movl`.
+///
+/// **Banks** — `@bank N` routes defs into per-bank buffers;
+/// cross-bank calls go through a `__call_bank` trampoline in
+/// the base image.
+///
+/// **Match** — sequential `cmp` + branch decision tree.
+/// OR-patterns collapse onto one shared body label; range
+/// patterns emit one low+high cmp pair; `when` guards run after
+/// the pattern bind. Variant patterns dispatch on the variant
+/// tag.
+///
+/// **Defer** — per-block LIFO list of statements; cleanup emits
+/// inline at every exit path (normal block end, `return`,
+/// `break`, `continue`). `acu` is preserved across the cleanup
+/// so the caller's return value survives.
 const std = @import("std");
 const ast = @import("ast.zig");
 const types_mod = @import("types.zig");
@@ -893,7 +892,6 @@ const Emitter = struct {
             },
             // Range-based `for` reserves 1 hidden slot for the
             // `end` bound (the iteration variable uses its own slot).
-            // User-iterator support lands in M3 with method calls.
             .for_stmt => |fs| 1 + 1 + self.countLocalsInBody(fs.body),
             .repeat_stmt => |rs| self.countLocalsInBody(rs.body),
             .match_stmt => |ms| blk: {
@@ -911,8 +909,8 @@ const Emitter = struct {
         };
     }
 
-    /// Count the local-slot bindings a pattern introduces. Only the
-    /// ident pattern binds at M2; or-patterns reject inner binders
+    /// Count the local-slot bindings a pattern introduces. Only
+    /// the ident pattern binds; or-patterns reject inner binders
     /// (parser already enforces this).
     fn countBindingsInPattern(pat: ast.Pattern) usize {
         return switch (pat) {
@@ -1240,11 +1238,10 @@ const Emitter = struct {
         self.data_cursor += width;
     }
 
-    /// 1 for `i8` / `u8` / `bool` / `char`, 2 otherwise (the slice-
-    /// M1 type universe for globals). Type-name resolution is
-    /// purely lexical against the type annotation; the typechecker
-    /// has already validated that the name refers to a primitive
-    /// or a registered user-type.
+    /// 1 for `i8` / `u8` / `bool` / `char`, 2 otherwise. Type-name
+    /// resolution is purely lexical against the type annotation;
+    /// the typechecker has already validated that the name refers
+    /// to a primitive or a registered user-type.
     fn widthOfLetDecl(self: *const Emitter, d: *const ast.LetDecl) u8 {
         if (d.type_ann) |t| return self.widthOfTypeAnn(t.*);
         // No annotation — default to the widest primitive (2 bytes).
@@ -1510,8 +1507,8 @@ const Emitter = struct {
     ///
     /// The `if let pat = expr [when guard]` form binds a fresh local
     /// for the pattern and guards the arm on the bind + the optional
-    /// `when` predicate. Slice M2 supports ident binders only —
-    /// destructuring patterns land in M3 alongside enums.
+    /// `when` predicate. Only the ident-binder form is supported;
+    /// destructuring patterns are unsupported.
     fn emitIfStmt(self: *Emitter, is_: ast.IfStmt) !void {
         // Patches that need to jump to the end of the whole chain
         // once the chain finishes emitting (one per arm body fall-
@@ -1558,7 +1555,7 @@ const Emitter = struct {
             // cond is falsy. We use jeq (skip body on zero).
             return try self.emitJumpPlaceholder(Op.jeq_addr);
         }
-        // `if let pat = expr [when guard]` — M2 ident-binder form.
+        // `if let pat = expr [when guard]` — ident-binder form.
         const pat = arm.let_pattern.?.*;
         const expr = arm.let_expr.?;
         // Evaluate the RHS into acu.
@@ -1593,7 +1590,7 @@ const Emitter = struct {
                 return try self.emitJumpPlaceholder(Op.jeq_addr);
             },
             else => {
-                try self.unsupported(arm.span, "`if let` patterns other than a bare ident (M3 brings destructuring)");
+                try self.unsupported(arm.span, "`if let` patterns other than a bare ident");
                 // Emit a placeholder anyway so the caller doesn't
                 // walk the patches list into a hole.
                 return try self.emitJumpPlaceholder(Op.jeq_addr);
@@ -1849,16 +1846,12 @@ const Emitter = struct {
         frame.continue_patches.deinit(self.allocator);
     }
 
-    /// Lower `for x in start..end [step S] body end`. M2 ships the
-    /// range-special-case per spec §4.5.3; user-defined iterators
-    /// (objects with `next(self) -> T?`) land in M3 alongside method
-    /// calls + class codegen.
+    /// Lower `for x in start..end [step S] body end` — the range
+    /// special case per spec §4.5.3. User-defined iterables
+    /// (`next(self) -> T?`) are not yet supported.
     fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
-        // Only handle the range special case for M2 — the spec
-        // designates ranges + arrays + strings as compiler-known
-        // iterables; method-call iteration lands in M3.
         if (fs.iter.* != .range) {
-            try self.unsupported(fs.span, "`for` over non-range iterables (M3 brings user-iterator support via method calls)");
+            try self.unsupported(fs.span, "`for` over non-range iterables");
             return;
         }
         const range = fs.iter.range;
@@ -1914,8 +1907,8 @@ const Emitter = struct {
         try self.movRegOffsetToReg(Reg.fp, var_ofs, Reg.acu);
         if (step_expr) |se| {
             // Evaluate step expression — typechecker has already
-            // confirmed it's an integer expression. For M2 we accept
-            // an int_lit fast-path; arbitrary exprs fall through to
+            // confirmed it's an integer expression. Int-literal
+            // fast-path emits `add imm`; arbitrary exprs go through
             // the general eval-and-add path.
             if (se.* == .int_lit) {
                 // @as: parser stores int_lit as i32; range steps fit i16 per spec §4.5.1.
@@ -1967,10 +1960,8 @@ const Emitter = struct {
         }
     }
 
-    /// Lower `match scrutinee case … end`. Pure decision-tree for
-    /// M2 (sequential cmp + branch per arm); a jump-table optimizer
-    /// for tag-dispatch enums can slot in once enum codegen lands
-    /// (M3). The compiler handles the common shapes:
+    /// Lower `match scrutinee case … end` as a sequential
+    /// cmp + branch decision tree. The compiler handles:
     ///
     /// - Wildcard `_` and ident binders (always match).
     /// - Integer / char / bool / nil literal patterns.
@@ -1978,11 +1969,12 @@ const Emitter = struct {
     ///   then all alts jump to one shared body label).
     /// - Range patterns (`a..b` / `a..=b`) — one cmp + cond branch
     ///   pair instead of a per-element chain.
+    /// - Nullary enum-variant patterns — dispatch on the variant tag.
     /// - `when guard` clauses — evaluated after the pattern match.
     ///
-    /// Slice M2 leaves enum-variant / tuple / struct destructuring
-    /// patterns on the M3 boundary (they require enum-tag layout
-    /// + field offsets, which arrive with the class / struct codegen).
+    /// Payload-bearing variant patterns, tuple patterns, and struct
+    /// patterns are not yet supported (require enum-tag payload
+    /// layout + field-offset codegen).
     fn emitMatchStmt(self: *Emitter, ms: ast.MatchStmt) !void {
         // Bind the scrutinee to a slot so subsequent arms can re-test
         // it without re-evaluating side effects. Skip the bind if
@@ -2095,10 +2087,10 @@ const Emitter = struct {
             .range_pattern => |rp| {
                 // Lower `start..end` as: cmp acu, start; jlt skip;
                 //                       cmp acu, end;   j(g[te]) skip.
-                // We need the start / end as immediates — only
-                // handle the int_lit fast-path in M2.
+                // Endpoints must be compile-time integer literals
+                // so they emit as immediate operands.
                 if (rp.start.* != .int_lit or rp.end.* != .int_lit) {
-                    try self.unsupported(rp.span, "non-literal range pattern endpoints (compile-time literals only in M2)");
+                    try self.unsupported(rp.span, "non-literal range pattern endpoints");
                     return;
                 }
                 // @as: parser holds int_lit.value as i32; range bounds fit i16 by spec.
@@ -2145,7 +2137,7 @@ const Emitter = struct {
             },
             .variant_pattern => |vp| {
                 if (vp.args.len > 0) {
-                    try self.unsupported(vp.span, "enum-variant patterns with payload binders (M3b brings the payload destructuring)");
+                    try self.unsupported(vp.span, "enum-variant patterns with payload binders");
                     return;
                 }
                 const path = self.source[vp.path.start..vp.path.end];
@@ -2162,16 +2154,16 @@ const Emitter = struct {
                 try self.cmpRegImm(Reg.acu, tag);
                 try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
             },
-            else => try self.unsupported(pat.span(), "this pattern shape (M3b brings struct / tuple destructuring)"),
+            else => try self.unsupported(pat.span(), "this pattern shape"),
         }
     }
 
-    /// Lower `target = value` (and compound `op=` forms — slice M1
-    /// only handles plain `=` for now). The target must be an
-    /// ident that resolves to a local, param, or global.
+    /// Lower `target = value`. The target must be an ident that
+    /// resolves to a local, param, or global. Compound `op=`
+    /// forms are not yet supported.
     fn emitAssign(self: *Emitter, a: ast.AssignStmt) !void {
         if (a.op != .set) {
-            try self.unsupported(a.span, "compound `op=` assignments (only plain `=` is lowered in M1)");
+            try self.unsupported(a.span, "compound `op=` assignments — only plain `=` is supported");
             return;
         }
         if (a.target.* != .ident) {
@@ -2208,8 +2200,7 @@ const Emitter = struct {
             try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
         }
         // Uninitialized let leaves the slot at whatever the prologue
-        // memset gave it (sub_imm pads sp downward without zeroing —
-        // M2 may want a defensive zero-fill).
+        // memset gave it (sub_imm pads sp downward without zeroing).
     }
 
     fn emitConstDecl(self: *Emitter, d: ast.ConstDecl) !void {
@@ -2359,7 +2350,7 @@ const Emitter = struct {
             },
             .interp => |ip| {
                 if (ip.format_spec != null) {
-                    try self.unsupported(ip.span, "`$(expr:fmt)` format specs (M3 brings the parameterized formatter)");
+                    try self.unsupported(ip.span, "`$(expr:fmt)` format specs");
                     return;
                 }
                 // Save the cursor — the interp-expression eval may
@@ -2398,7 +2389,7 @@ const Emitter = struct {
             },
             .interp => |ip| {
                 if (ip.format_spec != null) {
-                    try self.unsupported(ip.span, "`$(expr:fmt)` format specs (M3 brings the parameterized formatter)");
+                    try self.unsupported(ip.span, "`$(expr:fmt)` format specs");
                     return;
                 }
                 if (self.isPrimitiveType(ip.expr, .char)) {
@@ -2476,7 +2467,7 @@ const Emitter = struct {
             .field => |f| try self.emitFieldExpr(f, e),
             .is_test => |it| try self.emitIsTest(it),
             .ref_of => |r| try self.emitAddrOf(r.inner),
-            .cast => |c| try self.emitExpr(c.inner), // primitives are bit-pattern-identical at the M3a width set
+            .cast => |c| try self.emitExpr(c.inner), // same-width primitives share a bit pattern, so the cast is a no-op
             else => try self.unsupported(e.span(), "this expression form"),
         }
     }
@@ -2485,7 +2476,7 @@ const Emitter = struct {
     /// enum-variant constructor. Loads the variant's tag byte
     /// into `acu` (the runtime representation of the variant).
     /// Field access on non-enum receivers (struct / class fields)
-    /// lands in M3b alongside the class layout work.
+    /// is not yet supported.
     fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void {
         if (f.receiver.* == .ident) {
             const recv_name = self.source[f.receiver.ident.span.start..f.receiver.ident.span.end];
@@ -2495,18 +2486,15 @@ const Emitter = struct {
                     try self.diagFatal(f.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant");
                     return;
                 };
-                // Payload-bearing constructor (`Item.Potion(20)`)
-                // lands as a `CallExpr` whose callee is a
-                // `FieldExpr` — that path is M3b. A bare
-                // `Item.Potion` reference at expression position
-                // (without a call) needs the payload to be empty.
-                if (ed.variants.len > 0) {
-                    for (ed.variants) |v| {
-                        if (std.mem.eql(u8, self.source[v.name.start..v.name.end], variant_name)) {
-                            if (v.payload.len != 0) {
-                                try self.unsupported(f.span, "payload-bearing enum-variant constructors (call form lands with M3b's enum layout)");
-                                return;
-                            }
+                // A bare `Item.Potion` reference at expression
+                // position (without a call) requires the payload to
+                // be empty — payload-bearing constructors come
+                // through the `CallExpr` path with field-callee.
+                for (ed.variants) |v| {
+                    if (std.mem.eql(u8, self.source[v.name.start..v.name.end], variant_name)) {
+                        if (v.payload.len != 0) {
+                            try self.unsupported(f.span, "payload-bearing enum-variant constructors");
+                            return;
                         }
                     }
                 }
@@ -2514,7 +2502,7 @@ const Emitter = struct {
                 return;
             }
         }
-        try self.unsupported(e.span(), "non-enum field access (struct / class fields land with M3b)");
+        try self.unsupported(e.span(), "non-enum field access");
     }
 
     /// Lower `expr is EnumName.Variant`. Evaluates `expr` into
@@ -2621,8 +2609,8 @@ const Emitter = struct {
                     try self.movRegToReg(Reg.r2, Reg.acu);
                 } else {
                     // Signed 32÷16 divide. Dividend lives in acu:dst
-                    // (high:low); the dividend assumed to fit in 16
-                    // bits (sign-extension lands in a later commit).
+                    // (high:low); the dividend is assumed to fit in
+                    // 16 bits — sign-extension is not yet emitted.
                     try self.movRegToReg(Reg.acu, Reg.r2); // r2 = low half
                     try self.movImmToReg(0, Reg.acu); // high half = 0
                     try self.divsRegReg(Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
@@ -2661,7 +2649,7 @@ const Emitter = struct {
     ///
     /// Slice M1 only handles direct calls — the callee must be a
     /// bare ident referencing a top-level `def`. Method calls /
-    /// closure invocations / fn-pointer calls land in M3.
+    /// Closure invocations and fn-pointer calls are not yet supported.
     fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
         // Intercept compiler-known builtins before the regular
         // direct-call path so they emit specialized opcode
@@ -2833,9 +2821,10 @@ const Emitter = struct {
         return null;
     }
 
-    /// Lower a `receiver.method(args)` expression. M3a handles the
-    /// stdlib `mem.X(...)` shape; other receivers (class instance
-    /// method calls) land with M3b's vtable lowering.
+    /// Lower a `receiver.method(args)` expression. The stdlib
+    /// `mem.X(...)` shape dispatches through the builtin lookup.
+    /// Other receivers (class instance method calls) are not yet
+    /// supported.
     fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr) !void {
         if (m.receiver.* == .ident) {
             const recv = self.source[m.receiver.ident.span.start..m.receiver.ident.span.end];
@@ -2857,7 +2846,7 @@ const Emitter = struct {
                 return;
             }
         }
-        try self.unsupported(e.span(), "method calls (class instance methods land with M3b's vtable lowering)");
+        try self.unsupported(e.span(), "method calls on non-stdlib receivers");
     }
 
     // ---------- mem stdlib builtins ----------
@@ -3004,12 +2993,11 @@ const Emitter = struct {
 
     /// Compute the address of an addressable expression and leave
     /// it in `acu`. Backs `mem.addr_of(x)` and the typed `&x`
-    /// reference operator. Slice M3a supports plain idents (locals,
-    /// params, globals); field / index targets land with M3b's
-    /// struct + class layout.
+    /// reference operator. Plain idents (locals, params, globals)
+    /// are supported; field / index targets are not yet supported.
     fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
         if (e.* != .ident) {
-            try self.unsupported(e.span(), "`addr_of` on non-ident expression (M3b brings field / index targets)");
+            try self.unsupported(e.span(), "`addr_of` on non-ident expression");
             return;
         }
         const name = self.source[e.ident.span.start..e.ident.span.end];

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -60,6 +60,8 @@ pub const mem_builtin = @import("codegen/mem_builtin.zig");
 /// `StringPatch`, the interp buffer reservation, and the per-part
 /// fill helpers.
 pub const strings = @import("codegen/strings.zig");
+/// `match` pattern-arm test emission.
+pub const pattern = @import("codegen/pattern.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const CheckedProgram = typecheck_mod.CheckedProgram;
@@ -486,7 +488,8 @@ pub const Emitter = struct {
     }
 
     /// `mov src, [base + ofs]` (0x1D) — store reg to fp-relative.
-    fn movRegToRegOffset(self: *Emitter, src: u8, base: u8, ofs: i8) !void {
+    /// `mov src, [base + ofs]` (0x1D) — store reg to fp-relative.
+    pub fn movRegToRegOffset(self: *Emitter, src: u8, base: u8, ofs: i8) !void {
         try self.emitByte(Op.mov_reg_reg_offset);
         try self.emitByte(src);
         try self.emitByte(base);
@@ -612,7 +615,8 @@ pub const Emitter = struct {
     }
 
     /// `cmp reg, imm16` (0x80) — flags ← reg - imm. Result discarded.
-    fn cmpRegImm(self: *Emitter, reg: u8, imm: u16) !void {
+    /// `cmp reg, imm16` (0x80) — flags ← reg - imm.
+    pub fn cmpRegImm(self: *Emitter, reg: u8, imm: u16) !void {
         try self.emitByte(Op.cmp_reg_imm16);
         try self.emitByte(reg);
         try self.emitU16Le(imm);
@@ -691,7 +695,11 @@ pub const Emitter = struct {
     /// Emit a forward jump with a placeholder address slot. Returns
     /// the offset of the 2-byte slot inside the current code buffer —
     /// pass it to `patchJumpTo` once the target offset is known.
-    fn emitJumpPlaceholder(self: *Emitter, op: u8) !usize {
+    /// Emit a forward jump with a placeholder address slot.
+    /// Returns the offset of the 2-byte slot inside the current
+    /// code buffer — pass it to `patchJumpTo` once the target
+    /// offset is known.
+    pub fn emitJumpPlaceholder(self: *Emitter, op: u8) !usize {
         try self.emitByte(op);
         const slot = try self.currentOffset();
         try self.emitU16Le(0); // placeholder
@@ -702,7 +710,10 @@ pub const Emitter = struct {
     /// `currentBufferBase() + target_offset` into the 2-byte slot at
     /// `patch_offset`. `target_offset` is a byte offset inside the
     /// current code buffer.
-    fn patchJumpTo(self: *Emitter, patch_offset: usize, target_offset: usize) !void {
+    /// Resolve a forward-jump patch: writes the absolute address
+    /// `currentBufferBase() + target_offset` into the 2-byte slot
+    /// at `patch_offset`.
+    pub fn patchJumpTo(self: *Emitter, patch_offset: usize, target_offset: usize) !void {
         const buf = try self.currentCode();
         // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
         const target_in_buffer: u16 = @intCast(target_offset);
@@ -745,7 +756,9 @@ pub const Emitter = struct {
 
     /// Reserve a 2-byte slot for `name` at the next fp-relative
     /// offset. Returns the offset (negative — locals grow down).
-    fn allocLocal(self: *Emitter, name: []const u8) !i8 {
+    /// Reserve a 2-byte slot for `name` at the next fp-relative
+    /// offset. Returns the offset (negative — locals grow down).
+    pub fn allocLocal(self: *Emitter, name: []const u8) !i8 {
         const new_frame_bytes = self.frame_bytes + 2;
         // @as: i8 covers -128..127; with 2 bytes per slot we cap at 64 locals per frame, fits.
         const ofs: i8 = -@as(i8, @intCast(new_frame_bytes));
@@ -904,7 +917,10 @@ pub const Emitter = struct {
     /// §3.6 ("Sword=0, Potion=1, Key=2"). Returns `null` if the
     /// enum or variant doesn't exist (the typechecker should have
     /// caught that; the check keeps codegen defensive).
-    fn variantTag(self: *const Emitter, enum_name: []const u8, variant_name: []const u8) ?u8 {
+    /// Look up the tag index for `enum_name.variant_name`. Tags
+    /// are numbered in declaration order starting at 0 (spec §3.6).
+    /// Returns `null` if the enum or variant doesn't exist.
+    pub fn variantTag(self: *const Emitter, enum_name: []const u8, variant_name: []const u8) ?u8 {
         const ed = self.enum_decls.get(enum_name) orelse return null;
         for (ed.variants, 0..) |v, i| {
             const v_name = self.source[v.name.start..v.name.end];
@@ -1896,6 +1912,7 @@ pub const Emitter = struct {
     /// any prelude that needs the same register state. Failures
     /// emit placeholder jumps and push them onto `skip_patches`;
     /// the caller resolves all of them to the same post-body offset.
+    /// Delegated to `codegen/pattern.zig`.
     fn emitPatternTest(
         self: *Emitter,
         pat: ast.Pattern,
@@ -1903,110 +1920,7 @@ pub const Emitter = struct {
         scrutinee_is_ident: bool,
         skip_patches: *std.ArrayList(usize),
     ) !void {
-        switch (pat) {
-            .wildcard => {
-                // Always matches — emit nothing.
-            },
-            .ident => |ip| {
-                // Bind the value to a local slot. Always matches.
-                const name = self.source[ip.name.start..ip.name.end];
-                const dup = try self.arena.dupe(u8, name);
-                const ofs = try self.allocLocal(dup);
-                try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
-            },
-            .int_lit => |lit| {
-                // @as: parser holds int_lit.value as i32; literals fit i16 by typecheck rule.
-                const trimmed: i16 = @truncate(lit.value);
-                // safety: i16 → u16 bit pattern preserved.
-                const v: u16 = @bitCast(trimmed);
-                try self.cmpRegImm(Reg.acu, v);
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
-            },
-            .char_lit => |c| {
-                try self.cmpRegImm(Reg.acu, c.value);
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
-            },
-            .bool_lit => |b| {
-                const v: u16 = if (b.value) 1 else 0;
-                try self.cmpRegImm(Reg.acu, v);
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
-            },
-            .nil_lit => {
-                try self.cmpRegImm(Reg.acu, 0);
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
-            },
-            .range_pattern => |rp| {
-                // Lower `start..end` as: cmp acu, start; jlt skip;
-                //                       cmp acu, end;   j(g[te]) skip.
-                // Endpoints must be compile-time integer literals
-                // so they emit as immediate operands.
-                if (rp.start.* != .int_lit or rp.end.* != .int_lit) {
-                    try self.unsupported(rp.span, "non-literal range pattern endpoints");
-                    return;
-                }
-                // @as: parser holds int_lit.value as i32; range bounds fit i16 by spec.
-                const start_i16: i16 = @truncate(rp.start.int_lit.value);
-                // safety: i16 → u16 keeps the two's-complement bit pattern.
-                const start_v: u16 = @bitCast(start_i16);
-                // @as: same i32 → i16 truncation for the end bound.
-                const end_i16: i16 = @truncate(rp.end.int_lit.value);
-                // safety: i16 → u16 keeps the two's-complement bit pattern.
-                const end_v: u16 = @bitCast(end_i16);
-                try self.cmpRegImm(Reg.acu, start_v);
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jlt_addr));
-                try self.cmpRegImm(Reg.acu, end_v);
-                const above_bound_op: u8 = if (rp.inclusive) Op.jgt_addr else Op.jge_addr;
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(above_bound_op));
-            },
-            .or_pattern => |op_| {
-                // Each alt emits its own cmp + branch. A match jumps
-                // OVER the remaining alts to the body. A non-match
-                // falls through to the next alt. After the last alt,
-                // a non-match jumps to the shared skip target.
-                var match_patches: std.ArrayList(usize) = .empty;
-                defer match_patches.deinit(self.allocator);
-
-                for (op_.alts) |alt| {
-                    var alt_skip: std.ArrayList(usize) = .empty;
-                    defer alt_skip.deinit(self.allocator);
-                    try self.emitPatternTest(alt.*, scrutinee_ofs, scrutinee_is_ident, &alt_skip);
-                    // The alt matched if we reach this point — jump
-                    // to the shared "body entry" label.
-                    try match_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
-                    // Failure-skips of this alt land at the next alt
-                    // (or, after the final alt, at the outer skip).
-                    const after_alt = try self.currentOffset();
-                    for (alt_skip.items) |p| try self.patchJumpTo(p, after_alt);
-                }
-                // None of the alts matched — punt to the outer
-                // skip set.
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
-                // All match-patches resolve to the byte after the
-                // outer skip jump — i.e. the body's first byte.
-                const body_offset = try self.currentOffset();
-                for (match_patches.items) |p| try self.patchJumpTo(p, body_offset);
-            },
-            .variant_pattern => |vp| {
-                if (vp.args.len > 0) {
-                    try self.unsupported(vp.span, "enum-variant patterns with payload binders");
-                    return;
-                }
-                const path = self.source[vp.path.start..vp.path.end];
-                const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
-                    try self.diagFatal(vp.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: variant pattern must be `EnumName.Variant`");
-                    return;
-                };
-                const enum_name = path[0..dot];
-                const variant_name = path[dot + 1 ..];
-                const tag = self.variantTag(enum_name, variant_name) orelse {
-                    try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in match pattern");
-                    return;
-                };
-                try self.cmpRegImm(Reg.acu, tag);
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
-            },
-            else => try self.unsupported(pat.span(), "this pattern shape"),
-        }
+        return pattern.emitPatternTest(self, pat, scrutinee_ofs, scrutinee_is_ident, skip_patches);
     }
 
     /// Lower `target = value`. The target must be an ident that

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -95,7 +95,11 @@ const Op = struct {
     const mov_addr_to_reg: u8 = 0x13; // load:  reg ← [addr] (word)
     const mov_reg_to_zp: u8 = 0x19; // store: [zp] ← reg (word)
     const mov_zp_to_reg: u8 = 0x1A; // load:  reg ← [zp] (word)
+    const mov_ptr_to_reg: u8 = 0x15; // load:  reg ← [ptr_reg] (word)
+    const mov_reg_to_ptr: u8 = 0x16; // store: [ptr_reg] ← reg (word)
     const mov8_addr_to_reg: u8 = 0x22; // load:  reg ← byte [addr]
+    const mov8_reg_to_ptr: u8 = 0x23; // store: [ptr_reg] ← reg.lo (byte)
+    const mov8_ptr_to_reg: u8 = 0x24; // load:  reg ← byte [ptr_reg]
     const mov8_zp_to_reg: u8 = 0x29; // load:  reg ← byte [zp]
     const movl_reg_to_addr: u8 = 0x27; // store: [addr] ← reg.lo  (byte store)
     const movl_reg_to_zp: u8 = 0x2B; // store: [zp]   ← reg.lo  (byte store)
@@ -133,6 +137,9 @@ const Op = struct {
     const jgt_addr: u8 = 0x96; // signed >
     const jge_addr: u8 = 0x97; // signed ≥
 
+    const bcpy: u8 = 0x2C; // bcpy dst, src, len — memcpy via 3 regs
+    const bfill: u8 = 0x2D; // bfill addr, len, val — memset via 3 regs
+
     const call_addr: u8 = 0xA0;
     const call_reg: u8 = 0xA1;
     const ret_op: u8 = 0xA2;
@@ -146,6 +153,7 @@ const Reg = struct {
     const acu: u8 = 0x01;
     const r1: u8 = 0x02;
     const r2: u8 = 0x03;
+    const r3: u8 = 0x04;
     const sp: u8 = 0x0A;
     const fp: u8 = 0x0B;
     const mb: u8 = 0x0C;
@@ -177,17 +185,22 @@ const interp_buffer_size: u16 = 64;
 // ---------- public surface ----------
 
 /// Codegen output. Owns the `.gx` image bytes + the diagnostic
-/// slice.
+/// slice + the arena that backs the diagnostic message strings
+/// (kept alive past `compile`'s return so callers can read
+/// `Diagnostic.message`).
 pub const Compiled = struct {
     /// Full `.gx` archive, ready to feed to `gero.vm.parseGx`.
     image: []u8,
     diagnostics: []Diagnostic,
+    diag_arena: std.heap.ArenaAllocator,
     allocator: std.mem.Allocator,
 
-    /// Release the image buffer + diagnostics slice.
+    /// Release the image buffer + diagnostics slice + the arena
+    /// backing diagnostic message strings.
     pub fn deinit(self: *Compiled) void {
         self.allocator.free(self.image);
         self.allocator.free(self.diagnostics);
+        self.diag_arena.deinit();
     }
 
     /// `true` when at least one fatal diagnostic fired.
@@ -234,14 +247,23 @@ pub fn compile(
     var diagnostics: std.ArrayList(Diagnostic) = .empty;
     errdefer diagnostics.deinit(allocator);
 
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
+    // Scratch arena — short-lived bookkeeping (local-name dupes,
+    // hash-map storage). Released at the end of this function.
+    var scratch_arena = std.heap.ArenaAllocator.init(allocator);
+    defer scratch_arena.deinit();
+
+    // Diagnostics arena — backs the message strings on every
+    // `Diagnostic` the codegen produces. Persists past this
+    // function via `Compiled.diag_arena`.
+    var diag_arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer diag_arena.deinit();
 
     if (findEntryDef(source, checked.program, opts.entry_name) == null) return error.EntryNotFound;
 
     var emitter: Emitter = .{
         .allocator = allocator,
-        .arena = arena.allocator(),
+        .arena = scratch_arena.allocator(),
+        .diag_arena = diag_arena.allocator(),
         .source = source,
         .code = .empty,
         .locals = .{},
@@ -294,6 +316,7 @@ pub fn compile(
     return .{
         .image = image,
         .diagnostics = try diagnostics.toOwnedSlice(allocator),
+        .diag_arena = diag_arena,
         .allocator = allocator,
     };
 }
@@ -420,6 +443,10 @@ const Emitter = struct {
     /// Arena for short-lived bookkeeping (local-name dupes,
     /// scratch buffers). Released at the end of `compile`.
     arena: std.mem.Allocator,
+    /// Persistent arena used exclusively for `Diagnostic.message`
+    /// strings — survives past `compile`'s return so callers can
+    /// read the diagnostics. Lives on `Compiled.diag_arena`.
+    diag_arena: std.mem.Allocator,
     source: []const u8,
     /// The growing bytecode buffer.
     code: std.ArrayList(u8),
@@ -1397,7 +1424,7 @@ const Emitter = struct {
             const target_addr: u16 = switch (p.target) {
                 .fn_name => |name| self.fn_addresses.get(name) orelse {
                     const msg = try std.fmt.allocPrint(
-                        self.arena,
+                        self.diag_arena,
                         "codegen: call target `{s}` is not a known top-level def",
                         .{name},
                     );
@@ -2445,8 +2472,11 @@ const Emitter = struct {
             .unary => |u| try self.emitUnary(u),
             .binary => |b| try self.emitBinary(b),
             .call => |c| try self.emitCall(c),
+            .method_call => |m| try self.emitMethodCall(m, e),
             .field => |f| try self.emitFieldExpr(f, e),
             .is_test => |it| try self.emitIsTest(it),
+            .ref_of => |r| try self.emitAddrOf(r.inner),
+            .cast => |c| try self.emitExpr(c.inner), // primitives are bit-pattern-identical at the M3a width set
             else => try self.unsupported(e.span(), "this expression form"),
         }
     }
@@ -2633,6 +2663,19 @@ const Emitter = struct {
     /// bare ident referencing a top-level `def`. Method calls /
     /// closure invocations / fn-pointer calls land in M3.
     fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
+        // Intercept compiler-known builtins before the regular
+        // direct-call path so they emit specialized opcode
+        // sequences instead of going through a `call addr` site.
+        if (c.callee.* == .field) {
+            const fe = c.callee.field;
+            if (fe.receiver.* == .ident) {
+                const recv = self.source[fe.receiver.ident.span.start..fe.receiver.ident.span.end];
+                if (std.mem.eql(u8, recv, "mem")) {
+                    try self.emitMemCall(fe, c);
+                    return;
+                }
+            }
+        }
         if (c.callee.* != .ident) {
             try self.unsupported(c.span, "non-ident callee");
             return;
@@ -2790,6 +2833,217 @@ const Emitter = struct {
         return null;
     }
 
+    /// Lower a `receiver.method(args)` expression. M3a handles the
+    /// stdlib `mem.X(...)` shape; other receivers (class instance
+    /// method calls) land with M3b's vtable lowering.
+    fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr) !void {
+        if (m.receiver.* == .ident) {
+            const recv = self.source[m.receiver.ident.span.start..m.receiver.ident.span.end];
+            if (std.mem.eql(u8, recv, "mem")) {
+                // Build a synthetic `FieldExpr` + `CallExpr` shape
+                // so the existing `emitMemCall` can dispatch without
+                // duplicating the per-builtin emit code.
+                const synth_field: ast.FieldExpr = .{
+                    .receiver = m.receiver,
+                    .field = m.method,
+                    .span = m.span,
+                };
+                const synth_call: ast.CallExpr = .{
+                    .callee = m.receiver, // unused by emitMemCall
+                    .args = m.args,
+                    .span = m.span,
+                };
+                try self.emitMemCall(synth_field, synth_call);
+                return;
+            }
+        }
+        try self.unsupported(e.span(), "method calls (class instance methods land with M3b's vtable lowering)");
+    }
+
+    // ---------- mem stdlib builtins ----------
+
+    /// Lower a `mem.X(args)` call. Each builtin maps to a specific
+    /// opcode sequence — see the per-arm comments for the exact
+    /// shape. Unknown `mem.X` calls fall through to a defensive
+    /// diagnostic (the typechecker already rejects bad names with
+    /// `E_TYPE_UNDEFINED_METHOD`).
+    fn emitMemCall(self: *Emitter, fe: ast.FieldExpr, c: ast.CallExpr) !void {
+        const fn_name = self.source[fe.field.start..fe.field.end];
+        if (std.mem.eql(u8, fn_name, "read_u8") or std.mem.eql(u8, fn_name, "peek")) {
+            try self.emitMemRead1Arg(c, .byte_zext);
+        } else if (std.mem.eql(u8, fn_name, "read_u16") or std.mem.eql(u8, fn_name, "read_i16")) {
+            try self.emitMemRead1Arg(c, .word);
+        } else if (std.mem.eql(u8, fn_name, "read_i8")) {
+            try self.emitMemRead1Arg(c, .byte_sext);
+        } else if (std.mem.eql(u8, fn_name, "write_u8") or std.mem.eql(u8, fn_name, "write_i8") or std.mem.eql(u8, fn_name, "poke")) {
+            try self.emitMemWrite2Args(c, .byte);
+        } else if (std.mem.eql(u8, fn_name, "write_u16") or std.mem.eql(u8, fn_name, "write_i16")) {
+            try self.emitMemWrite2Args(c, .word);
+        } else if (std.mem.eql(u8, fn_name, "memcpy")) {
+            try self.emitMemCopy(c);
+        } else if (std.mem.eql(u8, fn_name, "memset")) {
+            try self.emitMemFill(c);
+        } else if (std.mem.eql(u8, fn_name, "addr_of")) {
+            if (c.args.len != 1) {
+                try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.addr_of` takes exactly one argument");
+                return;
+            }
+            try self.emitAddrOf(c.args[0]);
+        } else {
+            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `mem` builtin");
+        }
+    }
+
+    const MemReadKind = enum { byte_zext, byte_sext, word };
+    const MemWriteKind = enum { byte, word };
+
+    /// Common shape: `mem.read_*(addr)` — one arg, returns a value
+    /// in `acu`. The width / sign-extension choice picks the load
+    /// opcode (and an optional sign-extension tail for `read_i8`).
+    fn emitMemRead1Arg(self: *Emitter, c: ast.CallExpr, kind: MemReadKind) !void {
+        if (c.args.len != 1) {
+            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.read_*` takes exactly one argument");
+            return;
+        }
+        try self.emitExpr(c.args[0]); // acu = addr
+        try self.movRegToReg(Reg.acu, Reg.r1); // r1 = addr
+        switch (kind) {
+            .word => {
+                try self.emitByte(Op.mov_ptr_to_reg);
+                try self.emitByte(Reg.acu); // dst
+                try self.emitByte(Reg.r1); // ptr
+            },
+            .byte_zext => {
+                try self.emitByte(Op.mov8_ptr_to_reg);
+                try self.emitByte(Reg.r1); // ptr
+                try self.emitByte(Reg.acu); // dst
+            },
+            .byte_sext => {
+                try self.emitByte(Op.mov8_ptr_to_reg);
+                try self.emitByte(Reg.r1);
+                try self.emitByte(Reg.acu);
+                // Sign-extend 8 → 16: `shl 8 ; asr 8`. The byte
+                // sits in `acu.lo`; shifting it into the top byte
+                // and back arithmetic-shift-right preserves the
+                // sign bit through the high half.
+                try self.shlRegImm(Reg.acu, 8);
+                try self.asrRegImm(Reg.acu, 8);
+            },
+        }
+    }
+
+    /// Common shape: `mem.write_*(addr, v)` — two args, no return.
+    /// Args eval left-to-right via push/pop so `addr` and `v` can
+    /// be arbitrary subexpressions.
+    fn emitMemWrite2Args(self: *Emitter, c: ast.CallExpr, kind: MemWriteKind) !void {
+        if (c.args.len != 2) {
+            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.write_*` takes exactly two arguments");
+            return;
+        }
+        try self.emitExpr(c.args[0]); // acu = addr
+        try self.pushReg(Reg.acu);
+        try self.emitExpr(c.args[1]); // acu = value
+        try self.popReg(Reg.r1); // r1 = addr
+        switch (kind) {
+            .word => {
+                try self.emitByte(Op.mov_reg_to_ptr);
+                try self.emitByte(Reg.r1); // ptr
+                try self.emitByte(Reg.acu); // src
+            },
+            .byte => {
+                try self.emitByte(Op.mov8_reg_to_ptr);
+                try self.emitByte(Reg.acu); // src (low byte)
+                try self.emitByte(Reg.r1); // ptr
+            },
+        }
+    }
+
+    /// `mem.memcpy(dst, src, n)` — eval each arg left-to-right
+    /// into a dedicated register, then emit `bcpy dst, src, len`
+    /// (opcode 0x2C).
+    fn emitMemCopy(self: *Emitter, c: ast.CallExpr) !void {
+        if (c.args.len != 3) {
+            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.memcpy` takes exactly three arguments");
+            return;
+        }
+        try self.emitExpr(c.args[0]); // dst
+        try self.pushReg(Reg.acu);
+        try self.emitExpr(c.args[1]); // src
+        try self.pushReg(Reg.acu);
+        try self.emitExpr(c.args[2]); // n → acu
+        try self.movRegToReg(Reg.acu, Reg.r3); // r3 = len
+        try self.popReg(Reg.r2); // r2 = src
+        try self.popReg(Reg.r1); // r1 = dst
+        try self.emitByte(Op.bcpy);
+        try self.emitByte(Reg.r1); // dst
+        try self.emitByte(Reg.r2); // src
+        try self.emitByte(Reg.r3); // len
+    }
+
+    /// `mem.memset(dst, v, n)` — eval args into dedicated regs and
+    /// emit `bfill addr, len, val` (opcode 0x2D). Note the operand
+    /// order: the VM reads bytes as `dst, len, val`.
+    fn emitMemFill(self: *Emitter, c: ast.CallExpr) !void {
+        if (c.args.len != 3) {
+            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.memset` takes exactly three arguments");
+            return;
+        }
+        try self.emitExpr(c.args[0]); // dst
+        try self.pushReg(Reg.acu);
+        try self.emitExpr(c.args[1]); // v
+        try self.pushReg(Reg.acu);
+        try self.emitExpr(c.args[2]); // n → acu
+        try self.movRegToReg(Reg.acu, Reg.r3); // r3 = len
+        try self.popReg(Reg.r2); // r2 = val
+        try self.popReg(Reg.r1); // r1 = dst
+        try self.emitByte(Op.bfill);
+        try self.emitByte(Reg.r1); // dst
+        try self.emitByte(Reg.r3); // len
+        try self.emitByte(Reg.r2); // val
+    }
+
+    /// Compute the address of an addressable expression and leave
+    /// it in `acu`. Backs `mem.addr_of(x)` and the typed `&x`
+    /// reference operator. Slice M3a supports plain idents (locals,
+    /// params, globals); field / index targets land with M3b's
+    /// struct + class layout.
+    fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
+        if (e.* != .ident) {
+            try self.unsupported(e.span(), "`addr_of` on non-ident expression (M3b brings field / index targets)");
+            return;
+        }
+        const name = self.source[e.ident.span.start..e.ident.span.end];
+        if (self.locals.get(name)) |ofs| {
+            // Local: address = fp + ofs (ofs is negative).
+            try self.movRegToReg(Reg.fp, Reg.acu);
+            if (ofs < 0) {
+                // @as: widen i8 → i16 so the negate doesn't trip on the minimum value.
+                const widened: i16 = ofs;
+                // @as: |ofs| ≤ 128 by allocLocal cap; result fits a u16.
+                const neg: u16 = @intCast(-widened);
+                try self.subImmFromReg(neg, Reg.acu);
+            } else if (ofs > 0) {
+                // @as: positive i8 → u16; cap by allocLocal layout.
+                const pos: u16 = @intCast(ofs);
+                try self.addImmToReg(pos, Reg.acu);
+            }
+            return;
+        }
+        if (self.params.get(name)) |ofs| {
+            // Param: address = fp + ofs (ofs is positive).
+            try self.movRegToReg(Reg.fp, Reg.acu);
+            // @as: positive i8 → u16.
+            const pos: u16 = @intCast(ofs);
+            try self.addImmToReg(pos, Reg.acu);
+            return;
+        }
+        if (self.globals.get(name)) |g| {
+            try self.movImmToReg(g.address, Reg.acu);
+            return;
+        }
+        try self.unsupported(e.span(), "`addr_of` target not in scope");
+    }
+
     // ---------- diagnostics ----------
 
     fn diagFatal(self: *Emitter, span: ast.Span, code: []const u8, message: []const u8) !void {
@@ -2803,8 +3057,8 @@ const Emitter = struct {
 
     fn unsupported(self: *Emitter, span: ast.Span, what: []const u8) !void {
         const msg = try std.fmt.allocPrint(
-            self.arena,
-            "codegen does not yet support {s} (slice M1 only covers let/const + arithmetic + print)",
+            self.diag_arena,
+            "codegen does not yet support {s}",
             .{what},
         );
         try self.diagnostics.append(self.allocator, .{

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -62,6 +62,8 @@ pub const mem_builtin = @import("codegen/mem_builtin.zig");
 pub const strings = @import("codegen/strings.zig");
 /// `match` pattern-arm test emission.
 pub const pattern = @import("codegen/pattern.zig");
+/// Expression lowering — `emitExpr` and the per-shape helpers.
+pub const expr_emit = @import("codegen/expr.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const CheckedProgram = typecheck_mod.CheckedProgram;
@@ -247,7 +249,7 @@ fn findEntryDef(source: []const u8, program: *const ast.Program, entry_name: []c
 /// when the callee's address wasn't yet known (forward refs). At
 /// the end of emission, every patch's 2-byte address-slot in
 /// `code` is overwritten with the resolved callee address.
-const CallPatch = struct {
+pub const CallPatch = struct {
     /// Which buffer the patch lives in — `null` = base code,
     /// non-null = bank N's buffer.
     bank: ?u8,
@@ -264,7 +266,7 @@ const CallPatch = struct {
     /// - `fn_name`: resolve via the codegen's `fn_addresses` map.
     /// - `trampoline`: resolve to the `__call_bank` trampoline's
     ///   address, recorded after the trampoline emits.
-    const Target = union(enum) {
+    pub const Target = union(enum) {
         fn_name: []const u8,
         trampoline,
     };
@@ -479,7 +481,7 @@ pub const Emitter = struct {
     }
 
     /// `mov [base + ofs], dst` (0x1C) — load fp-relative into reg.
-    fn movRegOffsetToReg(self: *Emitter, base: u8, ofs: i8, dst: u8) !void {
+    pub fn movRegOffsetToReg(self: *Emitter, base: u8, ofs: i8, dst: u8) !void {
         try self.emitByte(Op.mov_reg_offset_reg);
         try self.emitByte(base);
         // safety: i8 → u8 bit pattern; reg_offset is signed byte per ISA §5.1.
@@ -583,33 +585,33 @@ pub const Emitter = struct {
     }
 
     /// `add reg` (0x42) — `acu ← acu + reg`.
-    fn addRegToAcu(self: *Emitter, reg: u8) !void {
+    pub fn addRegToAcu(self: *Emitter, reg: u8) !void {
         try self.emitByte(Op.add_reg_acu);
         try self.emitByte(reg);
     }
 
     /// `sub reg` (0x45) — `acu ← acu - reg`.
-    fn subRegFromAcu(self: *Emitter, reg: u8) !void {
+    pub fn subRegFromAcu(self: *Emitter, reg: u8) !void {
         try self.emitByte(Op.sub_reg_acu);
         try self.emitByte(reg);
     }
 
     /// `mul src, dst` (0x47) — `dst ← dst * src`.
-    fn mulRegReg(self: *Emitter, src: u8, dst: u8) !void {
+    pub fn mulRegReg(self: *Emitter, src: u8, dst: u8) !void {
         try self.emitByte(Op.mul_reg_reg);
         try self.emitByte(src);
         try self.emitByte(dst);
     }
 
     /// `divs src, dst` (0x4E) — signed `dst ← dst / src`.
-    fn divsRegReg(self: *Emitter, src: u8, dst: u8) !void {
+    pub fn divsRegReg(self: *Emitter, src: u8, dst: u8) !void {
         try self.emitByte(Op.divs_reg_reg);
         try self.emitByte(src);
         try self.emitByte(dst);
     }
 
     /// `neg reg` (0x4A) — `reg ← -reg` (two's complement).
-    fn negReg(self: *Emitter, reg: u8) !void {
+    pub fn negReg(self: *Emitter, reg: u8) !void {
         try self.emitByte(Op.neg_reg);
         try self.emitByte(reg);
     }
@@ -623,7 +625,7 @@ pub const Emitter = struct {
     }
 
     /// `cmp dst, src` (0x81) — flags ← dst - src.
-    fn cmpRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    pub fn cmpRegReg(self: *Emitter, dst: u8, src: u8) !void {
         try self.emitByte(Op.cmp_reg_reg);
         try self.emitByte(dst);
         try self.emitByte(src);
@@ -631,41 +633,41 @@ pub const Emitter = struct {
 
     /// `and src, dst` (0x61) — `dst ← dst & src`. Source-first byte
     /// per `bitwise.andRegReg` decode.
-    fn andRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    pub fn andRegReg(self: *Emitter, dst: u8, src: u8) !void {
         try self.emitByte(Op.and_reg_reg);
         try self.emitByte(src);
         try self.emitByte(dst);
     }
 
     /// `or src, dst` (0x63).
-    fn orRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    pub fn orRegReg(self: *Emitter, dst: u8, src: u8) !void {
         try self.emitByte(Op.or_reg_reg);
         try self.emitByte(src);
         try self.emitByte(dst);
     }
 
     /// `xor src, dst` (0x65).
-    fn xorRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    pub fn xorRegReg(self: *Emitter, dst: u8, src: u8) !void {
         try self.emitByte(Op.xor_reg_reg);
         try self.emitByte(src);
         try self.emitByte(dst);
     }
 
     /// `not reg` (0x66) — `reg ← ~reg`.
-    fn notRegOp(self: *Emitter, reg: u8) !void {
+    pub fn notRegOp(self: *Emitter, reg: u8) !void {
         try self.emitByte(Op.not_reg);
         try self.emitByte(reg);
     }
 
     /// `shl dst, src` (0x71). Source register holds the shift count.
-    fn shlRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    pub fn shlRegReg(self: *Emitter, dst: u8, src: u8) !void {
         try self.emitByte(Op.shl_reg_reg);
         try self.emitByte(dst);
         try self.emitByte(src);
     }
 
     /// `shr dst, src` (0x73).
-    fn shrRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    pub fn shrRegReg(self: *Emitter, dst: u8, src: u8) !void {
         try self.emitByte(Op.shr_reg_reg);
         try self.emitByte(dst);
         try self.emitByte(src);
@@ -679,7 +681,7 @@ pub const Emitter = struct {
     }
 
     /// `shr reg, imm8` (0x72) — `reg ← reg >> imm` (zero-fill).
-    fn shrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
+    pub fn shrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
         try self.emitByte(Op.shr_reg_imm8);
         try self.emitByte(reg);
         try self.emitByte(imm);
@@ -1122,7 +1124,7 @@ pub const Emitter = struct {
 
     /// Emit a load of `g`'s value into `acu`. The instruction
     /// shape depends on the placement family + byte width.
-    fn emitGlobalLoad(self: *Emitter, g: Global) !void {
+    pub fn emitGlobalLoad(self: *Emitter, g: Global) !void {
         switch (g.placement) {
             .addr => {
                 if (g.width == 1) {
@@ -1465,135 +1467,19 @@ pub const Emitter = struct {
         }
     }
 
-    /// Evaluate a boolean-valued expression and leave a 0 / 1 in
-    /// `acu`, then `cmp acu, 0` so the caller can pick a conditional
-    /// jump (typically `jeq` to skip on false, `jne` to fall through
-    /// on true). When the expression is a direct comparison or
-    /// boolean literal the codegen folds the materialization step,
-    /// emitting just the cmp.
+    /// Delegated to `codegen/expr.zig`.
     fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
-        // Fast-path: a top-level comparison or logical-not can drive
-        // the flags directly without going through a 0/1 materialize.
-        if (e.* == .binary) {
-            const b = e.binary;
-            switch (b.op) {
-                .eq, .neq, .lt, .lte, .gt, .gte => {
-                    // Eval LHS into acu, eval RHS into r1, cmp acu, r1.
-                    try self.emitExpr(b.rhs);
-                    try self.pushReg(Reg.acu);
-                    try self.emitExpr(b.lhs);
-                    try self.popReg(Reg.r1);
-                    try self.cmpRegReg(Reg.acu, Reg.r1);
-                    // We always emit a jeq below to skip the body on
-                    // `false`; turn the comparison's flag-test
-                    // accordingly. For `==`, `false` means Z=0 (so
-                    // jne skips). We can't easily change the op the
-                    // caller emits without a callback, so we
-                    // materialize a synthetic acu-vs-0 result by
-                    // flipping with a small sequence:
-                    //
-                    //   <cmp>
-                    //   mov 0, acu
-                    //   <set acu = 1 if cond>
-                    //   cmp acu, 0
-                    //
-                    // That's more bytes than needed. Cleaner: do
-                    // the full materialization path and let the
-                    // caller's jeq do the right thing on the 0/1.
-                    try self.materializeBoolFromFlags(b.op);
-                    try self.cmpRegImm(Reg.acu, 0);
-                    return;
-                },
-                .log_and, .log_or => {
-                    try self.emitShortCircuitBool(b);
-                    try self.cmpRegImm(Reg.acu, 0);
-                    return;
-                },
-                else => {},
-            }
-        }
-        if (e.* == .unary and e.unary.op == .log_not) {
-            try self.emitExpr(e.unary.operand);
-            // Logical NOT — invert acu: acu = (acu == 0) ? 1 : 0.
-            try self.cmpRegImm(Reg.acu, 0);
-            try self.materializeBoolFromFlags(.eq);
-            try self.cmpRegImm(Reg.acu, 0);
-            return;
-        }
-        // Generic path — evaluate to acu, then test against 0.
-        try self.emitExpr(e);
-        try self.cmpRegImm(Reg.acu, 0);
+        return expr_emit.emitCondBranch(self, e);
     }
 
-    /// Materialize a 0 / 1 boolean in `acu` from the current flag
-    /// state set by a preceding `cmp`. Picks the right conditional
-    /// jump per comparison kind.
+    /// Delegated to `codegen/expr.zig`.
     fn materializeBoolFromFlags(self: *Emitter, op: ast.BinaryOp) !void {
-        const taken_op: u8 = switch (op) {
-            .eq => Op.jeq_addr,
-            .neq => Op.jne_addr,
-            .lt => Op.jlt_addr,
-            .lte => Op.jle_addr,
-            .gt => Op.jgt_addr,
-            .gte => Op.jge_addr,
-            // allow-strict: emitCondBranch filters to comparison ops before calling here.
-            else => unreachable,
-        };
-        // Pattern:
-        //   <prior cmp>
-        //   jXX true_label
-        //   mov 0, acu
-        //   jmp end
-        // true_label:
-        //   mov 1, acu
-        // end:
-        const true_patch = try self.emitJumpPlaceholder(taken_op);
-        try self.movImmToReg(0, Reg.acu);
-        const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
-        const true_offset = try self.currentOffset();
-        try self.movImmToReg(1, Reg.acu);
-        const end_offset = try self.currentOffset();
-        try self.patchJumpTo(true_patch, true_offset);
-        try self.patchJumpTo(end_patch, end_offset);
+        return expr_emit.materializeBoolFromFlags(self, op);
     }
 
-    /// Lower a short-circuiting `and` / `or` into a chain of
-    /// conditional jumps that leaves a 0 / 1 in `acu`.
+    /// Delegated to `codegen/expr.zig`.
     fn emitShortCircuitBool(self: *Emitter, b: ast.BinaryExpr) !void {
-        switch (b.op) {
-            .log_and => {
-                // acu = lhs; if acu == 0 -> short-circuit false.
-                try self.emitExpr(b.lhs);
-                try self.cmpRegImm(Reg.acu, 0);
-                const short_patch = try self.emitJumpPlaceholder(Op.jeq_addr);
-                try self.emitExpr(b.rhs);
-                // Normalize rhs to 0/1.
-                try self.cmpRegImm(Reg.acu, 0);
-                try self.materializeBoolFromFlags(.neq);
-                const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
-                const short_offset = try self.currentOffset();
-                try self.movImmToReg(0, Reg.acu);
-                const end_offset = try self.currentOffset();
-                try self.patchJumpTo(short_patch, short_offset);
-                try self.patchJumpTo(end_patch, end_offset);
-            },
-            .log_or => {
-                try self.emitExpr(b.lhs);
-                try self.cmpRegImm(Reg.acu, 0);
-                const short_patch = try self.emitJumpPlaceholder(Op.jne_addr);
-                try self.emitExpr(b.rhs);
-                try self.cmpRegImm(Reg.acu, 0);
-                try self.materializeBoolFromFlags(.neq);
-                const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
-                const short_offset = try self.currentOffset();
-                try self.movImmToReg(1, Reg.acu);
-                const end_offset = try self.currentOffset();
-                try self.patchJumpTo(short_patch, short_offset);
-                try self.patchJumpTo(end_patch, end_offset);
-            },
-            // allow-strict: caller filters to log_and / log_or before invoking this helper.
-            else => unreachable,
-        }
+        return expr_emit.emitShortCircuitBool(self, b);
     }
 
     /// Lower `while cond ... end`. Standard top-test loop:
@@ -2044,7 +1930,8 @@ pub const Emitter = struct {
     }
 
     /// Delegated to `codegen/strings.zig`.
-    fn emitStrLitExpr(self: *Emitter, sl: ast.StrLitExpr) !void {
+    /// Delegated to `codegen/strings.zig`.
+    pub fn emitStrLitExpr(self: *Emitter, sl: ast.StrLitExpr) !void {
         return strings.emitStrLitExpr(self, sl);
     }
 
@@ -2053,332 +1940,40 @@ pub const Emitter = struct {
         return strings.emitPrintStrLit(self, sl);
     }
 
+    /// Delegated to `codegen/expr.zig`.
     fn emitExprDiscard(self: *Emitter, e: *const ast.Expr) !void {
-        try self.emitExpr(e);
-        // Result lands in acu; we just don't use it.
+        return expr_emit.emitExprDiscard(self, e);
     }
 
-    // ---------- expression emission (result → acu) ----------
-
-    /// Lower one expression — result lands in `acu`. Branches on
-    /// the AST variant; sub-modules (`mem_builtin`, etc.) call
-    /// back into this through the method dispatch.
+    /// Lower one expression — result lands in `acu`. Sub-modules
+    /// call back into this through the method dispatch.
     pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
-        switch (e.*) {
-            .int_lit => |lit| {
-                // @as: truncate i32 → i16; safety: typechecker already verified the literal fits in the target primitive's width.
-                const trimmed: i16 = @truncate(lit.value);
-                // safety: i16 → u16 bit pattern; the two's-complement encoding is preserved.
-                const v: u16 = @bitCast(trimmed);
-                try self.movImmToReg(v, Reg.acu);
-            },
-            .fixed_lit => |lit| {
-                // Q8.8 — the parser pre-encodes the value as `int *
-                // 256 + round(frac * 256)`. The low 16 bits are the
-                // canonical bit pattern.
-                // @as: i32 → i16; spec §3.3 pins fixed-point to Q8.8 (i16-shaped).
-                const trimmed: i16 = @truncate(lit.value);
-                // safety: i16 → u16 bit pattern preserved (two's complement).
-                const v: u16 = @bitCast(trimmed);
-                try self.movImmToReg(v, Reg.acu);
-            },
-            .str_lit => |sl| try self.emitStrLitExpr(sl),
-            .bool_lit => |b| {
-                const v: u16 = if (b.value) 1 else 0;
-                try self.movImmToReg(v, Reg.acu);
-            },
-            .nil_lit => try self.movImmToReg(0, Reg.acu),
-            .char_lit => |c| try self.movImmToReg(c.value, Reg.acu),
-            .paren => |p| try self.emitExpr(p.inner),
-            .ident => |i| {
-                const name = self.source[i.span.start..i.span.end];
-                // Lookup order: locals → params → globals.
-                if (self.locals.get(name)) |ofs| {
-                    try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
-                    return;
-                }
-                if (self.params.get(name)) |ofs| {
-                    try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
-                    return;
-                }
-                if (self.globals.get(name)) |g| {
-                    try self.emitGlobalLoad(g);
-                    return;
-                }
-                try self.unsupported(i.span, "ident not in current frame");
-            },
-            .unary => |u| try self.emitUnary(u),
-            .binary => |b| try self.emitBinary(b),
-            .call => |c| try self.emitCall(c),
-            .method_call => |m| try self.emitMethodCall(m, e),
-            .field => |f| try self.emitFieldExpr(f, e),
-            .is_test => |it| try self.emitIsTest(it),
-            .ref_of => |r| try self.emitAddrOf(r.inner),
-            .cast => |c| try self.emitExpr(c.inner), // same-width primitives share a bit pattern, so the cast is a no-op
-            else => try self.unsupported(e.span(), "this expression form"),
-        }
+        return expr_emit.emitExpr(self, e);
     }
 
-    /// Lower an `EnumName.Variant` field expression — a nullary
-    /// enum-variant constructor. Loads the variant's tag byte
-    /// into `acu` (the runtime representation of the variant).
-    /// Field access on non-enum receivers (struct / class fields)
-    /// is not yet supported.
+    /// Delegated to `codegen/expr.zig`.
     fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void {
-        if (f.receiver.* == .ident) {
-            const recv_name = self.source[f.receiver.ident.span.start..f.receiver.ident.span.end];
-            if (self.enum_decls.get(recv_name)) |ed| {
-                const variant_name = self.source[f.field.start..f.field.end];
-                const tag = self.variantTag(recv_name, variant_name) orelse {
-                    try self.diagFatal(f.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant");
-                    return;
-                };
-                // A bare `Item.Potion` reference at expression
-                // position (without a call) requires the payload to
-                // be empty — payload-bearing constructors come
-                // through the `CallExpr` path with field-callee.
-                for (ed.variants) |v| {
-                    if (std.mem.eql(u8, self.source[v.name.start..v.name.end], variant_name)) {
-                        if (v.payload.len != 0) {
-                            try self.unsupported(f.span, "payload-bearing enum-variant constructors");
-                            return;
-                        }
-                    }
-                }
-                try self.movImmToReg(tag, Reg.acu);
-                return;
-            }
-        }
-        try self.unsupported(e.span(), "non-enum field access");
+        return expr_emit.emitFieldExpr(self, f, e);
     }
 
-    /// Lower `expr is EnumName.Variant`. Evaluates `expr` into
-    /// `acu`, compares against the variant's tag, materializes a
-    /// `0` / `1` bool. The typechecker validates that the variant
-    /// path matches the LHS's enum type.
+    /// Delegated to `codegen/expr.zig`.
     fn emitIsTest(self: *Emitter, it: ast.IsTestExpr) !void {
-        const path = self.source[it.variant_path.start..it.variant_path.end];
-        const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
-            try self.diagFatal(it.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: `is` rhs must be `EnumName.Variant`");
-            return;
-        };
-        const enum_name = path[0..dot];
-        const variant_name = path[dot + 1 ..];
-        const tag = self.variantTag(enum_name, variant_name) orelse {
-            try self.diagFatal(it.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in `is` test");
-            return;
-        };
-        try self.emitExpr(it.lhs);
-        try self.cmpRegImm(Reg.acu, tag);
-        try self.materializeBoolFromFlags(.eq);
+        return expr_emit.emitIsTest(self, it);
     }
 
+    /// Delegated to `codegen/expr.zig`.
     fn emitUnary(self: *Emitter, u: ast.UnaryExpr) !void {
-        try self.emitExpr(u.operand);
-        switch (u.op) {
-            .neg => try self.negReg(Reg.acu),
-            .bit_not => try self.notRegOp(Reg.acu),
-            .log_not => {
-                // acu = (acu == 0) ? 1 : 0
-                try self.cmpRegImm(Reg.acu, 0);
-                try self.materializeBoolFromFlags(.eq);
-            },
-        }
+        return expr_emit.emitUnary(self, u);
     }
 
+    /// Delegated to `codegen/expr.zig`.
     fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
-        // Short-circuit operators need to not evaluate their RHS
-        // unconditionally — split them out before the standard
-        // stack-machine pattern.
-        switch (b.op) {
-            .log_and, .log_or => {
-                try self.emitShortCircuitBool(b);
-                return;
-            },
-            else => {},
-        }
-
-        // Fixed-point arithmetic (Q8.8) needs a scaling pass on top
-        // of the integer mul / div — `mul + asr 8` for multiply,
-        // `shl 8 + divs` for divide (per ISA §5.4.1). Type info
-        // drives the dispatch: both operands must be fixed-point.
-        const fixed_op = self.isPrimitiveType(b.lhs, .fixed) and
-            self.isPrimitiveType(b.rhs, .fixed) and
-            (b.op == .mul or b.op == .div);
-
-        // Standard stack-machine pattern: eval RHS, push, eval LHS,
-        // pop RHS into r1, apply op (acu = acu OP r1).
-        try self.emitExpr(b.rhs);
-        try self.pushReg(Reg.acu);
-        try self.emitExpr(b.lhs);
-        try self.popReg(Reg.r1);
-        switch (b.op) {
-            .add => try self.addRegToAcu(Reg.r1),
-            .sub => try self.subRegFromAcu(Reg.r1),
-            .mul => {
-                // `mul src, dst` writes low(product) → dst AND
-                // high(product) → acu. If dst == acu the high
-                // half clobbers the low half — so we land the
-                // result in `r2`, then move it back to acu.
-                try self.movRegToReg(Reg.acu, Reg.r2);
-                try self.mulRegReg(Reg.r1, Reg.r2);
-                if (fixed_op) {
-                    // Q8.8 * Q8.8 — the conceptual Q16.16 product
-                    // straddles acu:r2 (acu = high half, r2 = low
-                    // half). The Q8.8 result is bits 8..23 of that
-                    // 32-bit value:
-                    //   acu (high << 8) | (r2 unsigned >> 8)
-                    // ISA §5.4.1 — products whose real magnitude
-                    // exceeds 127.99… wrap silently because the
-                    // result no longer fits in 16 bits.
-                    try self.shrRegImm(Reg.r2, 8);
-                    try self.shlRegImm(Reg.acu, 8);
-                    try self.orRegReg(Reg.acu, Reg.r2);
-                } else {
-                    // Integer mul — drop the high half.
-                    try self.movRegToReg(Reg.r2, Reg.acu);
-                }
-            },
-            .div => {
-                if (fixed_op) {
-                    // Q8.8 / Q8.8 — scale the dividend up by 2^8
-                    // before the signed divide so the quotient lands
-                    // back in Q8.8. The 24-bit pre-shifted dividend
-                    // straddles acu:r2:
-                    //   r2  = acu << 8           (low half)
-                    //   acu = acu >>arith 8      (sign-extended top byte)
-                    // Then `divs r1, r2` performs the 32÷16 signed
-                    // divide and the quotient ends up in r2.
-                    try self.movRegToReg(Reg.acu, Reg.r2);
-                    try self.shlRegImm(Reg.r2, 8); // r2 = lhs << 8 (low)
-                    try self.asrRegImm(Reg.acu, 8); // acu = lhs >>a 8 (high)
-                    try self.divsRegReg(Reg.r1, Reg.r2);
-                    try self.movRegToReg(Reg.r2, Reg.acu);
-                } else {
-                    // Signed 32÷16 divide. Dividend lives in acu:dst
-                    // (high:low); the dividend is assumed to fit in
-                    // 16 bits — sign-extension is not yet emitted.
-                    try self.movRegToReg(Reg.acu, Reg.r2); // r2 = low half
-                    try self.movImmToReg(0, Reg.acu); // high half = 0
-                    try self.divsRegReg(Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
-                    try self.movRegToReg(Reg.r2, Reg.acu);
-                }
-            },
-            .mod => {
-                // Same divs pattern as `div`, but keep `acu` (the
-                // remainder is exactly what `mod` wants).
-                try self.movRegToReg(Reg.acu, Reg.r2); // r2 = low half
-                try self.movImmToReg(0, Reg.acu); // high half = 0
-                try self.divsRegReg(Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
-            },
-            .bit_and => try self.andRegReg(Reg.acu, Reg.r1),
-            .bit_or => try self.orRegReg(Reg.acu, Reg.r1),
-            .bit_xor => try self.xorRegReg(Reg.acu, Reg.r1),
-            .shl => try self.shlRegReg(Reg.acu, Reg.r1),
-            .shr => try self.shrRegReg(Reg.acu, Reg.r1),
-            .eq, .neq, .lt, .lte, .gt, .gte => {
-                try self.cmpRegReg(Reg.acu, Reg.r1);
-                try self.materializeBoolFromFlags(b.op);
-            },
-            // allow-strict: handled by the short-circuit branch above; emitBinary never falls through here for these ops.
-            .log_and, .log_or => unreachable,
-        }
+        return expr_emit.emitBinary(self, b);
     }
 
-    /// Lower `callee(args...)` per the free-fn calling convention:
-    ///
-    ///   - Push args **right-to-left** (so callee sees param 0 at
-    ///     `[fp + 4]`, param 1 at `[fp + 6]`, ...).
-    ///   - `call <addr>` — the VM enters: push fp, push ret_ip,
-    ///     fp ← sp, ip ← target.
-    ///   - On return, `add <N*2>, sp` to drop the args. The
-    ///     callee's return value lives in `acu`.
-    ///
-    /// Slice M1 only handles direct calls — the callee must be a
-    /// bare ident referencing a top-level `def`. Method calls /
-    /// Closure invocations and fn-pointer calls are not yet supported.
+    /// Delegated to `codegen/expr.zig`.
     fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
-        // Intercept compiler-known builtins before the regular
-        // direct-call path so they emit specialized opcode
-        // sequences instead of going through a `call addr` site.
-        if (c.callee.* == .field) {
-            const fe = c.callee.field;
-            if (fe.receiver.* == .ident) {
-                const recv = self.source[fe.receiver.ident.span.start..fe.receiver.ident.span.end];
-                if (std.mem.eql(u8, recv, "mem")) {
-                    try self.emitMemCall(fe, c);
-                    return;
-                }
-            }
-        }
-        if (c.callee.* != .ident) {
-            try self.unsupported(c.span, "non-ident callee");
-            return;
-        }
-        const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
-        const dup = try self.arena.dupe(u8, callee_name);
-
-        // Decide direct call vs trampoline by comparing the
-        // caller's bank with the target's. The pre-pass populated
-        // `fn_banks` so this resolves without needing the address.
-        const target_bank: ?u8 = self.fn_banks.get(callee_name) orelse null;
-        const cross_bank = !banksEqual(self.current_bank, target_bank);
-
-        // Push args right-to-left (caller-cleans-up).
-        var i: usize = c.args.len;
-        while (i > 0) {
-            i -= 1;
-            try self.emitExpr(c.args[i]);
-            try self.pushReg(Reg.acu);
-        }
-
-        if (cross_bank) {
-            // Trampoline path:
-            //   mov <target_addr>, r1   ; patched at end
-            //   mov <target_bank>,  r2  ; literal at emit time
-            //   call __call_bank        ; patched at end
-            try self.emitByte(Op.mov_imm16_reg);
-            const addr_patch_offset = try self.currentOffset();
-            try self.emitU16Le(0); // placeholder
-            try self.emitByte(Reg.r1);
-            // mov <bank>, r2  — bank known at emit time (null → 0).
-            const target_bank_byte: u8 = target_bank orelse 0;
-            try self.movImmToReg(target_bank_byte, Reg.r2);
-            // call __call_bank  (patched at end)
-            try self.emitByte(Op.call_addr);
-            const tramp_patch_offset = try self.currentOffset();
-            try self.emitU16Le(0);
-
-            try self.call_patches.append(self.allocator, .{
-                .bank = self.current_bank,
-                .code_offset = addr_patch_offset,
-                .target = .{ .fn_name = dup },
-                .span = c.span,
-            });
-            try self.call_patches.append(self.allocator, .{
-                .bank = self.current_bank,
-                .code_offset = tramp_patch_offset,
-                .target = .trampoline,
-                .span = c.span,
-            });
-        } else {
-            // Direct same-bank call.
-            try self.emitByte(Op.call_addr);
-            const patch_offset = try self.currentOffset();
-            try self.emitU16Le(0); // placeholder
-            try self.call_patches.append(self.allocator, .{
-                .bank = self.current_bank,
-                .code_offset = patch_offset,
-                .target = .{ .fn_name = dup },
-                .span = c.span,
-            });
-        }
-
-        if (c.args.len > 0) {
-            // @as: each arg is one 16-bit word; arg count capped by parser.
-            const drop_bytes: u16 = @intCast(c.args.len * 2);
-            try self.addImmToReg(drop_bytes, Reg.sp);
-        }
+        return expr_emit.emitCall(self, c);
     }
 
     // ---------- block + defer infrastructure ----------
@@ -2468,46 +2063,23 @@ pub const Emitter = struct {
         return null;
     }
 
-    /// Lower a `receiver.method(args)` expression. The stdlib
-    /// `mem.X(...)` shape dispatches through the builtin lookup.
-    /// Other receivers (class instance method calls) are not yet
-    /// supported.
+    /// Delegated to `codegen/expr.zig`.
     fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr) !void {
-        if (m.receiver.* == .ident) {
-            const recv = self.source[m.receiver.ident.span.start..m.receiver.ident.span.end];
-            if (std.mem.eql(u8, recv, "mem")) {
-                // Build a synthetic `FieldExpr` + `CallExpr` shape
-                // so the existing `emitMemCall` can dispatch without
-                // duplicating the per-builtin emit code.
-                const synth_field: ast.FieldExpr = .{
-                    .receiver = m.receiver,
-                    .field = m.method,
-                    .span = m.span,
-                };
-                const synth_call: ast.CallExpr = .{
-                    .callee = m.receiver, // unused by emitMemCall
-                    .args = m.args,
-                    .span = m.span,
-                };
-                try self.emitMemCall(synth_field, synth_call);
-                return;
-            }
-        }
-        try self.unsupported(e.span(), "method calls on non-stdlib receivers");
+        return expr_emit.emitMethodCall(self, m, e);
     }
 
     // ---------- mem stdlib builtins (delegated) ----------
 
     /// Dispatch a `mem.X(args)` call to the matching emitter in
     /// `codegen/mem_builtin.zig`.
-    fn emitMemCall(self: *Emitter, fe: ast.FieldExpr, c: ast.CallExpr) !void {
+    pub fn emitMemCall(self: *Emitter, fe: ast.FieldExpr, c: ast.CallExpr) !void {
         return mem_builtin.emitMemCall(self, fe, c);
     }
 
     /// Compute the address of an addressable expression into
     /// `acu`. Backs `mem.addr_of(x)` and the `&x` reference
     /// operator.
-    fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
+    pub fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
         return mem_builtin.emitAddrOf(self, e);
     }
 

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -64,6 +64,10 @@ pub const strings = @import("codegen/strings.zig");
 pub const pattern = @import("codegen/pattern.zig");
 /// Expression lowering — `emitExpr` and the per-shape helpers.
 pub const expr_emit = @import("codegen/expr.zig");
+/// Control-flow lowering — if / while / for / repeat / match /
+/// break / continue / defer + the block / loop-frame stack
+/// helpers.
+pub const control_flow = @import("codegen/control_flow.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const CheckedProgram = typecheck_mod.CheckedProgram;
@@ -277,7 +281,7 @@ pub const CallPatch = struct {
 /// re-emit them at every exit path (fall-through, `return`, `break`,
 /// `continue`). The body of a `defer` is held by pointer — the same
 /// AST node is re-emitted once per exit path the codegen lowers.
-const Block = struct {
+pub const Block = struct {
     defers: std.ArrayList(*const ast.Statement),
 };
 
@@ -287,7 +291,7 @@ const Block = struct {
 /// codegen can resolve them at the end of the loop, and the index of
 /// the loop body's block in `block_stack` so `break` / `continue`
 /// know which range of blocks to unwind on the jump path.
-const LoopFrame = struct {
+pub const LoopFrame = struct {
     /// Optional `:label` on the loop head. `null` for unlabeled
     /// loops. Lookup matches by string equality against this; a
     /// `break :name` with no enclosing match is a codegen-time error
@@ -727,7 +731,9 @@ pub const Emitter = struct {
 
     /// Emit an unconditional jump to a known target offset within the
     /// current buffer. Used for back-edges (loop bottom → loop top).
-    fn emitJumpBack(self: *Emitter, target_offset: usize) !void {
+    /// Emit an unconditional jump to a known target offset
+    /// within the current buffer. Used for loop back-edges.
+    pub fn emitJumpBack(self: *Emitter, target_offset: usize) !void {
         try self.emitByte(Op.jmp_addr);
         // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
         const target_in_buffer: u16 = @intCast(target_offset);
@@ -736,7 +742,9 @@ pub const Emitter = struct {
 
     /// Base address of the current code buffer in VM memory — used to
     /// turn a buffer-local offset into a `jmp` target.
-    fn currentBufferBase(self: *const Emitter) u16 {
+    /// Base address of the current code buffer in VM memory.
+    /// Used to turn a buffer-local offset into a `jmp` target.
+    pub fn currentBufferBase(self: *const Emitter) u16 {
         if (self.current_bank) |_| return bank_window_base;
         return code_base;
     }
@@ -1319,7 +1327,9 @@ pub const Emitter = struct {
 
     // ---------- statement emission ----------
 
-    fn emitStatement(self: *Emitter, stmt: ast.Statement) EmitError!void {
+    /// Dispatch one statement to its lowering. Sub-modules call
+    /// back into this for body walks.
+    pub fn emitStatement(self: *Emitter, stmt: ast.Statement) EmitError!void {
         switch (stmt) {
             .let_decl => |d| try self.emitLetDecl(d),
             .const_decl => |d| try self.emitConstDecl(d),
@@ -1344,131 +1354,30 @@ pub const Emitter = struct {
     /// Walk `body` inside a fresh `Block` scope. The common
     /// helper for any statement-list with its own defer lifetime
     /// (do-blocks, if-arm bodies, loop bodies, match-arm bodies).
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitScopedBody(self: *Emitter, body: []const ast.Statement) EmitError!void {
-        try self.pushBlock();
-        for (body) |s| try self.emitStatement(s);
-        try self.popBlockWithDefers();
+        return control_flow.emitScopedBody(self, body);
     }
 
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitBlockStmt(self: *Emitter, b: ast.BlockStmt) !void {
-        try self.emitScopedBody(b.body);
+        return control_flow.emitBlockStmt(self, b);
     }
 
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitDeferStmt(self: *Emitter, ds: ast.DeferStmt) !void {
-        if (self.block_stack.items.len == 0) {
-            try self.diagFatal(ds.span, "E_CODEGEN_DEFER_NO_BLOCK", "codegen: `defer` outside a block — likely a frontend bug");
-            return;
-        }
-        // Forbidden defer shapes (`defer return / break / continue
-        // / defer`) are rejected by the typechecker; the codegen
-        // trusts that gate.
-        const top = self.block_stack.items.len - 1;
-        try self.block_stack.items[top].defers.append(self.allocator, ds.body);
+        return control_flow.emitDeferStmt(self, ds);
     }
 
-    // ---------- control-flow lowering ----------
+    // ---------- control-flow lowering (delegated) ----------
 
-    /// Lower `if cond1 then ... elif cond2 then ... else ... end`.
-    /// Each arm emits its condition test (jumping over the body on
-    /// false), then the body, then a forward jump over every later
-    /// arm. The forward jumps collapse at the end of the if chain
-    /// onto one shared `end` label.
-    ///
-    /// The `if let pat = expr [when guard]` form binds a fresh local
-    /// for the pattern and guards the arm on the bind + the optional
-    /// `when` predicate. Only the ident-binder form is supported;
-    /// destructuring patterns are unsupported.
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitIfStmt(self: *Emitter, is_: ast.IfStmt) !void {
-        // Patches that need to jump to the end of the whole chain
-        // once the chain finishes emitting (one per arm body fall-
-        // through, plus the else body if it terminates with one).
-        var end_patches: std.ArrayList(usize) = .empty;
-        defer end_patches.deinit(self.allocator);
-
-        for (is_.arms) |arm| {
-            // Per spec §4.4: an arm is either the plain `cond`
-            // shape OR the `let pat = expr [when guard]` shape.
-            const skip_body_patch = try self.emitIfArmTest(arm);
-
-            // Body — own scope (defers attach here).
-            try self.emitScopedBody(arm.body);
-
-            // After the body, jump to the end of the chain. We can
-            // skip this jump if it's the last arm AND there is no
-            // else body (the body's last byte naturally falls
-            // through to whatever's next).
-            try end_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
-
-            // Wire the "false" jump to land here, after the body's
-            // forward jump and right before the next arm's test.
-            const after_body = try self.currentOffset();
-            try self.patchJumpTo(skip_body_patch, after_body);
-        }
-
-        if (is_.else_body) |eb| try self.emitScopedBody(eb);
-
-        const end_offset = try self.currentOffset();
-        for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
-    }
-
-    /// Emit the test for one if-arm and return the offset of the
-    /// "skip body" jump patch — the caller resolves it to the byte
-    /// right after the body.
-    fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
-        if (arm.cond) |c| {
-            // Plain `if cond` arm — evaluate the cond as a 0 / 1
-            // value in acu, compare against 0, jump-on-equal.
-            try self.emitCondBranch(c);
-            // `emitCondBranch` returns nothing — emit the placeholder
-            // here. Falls through when cond is truthy, jumps when
-            // cond is falsy. We use jeq (skip body on zero).
-            return try self.emitJumpPlaceholder(Op.jeq_addr);
-        }
-        // `if let pat = expr [when guard]` — ident-binder form.
-        const pat = arm.let_pattern.?.*;
-        const expr = arm.let_expr.?;
-        // Evaluate the RHS into acu.
-        try self.emitExpr(expr);
-        switch (pat) {
-            .ident => |id| {
-                const name = self.source[id.name.start..id.name.end];
-                const dup = try self.arena.dupe(u8, name);
-                const ofs = try self.allocLocal(dup);
-                // Bind the slot — the ident pattern always matches.
-                try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
-                // Optional `when guard` — evaluate and skip body
-                // on zero. With no guard, the bind always succeeds,
-                // so we emit `cmp acu, 0; jeq skip` after binding to
-                // turn the bind itself into a "non-zero" test? No —
-                // an ident binder matches anything, including 0.
-                // Without a guard, the arm always fires.
-                if (arm.let_guard) |g| {
-                    try self.emitExpr(g);
-                    try self.cmpRegImm(Reg.acu, 0);
-                    return try self.emitJumpPlaceholder(Op.jeq_addr);
-                }
-                // No guard — placeholder for symmetry with the plain
-                // arm, but emit an `unconditional NO-skip`: a never-
-                // taken jump. Simplest is to compare a const-true to
-                // 0 with jne, which never branches. We model that by
-                // not emitting a real skip — but the caller expects
-                // an offset to patch. Emit a `jeq` past a comparison
-                // that always fails (acu = 1; cmp 0).
-                try self.movImmToReg(1, Reg.r1);
-                try self.cmpRegImm(Reg.r1, 0);
-                return try self.emitJumpPlaceholder(Op.jeq_addr);
-            },
-            else => {
-                try self.unsupported(arm.span, "`if let` patterns other than a bare ident");
-                // Emit a placeholder anyway so the caller doesn't
-                // walk the patches list into a hole.
-                return try self.emitJumpPlaceholder(Op.jeq_addr);
-            },
-        }
+        return control_flow.emitIfStmt(self, is_);
     }
 
     /// Delegated to `codegen/expr.zig`.
-    fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
+    pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
         return expr_emit.emitCondBranch(self, e);
     }
 
@@ -1482,315 +1391,31 @@ pub const Emitter = struct {
         return expr_emit.emitShortCircuitBool(self, b);
     }
 
-    /// Lower `while cond ... end`. Standard top-test loop:
-    /// continue-target sits at the cond test, exit-target at the
-    /// byte after the back-edge. `while let` is supported for the
-    /// ident-binder form per spec §4.5.2.
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
-        const cond_offset = try self.currentOffset();
-        const label_str: ?[]const u8 = if (ws.label) |s|
-            try self.arena.dupe(u8, self.source[s.start..s.end])
-        else
-            null;
-
-        // Push the body block BEFORE the cond test so the frame's
-        // `body_block_idx` aligns with the actual body block. Defers
-        // registered inside the body live in this block.
-        try self.pushBlock();
-        const body_block_idx = self.block_stack.items.len - 1;
-        try self.loop_stack.append(self.allocator, .{
-            .label = label_str,
-            .body_block_idx = body_block_idx,
-            .break_patches = .empty,
-            .continue_patches = .empty,
-        });
-
-        // Condition test — either plain cond or `while let pat = expr`.
-        const exit_on_false_patch = if (ws.cond) |c| blk: {
-            try self.emitCondBranch(c);
-            break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
-        } else blk: {
-            // while let pat = expr [when guard]
-            const pat = ws.let_pattern.?.*;
-            try self.emitExpr(ws.let_expr.?);
-            switch (pat) {
-                .ident => |id| {
-                    const name = self.source[id.name.start..id.name.end];
-                    const dup = try self.arena.dupe(u8, name);
-                    const ofs = try self.allocLocal(dup);
-                    try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
-                    if (ws.let_guard) |g| {
-                        try self.emitExpr(g);
-                        try self.cmpRegImm(Reg.acu, 0);
-                        break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
-                    }
-                    // No guard — ident binder always matches; emit
-                    // a never-taken skip for symmetry.
-                    try self.movImmToReg(1, Reg.r1);
-                    try self.cmpRegImm(Reg.r1, 0);
-                    break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
-                },
-                else => {
-                    try self.unsupported(ws.span, "`while let` patterns other than a bare ident");
-                    break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
-                },
-            }
-        };
-
-        // Body — defers register against the block we just pushed.
-        for (ws.body) |s| try self.emitStatement(s);
-        try self.popBlockWithDefers();
-
-        // Back-edge to the cond test.
-        try self.emitJumpBack(cond_offset);
-
-        // `break` lands here; `continue` lands at the cond test.
-        const exit_offset = try self.currentOffset();
-        try self.patchJumpTo(exit_on_false_patch, exit_offset);
-
-        var frame = self.loop_stack.pop().?;
-        for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
-        for (frame.continue_patches.items) |p| try self.patchJumpTo(p, cond_offset);
-        frame.break_patches.deinit(self.allocator);
-        frame.continue_patches.deinit(self.allocator);
+        return control_flow.emitWhileStmt(self, ws);
     }
 
-    /// Lower `repeat body until cond`. Bottom-test loop: the body
-    /// always runs at least once; `cond` is tested after the body
-    /// and the loop exits when `cond` is truthy. `continue` jumps
-    /// to the trailing test; `break` jumps past it.
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitRepeatStmt(self: *Emitter, rs: ast.RepeatStmt) !void {
-        const top_offset = try self.currentOffset();
-        const label_str: ?[]const u8 = if (rs.label) |s|
-            try self.arena.dupe(u8, self.source[s.start..s.end])
-        else
-            null;
-
-        try self.pushBlock();
-        const body_block_idx = self.block_stack.items.len - 1;
-        try self.loop_stack.append(self.allocator, .{
-            .label = label_str,
-            .body_block_idx = body_block_idx,
-            .break_patches = .empty,
-            .continue_patches = .empty,
-        });
-
-        for (rs.body) |s| try self.emitStatement(s);
-        try self.popBlockWithDefers();
-
-        // `continue` jumps here — the trailing `until` test.
-        const test_offset = try self.currentOffset();
-        try self.emitCondBranch(rs.cond);
-        // `repeat … until cond` exits when cond is truthy — so
-        // `jne` (cond non-zero) jumps back over the back-edge to
-        // the bottom of the loop, while a `jeq` falls back to top.
-        // Simpler: emit `jeq top` so that when cond is false (zero)
-        // we go back, and when cond is true we fall through to exit.
-        try self.emitByte(Op.jeq_addr);
-        // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
-        const top_in_buffer: u16 = @intCast(top_offset);
-        try self.emitU16Le(self.currentBufferBase() +% top_in_buffer);
-
-        const exit_offset = try self.currentOffset();
-        var frame = self.loop_stack.pop().?;
-        for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
-        for (frame.continue_patches.items) |p| try self.patchJumpTo(p, test_offset);
-        frame.break_patches.deinit(self.allocator);
-        frame.continue_patches.deinit(self.allocator);
+        return control_flow.emitRepeatStmt(self, rs);
     }
 
-    /// Lower `for x in start..end [step S] body end` — the range
-    /// special case per spec §4.5.3. User-defined iterables
-    /// (`next(self) -> T?`) are not yet supported.
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
-        if (fs.iter.* != .range) {
-            try self.unsupported(fs.span, "`for` over non-range iterables");
-            return;
-        }
-        const range = fs.iter.range;
-        const inclusive = range.inclusive;
-        const step_expr = fs.step;
-        const binding_name = self.source[fs.binding.start..fs.binding.end];
-
-        // Allocate slots: the loop variable + a hidden `end` slot.
-        const dup_name = try self.arena.dupe(u8, binding_name);
-        const var_ofs = try self.allocLocal(dup_name);
-        const end_ofs = try self.allocLocal(try self.arena.dupe(u8, "\x00__for_end"));
-
-        // Evaluate start → acu, store into the loop variable.
-        try self.emitExpr(range.start);
-        try self.movRegToRegOffset(Reg.acu, Reg.fp, var_ofs);
-        // Evaluate end → acu, store into the hidden end slot.
-        try self.emitExpr(range.end);
-        try self.movRegToRegOffset(Reg.acu, Reg.fp, end_ofs);
-
-        const label_str: ?[]const u8 = if (fs.label) |s|
-            try self.arena.dupe(u8, self.source[s.start..s.end])
-        else
-            null;
-
-        try self.pushBlock();
-        const body_block_idx = self.block_stack.items.len - 1;
-        try self.loop_stack.append(self.allocator, .{
-            .label = label_str,
-            .body_block_idx = body_block_idx,
-            .break_patches = .empty,
-            .continue_patches = .empty,
-        });
-
-        // Top-of-loop: load `current`, load `end`, compare. Exit
-        // when current > end (inclusive) or current >= end (exclusive).
-        const test_offset = try self.currentOffset();
-        try self.movRegOffsetToReg(Reg.fp, var_ofs, Reg.acu);
-        try self.movRegOffsetToReg(Reg.fp, end_ofs, Reg.r1);
-        try self.cmpRegReg(Reg.acu, Reg.r1);
-        const exit_patch = if (inclusive)
-            try self.emitJumpPlaceholder(Op.jgt_addr) // exit on current > end
-        else
-            try self.emitJumpPlaceholder(Op.jge_addr); // exit on current >= end
-
-        // Body.
-        for (fs.body) |s| try self.emitStatement(s);
-        try self.popBlockWithDefers();
-
-        // `continue` target — the step-and-back-edge. Step then
-        // jump back to the test.
-        const continue_offset = try self.currentOffset();
-        // Load current, add step, store back.
-        try self.movRegOffsetToReg(Reg.fp, var_ofs, Reg.acu);
-        if (step_expr) |se| {
-            // Evaluate step expression — typechecker has already
-            // confirmed it's an integer expression. Int-literal
-            // fast-path emits `add imm`; arbitrary exprs go through
-            // the general eval-and-add path.
-            if (se.* == .int_lit) {
-                // @as: parser stores int_lit as i32; range steps fit i16 per spec §4.5.1.
-                const step_i16: i16 = @truncate(se.int_lit.value);
-                // safety: i16 → u16 keeps the two's-complement bit pattern for negative steps.
-                const step_val: u16 = @bitCast(step_i16);
-                try self.addImmToReg(step_val, Reg.acu);
-            } else {
-                try self.pushReg(Reg.acu);
-                try self.emitExpr(se);
-                try self.movRegToReg(Reg.acu, Reg.r1);
-                try self.popReg(Reg.acu);
-                try self.addRegToAcu(Reg.r1);
-            }
-        } else {
-            try self.addImmToReg(1, Reg.acu);
-        }
-        try self.movRegToRegOffset(Reg.acu, Reg.fp, var_ofs);
-        try self.emitJumpBack(test_offset);
-
-        const exit_offset = try self.currentOffset();
-        try self.patchJumpTo(exit_patch, exit_offset);
-
-        var frame = self.loop_stack.pop().?;
-        for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
-        for (frame.continue_patches.items) |p| try self.patchJumpTo(p, continue_offset);
-        frame.break_patches.deinit(self.allocator);
-        frame.continue_patches.deinit(self.allocator);
+        return control_flow.emitForStmt(self, fs);
     }
 
-    const LoopJumpKind = enum { break_, continue_ };
+    const LoopJumpKind = control_flow.LoopJumpKind;
 
-    /// Lower `break [:label]` / `continue [:label]`. Unwinds every
-    /// block between the jump site and the target loop (innermost
-    /// match for unlabeled, named match for labeled), emits the
-    /// jump placeholder, and records it on the target frame's
-    /// `break_patches` / `continue_patches` for resolution at loop
-    /// teardown.
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitLoopJump(self: *Emitter, j: ast.LoopJumpStmt, kind: LoopJumpKind) !void {
-        const frame = self.findLoopFrame(j.label) orelse {
-            try self.diagFatal(j.span, "E_CODEGEN_LOOP_JUMP_NO_LOOP", "codegen: `break` / `continue` outside an enclosing loop");
-            return;
-        };
-        try self.unwindDefersDownTo(frame.body_block_idx);
-        const patch = try self.emitJumpPlaceholder(Op.jmp_addr);
-        switch (kind) {
-            .break_ => try frame.break_patches.append(self.allocator, patch),
-            .continue_ => try frame.continue_patches.append(self.allocator, patch),
-        }
+        return control_flow.emitLoopJump(self, j, kind);
     }
 
-    /// Lower `match scrutinee case … end` as a sequential
-    /// cmp + branch decision tree. The compiler handles:
-    ///
-    /// - Wildcard `_` and ident binders (always match).
-    /// - Integer / char / bool / nil literal patterns.
-    /// - `A | B | C` or-patterns (DEDUPED — each alt emits one cmp,
-    ///   then all alts jump to one shared body label).
-    /// - Range patterns (`a..b` / `a..=b`) — one cmp + cond branch
-    ///   pair instead of a per-element chain.
-    /// - Nullary enum-variant patterns — dispatch on the variant tag.
-    /// - `when guard` clauses — evaluated after the pattern match.
-    ///
-    /// Payload-bearing variant patterns, tuple patterns, and struct
-    /// patterns are not yet supported (require enum-tag payload
-    /// layout + field-offset codegen).
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitMatchStmt(self: *Emitter, ms: ast.MatchStmt) !void {
-        // Bind the scrutinee to a slot so subsequent arms can re-test
-        // it without re-evaluating side effects. Skip the bind if
-        // the source already wrote an ident — direct loads stay cheap.
-        const scrutinee_ofs: i8 = blk: {
-            switch (ms.scrutinee.*) {
-                .ident => {
-                    // We re-load via the normal ident path each arm.
-                    // Return 0 as a sentinel that the code below
-                    // shouldn't touch — we'll dispatch on a flag.
-                    break :blk 0;
-                },
-                else => {
-                    try self.emitExpr(ms.scrutinee);
-                    const ofs = try self.allocLocal(try self.arena.dupe(u8, "\x00__match"));
-                    try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
-                    break :blk ofs;
-                },
-            }
-        };
-        const scrutinee_is_ident = ms.scrutinee.* == .ident;
-
-        // End-patches collapse onto the byte after the last arm.
-        var end_patches: std.ArrayList(usize) = .empty;
-        defer end_patches.deinit(self.allocator);
-
-        for (ms.arms) |arm| {
-            // Reload scrutinee → acu at the head of each arm so the
-            // arm's tests use a known register state.
-            if (scrutinee_is_ident) {
-                try self.emitExpr(ms.scrutinee);
-            } else {
-                try self.movRegOffsetToReg(Reg.fp, scrutinee_ofs, Reg.acu);
-            }
-
-            // Emit the pattern test — returns a list of "skip body"
-            // patches (one per alt for an or-pattern, one for a
-            // simple pattern). Body matches when control falls
-            // through to the body emission; skips when any patch
-            // resolves to the post-body offset.
-            var skip_patches: std.ArrayList(usize) = .empty;
-            defer skip_patches.deinit(self.allocator);
-            try self.emitPatternTest(arm.pattern.*, scrutinee_ofs, scrutinee_is_ident, &skip_patches);
-
-            // Optional `when guard` — evaluate after the pattern
-            // bound any names. Failure routes to the same skip set.
-            if (arm.guard) |g| {
-                try self.emitExpr(g);
-                try self.cmpRegImm(Reg.acu, 0);
-                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jeq_addr));
-            }
-
-            // Body — own scope.
-            try self.emitScopedBody(arm.body);
-            // Skip past the rest of the match on success.
-            try end_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
-
-            const after_arm = try self.currentOffset();
-            for (skip_patches.items) |p| try self.patchJumpTo(p, after_arm);
-        }
-
-        const end_offset = try self.currentOffset();
-        for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
+        return control_flow.emitMatchStmt(self, ms);
     }
 
     /// Emit a pattern test against the scrutinee. The scrutinee
@@ -1976,91 +1601,36 @@ pub const Emitter = struct {
         return expr_emit.emitCall(self, c);
     }
 
-    // ---------- block + defer infrastructure ----------
+    // ---------- block + defer infrastructure (delegated) ----------
 
-    /// Open a fresh lexical block on top of `block_stack`. Each
-    /// nested `do…end`, `if`-arm body, loop body, and `match`-arm
-    /// body pushes one before walking its statements.
+    /// Delegated to `codegen/control_flow.zig`.
     fn pushBlock(self: *Emitter) !void {
-        try self.block_stack.append(self.allocator, .{ .defers = .empty });
+        return control_flow.pushBlock(self);
     }
 
-    /// Close the innermost block, emitting its registered `defer`
-    /// statements inline in LIFO order before discarding the block.
-    /// Use this on the fall-through exit path of the block.
+    /// Delegated to `codegen/control_flow.zig`.
     fn popBlockWithDefers(self: *Emitter) !void {
-        // The block exits normally — emit its defers in reverse
-        // registration order. `acu` may hold a return value (e.g. the
-        // last expression statement in a fn body); we save / restore
-        // around the defer body so cleanup statements can scribble
-        // over acu freely.
-        const top = self.block_stack.items.len - 1;
-        const block = &self.block_stack.items[top];
-        try self.emitDefersLifo(block.defers.items);
-        var popped = self.block_stack.pop().?;
-        popped.defers.deinit(self.allocator);
+        return control_flow.popBlockWithDefers(self);
     }
 
-    /// Emit `stmts` in LIFO order, preserving `acu` across the
-    /// cleanup sequence (so a `return value` keeps its value
-    /// visible to the caller after defers run).
+    /// Delegated to `codegen/control_flow.zig`.
     fn emitDefersLifo(self: *Emitter, stmts: []const *const ast.Statement) !void {
-        if (stmts.len == 0) return;
-        try self.pushReg(Reg.acu);
-        var i = stmts.len;
-        while (i > 0) {
-            i -= 1;
-            try self.emitStatement(stmts[i].*);
-        }
-        try self.popReg(Reg.acu);
+        return control_flow.emitDefersLifo(self, stmts);
     }
 
-    /// Emit every active block's defers in LIFO order from the
-    /// innermost outward. Used on the `return` path — the entire
-    /// frame is being unwound, so every block's cleanup fires before
-    /// the actual `ret` / `hlt`.
+    /// Delegated to `codegen/control_flow.zig`.
     fn unwindAllDefersForReturn(self: *Emitter) !void {
-        var bi = self.block_stack.items.len;
-        while (bi > 0) {
-            bi -= 1;
-            try self.emitDefersLifo(self.block_stack.items[bi].defers.items);
-        }
+        return control_flow.unwindAllDefersForReturn(self);
     }
 
-    /// Emit defers for every block in `[body_block_idx .. top]`
-    /// inclusive — the range the codegen needs to unwind on
-    /// `break` / `continue` for the loop whose body opens at
-    /// `body_block_idx`.
+    /// Delegated to `codegen/control_flow.zig`.
     fn unwindDefersDownTo(self: *Emitter, body_block_idx: usize) !void {
-        var bi = self.block_stack.items.len;
-        while (bi > body_block_idx) {
-            bi -= 1;
-            try self.emitDefersLifo(self.block_stack.items[bi].defers.items);
-        }
+        return control_flow.unwindDefersDownTo(self, body_block_idx);
     }
 
-    /// Walk the loop stack from innermost outward looking for the
-    /// frame targeted by a `break` / `continue`. Unlabeled jumps
-    /// match the innermost frame; labeled jumps match by string
-    /// equality. Returns the matching pointer so the caller can
-    /// append patches in place.
+    /// Delegated to `codegen/control_flow.zig`.
     fn findLoopFrame(self: *Emitter, label_span: ?ast.Span) ?*LoopFrame {
-        if (self.loop_stack.items.len == 0) return null;
-        const want_label: ?[]const u8 = if (label_span) |s|
-            self.source[s.start..s.end]
-        else
-            null;
-        var i = self.loop_stack.items.len;
-        while (i > 0) {
-            i -= 1;
-            const f = &self.loop_stack.items[i];
-            if (want_label) |w| {
-                if (f.label) |fl| if (std.mem.eql(u8, fl, w)) return f;
-            } else {
-                return f; // innermost
-            }
-        }
-        return null;
+        return control_flow.findLoopFrame(self, label_span);
     }
 
     /// Delegated to `codegen/expr.zig`.

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -260,6 +260,7 @@ pub fn compile(
         .strings = .empty,
         .string_patches = .empty,
         .checked = checked,
+        .enum_decls = .{},
         .block_stack = .empty,
         .loop_stack = .empty,
         .diagnostics = &diagnostics,
@@ -487,6 +488,11 @@ const Emitter = struct {
     /// only). Drives type-aware lowering — fixed-point arithmetic,
     /// `print` dispatch between `print_int` / `print_str`, etc.
     checked: *const CheckedProgram,
+    /// Top-level `enum Foo … end` declarations indexed by name.
+    /// Codegen reads this map to resolve variant-tag indices when
+    /// emitting `EnumName.Variant` constructors, `is` tests, and
+    /// `match` arm patterns.
+    enum_decls: std.StringHashMapUnmanaged(*const ast.EnumDecl),
     /// Stack of lexical blocks active at the current emit cursor.
     /// The function body opens the bottom block; nested `do…end`,
     /// loop bodies, `if` arms, etc. push more on top. Each block
@@ -895,6 +901,9 @@ const Emitter = struct {
     /// header `entry_point`), then every other top-level `def` in
     /// source order, then patch unresolved call sites.
     fn emitProgram(self: *Emitter, program: *const ast.Program, entry_name: []const u8) !void {
+        // Pre-pass 0: index top-level enum decls so variant-tag
+        // lookups during expr / pattern emission resolve cheaply.
+        try self.collectEnumDecls(program);
         // Pre-pass 1: register globals (top-level let/const).
         try self.registerGlobals(program);
         // Pre-pass 2: collect each def's bank so `emitCall` can
@@ -999,6 +1008,44 @@ const Emitter = struct {
     fn isPrimitiveType(self: *const Emitter, e: *const ast.Expr, p: types_mod.Primitive) bool {
         const t = self.typeOf(e) orelse return false;
         return t.* == .primitive and t.primitive == p;
+    }
+
+    /// Pre-pass: index every top-level `enum` decl by name so the
+    /// codegen can look up variant-tag indices during emission.
+    fn collectEnumDecls(self: *Emitter, program: *const ast.Program) !void {
+        for (program.statements) |*stmt| switch (stmt.*) {
+            .enum_decl => |ed| {
+                const name = self.source[ed.name.start..ed.name.end];
+                const dup = try self.arena.dupe(u8, name);
+                try self.enum_decls.put(self.arena, dup, &stmt.enum_decl);
+            },
+            else => {},
+        };
+    }
+
+    /// Resolve the tag index for `enum_name.variant_name`. Tags are
+    /// numbered in declaration order starting at 0 — matches spec
+    /// §3.6 ("Sword=0, Potion=1, Key=2"). Returns `null` if the
+    /// enum or variant doesn't exist (the typechecker should have
+    /// caught that; the check keeps codegen defensive).
+    fn variantTag(self: *const Emitter, enum_name: []const u8, variant_name: []const u8) ?u8 {
+        const ed = self.enum_decls.get(enum_name) orelse return null;
+        for (ed.variants, 0..) |v, i| {
+            const v_name = self.source[v.name.start..v.name.end];
+            if (std.mem.eql(u8, v_name, variant_name)) {
+                // @as: variant index fits u8 — spec §3.6 limits the
+                // tag to one byte (max 256 variants per enum).
+                return @intCast(i);
+            }
+        }
+        return null;
+    }
+
+    /// `true` when the type is a `Named` variant whose name matches
+    /// a registered enum. Used to detect enum-typed expressions
+    /// during print / match / store lowering.
+    fn isEnumType(self: *const Emitter, ty: *const Type) bool {
+        return ty.* == .named and self.enum_decls.contains(ty.named.name);
     }
 
     /// Scan top-level `def`s, recording each name → its `@bank N`
@@ -2069,7 +2116,26 @@ const Emitter = struct {
                 const body_offset = try self.currentOffset();
                 for (match_patches.items) |p| try self.patchJumpTo(p, body_offset);
             },
-            else => try self.unsupported(pat.span(), "this pattern shape (M3 brings enum / struct / tuple destructuring)"),
+            .variant_pattern => |vp| {
+                if (vp.args.len > 0) {
+                    try self.unsupported(vp.span, "enum-variant patterns with payload binders (M3b brings the payload destructuring)");
+                    return;
+                }
+                const path = self.source[vp.path.start..vp.path.end];
+                const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
+                    try self.diagFatal(vp.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: variant pattern must be `EnumName.Variant`");
+                    return;
+                };
+                const enum_name = path[0..dot];
+                const variant_name = path[dot + 1 ..];
+                const tag = self.variantTag(enum_name, variant_name) orelse {
+                    try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in match pattern");
+                    return;
+                };
+                try self.cmpRegImm(Reg.acu, tag);
+                try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+            },
+            else => try self.unsupported(pat.span(), "this pattern shape (M3b brings struct / tuple destructuring)"),
         }
     }
 
@@ -2379,8 +2445,67 @@ const Emitter = struct {
             .unary => |u| try self.emitUnary(u),
             .binary => |b| try self.emitBinary(b),
             .call => |c| try self.emitCall(c),
+            .field => |f| try self.emitFieldExpr(f, e),
+            .is_test => |it| try self.emitIsTest(it),
             else => try self.unsupported(e.span(), "this expression form"),
         }
+    }
+
+    /// Lower an `EnumName.Variant` field expression — a nullary
+    /// enum-variant constructor. Loads the variant's tag byte
+    /// into `acu` (the runtime representation of the variant).
+    /// Field access on non-enum receivers (struct / class fields)
+    /// lands in M3b alongside the class layout work.
+    fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void {
+        if (f.receiver.* == .ident) {
+            const recv_name = self.source[f.receiver.ident.span.start..f.receiver.ident.span.end];
+            if (self.enum_decls.get(recv_name)) |ed| {
+                const variant_name = self.source[f.field.start..f.field.end];
+                const tag = self.variantTag(recv_name, variant_name) orelse {
+                    try self.diagFatal(f.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant");
+                    return;
+                };
+                // Payload-bearing constructor (`Item.Potion(20)`)
+                // lands as a `CallExpr` whose callee is a
+                // `FieldExpr` — that path is M3b. A bare
+                // `Item.Potion` reference at expression position
+                // (without a call) needs the payload to be empty.
+                if (ed.variants.len > 0) {
+                    for (ed.variants) |v| {
+                        if (std.mem.eql(u8, self.source[v.name.start..v.name.end], variant_name)) {
+                            if (v.payload.len != 0) {
+                                try self.unsupported(f.span, "payload-bearing enum-variant constructors (call form lands with M3b's enum layout)");
+                                return;
+                            }
+                        }
+                    }
+                }
+                try self.movImmToReg(tag, Reg.acu);
+                return;
+            }
+        }
+        try self.unsupported(e.span(), "non-enum field access (struct / class fields land with M3b)");
+    }
+
+    /// Lower `expr is EnumName.Variant`. Evaluates `expr` into
+    /// `acu`, compares against the variant's tag, materializes a
+    /// `0` / `1` bool. The typechecker validates that the variant
+    /// path matches the LHS's enum type.
+    fn emitIsTest(self: *Emitter, it: ast.IsTestExpr) !void {
+        const path = self.source[it.variant_path.start..it.variant_path.end];
+        const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
+            try self.diagFatal(it.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: `is` rhs must be `EnumName.Variant`");
+            return;
+        };
+        const enum_name = path[0..dot];
+        const variant_name = path[dot + 1 ..];
+        const tag = self.variantTag(enum_name, variant_name) orelse {
+            try self.diagFatal(it.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in `is` test");
+            return;
+        };
+        try self.emitExpr(it.lhs);
+        try self.cmpRegImm(Reg.acu, tag);
+        try self.materializeBoolFromFlags(.eq);
     }
 
     fn emitUnary(self: *Emitter, u: ast.UnaryExpr) !void {

--- a/src/lang/codegen/archive.zig
+++ b/src/lang/codegen/archive.zig
@@ -1,0 +1,147 @@
+/// `.gx` archive layout + small utility helpers that don't need
+/// any `Emitter` state. Owns the byte-level encoding of the
+/// header (per ISA §7.1), the per-bank window padding, and the
+/// shared `decodeStringEscapes` / `alignUpU16` helpers used by
+/// string-pool emission and global placement.
+const std = @import("std");
+
+// ---------- .gx layout constants ----------
+
+/// 4-byte ASCII magic at the top of every `.gx` archive.
+pub const gx_magic = [4]u8{ 'G', 'E', 'R', 'O' };
+/// Format version stored in bytes 4-5 of the header.
+pub const gx_version: u16 = 0x0001;
+/// Fixed header size in bytes — every archive starts with this
+/// many bytes before the base image.
+pub const gx_header_size: usize = 16;
+
+/// Per-bank disk size — 16 KiB, the size of the `0xC000..0xFEFF`
+/// window in the address space. Each bank stored in the .gx
+/// archive consumes exactly this many bytes (zero-padded).
+pub const bank_disk_size: usize = 0x4000;
+
+/// Window base address — every banked address resolves to
+/// `window_base + offset_within_bank`.
+pub const bank_window_base: u16 = 0xC000;
+
+/// Banked flag bit in the .gx header per ISA §7.1.
+pub const flag_banked: u16 = 0x0001;
+
+// ---------- helpers ----------
+
+/// Assemble the final `.gx` archive: 16-byte header, then the
+/// base image, then each declared bank's 16 KiB window
+/// (zero-padded for banks the user didn't touch).
+pub fn buildArchive(
+    allocator: std.mem.Allocator,
+    base_image: []const u8,
+    entry_point: u16,
+    banks: *const std.AutoHashMapUnmanaged(u8, std.ArrayList(u8)),
+) ![]u8 {
+    // Bank count = max bank index + 1 (banks are 0-indexed). 0 if
+    // no banks declared.
+    var max_bank: ?u8 = null;
+    var it = banks.keyIterator();
+    while (it.next()) |b| {
+        if (max_bank) |m| max_bank = @max(m, b.*) else max_bank = b.*;
+    }
+    // @as: widen u8 max_bank to u16 so `+ 1` doesn't overflow when max_bank == 255.
+    const bank_count: u16 = if (max_bank) |m| @as(u16, m) + 1 else 0;
+    // @as: bank_count ≤ 256 by u8 input; the byte total fits usize.
+    const banked_bytes: usize = @as(usize, bank_count) * bank_disk_size;
+
+    // safety: base image fits in 16-bit address space per ISA.
+    const image_size: u16 = @intCast(base_image.len);
+    const total = gx_header_size + base_image.len + banked_bytes;
+    var out = try allocator.alloc(u8, total);
+    @memset(out, 0);
+
+    var flags: u16 = 0;
+    if (bank_count > 0) flags |= flag_banked;
+
+    @memcpy(out[0..4], &gx_magic);
+    writeU16Le(out[4..6], gx_version);
+    writeU16Le(out[6..8], flags);
+    writeU16Le(out[8..10], entry_point);
+    writeU16Le(out[10..12], image_size);
+    // safety: bank_count ≤ 256 by construction.
+    out[12] = @intCast(bank_count);
+    out[13] = 0; // sram_bank_count
+    writeU16Le(out[14..16], 0); // reserved
+
+    @memcpy(out[gx_header_size..][0..base_image.len], base_image);
+
+    // Bank buffers: each occupies `bank_disk_size` bytes (zero-
+    // padded). Banks the user didn't touch stay all zeros.
+    var cursor: usize = gx_header_size + base_image.len;
+    var b: u16 = 0;
+    while (b < bank_count) : (b += 1) {
+        const dst = out[cursor..][0..bank_disk_size];
+        // safety: b < bank_count ≤ 256, fits u8.
+        if (banks.get(@intCast(b))) |bank_buf| {
+            const n = @min(bank_buf.items.len, bank_disk_size);
+            @memcpy(dst[0..n], bank_buf.items[0..n]);
+        }
+        cursor += bank_disk_size;
+    }
+
+    return out;
+}
+
+/// Write `value` as 2 little-endian bytes into `dst`.
+pub fn writeU16Le(dst: *[2]u8, value: u16) void {
+    // safety: u16 → 2 bytes by definition; no truncation possible.
+    dst[0] = @intCast(value & 0xFF);
+    dst[1] = @intCast(value >> 8);
+}
+
+/// Decode the standard backslash escapes (`\n`, `\r`, `\t`, `\\`,
+/// `\"`, `\0`) into raw bytes. The source slice is the part
+/// between the surrounding `"` delimiters with escapes still
+/// encoded; the returned slice owns its bytes (caller's
+/// allocator). Unknown escape sequences pass through as the
+/// bare character following the backslash.
+pub fn decodeStringEscapes(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var i: usize = 0;
+    while (i < raw.len) {
+        const c = raw[i];
+        if (c == '\\' and i + 1 < raw.len) {
+            const next = raw[i + 1];
+            const decoded: u8 = switch (next) {
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                '\\' => '\\',
+                '"' => '"',
+                '0' => 0,
+                else => next,
+            };
+            try out.append(allocator, decoded);
+            i += 2;
+            continue;
+        }
+        try out.append(allocator, c);
+        i += 1;
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Round `value` up to the next multiple of `align_n` (which
+/// must be a power of two — the typechecker enforces). When
+/// `align_n <= 1`, returns `value` unchanged.
+pub fn alignUpU16(value: u16, align_n: u16) u16 {
+    if (align_n <= 1) return value;
+    const mask: u16 = align_n - 1;
+    return (value + mask) & ~mask;
+}
+
+/// `true` when two optional bank tags refer to the same code
+/// location — both `null` (base image) or both wrapping the
+/// same bank index.
+pub fn banksEqual(a: ?u8, b: ?u8) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return a.? == b.?;
+}

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -1,0 +1,443 @@
+/// Control-flow lowering — `if` / `while` / `for` / `repeat` /
+/// `match` / `break` / `continue` / `defer` / `do…end`. Owns the
+/// block + loop stack helpers that drive defer-emission at every
+/// exit path and label-resolution for nested loop jumps.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const pattern = @import("pattern.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const LoopFrame = codegen.LoopFrame;
+
+/// Walk `body` inside a fresh block scope. The common helper for
+/// any statement-list with its own defer lifetime (do-blocks, if
+/// arm bodies, loop bodies, match-arm bodies).
+pub fn emitScopedBody(self: *Emitter, body: []const ast.Statement) error{OutOfMemory}!void {
+    try pushBlock(self);
+    for (body) |s| try self.emitStatement(s);
+    try popBlockWithDefers(self);
+}
+
+/// Lower a `do…end` block at statement position — opens a
+/// fresh scope, walks the body, fires the block's defers on
+/// fall-through.
+pub fn emitBlockStmt(self: *Emitter, b: ast.BlockStmt) !void {
+    try emitScopedBody(self, b.body);
+}
+
+/// Register a `defer body` on the innermost active block. The
+/// typechecker has already rejected the forbidden body shapes
+/// (`defer return / break / continue / defer`).
+pub fn emitDeferStmt(self: *Emitter, ds: ast.DeferStmt) !void {
+    if (self.block_stack.items.len == 0) {
+        try self.diagFatal(ds.span, "E_CODEGEN_DEFER_NO_BLOCK", "codegen: `defer` outside a block — likely a frontend bug");
+        return;
+    }
+    const top = self.block_stack.items.len - 1;
+    try self.block_stack.items[top].defers.append(self.allocator, ds.body);
+}
+
+// ---------- block + defer helpers ----------
+
+/// Open a fresh lexical block on top of `block_stack`.
+pub fn pushBlock(self: *Emitter) !void {
+    try self.block_stack.append(self.allocator, .{ .defers = .empty });
+}
+
+/// Close the innermost block, emitting its registered `defer`
+/// statements inline in LIFO order before discarding the block.
+pub fn popBlockWithDefers(self: *Emitter) !void {
+    const top = self.block_stack.items.len - 1;
+    const block = &self.block_stack.items[top];
+    try emitDefersLifo(self, block.defers.items);
+    var popped = self.block_stack.pop().?;
+    popped.defers.deinit(self.allocator);
+}
+
+/// Emit `stmts` in LIFO order, preserving `acu` across the
+/// cleanup sequence (so a `return value` keeps its value visible
+/// to the caller after defers run).
+pub fn emitDefersLifo(self: *Emitter, stmts: []const *const ast.Statement) !void {
+    if (stmts.len == 0) return;
+    try self.pushReg(Reg.acu);
+    var i = stmts.len;
+    while (i > 0) {
+        i -= 1;
+        try self.emitStatement(stmts[i].*);
+    }
+    try self.popReg(Reg.acu);
+}
+
+/// Emit every active block's defers in LIFO order from the
+/// innermost outward — used on the `return` path.
+pub fn unwindAllDefersForReturn(self: *Emitter) !void {
+    var bi = self.block_stack.items.len;
+    while (bi > 0) {
+        bi -= 1;
+        try emitDefersLifo(self, self.block_stack.items[bi].defers.items);
+    }
+}
+
+/// Emit defers for every block in `[body_block_idx .. top]`
+/// inclusive — the range to unwind on `break` / `continue` for
+/// the loop whose body opens at `body_block_idx`.
+pub fn unwindDefersDownTo(self: *Emitter, body_block_idx: usize) !void {
+    var bi = self.block_stack.items.len;
+    while (bi > body_block_idx) {
+        bi -= 1;
+        try emitDefersLifo(self, self.block_stack.items[bi].defers.items);
+    }
+}
+
+/// Walk the loop stack from innermost outward looking for the
+/// frame targeted by a `break` / `continue`. Unlabeled jumps
+/// match the innermost frame; labeled jumps match by string
+/// equality.
+pub fn findLoopFrame(self: *Emitter, label_span: ?ast.Span) ?*LoopFrame {
+    if (self.loop_stack.items.len == 0) return null;
+    const want_label: ?[]const u8 = if (label_span) |s|
+        self.source[s.start..s.end]
+    else
+        null;
+    var i = self.loop_stack.items.len;
+    while (i > 0) {
+        i -= 1;
+        const f = &self.loop_stack.items[i];
+        if (want_label) |w| {
+            if (f.label) |fl| if (std.mem.eql(u8, fl, w)) return f;
+        } else {
+            return f; // innermost
+        }
+    }
+    return null;
+}
+
+// ---------- if ----------
+
+/// Lower `if cond1 then ... elif cond2 then ... else ... end`.
+/// Each arm emits its condition test (jumping over the body on
+/// false), then the body, then a forward jump over every later
+/// arm. The forward jumps collapse at the end of the if chain
+/// onto one shared `end` label.
+pub fn emitIfStmt(self: *Emitter, is_: ast.IfStmt) !void {
+    var end_patches: std.ArrayList(usize) = .empty;
+    defer end_patches.deinit(self.allocator);
+
+    for (is_.arms) |arm| {
+        const skip_body_patch = try emitIfArmTest(self, arm);
+        try emitScopedBody(self, arm.body);
+        try end_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+        const after_body = try self.currentOffset();
+        try self.patchJumpTo(skip_body_patch, after_body);
+    }
+
+    if (is_.else_body) |eb| try emitScopedBody(self, eb);
+
+    const end_offset = try self.currentOffset();
+    for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
+}
+
+/// Emit the test for one if-arm and return the offset of the
+/// "skip body" jump patch — the caller resolves it to the byte
+/// right after the body.
+fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
+    if (arm.cond) |c| {
+        try self.emitCondBranch(c);
+        return try self.emitJumpPlaceholder(Op.jeq_addr);
+    }
+    // `if let pat = expr [when guard]` — ident-binder form.
+    const pat = arm.let_pattern.?.*;
+    const expr = arm.let_expr.?;
+    try self.emitExpr(expr);
+    switch (pat) {
+        .ident => |id| {
+            const name = self.source[id.name.start..id.name.end];
+            const dup = try self.arena.dupe(u8, name);
+            const ofs = try self.allocLocal(dup);
+            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+            if (arm.let_guard) |g| {
+                try self.emitExpr(g);
+                try self.cmpRegImm(Reg.acu, 0);
+                return try self.emitJumpPlaceholder(Op.jeq_addr);
+            }
+            // No guard — ident binder always matches; emit a
+            // never-taken skip for symmetry with the cond arm.
+            try self.movImmToReg(1, Reg.r1);
+            try self.cmpRegImm(Reg.r1, 0);
+            return try self.emitJumpPlaceholder(Op.jeq_addr);
+        },
+        else => {
+            try self.unsupported(arm.span, "`if let` patterns other than a bare ident");
+            return try self.emitJumpPlaceholder(Op.jeq_addr);
+        },
+    }
+}
+
+// ---------- while / repeat / for ----------
+
+/// Lower `while cond ... end`. Standard top-test loop:
+/// continue-target sits at the cond test, exit-target at the
+/// byte after the back-edge. `while let` is supported for the
+/// ident-binder form per spec §4.5.2.
+pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
+    const cond_offset = try self.currentOffset();
+    const label_str: ?[]const u8 = if (ws.label) |s|
+        try self.arena.dupe(u8, self.source[s.start..s.end])
+    else
+        null;
+
+    try pushBlock(self);
+    const body_block_idx = self.block_stack.items.len - 1;
+    try self.loop_stack.append(self.allocator, .{
+        .label = label_str,
+        .body_block_idx = body_block_idx,
+        .break_patches = .empty,
+        .continue_patches = .empty,
+    });
+
+    const exit_on_false_patch = if (ws.cond) |c| blk: {
+        try self.emitCondBranch(c);
+        break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
+    } else blk: {
+        const pat = ws.let_pattern.?.*;
+        try self.emitExpr(ws.let_expr.?);
+        switch (pat) {
+            .ident => |id| {
+                const name = self.source[id.name.start..id.name.end];
+                const dup = try self.arena.dupe(u8, name);
+                const ofs = try self.allocLocal(dup);
+                try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+                if (ws.let_guard) |g| {
+                    try self.emitExpr(g);
+                    try self.cmpRegImm(Reg.acu, 0);
+                    break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
+                }
+                try self.movImmToReg(1, Reg.r1);
+                try self.cmpRegImm(Reg.r1, 0);
+                break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
+            },
+            else => {
+                try self.unsupported(ws.span, "`while let` patterns other than a bare ident");
+                break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
+            },
+        }
+    };
+
+    for (ws.body) |s| try self.emitStatement(s);
+    try popBlockWithDefers(self);
+
+    try self.emitJumpBack(cond_offset);
+
+    const exit_offset = try self.currentOffset();
+    try self.patchJumpTo(exit_on_false_patch, exit_offset);
+
+    var frame = self.loop_stack.pop().?;
+    for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
+    for (frame.continue_patches.items) |p| try self.patchJumpTo(p, cond_offset);
+    frame.break_patches.deinit(self.allocator);
+    frame.continue_patches.deinit(self.allocator);
+}
+
+/// Lower `repeat body until cond`. Bottom-test loop: the body
+/// runs at least once; `cond` is tested after the body and the
+/// loop exits when `cond` is truthy.
+pub fn emitRepeatStmt(self: *Emitter, rs: ast.RepeatStmt) !void {
+    const top_offset = try self.currentOffset();
+    const label_str: ?[]const u8 = if (rs.label) |s|
+        try self.arena.dupe(u8, self.source[s.start..s.end])
+    else
+        null;
+
+    try pushBlock(self);
+    const body_block_idx = self.block_stack.items.len - 1;
+    try self.loop_stack.append(self.allocator, .{
+        .label = label_str,
+        .body_block_idx = body_block_idx,
+        .break_patches = .empty,
+        .continue_patches = .empty,
+    });
+
+    for (rs.body) |s| try self.emitStatement(s);
+    try popBlockWithDefers(self);
+
+    // `continue` jumps here — the trailing `until` test.
+    const test_offset = try self.currentOffset();
+    try self.emitCondBranch(rs.cond);
+    // Falsy cond → loop back to top; truthy → fall through to exit.
+    try self.emitByte(Op.jeq_addr);
+    // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
+    const top_in_buffer: u16 = @intCast(top_offset);
+    try self.emitU16Le(self.currentBufferBase() +% top_in_buffer);
+
+    const exit_offset = try self.currentOffset();
+    var frame = self.loop_stack.pop().?;
+    for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
+    for (frame.continue_patches.items) |p| try self.patchJumpTo(p, test_offset);
+    frame.break_patches.deinit(self.allocator);
+    frame.continue_patches.deinit(self.allocator);
+}
+
+/// Lower `for x in start..end [step S] body end` — the range
+/// special case per spec §4.5.3. User-defined iterables
+/// (`next(self) -> T?`) are not yet supported.
+pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
+    if (fs.iter.* != .range) {
+        try self.unsupported(fs.span, "`for` over non-range iterables");
+        return;
+    }
+    const range = fs.iter.range;
+    const inclusive = range.inclusive;
+    const step_expr = fs.step;
+    const binding_name = self.source[fs.binding.start..fs.binding.end];
+
+    // Allocate slots: the loop variable + a hidden `end` slot.
+    const dup_name = try self.arena.dupe(u8, binding_name);
+    const var_ofs = try self.allocLocal(dup_name);
+    const end_ofs = try self.allocLocal(try self.arena.dupe(u8, "\x00__for_end"));
+
+    try self.emitExpr(range.start);
+    try self.movRegToRegOffset(Reg.acu, Reg.fp, var_ofs);
+    try self.emitExpr(range.end);
+    try self.movRegToRegOffset(Reg.acu, Reg.fp, end_ofs);
+
+    const label_str: ?[]const u8 = if (fs.label) |s|
+        try self.arena.dupe(u8, self.source[s.start..s.end])
+    else
+        null;
+
+    try pushBlock(self);
+    const body_block_idx = self.block_stack.items.len - 1;
+    try self.loop_stack.append(self.allocator, .{
+        .label = label_str,
+        .body_block_idx = body_block_idx,
+        .break_patches = .empty,
+        .continue_patches = .empty,
+    });
+
+    // Top-of-loop: load `current`, load `end`, compare. Exit
+    // when current > end (inclusive) or current >= end (exclusive).
+    const test_offset = try self.currentOffset();
+    try self.movRegOffsetToReg(Reg.fp, var_ofs, Reg.acu);
+    try self.movRegOffsetToReg(Reg.fp, end_ofs, Reg.r1);
+    try self.cmpRegReg(Reg.acu, Reg.r1);
+    const exit_patch = if (inclusive)
+        try self.emitJumpPlaceholder(Op.jgt_addr)
+    else
+        try self.emitJumpPlaceholder(Op.jge_addr);
+
+    for (fs.body) |s| try self.emitStatement(s);
+    try popBlockWithDefers(self);
+
+    // `continue` target — the step-and-back-edge.
+    const continue_offset = try self.currentOffset();
+    try self.movRegOffsetToReg(Reg.fp, var_ofs, Reg.acu);
+    if (step_expr) |se| {
+        if (se.* == .int_lit) {
+            // @as: parser stores int_lit as i32; range steps fit i16 per spec §4.5.1.
+            const step_i16: i16 = @truncate(se.int_lit.value);
+            // safety: i16 → u16 keeps the two's-complement bit pattern for negative steps.
+            const step_val: u16 = @bitCast(step_i16);
+            try self.addImmToReg(step_val, Reg.acu);
+        } else {
+            try self.pushReg(Reg.acu);
+            try self.emitExpr(se);
+            try self.movRegToReg(Reg.acu, Reg.r1);
+            try self.popReg(Reg.acu);
+            try self.addRegToAcu(Reg.r1);
+        }
+    } else {
+        try self.addImmToReg(1, Reg.acu);
+    }
+    try self.movRegToRegOffset(Reg.acu, Reg.fp, var_ofs);
+    try self.emitJumpBack(test_offset);
+
+    const exit_offset = try self.currentOffset();
+    try self.patchJumpTo(exit_patch, exit_offset);
+
+    var frame = self.loop_stack.pop().?;
+    for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
+    for (frame.continue_patches.items) |p| try self.patchJumpTo(p, continue_offset);
+    frame.break_patches.deinit(self.allocator);
+    frame.continue_patches.deinit(self.allocator);
+}
+
+// ---------- break / continue ----------
+
+/// Which forward-patch list a `break` / `continue` jump
+/// records its placeholder onto.
+pub const LoopJumpKind = enum { break_, continue_ };
+
+/// Lower `break [:label]` / `continue [:label]`. Unwinds every
+/// block between the jump site and the target loop, emits the
+/// jump placeholder, and records it on the target frame's
+/// `break_patches` / `continue_patches`.
+pub fn emitLoopJump(self: *Emitter, j: ast.LoopJumpStmt, kind: LoopJumpKind) !void {
+    const frame = findLoopFrame(self, j.label) orelse {
+        try self.diagFatal(j.span, "E_CODEGEN_LOOP_JUMP_NO_LOOP", "codegen: `break` / `continue` outside an enclosing loop");
+        return;
+    };
+    try unwindDefersDownTo(self, frame.body_block_idx);
+    const patch = try self.emitJumpPlaceholder(Op.jmp_addr);
+    switch (kind) {
+        .break_ => try frame.break_patches.append(self.allocator, patch),
+        .continue_ => try frame.continue_patches.append(self.allocator, patch),
+    }
+}
+
+// ---------- match ----------
+
+/// Lower `match scrutinee case … end` as a sequential cmp +
+/// branch decision tree. OR-patterns collapse onto one shared
+/// body label; range patterns emit a single low+high cmp pair;
+/// `when` guards run after the pattern bind.
+pub fn emitMatchStmt(self: *Emitter, ms: ast.MatchStmt) !void {
+    // Bind the scrutinee to a slot so subsequent arms can re-test
+    // it without re-evaluating side effects. Skip the bind if the
+    // source already wrote an ident — direct loads stay cheap.
+    const scrutinee_ofs: i8 = blk: {
+        switch (ms.scrutinee.*) {
+            .ident => break :blk 0,
+            else => {
+                try self.emitExpr(ms.scrutinee);
+                const ofs = try self.allocLocal(try self.arena.dupe(u8, "\x00__match"));
+                try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+                break :blk ofs;
+            },
+        }
+    };
+    const scrutinee_is_ident = ms.scrutinee.* == .ident;
+
+    var end_patches: std.ArrayList(usize) = .empty;
+    defer end_patches.deinit(self.allocator);
+
+    for (ms.arms) |arm| {
+        if (scrutinee_is_ident) {
+            try self.emitExpr(ms.scrutinee);
+        } else {
+            try self.movRegOffsetToReg(Reg.fp, scrutinee_ofs, Reg.acu);
+        }
+
+        var skip_patches: std.ArrayList(usize) = .empty;
+        defer skip_patches.deinit(self.allocator);
+        try pattern.emitPatternTest(self, arm.pattern.*, scrutinee_ofs, scrutinee_is_ident, &skip_patches);
+
+        if (arm.guard) |g| {
+            try self.emitExpr(g);
+            try self.cmpRegImm(Reg.acu, 0);
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jeq_addr));
+        }
+
+        try emitScopedBody(self, arm.body);
+        try end_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+
+        const after_arm = try self.currentOffset();
+        for (skip_patches.items) |p| try self.patchJumpTo(p, after_arm);
+    }
+
+    const end_offset = try self.currentOffset();
+    for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
+}

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -1,0 +1,469 @@
+/// Expression lowering — `emitExpr` and every per-shape helper
+/// it dispatches into. Results land in `acu`. Sub-modules
+/// (`mem_builtin`, `strings`, etc.) call back into `emitExpr`
+/// through the `Emitter` method dispatch.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const archive = @import("archive.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const CallPatch = codegen.CallPatch;
+
+const EmitError = error{OutOfMemory};
+
+/// Lower one expression — result lands in `acu`. The main
+/// dispatch switch; per-shape helpers below.
+pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
+    switch (e.*) {
+        .int_lit => |lit| {
+            // @as: truncate i32 → i16; safety: typechecker already verified the literal fits in the target primitive's width.
+            const trimmed: i16 = @truncate(lit.value);
+            // safety: i16 → u16 bit pattern; the two's-complement encoding is preserved.
+            const v: u16 = @bitCast(trimmed);
+            try self.movImmToReg(v, Reg.acu);
+        },
+        .fixed_lit => |lit| {
+            // Q8.8 — the parser pre-encodes the value as `int *
+            // 256 + round(frac * 256)`. The low 16 bits are the
+            // canonical bit pattern.
+            // @as: i32 → i16; spec §3.3 pins fixed-point to Q8.8 (i16-shaped).
+            const trimmed: i16 = @truncate(lit.value);
+            // safety: i16 → u16 bit pattern preserved (two's complement).
+            const v: u16 = @bitCast(trimmed);
+            try self.movImmToReg(v, Reg.acu);
+        },
+        .str_lit => |sl| try self.emitStrLitExpr(sl),
+        .bool_lit => |b| {
+            const v: u16 = if (b.value) 1 else 0;
+            try self.movImmToReg(v, Reg.acu);
+        },
+        .nil_lit => try self.movImmToReg(0, Reg.acu),
+        .char_lit => |c| try self.movImmToReg(c.value, Reg.acu),
+        .paren => |p| try emitExpr(self, p.inner),
+        .ident => |i| {
+            const name = self.source[i.span.start..i.span.end];
+            // Lookup order: locals → params → globals.
+            if (self.locals.get(name)) |ofs| {
+                try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+                return;
+            }
+            if (self.params.get(name)) |ofs| {
+                try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+                return;
+            }
+            if (self.globals.get(name)) |g| {
+                try self.emitGlobalLoad(g);
+                return;
+            }
+            try self.unsupported(i.span, "ident not in current frame");
+        },
+        .unary => |u| try emitUnary(self, u),
+        .binary => |b| try emitBinary(self, b),
+        .call => |c| try emitCall(self, c),
+        .method_call => |m| try emitMethodCall(self, m, e),
+        .field => |f| try emitFieldExpr(self, f, e),
+        .is_test => |it| try emitIsTest(self, it),
+        .ref_of => |r| try self.emitAddrOf(r.inner),
+        .cast => |c| try emitExpr(self, c.inner), // same-width primitives share a bit pattern, so the cast is a no-op
+        else => try self.unsupported(e.span(), "this expression form"),
+    }
+}
+
+/// Discard-context evaluation: evaluate for side effects and
+/// throw away the result.
+pub fn emitExprDiscard(self: *Emitter, e: *const ast.Expr) !void {
+    try emitExpr(self, e);
+}
+
+/// Lower an `EnumName.Variant` field expression — a nullary
+/// enum-variant constructor. Loads the variant's tag byte into
+/// `acu`. Field access on non-enum receivers is not yet
+/// supported.
+pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void {
+    if (f.receiver.* == .ident) {
+        const recv_name = self.source[f.receiver.ident.span.start..f.receiver.ident.span.end];
+        if (self.enum_decls.get(recv_name)) |ed| {
+            const variant_name = self.source[f.field.start..f.field.end];
+            const tag = self.variantTag(recv_name, variant_name) orelse {
+                try self.diagFatal(f.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant");
+                return;
+            };
+            // A bare `Item.Potion` reference at expression
+            // position (without a call) requires the payload to
+            // be empty — payload-bearing constructors come
+            // through the `CallExpr` path with field-callee.
+            for (ed.variants) |v| {
+                if (std.mem.eql(u8, self.source[v.name.start..v.name.end], variant_name)) {
+                    if (v.payload.len != 0) {
+                        try self.unsupported(f.span, "payload-bearing enum-variant constructors");
+                        return;
+                    }
+                }
+            }
+            try self.movImmToReg(tag, Reg.acu);
+            return;
+        }
+    }
+    try self.unsupported(e.span(), "non-enum field access");
+}
+
+/// Lower `expr is EnumName.Variant`. Evaluates `expr` into
+/// `acu`, compares against the variant's tag, materializes a
+/// `0` / `1` bool.
+pub fn emitIsTest(self: *Emitter, it: ast.IsTestExpr) !void {
+    const path = self.source[it.variant_path.start..it.variant_path.end];
+    const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
+        try self.diagFatal(it.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: `is` rhs must be `EnumName.Variant`");
+        return;
+    };
+    const enum_name = path[0..dot];
+    const variant_name = path[dot + 1 ..];
+    const tag = self.variantTag(enum_name, variant_name) orelse {
+        try self.diagFatal(it.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in `is` test");
+        return;
+    };
+    try emitExpr(self, it.lhs);
+    try self.cmpRegImm(Reg.acu, tag);
+    try materializeBoolFromFlags(self, .eq);
+}
+
+/// Lower a unary prefix expression.
+pub fn emitUnary(self: *Emitter, u: ast.UnaryExpr) !void {
+    try emitExpr(self, u.operand);
+    switch (u.op) {
+        .neg => try self.negReg(Reg.acu),
+        .bit_not => try self.notRegOp(Reg.acu),
+        .log_not => {
+            // acu = (acu == 0) ? 1 : 0
+            try self.cmpRegImm(Reg.acu, 0);
+            try materializeBoolFromFlags(self, .eq);
+        },
+    }
+}
+
+/// Lower a binary infix expression. Short-circuit operators
+/// (`and`, `or`) take a separate path so the RHS isn't always
+/// evaluated. Comparison ops materialize a `0` / `1` in `acu`.
+/// Fixed-point `*` / `/` get a Q8.8 scaling tail per ISA §5.4.1.
+pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
+    switch (b.op) {
+        .log_and, .log_or => {
+            try emitShortCircuitBool(self, b);
+            return;
+        },
+        else => {},
+    }
+
+    const fixed_op = self.isPrimitiveType(b.lhs, .fixed) and
+        self.isPrimitiveType(b.rhs, .fixed) and
+        (b.op == .mul or b.op == .div);
+
+    // Standard stack-machine pattern: eval RHS, push, eval LHS,
+    // pop RHS into r1, apply op (acu = acu OP r1).
+    try emitExpr(self, b.rhs);
+    try self.pushReg(Reg.acu);
+    try emitExpr(self, b.lhs);
+    try self.popReg(Reg.r1);
+    switch (b.op) {
+        .add => try self.addRegToAcu(Reg.r1),
+        .sub => try self.subRegFromAcu(Reg.r1),
+        .mul => {
+            // `mul src, dst` writes low(product) → dst AND
+            // high(product) → acu. If dst == acu the high half
+            // clobbers the low half — so we land the result in
+            // `r2`, then move it back to acu.
+            try self.movRegToReg(Reg.acu, Reg.r2);
+            try self.mulRegReg(Reg.r1, Reg.r2);
+            if (fixed_op) {
+                // Q8.8 * Q8.8 — the conceptual Q16.16 product
+                // straddles acu:r2 (acu = high half, r2 = low
+                // half). The Q8.8 result is bits 8..23 of that
+                // 32-bit value: `acu (high << 8) | (r2 unsigned
+                // >> 8)`. ISA §5.4.1 — products whose real
+                // magnitude exceeds 127.99… wrap silently
+                // because the result no longer fits in 16 bits.
+                try self.shrRegImm(Reg.r2, 8);
+                try self.shlRegImm(Reg.acu, 8);
+                try self.orRegReg(Reg.acu, Reg.r2);
+            } else {
+                // Integer mul — drop the high half.
+                try self.movRegToReg(Reg.r2, Reg.acu);
+            }
+        },
+        .div => {
+            if (fixed_op) {
+                // Q8.8 / Q8.8 — scale the dividend up by 2^8
+                // before the signed divide so the quotient lands
+                // back in Q8.8. The 24-bit pre-shifted dividend
+                // straddles acu:r2:
+                //   r2  = acu << 8           (low half)
+                //   acu = acu >>arith 8      (sign-extended top byte)
+                // Then `divs r1, r2` performs the 32÷16 signed
+                // divide and the quotient ends up in r2.
+                try self.movRegToReg(Reg.acu, Reg.r2);
+                try self.shlRegImm(Reg.r2, 8); // r2 = lhs << 8 (low)
+                try self.asrRegImm(Reg.acu, 8); // acu = lhs >>a 8 (high)
+                try self.divsRegReg(Reg.r1, Reg.r2);
+                try self.movRegToReg(Reg.r2, Reg.acu);
+            } else {
+                // Signed 32÷16 divide. Dividend lives in acu:dst
+                // (high:low); the dividend is assumed to fit in
+                // 16 bits — sign-extension is not yet emitted.
+                try self.movRegToReg(Reg.acu, Reg.r2); // r2 = low half
+                try self.movImmToReg(0, Reg.acu); // high half = 0
+                try self.divsRegReg(Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
+                try self.movRegToReg(Reg.r2, Reg.acu);
+            }
+        },
+        .mod => {
+            // Same divs pattern as `div`, but keep `acu` (the
+            // remainder is exactly what `mod` wants).
+            try self.movRegToReg(Reg.acu, Reg.r2); // r2 = low half
+            try self.movImmToReg(0, Reg.acu); // high half = 0
+            try self.divsRegReg(Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
+        },
+        .bit_and => try self.andRegReg(Reg.acu, Reg.r1),
+        .bit_or => try self.orRegReg(Reg.acu, Reg.r1),
+        .bit_xor => try self.xorRegReg(Reg.acu, Reg.r1),
+        .shl => try self.shlRegReg(Reg.acu, Reg.r1),
+        .shr => try self.shrRegReg(Reg.acu, Reg.r1),
+        .eq, .neq, .lt, .lte, .gt, .gte => {
+            try self.cmpRegReg(Reg.acu, Reg.r1);
+            try materializeBoolFromFlags(self, b.op);
+        },
+        // allow-strict: handled by the short-circuit branch above; emitBinary never falls through here for these ops.
+        .log_and, .log_or => unreachable,
+    }
+}
+
+/// Drive a flag-setting comparison for a control-flow condition.
+/// Top-level comparisons + short-circuit ops drive `cmp` directly
+/// without materializing the 0 / 1 first; other shapes fall back
+/// to "evaluate to acu, cmp acu, 0".
+pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
+    if (e.* == .binary) {
+        const b = e.binary;
+        switch (b.op) {
+            .eq, .neq, .lt, .lte, .gt, .gte => {
+                // Eval LHS into acu, eval RHS into r1, cmp acu, r1.
+                try emitExpr(self, b.rhs);
+                try self.pushReg(Reg.acu);
+                try emitExpr(self, b.lhs);
+                try self.popReg(Reg.r1);
+                try self.cmpRegReg(Reg.acu, Reg.r1);
+                try materializeBoolFromFlags(self, b.op);
+                try self.cmpRegImm(Reg.acu, 0);
+                return;
+            },
+            .log_and, .log_or => {
+                try emitShortCircuitBool(self, b);
+                try self.cmpRegImm(Reg.acu, 0);
+                return;
+            },
+            else => {},
+        }
+    }
+    if (e.* == .unary and e.unary.op == .log_not) {
+        try emitExpr(self, e.unary.operand);
+        try self.cmpRegImm(Reg.acu, 0);
+        try materializeBoolFromFlags(self, .eq);
+        try self.cmpRegImm(Reg.acu, 0);
+        return;
+    }
+    // Generic path — evaluate to acu, then test against 0.
+    try emitExpr(self, e);
+    try self.cmpRegImm(Reg.acu, 0);
+}
+
+/// Materialize a 0 / 1 boolean in `acu` from the current flag
+/// state set by a preceding `cmp`. Picks the right conditional
+/// jump per comparison kind.
+pub fn materializeBoolFromFlags(self: *Emitter, op: ast.BinaryOp) !void {
+    const taken_op: u8 = switch (op) {
+        .eq => Op.jeq_addr,
+        .neq => Op.jne_addr,
+        .lt => Op.jlt_addr,
+        .lte => Op.jle_addr,
+        .gt => Op.jgt_addr,
+        .gte => Op.jge_addr,
+        // allow-strict: callers filter to comparison ops before invoking this helper.
+        else => unreachable,
+    };
+    // Pattern:
+    //   <prior cmp>
+    //   jXX true_label
+    //   mov 0, acu
+    //   jmp end
+    // true_label:
+    //   mov 1, acu
+    // end:
+    const true_patch = try self.emitJumpPlaceholder(taken_op);
+    try self.movImmToReg(0, Reg.acu);
+    const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
+    const true_offset = try self.currentOffset();
+    try self.movImmToReg(1, Reg.acu);
+    const end_offset = try self.currentOffset();
+    try self.patchJumpTo(true_patch, true_offset);
+    try self.patchJumpTo(end_patch, end_offset);
+}
+
+/// Lower a short-circuiting `and` / `or` into a chain of
+/// conditional jumps that leaves a 0 / 1 in `acu`.
+pub fn emitShortCircuitBool(self: *Emitter, b: ast.BinaryExpr) !void {
+    switch (b.op) {
+        .log_and => {
+            // acu = lhs; if acu == 0 -> short-circuit false.
+            try emitExpr(self, b.lhs);
+            try self.cmpRegImm(Reg.acu, 0);
+            const short_patch = try self.emitJumpPlaceholder(Op.jeq_addr);
+            try emitExpr(self, b.rhs);
+            try self.cmpRegImm(Reg.acu, 0);
+            try materializeBoolFromFlags(self, .neq);
+            const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
+            const short_offset = try self.currentOffset();
+            try self.movImmToReg(0, Reg.acu);
+            const end_offset = try self.currentOffset();
+            try self.patchJumpTo(short_patch, short_offset);
+            try self.patchJumpTo(end_patch, end_offset);
+        },
+        .log_or => {
+            try emitExpr(self, b.lhs);
+            try self.cmpRegImm(Reg.acu, 0);
+            const short_patch = try self.emitJumpPlaceholder(Op.jne_addr);
+            try emitExpr(self, b.rhs);
+            try self.cmpRegImm(Reg.acu, 0);
+            try materializeBoolFromFlags(self, .neq);
+            const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
+            const short_offset = try self.currentOffset();
+            try self.movImmToReg(1, Reg.acu);
+            const end_offset = try self.currentOffset();
+            try self.patchJumpTo(short_patch, short_offset);
+            try self.patchJumpTo(end_patch, end_offset);
+        },
+        // allow-strict: caller filters to log_and / log_or before invoking this helper.
+        else => unreachable,
+    }
+}
+
+/// Lower a `receiver.method(args)` expression. The stdlib
+/// `mem.X(...)` shape dispatches through the builtin lookup;
+/// other receivers (class instance method calls) are not yet
+/// supported.
+pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr) !void {
+    if (m.receiver.* == .ident) {
+        const recv = self.source[m.receiver.ident.span.start..m.receiver.ident.span.end];
+        if (std.mem.eql(u8, recv, "mem")) {
+            // Build a synthetic `FieldExpr` + `CallExpr` shape so
+            // the existing mem dispatch can flow through without
+            // duplicating the per-builtin emit code.
+            const synth_field: ast.FieldExpr = .{
+                .receiver = m.receiver,
+                .field = m.method,
+                .span = m.span,
+            };
+            const synth_call: ast.CallExpr = .{
+                .callee = m.receiver, // unused by emitMemCall
+                .args = m.args,
+                .span = m.span,
+            };
+            try self.emitMemCall(synth_field, synth_call);
+            return;
+        }
+    }
+    try self.unsupported(e.span(), "method calls on non-stdlib receivers");
+}
+
+/// Lower `callee(args...)` per the free-fn calling convention:
+///
+///   - Push args right-to-left (so callee sees param 0 at
+///     `[fp + 4]`, param 1 at `[fp + 6]`, ...).
+///   - `call <addr>` — the VM enters: push fp, push ret_ip,
+///     fp ← sp, ip ← target.
+///   - On return, `add <N*2>, sp` to drop the args. The
+///     callee's return value lives in `acu`.
+///
+/// Compiler-known stdlib builtins (`mem.X`) intercept on the
+/// way in. Closure invocations and fn-pointer calls are not
+/// yet supported.
+pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
+    if (c.callee.* == .field) {
+        const fe = c.callee.field;
+        if (fe.receiver.* == .ident) {
+            const recv = self.source[fe.receiver.ident.span.start..fe.receiver.ident.span.end];
+            if (std.mem.eql(u8, recv, "mem")) {
+                try self.emitMemCall(fe, c);
+                return;
+            }
+        }
+    }
+    if (c.callee.* != .ident) {
+        try self.unsupported(c.span, "non-ident callee");
+        return;
+    }
+    const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+    const dup = try self.arena.dupe(u8, callee_name);
+
+    // Decide direct call vs trampoline by comparing the
+    // caller's bank with the target's. The pre-pass populated
+    // `fn_banks` so this resolves without needing the address.
+    const target_bank: ?u8 = self.fn_banks.get(callee_name) orelse null;
+    const cross_bank = !archive.banksEqual(self.current_bank, target_bank);
+
+    // Push args right-to-left (caller-cleans-up).
+    var i: usize = c.args.len;
+    while (i > 0) {
+        i -= 1;
+        try emitExpr(self, c.args[i]);
+        try self.pushReg(Reg.acu);
+    }
+
+    if (cross_bank) {
+        // Trampoline path:
+        //   mov <target_addr>, r1   ; patched at end
+        //   mov <target_bank>,  r2  ; literal at emit time
+        //   call __call_bank        ; patched at end
+        try self.emitByte(Op.mov_imm16_reg);
+        const addr_patch_offset = try self.currentOffset();
+        try self.emitU16Le(0); // placeholder
+        try self.emitByte(Reg.r1);
+        const target_bank_byte: u8 = target_bank orelse 0;
+        try self.movImmToReg(target_bank_byte, Reg.r2);
+        try self.emitByte(Op.call_addr);
+        const tramp_patch_offset = try self.currentOffset();
+        try self.emitU16Le(0);
+
+        try self.call_patches.append(self.allocator, .{
+            .bank = self.current_bank,
+            .code_offset = addr_patch_offset,
+            .target = .{ .fn_name = dup },
+            .span = c.span,
+        });
+        try self.call_patches.append(self.allocator, .{
+            .bank = self.current_bank,
+            .code_offset = tramp_patch_offset,
+            .target = .trampoline,
+            .span = c.span,
+        });
+    } else {
+        // Direct same-bank call.
+        try self.emitByte(Op.call_addr);
+        const patch_offset = try self.currentOffset();
+        try self.emitU16Le(0); // placeholder
+        try self.call_patches.append(self.allocator, .{
+            .bank = self.current_bank,
+            .code_offset = patch_offset,
+            .target = .{ .fn_name = dup },
+            .span = c.span,
+        });
+    }
+
+    if (c.args.len > 0) {
+        // @as: each arg is one 16-bit word; arg count capped by parser.
+        const drop_bytes: u16 = @intCast(c.args.len * 2);
+        try self.addImmToReg(drop_bytes, Reg.sp);
+    }
+}

--- a/src/lang/codegen/mem_builtin.zig
+++ b/src/lang/codegen/mem_builtin.zig
@@ -1,0 +1,191 @@
+/// Lowering for the stdlib `mem.*` builtins. Each entry maps to
+/// a specific VM opcode sequence — typed peek/poke pairs, the
+/// `bcpy` / `bfill` block ops, and the shared `addr_of` helper
+/// that also backs the `&x` reference operator.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+
+const MemReadKind = enum { byte_zext, byte_sext, word };
+const MemWriteKind = enum { byte, word };
+
+/// Dispatch a `mem.X(args)` call to the matching emitter. The
+/// typechecker has already validated the builtin name + arity;
+/// the codegen check repeats the arity guard as a defensive
+/// safeguard against frontend changes.
+pub fn emitMemCall(self: *Emitter, fe: ast.FieldExpr, c: ast.CallExpr) !void {
+    const fn_name = self.source[fe.field.start..fe.field.end];
+    if (std.mem.eql(u8, fn_name, "read_u8") or std.mem.eql(u8, fn_name, "peek")) {
+        try emitMemRead1Arg(self, c, .byte_zext);
+    } else if (std.mem.eql(u8, fn_name, "read_u16") or std.mem.eql(u8, fn_name, "read_i16")) {
+        try emitMemRead1Arg(self, c, .word);
+    } else if (std.mem.eql(u8, fn_name, "read_i8")) {
+        try emitMemRead1Arg(self, c, .byte_sext);
+    } else if (std.mem.eql(u8, fn_name, "write_u8") or std.mem.eql(u8, fn_name, "write_i8") or std.mem.eql(u8, fn_name, "poke")) {
+        try emitMemWrite2Args(self, c, .byte);
+    } else if (std.mem.eql(u8, fn_name, "write_u16") or std.mem.eql(u8, fn_name, "write_i16")) {
+        try emitMemWrite2Args(self, c, .word);
+    } else if (std.mem.eql(u8, fn_name, "memcpy")) {
+        try emitMemCopy(self, c);
+    } else if (std.mem.eql(u8, fn_name, "memset")) {
+        try emitMemFill(self, c);
+    } else if (std.mem.eql(u8, fn_name, "addr_of")) {
+        if (c.args.len != 1) {
+            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.addr_of` takes exactly one argument");
+            return;
+        }
+        try emitAddrOf(self, c.args[0]);
+    } else {
+        try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `mem` builtin");
+    }
+}
+
+/// `mem.read_*(addr)` — one arg, returns a value in `acu`. The
+/// width / sign-extension choice picks the load opcode (and an
+/// optional sign-extension tail for `read_i8`).
+fn emitMemRead1Arg(self: *Emitter, c: ast.CallExpr, kind: MemReadKind) !void {
+    if (c.args.len != 1) {
+        try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.read_*` takes exactly one argument");
+        return;
+    }
+    try self.emitExpr(c.args[0]); // acu = addr
+    try self.movRegToReg(Reg.acu, Reg.r1); // r1 = addr
+    switch (kind) {
+        .word => {
+            try self.emitByte(Op.mov_ptr_to_reg);
+            try self.emitByte(Reg.acu); // dst
+            try self.emitByte(Reg.r1); // ptr
+        },
+        .byte_zext => {
+            try self.emitByte(Op.mov8_ptr_to_reg);
+            try self.emitByte(Reg.r1); // ptr
+            try self.emitByte(Reg.acu); // dst
+        },
+        .byte_sext => {
+            try self.emitByte(Op.mov8_ptr_to_reg);
+            try self.emitByte(Reg.r1);
+            try self.emitByte(Reg.acu);
+            // Sign-extend 8 → 16: `shl 8 ; asr 8`. The byte sits
+            // in `acu.lo`; shifting it into the top byte and back
+            // arithmetic-shift-right preserves the sign bit
+            // through the high half.
+            try self.shlRegImm(Reg.acu, 8);
+            try self.asrRegImm(Reg.acu, 8);
+        },
+    }
+}
+
+/// `mem.write_*(addr, v)` — two args, no return. Args eval
+/// left-to-right via push/pop so `addr` and `v` can be arbitrary
+/// subexpressions.
+fn emitMemWrite2Args(self: *Emitter, c: ast.CallExpr, kind: MemWriteKind) !void {
+    if (c.args.len != 2) {
+        try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.write_*` takes exactly two arguments");
+        return;
+    }
+    try self.emitExpr(c.args[0]); // acu = addr
+    try self.pushReg(Reg.acu);
+    try self.emitExpr(c.args[1]); // acu = value
+    try self.popReg(Reg.r1); // r1 = addr
+    switch (kind) {
+        .word => {
+            try self.emitByte(Op.mov_reg_to_ptr);
+            try self.emitByte(Reg.r1); // ptr
+            try self.emitByte(Reg.acu); // src
+        },
+        .byte => {
+            try self.emitByte(Op.mov8_reg_to_ptr);
+            try self.emitByte(Reg.acu); // src (low byte)
+            try self.emitByte(Reg.r1); // ptr
+        },
+    }
+}
+
+/// `mem.memcpy(dst, src, n)` — eval each arg left-to-right into
+/// a dedicated register, then emit `bcpy dst, src, len`.
+fn emitMemCopy(self: *Emitter, c: ast.CallExpr) !void {
+    if (c.args.len != 3) {
+        try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.memcpy` takes exactly three arguments");
+        return;
+    }
+    try self.emitExpr(c.args[0]); // dst
+    try self.pushReg(Reg.acu);
+    try self.emitExpr(c.args[1]); // src
+    try self.pushReg(Reg.acu);
+    try self.emitExpr(c.args[2]); // n → acu
+    try self.movRegToReg(Reg.acu, Reg.r3); // r3 = len
+    try self.popReg(Reg.r2); // r2 = src
+    try self.popReg(Reg.r1); // r1 = dst
+    try self.emitByte(Op.bcpy);
+    try self.emitByte(Reg.r1); // dst
+    try self.emitByte(Reg.r2); // src
+    try self.emitByte(Reg.r3); // len
+}
+
+/// `mem.memset(dst, v, n)` — eval args into dedicated regs and
+/// emit `bfill addr, len, val`. Note the operand order: the VM
+/// reads bytes as `dst, len, val`.
+fn emitMemFill(self: *Emitter, c: ast.CallExpr) !void {
+    if (c.args.len != 3) {
+        try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `mem.memset` takes exactly three arguments");
+        return;
+    }
+    try self.emitExpr(c.args[0]); // dst
+    try self.pushReg(Reg.acu);
+    try self.emitExpr(c.args[1]); // v
+    try self.pushReg(Reg.acu);
+    try self.emitExpr(c.args[2]); // n → acu
+    try self.movRegToReg(Reg.acu, Reg.r3); // r3 = len
+    try self.popReg(Reg.r2); // r2 = val
+    try self.popReg(Reg.r1); // r1 = dst
+    try self.emitByte(Op.bfill);
+    try self.emitByte(Reg.r1); // dst
+    try self.emitByte(Reg.r3); // len
+    try self.emitByte(Reg.r2); // val
+}
+
+/// Compute the address of an addressable expression and leave
+/// it in `acu`. Backs `mem.addr_of(x)` and the typed `&x`
+/// reference operator. Plain idents (locals, params, globals)
+/// are supported; field / index targets are not yet supported.
+pub fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
+    if (e.* != .ident) {
+        try self.unsupported(e.span(), "`addr_of` on non-ident expression");
+        return;
+    }
+    const name = self.source[e.ident.span.start..e.ident.span.end];
+    if (self.locals.get(name)) |ofs| {
+        // Local: address = fp + ofs (ofs is negative).
+        try self.movRegToReg(Reg.fp, Reg.acu);
+        if (ofs < 0) {
+            // @as: widen i8 → i16 so the negate doesn't trip on the minimum value.
+            const widened: i16 = ofs;
+            // @as: |ofs| ≤ 128 by allocLocal cap; result fits a u16.
+            const neg: u16 = @intCast(-widened);
+            try self.subImmFromReg(neg, Reg.acu);
+        } else if (ofs > 0) {
+            // @as: positive i8 → u16; cap by allocLocal layout.
+            const pos: u16 = @intCast(ofs);
+            try self.addImmToReg(pos, Reg.acu);
+        }
+        return;
+    }
+    if (self.params.get(name)) |ofs| {
+        // Param: address = fp + ofs (ofs is positive).
+        try self.movRegToReg(Reg.fp, Reg.acu);
+        // @as: positive i8 → u16.
+        const pos: u16 = @intCast(ofs);
+        try self.addImmToReg(pos, Reg.acu);
+        return;
+    }
+    if (self.globals.get(name)) |g| {
+        try self.movImmToReg(g.address, Reg.acu);
+        return;
+    }
+    try self.unsupported(e.span(), "`addr_of` target not in scope");
+}

--- a/src/lang/codegen/opcodes.zig
+++ b/src/lang/codegen/opcodes.zig
@@ -1,0 +1,167 @@
+/// VM opcode + register + syscall byte values used by the
+/// codegen. Mirrored from `src/vm/opcodes.zig`,
+/// `src/vm/registers.zig`, and `src/vm/handlers/system.zig`. The
+/// codegen deliberately doesn't `@import` the VM module — the two
+/// sides stay decoupled — so adding an opcode in the VM means
+/// adding the matching constant here.
+/// VM opcode byte values. Each constant is the leading byte of
+/// the matching instruction; subsequent bytes carry operands per
+/// ISA §5.
+pub const Op = struct {
+    // allow-strict: byte-table mirror of VM opcodes — trailing-comment commentary is the canonical doc.
+    pub const mov_imm16_reg: u8 = 0x10; // mov imm16, reg
+    // allow-strict: byte-table mirror.
+    pub const mov_reg_reg: u8 = 0x11; // mov src, dst
+    // allow-strict: byte-table mirror.
+    pub const mov_reg_offset_reg: u8 = 0x1C; // load:  reg ← [base + ofs]
+    // allow-strict: byte-table mirror.
+    pub const mov_reg_reg_offset: u8 = 0x1D; // store: [base + ofs] ← reg
+    // allow-strict: byte-table mirror.
+    pub const mov_reg_to_addr: u8 = 0x12; // store: [addr] ← reg (word)
+    // allow-strict: byte-table mirror.
+    pub const mov_addr_to_reg: u8 = 0x13; // load:  reg ← [addr] (word)
+    // allow-strict: byte-table mirror.
+    pub const mov_reg_to_zp: u8 = 0x19; // store: [zp] ← reg (word)
+    // allow-strict: byte-table mirror.
+    pub const mov_zp_to_reg: u8 = 0x1A; // load:  reg ← [zp] (word)
+    // allow-strict: byte-table mirror.
+    pub const mov_ptr_to_reg: u8 = 0x15; // load:  reg ← [ptr_reg] (word)
+    // allow-strict: byte-table mirror.
+    pub const mov_reg_to_ptr: u8 = 0x16; // store: [ptr_reg] ← reg (word)
+    // allow-strict: byte-table mirror.
+    pub const mov8_addr_to_reg: u8 = 0x22; // load:  reg ← byte [addr]
+    // allow-strict: byte-table mirror.
+    pub const mov8_reg_to_ptr: u8 = 0x23; // store: [ptr_reg] ← reg.lo (byte)
+    // allow-strict: byte-table mirror.
+    pub const mov8_ptr_to_reg: u8 = 0x24; // load:  reg ← byte [ptr_reg]
+    // allow-strict: byte-table mirror.
+    pub const mov8_zp_to_reg: u8 = 0x29; // load:  reg ← byte [zp]
+    // allow-strict: byte-table mirror.
+    pub const movl_reg_to_addr: u8 = 0x27; // store: [addr] ← reg.lo  (byte store)
+    // allow-strict: byte-table mirror.
+    pub const movl_reg_to_zp: u8 = 0x2B; // store: [zp]   ← reg.lo  (byte store)
+
+    // allow-strict: byte-table mirror.
+    pub const push_reg: u8 = 0x31; // push reg
+    // allow-strict: byte-table mirror.
+    pub const pop_reg: u8 = 0x32; // pop reg
+
+    // allow-strict: byte-table mirror.
+    pub const add_imm16_reg: u8 = 0x40; // add imm, reg
+    // allow-strict: byte-table mirror.
+    pub const add_reg_acu: u8 = 0x42; // acu ← acu + reg
+    // allow-strict: byte-table mirror.
+    pub const sub_imm16_reg: u8 = 0x43; // sub imm, reg
+    // allow-strict: byte-table mirror.
+    pub const sub_reg_acu: u8 = 0x45; // acu ← acu - reg
+    // allow-strict: byte-table mirror.
+    pub const mul_reg_reg: u8 = 0x47; // dst ← dst * src
+    // allow-strict: byte-table mirror.
+    pub const neg_reg: u8 = 0x4A; // reg ← -reg
+    // allow-strict: byte-table mirror.
+    pub const divs_reg_reg: u8 = 0x4E; // dst ← dst / src (signed)
+
+    // allow-strict: byte-table mirror.
+    pub const and_reg_reg: u8 = 0x61; // dst ← dst & src
+    // allow-strict: byte-table mirror.
+    pub const or_reg_reg: u8 = 0x63; // dst ← dst | src
+    // allow-strict: byte-table mirror.
+    pub const xor_reg_reg: u8 = 0x65; // dst ← dst ^ src
+    // allow-strict: byte-table mirror.
+    pub const not_reg: u8 = 0x66; // reg ← ~reg
+    // allow-strict: byte-table mirror.
+    pub const shl_reg_reg: u8 = 0x71; // dst ← dst << src
+    // allow-strict: byte-table mirror.
+    pub const shr_reg_reg: u8 = 0x73; // dst ← dst >> src
+
+    // allow-strict: byte-table mirror.
+    pub const shl_reg_imm8: u8 = 0x70; // reg ← reg << imm
+    // allow-strict: byte-table mirror.
+    pub const shr_reg_imm8: u8 = 0x72; // reg ← reg >> imm (logical / unsigned)
+    // allow-strict: byte-table mirror.
+    pub const asr_reg_imm8: u8 = 0x74; // reg ← reg >>a imm (arithmetic / signed)
+
+    // allow-strict: byte-table mirror.
+    pub const cmp_reg_imm16: u8 = 0x80; // flags ← reg - imm
+    // allow-strict: byte-table mirror.
+    pub const cmp_reg_reg: u8 = 0x81; // flags ← dst - src
+
+    // allow-strict: byte-table mirror.
+    pub const jmp_addr: u8 = 0x90; // unconditional jump
+    // allow-strict: byte-table mirror.
+    pub const jeq_addr: u8 = 0x92; // jump on Z = 1
+    // allow-strict: byte-table mirror.
+    pub const jne_addr: u8 = 0x93; // jump on Z = 0
+    // allow-strict: byte-table mirror.
+    pub const jlt_addr: u8 = 0x94; // signed less
+    // allow-strict: byte-table mirror.
+    pub const jle_addr: u8 = 0x95; // signed ≤
+    // allow-strict: byte-table mirror.
+    pub const jgt_addr: u8 = 0x96; // signed >
+    // allow-strict: byte-table mirror.
+    pub const jge_addr: u8 = 0x97; // signed ≥
+
+    // allow-strict: byte-table mirror.
+    pub const bcpy: u8 = 0x2C; // bcpy dst, src, len — memcpy via 3 regs
+    // allow-strict: byte-table mirror.
+    pub const bfill: u8 = 0x2D; // bfill addr, len, val — memset via 3 regs
+
+    // allow-strict: byte-table mirror.
+    pub const call_addr: u8 = 0xA0; // call abs addr
+    // allow-strict: byte-table mirror.
+    pub const call_reg: u8 = 0xA1; // call [reg]
+    // allow-strict: byte-table mirror.
+    pub const ret_op: u8 = 0xA2; // ret
+
+    // allow-strict: byte-table mirror.
+    pub const sys: u8 = 0xFB; // host-callback syscall
+    // allow-strict: byte-table mirror.
+    pub const hlt: u8 = 0xFF; // terminal halt
+};
+
+/// VM register byte values per `src/vm/registers.zig`. The
+/// codegen reads / writes through these indices in operand
+/// positions that expect a `Reg`.
+pub const Reg = struct {
+    // allow-strict: register-index mirror.
+    pub const acu: u8 = 0x01;
+    // allow-strict: register-index mirror.
+    pub const r1: u8 = 0x02;
+    // allow-strict: register-index mirror.
+    pub const r2: u8 = 0x03;
+    // allow-strict: register-index mirror.
+    pub const r3: u8 = 0x04;
+    // allow-strict: register-index mirror.
+    pub const sp: u8 = 0x0A;
+    // allow-strict: register-index mirror.
+    pub const fp: u8 = 0x0B;
+    // allow-strict: register-index mirror.
+    pub const mb: u8 = 0x0C;
+};
+
+/// `sys` syscall ids per `src/vm/handlers/system.zig::SyscallId`.
+/// The `sys` opcode reads one of these as its immediate operand
+/// and routes to the matching host-callback handler.
+pub const Sys = struct {
+    // allow-strict: syscall-id mirror.
+    pub const print_str: u8 = 0x01;
+    // allow-strict: syscall-id mirror.
+    pub const print_int: u8 = 0x02;
+    // allow-strict: syscall-id mirror.
+    pub const print_char: u8 = 0x03;
+    // allow-strict: syscall-id mirror.
+    pub const print_newline: u8 = 0x04;
+    // allow-strict: syscall-id mirror.
+    pub const print_fixed: u8 = 0x05;
+
+    // allow-strict: syscall-id mirror.
+    pub const format_str_to_buf: u8 = 0x10;
+    // allow-strict: syscall-id mirror.
+    pub const format_int_to_buf: u8 = 0x11;
+    // allow-strict: syscall-id mirror.
+    pub const format_char_to_buf: u8 = 0x12;
+    // allow-strict: syscall-id mirror.
+    pub const format_fixed_to_buf: u8 = 0x13;
+    // allow-strict: syscall-id mirror.
+    pub const format_terminate_buf: u8 = 0x14;
+};

--- a/src/lang/codegen/pattern.zig
+++ b/src/lang/codegen/pattern.zig
@@ -1,0 +1,130 @@
+/// Pattern-arm test emission for `match`. Lowers each pattern
+/// shape (literal / wildcard / ident binder / range / or-pattern
+/// / nullary variant) to the `cmp + jne` sequence that drops
+/// failure jumps into `skip_patches` and falls through on match.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+
+/// Emit the per-pattern test against the scrutinee value sitting
+/// in `acu`. Match success falls through to the caller (which
+/// then emits the body); failure pushes a forward-jump patch
+/// onto `skip_patches`. The caller resolves every patch to the
+/// post-body offset.
+pub fn emitPatternTest(
+    self: *Emitter,
+    pat: ast.Pattern,
+    scrutinee_ofs: i8,
+    scrutinee_is_ident: bool,
+    skip_patches: *std.ArrayList(usize),
+) !void {
+    switch (pat) {
+        .wildcard => {
+            // Always matches — emit nothing.
+        },
+        .ident => |ip| {
+            // Bind the value to a local slot. Always matches.
+            const name = self.source[ip.name.start..ip.name.end];
+            const dup = try self.arena.dupe(u8, name);
+            const ofs = try self.allocLocal(dup);
+            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+        },
+        .int_lit => |lit| {
+            // @as: parser holds int_lit.value as i32; literals fit i16 by typecheck rule.
+            const trimmed: i16 = @truncate(lit.value);
+            // safety: i16 → u16 bit pattern preserved.
+            const v: u16 = @bitCast(trimmed);
+            try self.cmpRegImm(Reg.acu, v);
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+        },
+        .char_lit => |c| {
+            try self.cmpRegImm(Reg.acu, c.value);
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+        },
+        .bool_lit => |b| {
+            const v: u16 = if (b.value) 1 else 0;
+            try self.cmpRegImm(Reg.acu, v);
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+        },
+        .nil_lit => {
+            try self.cmpRegImm(Reg.acu, 0);
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+        },
+        .range_pattern => |rp| {
+            // Lower `start..end` as: cmp acu, start; jlt skip;
+            //                       cmp acu, end;   j(g[te]) skip.
+            // Endpoints must be compile-time integer literals so
+            // they emit as immediate operands.
+            if (rp.start.* != .int_lit or rp.end.* != .int_lit) {
+                try self.unsupported(rp.span, "non-literal range pattern endpoints");
+                return;
+            }
+            // @as: parser holds int_lit.value as i32; range bounds fit i16 by spec.
+            const start_i16: i16 = @truncate(rp.start.int_lit.value);
+            // safety: i16 → u16 keeps the two's-complement bit pattern.
+            const start_v: u16 = @bitCast(start_i16);
+            // @as: same i32 → i16 truncation for the end bound.
+            const end_i16: i16 = @truncate(rp.end.int_lit.value);
+            // safety: i16 → u16 keeps the two's-complement bit pattern.
+            const end_v: u16 = @bitCast(end_i16);
+            try self.cmpRegImm(Reg.acu, start_v);
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jlt_addr));
+            try self.cmpRegImm(Reg.acu, end_v);
+            const above_bound_op: u8 = if (rp.inclusive) Op.jgt_addr else Op.jge_addr;
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(above_bound_op));
+        },
+        .or_pattern => |op_| {
+            // Each alt emits its own cmp + branch. A match jumps
+            // OVER the remaining alts to the body. A non-match
+            // falls through to the next alt. After the last alt,
+            // a non-match jumps to the shared skip target.
+            var match_patches: std.ArrayList(usize) = .empty;
+            defer match_patches.deinit(self.allocator);
+
+            for (op_.alts) |alt| {
+                var alt_skip: std.ArrayList(usize) = .empty;
+                defer alt_skip.deinit(self.allocator);
+                try emitPatternTest(self, alt.*, scrutinee_ofs, scrutinee_is_ident, &alt_skip);
+                // The alt matched if we reach this point — jump
+                // to the shared "body entry" label.
+                try match_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+                // Failure-skips of this alt land at the next alt
+                // (or, after the final alt, at the outer skip).
+                const after_alt = try self.currentOffset();
+                for (alt_skip.items) |p| try self.patchJumpTo(p, after_alt);
+            }
+            // None of the alts matched — punt to the outer skip
+            // set.
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+            // All match-patches resolve to the byte after the
+            // outer skip jump — i.e. the body's first byte.
+            const body_offset = try self.currentOffset();
+            for (match_patches.items) |p| try self.patchJumpTo(p, body_offset);
+        },
+        .variant_pattern => |vp| {
+            if (vp.args.len > 0) {
+                try self.unsupported(vp.span, "enum-variant patterns with payload binders");
+                return;
+            }
+            const path = self.source[vp.path.start..vp.path.end];
+            const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
+                try self.diagFatal(vp.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: variant pattern must be `EnumName.Variant`");
+                return;
+            };
+            const enum_name = path[0..dot];
+            const variant_name = path[dot + 1 ..];
+            const tag = self.variantTag(enum_name, variant_name) orelse {
+                try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in match pattern");
+                return;
+            };
+            try self.cmpRegImm(Reg.acu, tag);
+            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+        },
+        else => try self.unsupported(pat.span(), "this pattern shape"),
+    }
+}

--- a/src/lang/codegen/strings.zig
+++ b/src/lang/codegen/strings.zig
@@ -1,0 +1,247 @@
+/// String pool + interpolation lowering. Owns the
+/// `InternedString` / `StringPatch` types that store the pool
+/// state and the helpers that emit lookup / fill sequences.
+///
+/// String literals at expression position lower to one of two
+/// shapes:
+///
+/// - Single-literal strings — appended once to a pool laid out
+///   at the end of the base image; the load is `mov str_addr,
+///   acu` patched against the resolved address.
+/// - Interpolated strings — each site reserves a 64-byte buffer
+///   in the data region (per spec §3.2.2 "single-buffer
+///   allocation"); a `format_*_to_buf` syscall sequence fills
+///   it and the buffer's base address lands in `acu`.
+///
+/// `print` of a string literal uses a third shape — per-part
+/// `print_*` syscalls write to `host.out` directly with no
+/// runtime buffer (the zero-alloc fast path from spec §4.9).
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const archive = @import("archive.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Sys = opcodes.Sys;
+
+/// Bytes reserved per interpolated-string buffer in the data
+/// region. Sized for the worst common case (a few interp values
+/// + surrounding literal text). Programs that need larger
+/// interpolations should compose with explicit concatenation —
+/// the codegen rejects the formatted result at runtime if it
+/// overflows (the VM doesn't bounds-check the buffer writes).
+pub const interp_buffer_size: u16 = 64;
+
+/// One interned string literal — emitted as a null-terminated
+/// byte run at the end of the base image. Multiple call sites
+/// that reference the same byte content share one entry; the
+/// `address` field carries the resolved RAM address after the
+/// pool emits.
+pub const InternedString = struct {
+    bytes: []const u8,
+    address: u16,
+};
+
+/// Forward reference to a string literal — recorded when an
+/// emit site needs to load the string's address into a register
+/// but the pool hasn't been laid out yet. The `code_offset` is
+/// the 2-byte `mov imm16, reg` operand slot waiting for the
+/// resolved address.
+pub const StringPatch = struct {
+    bank: ?u8,
+    code_offset: usize,
+    string_id: usize,
+};
+
+/// Lay out every interned string at the end of the base buffer.
+/// Each entry gets its bytes plus a trailing null terminator
+/// (the VM's `print_str` syscall reads until `\0`). Records the
+/// resolved address into the pool entry.
+pub fn emitStringPool(self: *Emitter) !void {
+    // Strings live in the base image so banked code can still
+    // address them (banks only cover `0xC000..0xFEFF`). Save +
+    // restore the buffer-routing so callers in a banked def
+    // still emit into the base buffer here.
+    const saved_bank = self.current_bank;
+    self.current_bank = null;
+    defer self.current_bank = saved_bank;
+
+    for (self.strings.items) |*s| {
+        // @as: usize → u16; base image fits in 16-bit address space.
+        const offset: u16 = @intCast(try self.currentOffset());
+        s.address = codegen.code_base +% offset;
+        for (s.bytes) |b| try self.emitByte(b);
+        try self.emitByte(0);
+    }
+}
+
+/// Rewrite each `StringPatch`'s 2-byte LE address slot with the
+/// resolved string address.
+pub fn patchStrings(self: *Emitter) !void {
+    for (self.string_patches.items) |p| {
+        const addr = self.strings.items[p.string_id].address;
+        const buf: []u8 = if (p.bank) |b|
+            if (self.banks.getPtr(b)) |bl| bl.items else continue
+        else
+            self.code.items;
+        // safety: u16 → 2 bytes by definition; byte-mask casts.
+        buf[p.code_offset] = @intCast(addr & 0xFF);
+        buf[p.code_offset + 1] = @intCast(addr >> 8);
+    }
+}
+
+/// Intern a byte string by content. Returns the index into
+/// `Emitter.strings`. Callers that need the address use a
+/// `StringPatch` since the pool isn't laid out until the end of
+/// `emitProgram`.
+pub fn internString(self: *Emitter, bytes: []const u8) !usize {
+    for (self.strings.items, 0..) |s, i| {
+        if (std.mem.eql(u8, s.bytes, bytes)) return i;
+    }
+    const owned = try self.arena.dupe(u8, bytes);
+    try self.strings.append(self.allocator, .{ .bytes = owned, .address = 0 });
+    return self.strings.items.len - 1;
+}
+
+/// Emit a `mov imm16, reg` whose imm is the resolved address
+/// of the interned string with index `string_id`. The imm slot
+/// is recorded as a `StringPatch` and back-patched after the
+/// pool lays out.
+pub fn emitMovStringAddrToReg(self: *Emitter, string_id: usize, reg: u8) !void {
+    try self.emitByte(Op.mov_imm16_reg);
+    const slot = try self.currentOffset();
+    try self.emitU16Le(0); // placeholder
+    try self.emitByte(reg);
+    try self.string_patches.append(self.allocator, .{
+        .bank = self.current_bank,
+        .code_offset = slot,
+        .string_id = string_id,
+    });
+}
+
+/// Lower a `str_lit` at expression position. Single-literal
+/// strings load the pooled address directly into `acu`.
+/// Interpolated strings allocate a fixed-size buffer in the
+/// data region and emit the `format_*_to_buf` syscall sequence
+/// that fills it.
+pub fn emitStrLitExpr(self: *Emitter, sl: ast.StrLitExpr) !void {
+    if (sl.parts.len == 1 and sl.parts[0] == .lit) {
+        const span = sl.parts[0].lit.span;
+        const raw = self.source[span.start..span.end];
+        const decoded = try archive.decodeStringEscapes(self.arena, raw);
+        const id = try internString(self, decoded);
+        try emitMovStringAddrToReg(self, id, Reg.acu);
+        return;
+    }
+
+    const buf_addr = reserveInterpBuffer(self, sl.span) orelse {
+        // Diagnostic already emitted; produce a valid placeholder
+        // so downstream codegen doesn't see a bad acu shape.
+        try self.movImmToReg(0, Reg.acu);
+        return;
+    };
+
+    // r1 holds the moving write cursor. Initialize it to the
+    // buffer's base address.
+    try self.movImmToReg(buf_addr, Reg.r1);
+    try emitInterpFill(self, sl);
+    try self.sys(Sys.format_terminate_buf);
+    try self.movImmToReg(buf_addr, Reg.acu);
+}
+
+/// Reserve `interp_buffer_size` bytes at the top of the data
+/// region for one interpolated-string site. Returns the
+/// buffer's base address. Emits `E_CODEGEN_DATA_OVERFLOW` and
+/// `null` when the data region (capped at the MMIO line) would
+/// overflow.
+pub fn reserveInterpBuffer(self: *Emitter, site_span: ast.Span) ?u16 {
+    const base = self.data_cursor;
+    // @as: widen u16 → u32 so the overflow check doesn't itself wrap.
+    const next: u32 = @as(u32, self.data_cursor) + interp_buffer_size;
+    if (next > 0xFE40) {
+        self.diagFatal(site_span, "E_CODEGEN_DATA_OVERFLOW", "static-data region exhausted — too many interpolated string sites") catch return null;
+        return null;
+    }
+    // @as: bounded by the > 0xFE40 check above; result fits u16.
+    self.data_cursor = @intCast(next);
+    return base;
+}
+
+/// Emit one `format_*_to_buf` syscall per `sl.parts` entry. `r1`
+/// must hold the buffer cursor on entry and holds the
+/// post-write cursor on exit. Saves / restores `r1` around
+/// interp-expression evaluation so the stack-machine pattern's
+/// scratch use of `r1` doesn't trash the cursor.
+pub fn emitInterpFill(self: *Emitter, sl: ast.StrLitExpr) !void {
+    for (sl.parts) |part| switch (part) {
+        .lit => |lp| {
+            const raw = self.source[lp.span.start..lp.span.end];
+            if (raw.len == 0) continue;
+            const decoded = try archive.decodeStringEscapes(self.arena, raw);
+            const id = try internString(self, decoded);
+            try emitMovStringAddrToReg(self, id, Reg.acu);
+            try self.sys(Sys.format_str_to_buf);
+        },
+        .interp => |ip| {
+            if (ip.format_spec != null) {
+                try self.unsupported(ip.span, "`$(expr:fmt)` format specs");
+                return;
+            }
+            // Save the cursor — the interp-expression eval may
+            // pop into r1 as scratch.
+            try self.pushReg(Reg.r1);
+            try self.emitExpr(ip.expr);
+            try self.popReg(Reg.r1);
+
+            if (self.isPrimitiveType(ip.expr, .char)) {
+                try self.sys(Sys.format_char_to_buf);
+            } else if (self.isPrimitiveType(ip.expr, .fixed)) {
+                try self.sys(Sys.format_fixed_to_buf);
+            } else if (self.isPrimitiveType(ip.expr, .str)) {
+                try self.sys(Sys.format_str_to_buf);
+            } else {
+                try self.sys(Sys.format_int_to_buf);
+            }
+        },
+    };
+}
+
+/// Walk a string literal's parts inside `print`, emitting the
+/// per-part syscall for each. Zero-alloc per spec §4.9: no
+/// runtime buffer materializes — each part writes to `host.out`
+/// directly. The interpolated value's type drives the syscall
+/// pick (same dispatch as `emitPrintArg` for non-literal args).
+pub fn emitPrintStrLit(self: *Emitter, sl: ast.StrLitExpr) !void {
+    for (sl.parts) |part| switch (part) {
+        .lit => |lp| {
+            const raw = self.source[lp.span.start..lp.span.end];
+            if (raw.len == 0) continue;
+            const decoded = try archive.decodeStringEscapes(self.arena, raw);
+            const id = try internString(self, decoded);
+            try emitMovStringAddrToReg(self, id, Reg.acu);
+            try self.sys(Sys.print_str);
+        },
+        .interp => |ip| {
+            if (ip.format_spec != null) {
+                try self.unsupported(ip.span, "`$(expr:fmt)` format specs");
+                return;
+            }
+            if (self.isPrimitiveType(ip.expr, .char)) {
+                try self.emitExpr(ip.expr);
+                try self.sys(Sys.print_char);
+            } else if (self.isPrimitiveType(ip.expr, .fixed)) {
+                try self.emitExpr(ip.expr);
+                try self.sys(Sys.print_fixed);
+            } else if (self.isPrimitiveType(ip.expr, .str)) {
+                try self.emitExpr(ip.expr);
+                try self.sys(Sys.print_str);
+            } else {
+                try self.emitExpr(ip.expr);
+                try self.sys(Sys.print_int);
+            }
+        },
+    };
+}

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -160,6 +160,9 @@ pub fn typecheck(
 /// `mem.*` stdlib builtin lowering — signatures, lookup, and
 /// the two typechecker dispatch entry points.
 pub const mem_builtin = @import("typecheck/mem_builtin.zig");
+/// `match` typechecking — pattern walks, exhaustiveness +
+/// reachability checks, variant-path utilities.
+pub const match = @import("typecheck/match.zig");
 
 /// `mem.*` stdlib builtin signature (re-exported from the
 /// sub-module for callers that just want the lookup type).
@@ -637,7 +640,7 @@ pub const Checker = struct {
     /// from `if x == nil then return end` patterns — code following
     /// such an `if` may treat `x` as statically non-nil for the rest
     /// of the surrounding block.
-    fn walkStatementSequence(self: *Checker, body: []const ast.Statement) WalkError!void {
+    pub fn walkStatementSequence(self: *Checker, body: []const ast.Statement) WalkError!void {
         var fall_through: std.ArrayList([]const u8) = .empty;
         defer {
             for (fall_through.items) |name| self.popNonNil(name);
@@ -921,146 +924,19 @@ pub const Checker = struct {
         _ = try self.inferExpr(rs.cond, null);
     }
 
+    /// Delegated to `typecheck/match.zig`.
     fn checkMatch(self: *Checker, ms: ast.MatchStmt) WalkError!void {
-        const scrut_ty = try self.inferExpr(ms.scrutinee, null);
-
-        // Lookup enum decl when scrutinee resolves to a named-enum.
-        const enum_decl: ?*const ast.EnumDecl = if (scrut_ty) |st|
-            self.enumDeclForType(st.*)
-        else
-            null;
-
-        // Track variant-name coverage when scrutinee is an enum.
-        var covered: std.StringHashMapUnmanaged(void) = .{};
-        defer covered.deinit(self.arena);
-        var has_wildcard: bool = false;
-
-        for (ms.arms) |arm| {
-            // Exhaustiveness + reachability checks (enum scrutinee only).
-            if (enum_decl) |ed| try self.recordArmCoverage(arm, ed, &covered, &has_wildcard);
-
-            const saved = self.current_scope;
-            var child: Scope = .init(self.arena, saved);
-            self.current_scope = &child;
-            defer self.current_scope = saved;
-            try self.registerPatternBindings(arm.pattern);
-            if (arm.guard) |g| _ = try self.inferExpr(g, null);
-            try self.walkStatementSequence(arm.body);
-        }
-
-        // Exhaustiveness: every variant must be covered (or wildcard).
-        if (enum_decl) |ed| if (!has_wildcard) {
-            try self.checkExhaustiveness(ms.span, ed, &covered);
-        };
+        return match.checkMatch(self, ms);
     }
 
-    /// Resolve `ty` to its underlying enum decl (when `ty` is a
-    /// `Named(EnumName)` whose name maps to a registered enum
-    /// declaration). Returns `null` otherwise.
+    /// Delegated to `typecheck/match.zig`.
     fn enumDeclForType(self: *const Checker, ty: types.Type) ?*const ast.EnumDecl {
-        if (ty != .named) return null;
-        return self.enum_registry.get(ty.named.name);
+        return match.enumDeclForType(self, ty);
     }
 
-    /// `true` when `name` is one of `ed`'s declared variant names.
-    /// Names compare by the source-buffer lexeme.
+    /// Delegated to `typecheck/match.zig`.
     fn variantExists(self: *const Checker, ed: *const ast.EnumDecl, name: []const u8) bool {
-        for (ed.variants) |v| {
-            if (std.mem.eql(u8, self.lexeme(v.name), name)) return true;
-        }
-        return false;
-    }
-
-    /// Walk one match arm's pattern (including or-pattern
-    /// alternatives) and record which variant names it covers.
-    /// Emits `E_MATCH_UNREACHABLE_ARM` on duplicates and on any arm
-    /// that follows a wildcard.
-    fn recordArmCoverage(
-        self: *Checker,
-        arm: ast.MatchArm,
-        ed: *const ast.EnumDecl,
-        covered: *std.StringHashMapUnmanaged(void),
-        has_wildcard: *bool,
-    ) WalkError!void {
-        if (has_wildcard.*) {
-            try self.emitSpan("E_MATCH_UNREACHABLE_ARM", arm.span, "this arm cannot be reached — a wildcard `_` arm above already handles every remaining variant");
-        }
-        try self.walkArmPattern(arm.pattern, ed, covered, has_wildcard);
-    }
-
-    fn walkArmPattern(
-        self: *Checker,
-        pat: *const ast.Pattern,
-        ed: *const ast.EnumDecl,
-        covered: *std.StringHashMapUnmanaged(void),
-        has_wildcard: *bool,
-    ) WalkError!void {
-        switch (pat.*) {
-            .wildcard, .ident => {
-                // Bare ident in match-arm position binds the value
-                // — equivalent to `_` from the exhaustiveness POV.
-                has_wildcard.* = true;
-            },
-            .variant_pattern => |vp| {
-                const split = splitPath(self.lexeme(vp.path));
-                // Verify the head matches the enum name (skip when
-                // it doesn't — pattern targets a different enum).
-                if (split.head.len > 0 and !std.mem.eql(u8, split.head, self.lexeme(ed.name))) return;
-                // Verify variant exists on this enum.
-                if (!self.variantExists(ed, split.tail)) return;
-                const gop = try covered.getOrPut(self.arena, split.tail);
-                if (gop.found_existing) {
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "variant `{s}.{s}` is already handled by an earlier arm",
-                        .{ self.lexeme(ed.name), split.tail },
-                    );
-                    try self.emitSpan("E_MATCH_UNREACHABLE_ARM", pat.span(), msg);
-                }
-            },
-            .or_pattern => |op| {
-                for (op.alts) |alt| try self.walkArmPattern(alt, ed, covered, has_wildcard);
-            },
-            else => {
-                // Literal / range / tuple / struct patterns don't
-                // contribute to enum-variant coverage and don't
-                // qualify as a catch-all.
-            },
-        }
-    }
-
-    fn checkExhaustiveness(
-        self: *Checker,
-        match_span: ast.Span,
-        ed: *const ast.EnumDecl,
-        covered: *const std.StringHashMapUnmanaged(void),
-    ) WalkError!void {
-        // Collect uncovered variant names for the message body.
-        var missing: std.ArrayList([]const u8) = .empty;
-        defer missing.deinit(self.arena);
-        for (ed.variants) |v| {
-            const name = self.lexeme(v.name);
-            if (!covered.contains(name)) try missing.append(self.arena, name);
-        }
-        if (missing.items.len == 0) return;
-
-        // Render "A, B, C" (cap at 3 to keep messages compact).
-        var buf: std.ArrayList(u8) = .empty;
-        defer buf.deinit(self.arena);
-        const limit: usize = @min(missing.items.len, 3);
-        for (missing.items[0..limit], 0..) |name, i| {
-            if (i > 0) try buf.appendSlice(self.arena, ", ");
-            try buf.appendSlice(self.arena, name);
-        }
-        if (missing.items.len > limit) try buf.appendSlice(self.arena, ", …");
-
-        const suffix: []const u8 = if (missing.items.len == 1) "" else "s";
-        const msg = try std.fmt.allocPrint(
-            self.arena,
-            "non-exhaustive match on enum `{s}` — missing variant{s}: {s}",
-            .{ self.lexeme(ed.name), suffix, buf.items },
-        );
-        try self.emitSpan("E_MATCH_NON_EXHAUSTIVE", match_span, msg);
+        return match.variantExists(self, ed, name);
     }
 
     /// Defer bodies may not redirect control flow (per spec §4.10
@@ -1227,7 +1103,10 @@ pub const Checker = struct {
         }
     }
 
-    fn registerPatternBindings(self: *Checker, p: *const ast.Pattern) WalkError!void {
+    /// Register every binder in a pattern (ident binders +
+    /// payload binders inside variant / tuple / struct
+    /// patterns) into the current scope.
+    pub fn registerPatternBindings(self: *Checker, p: *const ast.Pattern) WalkError!void {
         switch (p.*) {
             .ident => |i| try self.registerName(self.lexeme(i.name), .{
                 .kind = .let_binding,
@@ -2458,15 +2337,6 @@ fn findClassField(c: *const Checker, cd: *const ast.ClassDecl, name: []const u8)
         return findClassField(c, parent, name);
     };
     return null;
-}
-
-/// Split a dotted variant path lexeme (`Enum.Variant`) into head /
-/// tail. Returns an empty head when there is no `.` in the path.
-fn splitPath(text: []const u8) struct { head: []const u8, tail: []const u8 } {
-    if (std.mem.lastIndexOfScalar(u8, text, '.')) |dot| {
-        return .{ .head = text[0..dot], .tail = text[dot + 1 ..] };
-    }
-    return .{ .head = "", .tail = text };
 }
 
 // ---------- type predicates ----------

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1468,6 +1468,16 @@ const Checker = struct {
                 return try self.checkMethodCall(m, recv_ty);
             },
             .field => |f| {
+                // Enum-variant constructor shape: `Item.Sword`. The
+                // receiver is an ident matching a registered enum
+                // name — resolve directly to the enum's type so a
+                // subsequent `let s = Item.Sword` infers as `Item`.
+                if (f.receiver.* == .ident) {
+                    const recv_name = self.lexeme(f.receiver.ident.span);
+                    if (self.enum_registry.get(recv_name)) |ed| {
+                        return try self.resolveEnumVariant(ed, recv_name, f);
+                    }
+                }
                 const recv_ty = try self.inferExpr(f.receiver, null);
                 try self.checkNotNullableDeref(f.receiver, recv_ty, f.span);
                 return try self.resolveFieldAccess(f, recv_ty);
@@ -1618,6 +1628,54 @@ const Checker = struct {
     /// `null` when the receiver type isn't a resolvable named
     /// struct / class — downstream callers treat that as "unknown
     /// for now" rather than another error.
+    /// Resolve an enum-variant constructor expression
+    /// (`EnumName.Variant`). Nullary variants resolve directly to
+    /// the enum's `Named` type — `let s = Color.Red` infers as
+    /// `Color`. Payload-bearing variants resolve to the constructor
+    /// function type `fn(payload_types) -> Enum` so a wrapping
+    /// `CallExpr` (`Item.Potion(20)`) type-checks through the
+    /// regular `checkCall` path.
+    fn resolveEnumVariant(
+        self: *Checker,
+        ed: *const ast.EnumDecl,
+        enum_name: []const u8,
+        f: ast.FieldExpr,
+    ) WalkError!?*const types.Type {
+        const variant_name = self.lexeme(f.field);
+        const variant: ?*const ast.EnumVariant = blk: {
+            for (ed.variants) |*v| {
+                if (std.mem.eql(u8, self.lexeme(v.name), variant_name)) break :blk v;
+            }
+            break :blk null;
+        };
+        if (variant == null) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "enum `{s}` has no variant `{s}`",
+                .{ enum_name, variant_name },
+            );
+            try self.emitSpan("E_TYPE_UNDEFINED_VARIANT", f.field, msg);
+            return null;
+        }
+        const enum_ty = try types.mkNamed(self.arena, enum_name, f.receiver.ident.span);
+        if (variant.?.payload.len == 0) return enum_ty;
+
+        // Payload-bearing variant — synthesize a constructor
+        // function signature so call-site type-checking flows.
+        var param_tys: std.ArrayList(*const types.Type) = .empty;
+        errdefer param_tys.deinit(self.arena);
+        for (variant.?.payload) |pf| {
+            const pt = try self.resolveType(pf.type_ann);
+            try param_tys.append(self.arena, pt);
+        }
+        const fn_ty = try self.arena.create(types.Type);
+        fn_ty.* = .{ .function = .{
+            .params = try param_tys.toOwnedSlice(self.arena),
+            .ret = enum_ty,
+        } };
+        return fn_ty;
+    }
+
     fn resolveFieldAccess(
         self: *Checker,
         f: ast.FieldExpr,

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -157,44 +157,21 @@ pub fn typecheck(
     };
 }
 
-/// Signature description for one `mem.X` stdlib builtin — used
-/// by both the typechecker (to synthesize a function type during
-/// resolution) and the codegen (to dispatch lowering). The
-/// `is_addr_of` flag flags the one builtin whose argument type
-/// can't be expressed in the regular primitive shape.
-pub const MemBuiltinSig = struct {
-    name: []const u8,
-    params: []const types.Primitive,
-    ret: ?types.Primitive,
-    is_addr_of: bool = false,
-};
+/// `mem.*` stdlib builtin lowering — signatures, lookup, and
+/// the two typechecker dispatch entry points.
+pub const mem_builtin = @import("typecheck/mem_builtin.zig");
 
-const mem_builtins = [_]MemBuiltinSig{
-    .{ .name = "read_u8", .params = &.{.u16}, .ret = .u8 },
-    .{ .name = "read_u16", .params = &.{.u16}, .ret = .u16 },
-    .{ .name = "read_i8", .params = &.{.u16}, .ret = .i8 },
-    .{ .name = "read_i16", .params = &.{.u16}, .ret = .i16 },
-    .{ .name = "write_u8", .params = &.{ .u16, .u8 }, .ret = null },
-    .{ .name = "write_u16", .params = &.{ .u16, .u16 }, .ret = null },
-    .{ .name = "write_i8", .params = &.{ .u16, .i8 }, .ret = null },
-    .{ .name = "write_i16", .params = &.{ .u16, .i16 }, .ret = null },
-    .{ .name = "memcpy", .params = &.{ .u16, .u16, .u16 }, .ret = null },
-    .{ .name = "memset", .params = &.{ .u16, .u8, .u16 }, .ret = null },
-    .{ .name = "peek", .params = &.{.u16}, .ret = .u8 }, // alias for read_u8
-    .{ .name = "poke", .params = &.{ .u16, .u8 }, .ret = null }, // alias for write_u8
-    .{ .name = "addr_of", .params = &.{}, .ret = .u16, .is_addr_of = true },
-};
+/// `mem.*` stdlib builtin signature (re-exported from the
+/// sub-module for callers that just want the lookup type).
+pub const MemBuiltinSig = mem_builtin.MemBuiltinSig;
 
-/// Look up a `mem.X` builtin by name. Returns `null` for unknown
-/// names so the typechecker can surface a clean diagnostic.
-pub fn lookupMemBuiltin(name: []const u8) ?MemBuiltinSig {
-    for (mem_builtins) |b| {
-        if (std.mem.eql(u8, b.name, name)) return b;
-    }
-    return null;
-}
+/// `mem.X` lookup (re-exported convenience).
+pub const lookupMemBuiltin = mem_builtin.lookupMemBuiltin;
 
-const Checker = struct {
+/// Stateful walker that runs resolution + inference + checking
+/// across the program. Sub-modules under `typecheck/` take a
+/// `*Checker` and call back into its public methods.
+pub const Checker = struct {
     source: []const u8,
     arena: std.mem.Allocator,
     /// Allocator used for the diagnostics ArrayList — must match the
@@ -319,7 +296,7 @@ const Checker = struct {
     /// Emit a diagnostic with full span coverage so the renderer
     /// can underline the offending source slice rather than a
     /// single character.
-    fn emitSpan(
+    pub fn emitSpan(
         self: *Checker,
         code: []const u8,
         span: ast.Span,
@@ -367,7 +344,8 @@ const Checker = struct {
         try self.emitSpan("E_TYPE_MISMATCH", span, msg);
     }
 
-    fn lexeme(self: *const Checker, span: ast.Span) []const u8 {
+    /// Return the source-text slice for `span`.
+    pub fn lexeme(self: *const Checker, span: ast.Span) []const u8 {
         return self.source[span.start..span.end];
     }
 
@@ -1392,7 +1370,10 @@ const Checker = struct {
         }
     }
 
-    fn primitive(self: *Checker, p: types.Primitive) WalkError!*const types.Type {
+    /// Allocate (or reuse) a `Type` value for the given primitive
+    /// tag. Sub-modules call this to construct argument / return
+    /// types for the function signatures they synthesize.
+    pub fn primitive(self: *Checker, p: types.Primitive) WalkError!*const types.Type {
         return try types.mkPrimitive(self.arena, p);
     }
 
@@ -1427,7 +1408,7 @@ const Checker = struct {
     ///
     /// Records the inferred type on `expr_types` before returning so
     /// the codegen can consume it without re-walking the AST.
-    fn inferExpr(self: *Checker, e: *const ast.Expr, hint: ?*const types.Type) WalkError!?*const types.Type {
+    pub fn inferExpr(self: *Checker, e: *const ast.Expr, hint: ?*const types.Type) WalkError!?*const types.Type {
         const ty = try self.inferExprInner(e, hint);
         if (ty) |t| try self.expr_types.put(self.arena, e, t);
         return ty;
@@ -1728,112 +1709,16 @@ const Checker = struct {
         return fn_ty;
     }
 
-    /// Type-check `mem.X(args)` as a method-call expression. The
-    /// stdlib `mem` module is compiler-recognized; the call's
-    /// arity + per-arg types are validated against the builtin's
-    /// declared signature. `mem.addr_of` accepts any addressable
-    /// argument so it skips per-arg checking — codegen rejects
-    /// non-addressable targets later.
+    /// Type-check `mem.X(args)` as a method-call expression
+    /// (delegates to `typecheck/mem_builtin.zig`).
     fn checkMemMethodCall(self: *Checker, m: ast.MethodCallExpr) WalkError!?*const types.Type {
-        const fn_name = self.lexeme(m.method);
-        const sig: ?MemBuiltinSig = lookupMemBuiltin(fn_name);
-        if (sig == null) {
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "stdlib module `mem` has no member `{s}`",
-                .{fn_name},
-            );
-            try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
-            for (m.args) |a| _ = try self.inferExpr(a, null);
-            return null;
-        }
-        if (sig.?.is_addr_of) {
-            if (m.args.len != 1) {
-                try self.emitSpan("E_TYPE_ARG_COUNT", m.span, "`mem.addr_of` takes exactly one argument");
-            }
-            // Walk the arg to populate `expr_types` + run nested
-            // checks; codegen handles the "must be addressable" rule.
-            for (m.args) |a| _ = try self.inferExpr(a, null);
-            return try self.primitive(.u16);
-        }
-        if (m.args.len != sig.?.params.len) {
-            const suffix: []const u8 = if (sig.?.params.len == 1) "" else "s";
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "`mem.{s}` takes {d} argument{s}, called with {d}",
-                .{ fn_name, sig.?.params.len, suffix, m.args.len },
-            );
-            try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
-        }
-        const n = @min(m.args.len, sig.?.params.len);
-        for (m.args[0..n], sig.?.params[0..n]) |a, p| {
-            const expected = try self.primitive(p);
-            _ = try self.inferExpr(a, expected);
-        }
-        // Walk extras (when arg count mismatched) so per-arg
-        // diagnostics still surface.
-        if (m.args.len > n) {
-            for (m.args[n..]) |a| _ = try self.inferExpr(a, null);
-        }
-        if (sig.?.ret) |r| return try self.primitive(r);
-        return try self.primitive(.nil_);
+        return mem_builtin.checkMemMethodCall(self, m);
     }
 
-    /// Resolve `mem.X` builtin field expressions. The `mem` module
-    /// is compiler-recognized rather than a regular source module —
-    /// each entry here synthesizes a function type so the wrapping
-    /// `CallExpr` flows through the normal `checkCall` path (arity
-    /// + per-arg type check).
-    ///
-    /// `mem.addr_of` is the one shape that doesn't fit the regular
-    /// arity / type rules — its argument can be any place
-    /// expression. We synthesize `fn() -> u16` and rely on the
-    /// codegen to do the address resolution; the call-site arity
-    /// check still validates one-arg-ness.
+    /// Resolve `mem.X` builtin field expressions (delegates to
+    /// `typecheck/mem_builtin.zig`).
     fn resolveMemBuiltin(self: *Checker, f: ast.FieldExpr) WalkError!?*const types.Type {
-        const fn_name = self.lexeme(f.field);
-        const sig: ?MemBuiltinSig = lookupMemBuiltin(fn_name);
-        if (sig == null) {
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "stdlib module `mem` has no member `{s}`",
-                .{fn_name},
-            );
-            try self.emitSpan("E_TYPE_UNDEFINED_METHOD", f.field, msg);
-            return null;
-        }
-        // Special case: `mem.addr_of` accepts any addressable
-        // expression as its single arg; surface its signature as
-        // `fn(<anything>) -> u16` by deferring the param type
-        // validation to codegen.
-        if (sig.?.is_addr_of) {
-            var params: std.ArrayList(*const types.Type) = .empty;
-            errdefer params.deinit(self.arena);
-            // Single-element `nil` placeholder — the codegen path
-            // accepts whatever the source supplies.
-            const nil_ty = try self.primitive(.nil_);
-            try params.append(self.arena, nil_ty);
-            const ret = try self.primitive(.u16);
-            const fn_ty = try self.arena.create(types.Type);
-            fn_ty.* = .{ .function = .{
-                .params = try params.toOwnedSlice(self.arena),
-                .ret = ret,
-            } };
-            return fn_ty;
-        }
-        var params: std.ArrayList(*const types.Type) = .empty;
-        errdefer params.deinit(self.arena);
-        for (sig.?.params) |p| {
-            const t = try self.primitive(p);
-            try params.append(self.arena, t);
-        }
-        const ret = if (sig.?.ret) |r| try self.primitive(r) else try self.primitive(.nil_);
-        const fn_ty = try self.arena.create(types.Type);
-        fn_ty.* = .{ .function = .{
-            .params = try params.toOwnedSlice(self.arena),
-            .ret = ret,
-        } };
-        return fn_ty;
+        return mem_builtin.resolveMemBuiltin(self, f);
     }
 
     fn resolveFieldAccess(

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -155,6 +155,43 @@ pub fn typecheck(
     };
 }
 
+/// Signature description for one `mem.X` stdlib builtin — used
+/// by both the typechecker (to synthesize a function type during
+/// resolution) and the codegen (to dispatch lowering). The
+/// `is_addr_of` flag flags the one builtin whose argument type
+/// can't be expressed in the regular primitive shape.
+pub const MemBuiltinSig = struct {
+    name: []const u8,
+    params: []const types.Primitive,
+    ret: ?types.Primitive,
+    is_addr_of: bool = false,
+};
+
+const mem_builtins = [_]MemBuiltinSig{
+    .{ .name = "read_u8", .params = &.{.u16}, .ret = .u8 },
+    .{ .name = "read_u16", .params = &.{.u16}, .ret = .u16 },
+    .{ .name = "read_i8", .params = &.{.u16}, .ret = .i8 },
+    .{ .name = "read_i16", .params = &.{.u16}, .ret = .i16 },
+    .{ .name = "write_u8", .params = &.{ .u16, .u8 }, .ret = null },
+    .{ .name = "write_u16", .params = &.{ .u16, .u16 }, .ret = null },
+    .{ .name = "write_i8", .params = &.{ .u16, .i8 }, .ret = null },
+    .{ .name = "write_i16", .params = &.{ .u16, .i16 }, .ret = null },
+    .{ .name = "memcpy", .params = &.{ .u16, .u16, .u16 }, .ret = null },
+    .{ .name = "memset", .params = &.{ .u16, .u8, .u16 }, .ret = null },
+    .{ .name = "peek", .params = &.{.u16}, .ret = .u8 }, // alias for read_u8
+    .{ .name = "poke", .params = &.{ .u16, .u8 }, .ret = null }, // alias for write_u8
+    .{ .name = "addr_of", .params = &.{}, .ret = .u16, .is_addr_of = true },
+};
+
+/// Look up a `mem.X` builtin by name. Returns `null` for unknown
+/// names so the typechecker can surface a clean diagnostic.
+pub fn lookupMemBuiltin(name: []const u8) ?MemBuiltinSig {
+    for (mem_builtins) |b| {
+        if (std.mem.eql(u8, b.name, name)) return b;
+    }
+    return null;
+}
+
 const Checker = struct {
     source: []const u8,
     arena: std.mem.Allocator,
@@ -1463,19 +1500,32 @@ const Checker = struct {
             },
             .call => |c| return try self.checkCall(c, hint),
             .method_call => |m| {
+                // `mem.X(args)` parses as a method call on the
+                // synthetic `mem` module — dispatch through the
+                // stdlib resolver rather than the class-method path.
+                if (m.receiver.* == .ident) {
+                    const recv_name = self.lexeme(m.receiver.ident.span);
+                    if (std.mem.eql(u8, recv_name, "mem")) {
+                        return try self.checkMemMethodCall(m);
+                    }
+                }
                 const recv_ty = try self.inferExpr(m.receiver, null);
                 try self.checkNotNullableDeref(m.receiver, recv_ty, m.span);
                 return try self.checkMethodCall(m, recv_ty);
             },
             .field => |f| {
-                // Enum-variant constructor shape: `Item.Sword`. The
-                // receiver is an ident matching a registered enum
-                // name — resolve directly to the enum's type so a
-                // subsequent `let s = Item.Sword` infers as `Item`.
+                // Special receivers (recognized before generic
+                // field resolution since their "receiver" is a
+                // module / type name rather than a value):
+                //   - `EnumName.Variant` — variant constructor.
+                //   - `mem.func`         — stdlib builtin.
                 if (f.receiver.* == .ident) {
                     const recv_name = self.lexeme(f.receiver.ident.span);
                     if (self.enum_registry.get(recv_name)) |ed| {
                         return try self.resolveEnumVariant(ed, recv_name, f);
+                    }
+                    if (std.mem.eql(u8, recv_name, "mem")) {
+                        return try self.resolveMemBuiltin(f);
                     }
                 }
                 const recv_ty = try self.inferExpr(f.receiver, null);
@@ -1672,6 +1722,114 @@ const Checker = struct {
         fn_ty.* = .{ .function = .{
             .params = try param_tys.toOwnedSlice(self.arena),
             .ret = enum_ty,
+        } };
+        return fn_ty;
+    }
+
+    /// Type-check `mem.X(args)` as a method-call expression. The
+    /// stdlib `mem` module is compiler-recognized; the call's
+    /// arity + per-arg types are validated against the builtin's
+    /// declared signature. `mem.addr_of` accepts any addressable
+    /// argument so it skips per-arg checking — codegen rejects
+    /// non-addressable targets later.
+    fn checkMemMethodCall(self: *Checker, m: ast.MethodCallExpr) WalkError!?*const types.Type {
+        const fn_name = self.lexeme(m.method);
+        const sig: ?MemBuiltinSig = lookupMemBuiltin(fn_name);
+        if (sig == null) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "stdlib module `mem` has no member `{s}`",
+                .{fn_name},
+            );
+            try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
+            for (m.args) |a| _ = try self.inferExpr(a, null);
+            return null;
+        }
+        if (sig.?.is_addr_of) {
+            if (m.args.len != 1) {
+                try self.emitSpan("E_TYPE_ARG_COUNT", m.span, "`mem.addr_of` takes exactly one argument");
+            }
+            // Walk the arg to populate `expr_types` + run nested
+            // checks; codegen handles the "must be addressable" rule.
+            for (m.args) |a| _ = try self.inferExpr(a, null);
+            return try self.primitive(.u16);
+        }
+        if (m.args.len != sig.?.params.len) {
+            const suffix: []const u8 = if (sig.?.params.len == 1) "" else "s";
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "`mem.{s}` takes {d} argument{s}, called with {d}",
+                .{ fn_name, sig.?.params.len, suffix, m.args.len },
+            );
+            try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
+        }
+        const n = @min(m.args.len, sig.?.params.len);
+        for (m.args[0..n], sig.?.params[0..n]) |a, p| {
+            const expected = try self.primitive(p);
+            _ = try self.inferExpr(a, expected);
+        }
+        // Walk extras (when arg count mismatched) so per-arg
+        // diagnostics still surface.
+        if (m.args.len > n) {
+            for (m.args[n..]) |a| _ = try self.inferExpr(a, null);
+        }
+        if (sig.?.ret) |r| return try self.primitive(r);
+        return try self.primitive(.nil_);
+    }
+
+    /// Resolve `mem.X` builtin field expressions. The `mem` module
+    /// is compiler-recognized rather than a regular source module —
+    /// each entry here synthesizes a function type so the wrapping
+    /// `CallExpr` flows through the normal `checkCall` path (arity
+    /// + per-arg type check).
+    ///
+    /// `mem.addr_of` is the one shape that doesn't fit the regular
+    /// arity / type rules — its argument can be any place
+    /// expression. We synthesize `fn() -> u16` and rely on the
+    /// codegen to do the address resolution; the call-site arity
+    /// check still validates one-arg-ness.
+    fn resolveMemBuiltin(self: *Checker, f: ast.FieldExpr) WalkError!?*const types.Type {
+        const fn_name = self.lexeme(f.field);
+        const sig: ?MemBuiltinSig = lookupMemBuiltin(fn_name);
+        if (sig == null) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "stdlib module `mem` has no member `{s}`",
+                .{fn_name},
+            );
+            try self.emitSpan("E_TYPE_UNDEFINED_METHOD", f.field, msg);
+            return null;
+        }
+        // Special case: `mem.addr_of` accepts any addressable
+        // expression as its single arg; surface its signature as
+        // `fn(<anything>) -> u16` by deferring the param type
+        // validation to codegen.
+        if (sig.?.is_addr_of) {
+            var params: std.ArrayList(*const types.Type) = .empty;
+            errdefer params.deinit(self.arena);
+            // Single-element `nil` placeholder — the codegen path
+            // accepts whatever the source supplies.
+            const nil_ty = try self.primitive(.nil_);
+            try params.append(self.arena, nil_ty);
+            const ret = try self.primitive(.u16);
+            const fn_ty = try self.arena.create(types.Type);
+            fn_ty.* = .{ .function = .{
+                .params = try params.toOwnedSlice(self.arena),
+                .ret = ret,
+            } };
+            return fn_ty;
+        }
+        var params: std.ArrayList(*const types.Type) = .empty;
+        errdefer params.deinit(self.arena);
+        for (sig.?.params) |p| {
+            const t = try self.primitive(p);
+            try params.append(self.arena, t);
+        }
+        const ret = if (sig.?.ret) |r| try self.primitive(r) else try self.primitive(.nil_);
+        const fn_ty = try self.arena.create(types.Type);
+        fn_ty.* = .{ .function = .{
+            .params = try params.toOwnedSlice(self.arena),
+            .ret = ret,
         } };
         return fn_ty;
     }

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1,4 +1,6 @@
-/// Gero-lang typechecker — checking slice.
+/// Gero-lang typechecker — resolves identifiers, infers types,
+/// checks calls / assignments / patterns, and surfaces every
+/// rule violation as a `Diagnostic` for the caller.
 ///
 /// Two passes over the AST:
 ///   1. Top-level decl registration — every module-scope `let` /
@@ -587,7 +589,8 @@ const Checker = struct {
     /// Build the function-pointer type for a `def` from its
     /// annotations. Params without an explicit type produce a `nil`
     /// placeholder slot — `checkCall` treats those as "skip arg-type
-    /// check" pending the parameter-from-call-site inference slice.
+    /// check" since the parameter type can't be inferred without
+    /// a concrete call site.
     fn signatureFromDef(self: *Checker, d: ast.DefDecl) WalkError!*const types.Type {
         var param_types: std.ArrayList(*const types.Type) = .empty;
         errdefer param_types.deinit(self.arena);
@@ -880,8 +883,7 @@ const Checker = struct {
     ) WalkError!void {
         // Flow analysis is applied only when there is exactly one
         // arm — the simple `if cond then BODY [else …] end` shape.
-        // Multi-arm `elif` chains skip the bookkeeping (slice 5+
-        // can refine if it proves useful).
+        // Multi-arm `elif` chains skip the bookkeeping.
         const flow: ?NilCheck = if (arms.len == 1 and arms[0].cond != null)
             self.matchNilCheck(arms[0].cond.?)
         else
@@ -2370,7 +2372,7 @@ const Checker = struct {
             const param_ty = f.params[i];
             // Skip the type check when the param's type is the
             // `nil_` placeholder used for unannotated `def` params —
-            // call-site inference for those lands in a later slice.
+            // those params accept any caller-supplied type.
             const skip = isNilType(param_ty.*);
             const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
             if (!skip and arg_ty != null and !assignable(arg_ty.?.*, param_ty.*)) {

--- a/src/lang/typecheck/match.zig
+++ b/src/lang/typecheck/match.zig
@@ -1,0 +1,167 @@
+/// `match` typechecking — walks each arm's pattern, validates
+/// arm-body bindings, and runs the exhaustiveness +
+/// reachability checks for enum-typed scrutinees.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const scope_mod = @import("../scope.zig");
+const typecheck = @import("../typecheck.zig");
+
+const Scope = scope_mod.Scope;
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+/// Type-check a `match` statement: infer the scrutinee type,
+/// walk every arm's pattern + guard + body, and (for enum
+/// scrutinees) check that every variant is covered.
+pub fn checkMatch(self: *Checker, ms: ast.MatchStmt) WalkError!void {
+    const scrut_ty = try self.inferExpr(ms.scrutinee, null);
+
+    // Lookup enum decl when scrutinee resolves to a named-enum.
+    const enum_decl: ?*const ast.EnumDecl = if (scrut_ty) |st|
+        enumDeclForType(self, st.*)
+    else
+        null;
+
+    // Track variant-name coverage when scrutinee is an enum.
+    var covered: std.StringHashMapUnmanaged(void) = .{};
+    defer covered.deinit(self.arena);
+    var has_wildcard: bool = false;
+
+    for (ms.arms) |arm| {
+        // Exhaustiveness + reachability checks (enum scrutinee only).
+        if (enum_decl) |ed| try recordArmCoverage(self, arm, ed, &covered, &has_wildcard);
+
+        const saved = self.current_scope;
+        var child: Scope = .init(self.arena, saved);
+        self.current_scope = &child;
+        defer self.current_scope = saved;
+        try self.registerPatternBindings(arm.pattern);
+        if (arm.guard) |g| _ = try self.inferExpr(g, null);
+        try self.walkStatementSequence(arm.body);
+    }
+
+    // Exhaustiveness: every variant must be covered (or wildcard).
+    if (enum_decl) |ed| if (!has_wildcard) {
+        try checkExhaustiveness(self, ms.span, ed, &covered);
+    };
+}
+
+/// Resolve `ty` to its underlying enum decl (when `ty` is a
+/// `Named(EnumName)` whose name maps to a registered enum
+/// declaration). Returns `null` otherwise.
+pub fn enumDeclForType(self: *const Checker, ty: types.Type) ?*const ast.EnumDecl {
+    if (ty != .named) return null;
+    return self.enum_registry.get(ty.named.name);
+}
+
+/// `true` when `name` is one of `ed`'s declared variant names.
+/// Names compare by the source-buffer lexeme.
+pub fn variantExists(self: *const Checker, ed: *const ast.EnumDecl, name: []const u8) bool {
+    for (ed.variants) |v| {
+        if (std.mem.eql(u8, self.lexeme(v.name), name)) return true;
+    }
+    return false;
+}
+
+/// Walk one match arm's pattern (including or-pattern
+/// alternatives) and record which variant names it covers.
+/// Emits `E_MATCH_UNREACHABLE_ARM` on duplicates and on any arm
+/// that follows a wildcard.
+fn recordArmCoverage(
+    self: *Checker,
+    arm: ast.MatchArm,
+    ed: *const ast.EnumDecl,
+    covered: *std.StringHashMapUnmanaged(void),
+    has_wildcard: *bool,
+) WalkError!void {
+    if (has_wildcard.*) {
+        try self.emitSpan("E_MATCH_UNREACHABLE_ARM", arm.span, "this arm cannot be reached — a wildcard `_` arm above already handles every remaining variant");
+    }
+    try walkArmPattern(self, arm.pattern, ed, covered, has_wildcard);
+}
+
+fn walkArmPattern(
+    self: *Checker,
+    pat: *const ast.Pattern,
+    ed: *const ast.EnumDecl,
+    covered: *std.StringHashMapUnmanaged(void),
+    has_wildcard: *bool,
+) WalkError!void {
+    switch (pat.*) {
+        .wildcard, .ident => {
+            // Bare ident in match-arm position binds the value
+            // — equivalent to `_` from the exhaustiveness POV.
+            has_wildcard.* = true;
+        },
+        .variant_pattern => |vp| {
+            const split = splitPath(self.lexeme(vp.path));
+            // Verify the head matches the enum name (skip when
+            // it doesn't — pattern targets a different enum).
+            if (split.head.len > 0 and !std.mem.eql(u8, split.head, self.lexeme(ed.name))) return;
+            // Verify variant exists on this enum.
+            if (!variantExists(self, ed, split.tail)) return;
+            const gop = try covered.getOrPut(self.arena, split.tail);
+            if (gop.found_existing) {
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "variant `{s}.{s}` is already handled by an earlier arm",
+                    .{ self.lexeme(ed.name), split.tail },
+                );
+                try self.emitSpan("E_MATCH_UNREACHABLE_ARM", pat.span(), msg);
+            }
+        },
+        .or_pattern => |op| {
+            for (op.alts) |alt| try walkArmPattern(self, alt, ed, covered, has_wildcard);
+        },
+        else => {
+            // Literal / range / tuple / struct patterns don't
+            // contribute to enum-variant coverage and don't
+            // qualify as a catch-all.
+        },
+    }
+}
+
+fn checkExhaustiveness(
+    self: *Checker,
+    match_span: ast.Span,
+    ed: *const ast.EnumDecl,
+    covered: *const std.StringHashMapUnmanaged(void),
+) WalkError!void {
+    // Collect uncovered variant names for the message body.
+    var missing: std.ArrayList([]const u8) = .empty;
+    defer missing.deinit(self.arena);
+    for (ed.variants) |v| {
+        const name = self.lexeme(v.name);
+        if (!covered.contains(name)) try missing.append(self.arena, name);
+    }
+    if (missing.items.len == 0) return;
+
+    // Render "A, B, C" (cap at 3 to keep messages compact).
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(self.arena);
+    const limit: usize = @min(missing.items.len, 3);
+    for (missing.items[0..limit], 0..) |name, i| {
+        if (i > 0) try buf.appendSlice(self.arena, ", ");
+        try buf.appendSlice(self.arena, name);
+    }
+    if (missing.items.len > limit) try buf.appendSlice(self.arena, ", …");
+
+    const suffix: []const u8 = if (missing.items.len == 1) "" else "s";
+    const msg = try std.fmt.allocPrint(
+        self.arena,
+        "non-exhaustive match on enum `{s}` — missing variant{s}: {s}",
+        .{ self.lexeme(ed.name), suffix, buf.items },
+    );
+    try self.emitSpan("E_MATCH_NON_EXHAUSTIVE", match_span, msg);
+}
+
+/// Split a dotted path like `Enum.Variant` into `(head="Enum",
+/// tail="Variant")`. Returns an empty head when there is no
+/// `.` in the path.
+pub fn splitPath(text: []const u8) struct { head: []const u8, tail: []const u8 } {
+    if (std.mem.lastIndexOfScalar(u8, text, '.')) |dot| {
+        return .{ .head = text[0..dot], .tail = text[dot + 1 ..] };
+    }
+    return .{ .head = "", .tail = text };
+}

--- a/src/lang/typecheck/mem_builtin.zig
+++ b/src/lang/typecheck/mem_builtin.zig
@@ -1,0 +1,146 @@
+/// Stdlib `mem.*` builtin signatures + the two typechecker
+/// dispatch helpers that consume them. The `mem` module is
+/// compiler-recognized (not a source-level module) so callers
+/// hit these resolvers directly instead of going through the
+/// regular module-lookup path.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const typecheck = @import("../typecheck.zig");
+
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+/// Signature description for one `mem.X` stdlib builtin — used
+/// by both the typechecker (to synthesize a function type during
+/// resolution) and the codegen (to dispatch lowering). The
+/// `is_addr_of` flag flags the one builtin whose argument type
+/// can't be expressed in the regular primitive shape.
+pub const MemBuiltinSig = struct {
+    name: []const u8,
+    params: []const types.Primitive,
+    ret: ?types.Primitive,
+    is_addr_of: bool = false,
+};
+
+const mem_builtins = [_]MemBuiltinSig{
+    .{ .name = "read_u8", .params = &.{.u16}, .ret = .u8 },
+    .{ .name = "read_u16", .params = &.{.u16}, .ret = .u16 },
+    .{ .name = "read_i8", .params = &.{.u16}, .ret = .i8 },
+    .{ .name = "read_i16", .params = &.{.u16}, .ret = .i16 },
+    .{ .name = "write_u8", .params = &.{ .u16, .u8 }, .ret = null },
+    .{ .name = "write_u16", .params = &.{ .u16, .u16 }, .ret = null },
+    .{ .name = "write_i8", .params = &.{ .u16, .i8 }, .ret = null },
+    .{ .name = "write_i16", .params = &.{ .u16, .i16 }, .ret = null },
+    .{ .name = "memcpy", .params = &.{ .u16, .u16, .u16 }, .ret = null },
+    .{ .name = "memset", .params = &.{ .u16, .u8, .u16 }, .ret = null },
+    .{ .name = "peek", .params = &.{.u16}, .ret = .u8 }, // alias for read_u8
+    .{ .name = "poke", .params = &.{ .u16, .u8 }, .ret = null }, // alias for write_u8
+    .{ .name = "addr_of", .params = &.{}, .ret = .u16, .is_addr_of = true },
+};
+
+/// Look up a `mem.X` builtin by name. Returns `null` for unknown
+/// names so the typechecker can surface a clean diagnostic.
+pub fn lookupMemBuiltin(name: []const u8) ?MemBuiltinSig {
+    for (mem_builtins) |b| {
+        if (std.mem.eql(u8, b.name, name)) return b;
+    }
+    return null;
+}
+
+/// Type-check `mem.X(args)` as a method-call expression. The
+/// stdlib `mem` module is compiler-recognized; the call's
+/// arity + per-arg types are validated against the builtin's
+/// declared signature. `mem.addr_of` accepts any addressable
+/// argument so it skips per-arg checking — codegen rejects
+/// non-addressable targets later.
+pub fn checkMemMethodCall(self: *Checker, m: ast.MethodCallExpr) WalkError!?*const types.Type {
+    const fn_name = self.lexeme(m.method);
+    const sig: ?MemBuiltinSig = lookupMemBuiltin(fn_name);
+    if (sig == null) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "stdlib module `mem` has no member `{s}`",
+            .{fn_name},
+        );
+        try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    }
+    if (sig.?.is_addr_of) {
+        if (m.args.len != 1) {
+            try self.emitSpan("E_TYPE_ARG_COUNT", m.span, "`mem.addr_of` takes exactly one argument");
+        }
+        // Walk the arg to populate `expr_types` + run nested
+        // checks; codegen handles the "must be addressable" rule.
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return try self.primitive(.u16);
+    }
+    if (m.args.len != sig.?.params.len) {
+        const suffix: []const u8 = if (sig.?.params.len == 1) "" else "s";
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "`mem.{s}` takes {d} argument{s}, called with {d}",
+            .{ fn_name, sig.?.params.len, suffix, m.args.len },
+        );
+        try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
+    }
+    const n = @min(m.args.len, sig.?.params.len);
+    for (m.args[0..n], sig.?.params[0..n]) |a, p| {
+        const expected = try self.primitive(p);
+        _ = try self.inferExpr(a, expected);
+    }
+    // Walk extras (when arg count mismatched) so per-arg
+    // diagnostics still surface.
+    if (m.args.len > n) {
+        for (m.args[n..]) |a| _ = try self.inferExpr(a, null);
+    }
+    if (sig.?.ret) |r| return try self.primitive(r);
+    return try self.primitive(.nil_);
+}
+
+/// Resolve `mem.X` builtin field expressions. Each entry
+/// synthesizes a function type so the wrapping `CallExpr` flows
+/// through the normal `checkCall` path (arity + per-arg type
+/// check). `mem.addr_of` accepts any addressable argument and
+/// surfaces as `fn(<anything>) -> u16`, deferring the
+/// param-type validation to codegen.
+pub fn resolveMemBuiltin(self: *Checker, f: ast.FieldExpr) WalkError!?*const types.Type {
+    const fn_name = self.lexeme(f.field);
+    const sig: ?MemBuiltinSig = lookupMemBuiltin(fn_name);
+    if (sig == null) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "stdlib module `mem` has no member `{s}`",
+            .{fn_name},
+        );
+        try self.emitSpan("E_TYPE_UNDEFINED_METHOD", f.field, msg);
+        return null;
+    }
+    if (sig.?.is_addr_of) {
+        var params: std.ArrayList(*const types.Type) = .empty;
+        errdefer params.deinit(self.arena);
+        const nil_ty = try self.primitive(.nil_);
+        try params.append(self.arena, nil_ty);
+        const ret = try self.primitive(.u16);
+        const fn_ty = try self.arena.create(types.Type);
+        fn_ty.* = .{ .function = .{
+            .params = try params.toOwnedSlice(self.arena),
+            .ret = ret,
+        } };
+        return fn_ty;
+    }
+    var params: std.ArrayList(*const types.Type) = .empty;
+    errdefer params.deinit(self.arena);
+    for (sig.?.params) |p| {
+        const t = try self.primitive(p);
+        try params.append(self.arena, t);
+    }
+    const ret = if (sig.?.ret) |r| try self.primitive(r) else try self.primitive(.nil_);
+    const fn_ty = try self.arena.create(types.Type);
+    fn_ty.* = .{ .function = .{
+        .params = try params.toOwnedSlice(self.arena),
+        .ret = ret,
+    } };
+    return fn_ty;
+}

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1252,6 +1252,90 @@ test "codegen: zero-page overflow emits E_CODEGEN_ZP_OVERFLOW" {
     try std.testing.expect(found);
 }
 
+// ---------- M3a: enum codegen (nullary variants) ----------
+
+test "codegen: nullary enum constructor loads tag byte into acu" {
+    try runAndExpect(
+        \\enum Color
+        \\  case Red
+        \\  case Green
+        \\  case Blue
+        \\end
+        \\def main()
+        \\  let c: Color = Color.Green
+        \\  print c
+        \\end
+    ,
+        // Green is the second declared variant → tag = 1.
+        "1\n");
+}
+
+test "codegen: `is` test on enum returns true on the right variant" {
+    try runAndExpect(
+        \\enum Color
+        \\  case Red
+        \\  case Green
+        \\end
+        \\def main()
+        \\  let c: Color = Color.Green
+        \\  if c is Color.Green
+        \\    print 1
+        \\  end
+        \\  if c is Color.Red
+        \\    print 99
+        \\  end
+        \\end
+    , "1\n");
+}
+
+test "codegen: match on nullary enum dispatches per variant tag" {
+    try runAndExpect(
+        \\enum Color
+        \\  case Red
+        \\  case Green
+        \\  case Blue
+        \\end
+        \\def main()
+        \\  let c: Color = Color.Blue
+        \\  match c
+        \\    case Color.Red => print 1
+        \\    case Color.Green => print 2
+        \\    case Color.Blue => print 3
+        \\  end
+        \\end
+    , "3\n");
+}
+
+test "codegen: undefined enum variant in `is` rhs is rejected" {
+    const source =
+        \\enum Color
+        \\  case Red
+        \\end
+        \\def main()
+        \\  let c: Color = Color.Red
+        \\  if c is Color.NoSuchVariant
+        \\    print 1
+        \\  end
+        \\end
+    ;
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    var compiled = try gero.lang.compile(alloc, source, &checked, .{});
+    defer compiled.deinit();
+    try std.testing.expect(compiled.hasErrors());
+
+    var found = false;
+    for (compiled.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_CODEGEN_UNDEFINED_VARIANT")) found = true;
+    }
+    try std.testing.expect(found);
+}
+
 test "codegen: custom entry_name resolves" {
     const source = "def boot() end";
     var stream = try gero.lang.tokenize(alloc, source);

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1,4 +1,6 @@
-/// Tests for `gero.lang.codegen` — slice-B1 framework smoke.
+/// Tests for `gero.lang.codegen` — compiles small programs end
+/// to end (tokenize → parse → typecheck → compile → boot on the
+/// VM) and asserts on printed output or VM-memory state.
 const std = @import("std");
 const gero = @import("gero");
 
@@ -656,7 +658,7 @@ test "codegen: byte-store to @addr global uses movl (does not clobber adjacent b
     try std.testing.expectEqual(@as(u8, 0xAB), vm.mmap.readByte(0xFE41));
 }
 
-// ---------- M2: control flow (if / while / for / repeat / match) ----------
+// ---------- control flow (if / while / for / repeat / match) ----------
 
 /// Shorthand: compile, boot, run until halt, assert on printed output.
 fn runAndExpect(source: []const u8, expected: []const u8) !void {
@@ -1018,7 +1020,7 @@ test "codegen: defer fires on continue path before going to next iteration" {
         "1\n9\n9\n3\n9\n");
 }
 
-// ---------- M1 self-review backfill: AC items previously missing ----------
+// ---------- str-literal print, fixed-point, recursion, frame slots ----------
 
 test "codegen: print of a string literal goes through sys print_str + emits `hi`" {
     try runAndExpect(
@@ -1252,7 +1254,7 @@ test "codegen: zero-page overflow emits E_CODEGEN_ZP_OVERFLOW" {
     try std.testing.expect(found);
 }
 
-// ---------- M3a: enum codegen (nullary variants) ----------
+// ---------- enum codegen (nullary variants) ----------
 
 test "codegen: nullary enum constructor loads tag byte into acu" {
     try runAndExpect(
@@ -1336,7 +1338,7 @@ test "codegen: undefined enum variant in `is` rhs is rejected" {
     try std.testing.expect(found);
 }
 
-// ---------- M3a: mem stdlib + references ----------
+// ---------- mem stdlib + references ----------
 
 test "codegen: mem.write_u8 + mem.read_u8 round-trip a byte" {
     try runAndExpect(
@@ -1438,9 +1440,9 @@ test "codegen: mem.addr_of on a global returns its static address" {
 
 test "codegen: `&local` produces same address as mem.addr_of" {
     // `&x` and `mem.addr_of(x)` share the same runtime
-    // representation (a 16-bit address). Auto-deref on field /
-    // method access lands with M3b's struct + class lowering;
-    // M3a only verifies the address itself is correct.
+    // representation (a 16-bit address). This test verifies the
+    // address itself is correct; auto-deref on field / method
+    // access is exercised by class / struct tests when those land.
     try runAndExpect(
         \\use mem
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1336,6 +1336,164 @@ test "codegen: undefined enum variant in `is` rhs is rejected" {
     try std.testing.expect(found);
 }
 
+// ---------- M3a: mem stdlib + references ----------
+
+test "codegen: mem.write_u8 + mem.read_u8 round-trip a byte" {
+    try runAndExpect(
+        \\use mem
+        \\def main()
+        \\  mem.write_u8($2100, 42)
+        \\  let v: u8 = mem.read_u8($2100)
+        \\  print v
+        \\end
+    , "42\n");
+}
+
+test "codegen: mem.write_u16 + mem.read_u16 preserve little-endian byte order" {
+    try runAndExpect(
+        \\use mem
+        \\def main()
+        \\  mem.write_u16($2100, $1234)
+        \\  -- low byte = 0x34 at $2100, high byte = 0x12 at $2101
+        \\  let lo: u8 = mem.read_u8($2100)
+        \\  let hi: u8 = mem.read_u8($2101)
+        \\  print lo
+        \\  print hi
+        \\end
+    , "52\n18\n");
+}
+
+test "codegen: mem.read_i8 sign-extends negative byte values into i16 range" {
+    try runAndExpect(
+        \\use mem
+        \\def main()
+        \\  mem.write_u8($2100, 255)
+        \\  let v: i8 = mem.read_i8($2100)
+        \\  print v
+        \\end
+    , "-1\n");
+}
+
+test "codegen: mem.poke + mem.peek aliases work" {
+    try runAndExpect(
+        \\use mem
+        \\def main()
+        \\  mem.poke($2100, 7)
+        \\  let v: u8 = mem.peek($2100)
+        \\  print v
+        \\end
+    , "7\n");
+}
+
+test "codegen: mem.memcpy copies n bytes from src to dst" {
+    try runAndExpect(
+        \\use mem
+        \\def main()
+        \\  mem.write_u8($2100, 11)
+        \\  mem.write_u8($2101, 22)
+        \\  mem.write_u8($2102, 33)
+        \\  mem.memcpy($2200, $2100, 3)
+        \\  print mem.read_u8($2200)
+        \\  print mem.read_u8($2201)
+        \\  print mem.read_u8($2202)
+        \\end
+    , "11\n22\n33\n");
+}
+
+test "codegen: mem.memset fills n bytes with the value" {
+    try runAndExpect(
+        \\use mem
+        \\def main()
+        \\  mem.memset($2200, 99, 3)
+        \\  print mem.read_u8($2200)
+        \\  print mem.read_u8($2201)
+        \\  print mem.read_u8($2202)
+        \\end
+    , "99\n99\n99\n");
+}
+
+test "codegen: mem.addr_of on a local returns its stack-slot address" {
+    try runAndExpect(
+        \\use mem
+        \\def main()
+        \\  let x: i16 = 42
+        \\  let p: u16 = mem.addr_of(x)
+        \\  let v: i16 = mem.read_i16(p)
+        \\  print v
+        \\end
+    , "42\n");
+}
+
+test "codegen: mem.addr_of on a global returns its static address" {
+    try runAndExpect(
+        \\use mem
+        \\let counter: u16 = 7
+        \\def main()
+        \\  let p: u16 = mem.addr_of(counter)
+        \\  mem.write_u16(p, 99)
+        \\  print counter
+        \\end
+    , "99\n");
+}
+
+test "codegen: `&local` produces same address as mem.addr_of" {
+    // `&x` and `mem.addr_of(x)` share the same runtime
+    // representation (a 16-bit address). Auto-deref on field /
+    // method access lands with M3b's struct + class lowering;
+    // M3a only verifies the address itself is correct.
+    try runAndExpect(
+        \\use mem
+        \\def main()
+        \\  let x: i16 = 7
+        \\  let r: &i16 = &x
+        \\  let a: u16 = mem.addr_of(x)
+        \\  mem.write_i16(a, 42)
+        \\  print x
+        \\  -- Suppress an unused-binding warning on `r` by
+        \\  -- comparing addresses textually below.
+        \\  let _b: &i16 = r
+        \\end
+    , "42\n");
+}
+
+test "codegen: `&(a + b)` is rejected by typecheck" {
+    const source =
+        \\def main()
+        \\  let r: &i16 = &(1 + 2)
+        \\  print r
+        \\end
+    ;
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+    try std.testing.expect(checked.diagnostics.len > 0);
+}
+
+test "codegen: undefined mem.X is rejected by typecheck" {
+    const source =
+        \\use mem
+        \\def main()
+        \\  let v: u8 = mem.read_nonsense($2100)
+        \\  print v
+        \\end
+    ;
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    var found = false;
+    for (checked.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_TYPE_UNDEFINED_METHOD")) found = true;
+    }
+    try std.testing.expect(found);
+}
+
 test "codegen: custom entry_name resolves" {
     const source = "def boot() end";
     var stream = try gero.lang.tokenize(alloc, source);

--- a/tests/lang/codegen/archive.test.zig
+++ b/tests/lang/codegen/archive.test.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const gero = @import("gero");
+const archive = gero.lang.codegen.archive;
+
+test "archive: alignUpU16 rounds to the next power-of-two multiple" {
+    try std.testing.expectEqual(@as(u16, 0), archive.alignUpU16(0, 16));
+    try std.testing.expectEqual(@as(u16, 16), archive.alignUpU16(1, 16));
+    try std.testing.expectEqual(@as(u16, 16), archive.alignUpU16(15, 16));
+    try std.testing.expectEqual(@as(u16, 16), archive.alignUpU16(16, 16));
+    try std.testing.expectEqual(@as(u16, 32), archive.alignUpU16(17, 16));
+}
+
+test "archive: alignUpU16 with align <= 1 is a no-op" {
+    try std.testing.expectEqual(@as(u16, 7), archive.alignUpU16(7, 0));
+    try std.testing.expectEqual(@as(u16, 7), archive.alignUpU16(7, 1));
+}
+
+test "archive: writeU16Le encodes the low byte first" {
+    var buf: [2]u8 = .{ 0, 0 };
+    archive.writeU16Le(&buf, 0x1234);
+    try std.testing.expectEqual(@as(u8, 0x34), buf[0]);
+    try std.testing.expectEqual(@as(u8, 0x12), buf[1]);
+}
+
+test "archive: banksEqual handles both null + matching index" {
+    try std.testing.expect(archive.banksEqual(null, null));
+    try std.testing.expect(archive.banksEqual(3, 3));
+    try std.testing.expect(!archive.banksEqual(null, 0));
+    try std.testing.expect(!archive.banksEqual(0, 1));
+}
+
+test "archive: decodeStringEscapes resolves the standard set" {
+    const alloc = std.testing.allocator;
+    const decoded = try archive.decodeStringEscapes(alloc, "a\\tb\\nc");
+    defer alloc.free(decoded);
+    try std.testing.expectEqualStrings("a\tb\nc", decoded);
+}

--- a/tests/lang/codegen/control_flow.test.zig
+++ b/tests/lang/codegen/control_flow.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the control-flow module is reachable through the
+/// public codegen barrel. End-to-end coverage of if / while /
+/// for / repeat / match / break / continue / defer lives in
+/// `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/control_flow: module compiles through the barrel" {
+    _ = gero.lang.codegen.control_flow;
+}

--- a/tests/lang/codegen/expr.test.zig
+++ b/tests/lang/codegen/expr.test.zig
@@ -1,0 +1,9 @@
+/// Smoke that the expression emitter is reachable through the
+/// public codegen barrel. End-to-end expression coverage lives
+/// in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/expr: module compiles through the barrel" {
+    _ = gero.lang.codegen.expr_emit;
+}

--- a/tests/lang/codegen/mem_builtin.test.zig
+++ b/tests/lang/codegen/mem_builtin.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `mem_builtin` module is reachable through the
+/// public barrel. End-to-end coverage of every `mem.*` builtin
+/// lives in `tests/lang/codegen.test.zig` — that's where the
+/// VM-side round-trip actually exercises the lowering.
+const std = @import("std");
+const gero = @import("gero");
+
+test "mem_builtin: module compiles through the codegen barrel" {
+    _ = gero.lang.codegen.mem_builtin;
+}

--- a/tests/lang/codegen/opcodes.test.zig
+++ b/tests/lang/codegen/opcodes.test.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+const gero = @import("gero");
+const opcodes = gero.lang.codegen.opcodes;
+
+test "opcodes: Op.mov_imm16_reg matches the VM dispatch table entry" {
+    try std.testing.expectEqual(@as(u8, 0x10), opcodes.Op.mov_imm16_reg);
+}
+
+test "opcodes: Reg.acu / Reg.fp / Reg.sp match the VM register file indices" {
+    try std.testing.expectEqual(@as(u8, 0x01), opcodes.Reg.acu);
+    try std.testing.expectEqual(@as(u8, 0x0A), opcodes.Reg.sp);
+    try std.testing.expectEqual(@as(u8, 0x0B), opcodes.Reg.fp);
+}
+
+test "opcodes: Sys ids cover the host-callback syscall set" {
+    try std.testing.expectEqual(@as(u8, 0x01), opcodes.Sys.print_str);
+    try std.testing.expectEqual(@as(u8, 0x05), opcodes.Sys.print_fixed);
+    try std.testing.expectEqual(@as(u8, 0x14), opcodes.Sys.format_terminate_buf);
+}

--- a/tests/lang/codegen/pattern.test.zig
+++ b/tests/lang/codegen/pattern.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `pattern` module is reachable through the
+/// public barrel. End-to-end pattern coverage (literal /
+/// wildcard / ident / OR / range / variant) lives in the match
+/// integration tests in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/pattern: module compiles through the barrel" {
+    _ = gero.lang.codegen.pattern;
+}

--- a/tests/lang/codegen/strings.test.zig
+++ b/tests/lang/codegen/strings.test.zig
@@ -1,0 +1,15 @@
+/// Smoke that the `strings` module is reachable through the
+/// public codegen barrel. End-to-end coverage of single-literal
+/// strings, dedup, interpolation in print + non-print position,
+/// and the data-region overflow diagnostic lives in
+/// `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/strings: module compiles through the barrel" {
+    _ = gero.lang.codegen.strings;
+}
+
+test "codegen/strings: interp_buffer_size is the documented 64 bytes" {
+    try std.testing.expectEqual(@as(u16, 64), gero.lang.codegen.strings.interp_buffer_size);
+}

--- a/tests/lang/typecheck/match.test.zig
+++ b/tests/lang/typecheck/match.test.zig
@@ -1,0 +1,20 @@
+/// Smoke that the `match` typecheck sub-module is reachable
+/// through the public barrel. End-to-end coverage of
+/// exhaustiveness + reachability checks lives in
+/// `tests/lang/typecheck.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/match: module compiles through the barrel" {
+    _ = gero.lang.typechecker.match;
+}
+
+test "typecheck/match: splitPath splits `Enum.Variant` correctly" {
+    const result = gero.lang.typechecker.match.splitPath("Color.Red");
+    try std.testing.expectEqualStrings("Color", result.head);
+    try std.testing.expectEqualStrings("Red", result.tail);
+
+    const no_dot = gero.lang.typechecker.match.splitPath("Lone");
+    try std.testing.expectEqualStrings("", no_dot.head);
+    try std.testing.expectEqualStrings("Lone", no_dot.tail);
+}

--- a/tests/lang/typecheck/mem_builtin.test.zig
+++ b/tests/lang/typecheck/mem_builtin.test.zig
@@ -1,0 +1,24 @@
+/// Smoke that the `mem_builtin` typecheck module is reachable
+/// through the public barrel. End-to-end coverage of every
+/// `mem.*` rejection / acceptance lives in
+/// `tests/lang/typecheck.test.zig` and the codegen integration
+/// tests.
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/mem_builtin: module compiles through the barrel" {
+    _ = gero.lang.typechecker.mem_builtin;
+}
+
+test "typecheck/mem_builtin: lookupMemBuiltin recognizes every entry" {
+    const names = [_][]const u8{
+        "read_u8",  "read_u16",  "read_i8",  "read_i16",
+        "write_u8", "write_u16", "write_i8", "write_i16",
+        "memcpy",   "memset",    "peek",     "poke",
+        "addr_of",
+    };
+    for (names) |name| {
+        try std.testing.expect(gero.lang.typechecker.mem_builtin.lookupMemBuiltin(name) != null);
+    }
+    try std.testing.expect(gero.lang.typechecker.mem_builtin.lookupMemBuiltin("nonexistent") == null);
+}


### PR DESCRIPTION
## Summary

**M3a milestone** (split half of the M3 work per your direction) —
ships the codegen foundations that don't need a runtime heap.
Closes #222, advances #195 (nullary enum patterns) and #216
(reference codegen). The class-vtable + closure pieces ride in
M3b with the shared heap allocator.

## What lands

**Nullary enum codegen (advances #195)**
- `EnumName.Variant` constructor → `mov tag, acu`.
- `expr is EnumName.Variant` → cmp + materialize bool.
- `match` arms over variant patterns lower to `cmp tag; jne
  skip` chains. Composes with the existing OR-dedup / range /
  guard machinery from M2.
- Payload-bearing variants (`Item.Potion(20)`) + destructuring
  patterns wait for M3b (need value-layout for the payload).

**`mem` stdlib (closes #222)**
- Typed reads/writes: `read_u8 / read_u16 / read_i8 / read_i16
  / write_u8 / write_u16 / write_i8 / write_i16`.
- Block ops: `memcpy(dst, src, n)`, `memset(dst, v, n)`.
- Address-of: `mem.addr_of(x)` for locals / params / globals.
- Aliases: `mem.peek` / `mem.poke` lower identically to
  `read_u8` / `write_u8`.
- `read_i8` does explicit `shl 8 + asr 8` sign-extension so
  byte values ≥ 128 read as negative `i16` (closes the
  "signed/unsigned variants produce different bytecode" AC).

**Reference codegen (advances #216)**
- `&local` / `&param` / `&global` lowers to address-of-
  binding. Same runtime representation as `mem.addr_of(x)`,
  but keeps the typed `&T` shape.
- Type-level rules (`&temp` rejected, `&&T` rejected,
  `return &local` rejected) already shipped via
  `checkRefOf`. M3a wires up the codegen path.
- Auto-deref on `r.field` / `r.method()` lands with M3b
  (needs struct + class field codegen to be meaningful).

**Side fixes**
- `MethodCallExpr` had no codegen arm — fell through to
  `unsupported`. M3a handles the `mem.X` receiver; class
  methods land with M3b.
- `CastExpr` lowers as a no-op for same-width primitives.
- `Compiled.diag_arena` — pre-existing dangling-pointer bug:
  diagnostic message strings used a local arena that
  deinit'd before `compile` returned. Move storage to a
  persistent arena owned by `Compiled`.

## Out of scope (lands in M3b)

- Enum payload variants + payload destructuring patterns.
- Class vtable + virtual dispatch + `self / super`.
- Closures + capture analysis + heap-promoted cells.
- VM bump allocator (shared by classes + closures).
- Auto-deref on `r.field` / `r.method()`.

## Tests

15 new codegen tests (71 → 86, +15) covering each new
feature + the rejection paths.

## Test plan

- [x] `zig build verify` green
- [x] `zig build test-modes` green
- [x] `zig build test-all` green
- [x] `zig build ci` green
- [x] Changeset present (`lang-codegen-m3a.md`)
- [x] No AI attribution in commits