### PR TITLE
feat(vm): M3b chunk 0 — heap bump allocator + M3a review-fix rattrapage

### DIFF
--- a/.changeset/vm-heap-allocator.md
+++ b/.changeset/vm-heap-allocator.md
@@ -1,0 +1,40 @@
+---
+bump: minor
+---
+
+VM bump allocator — shared infrastructure for M3b's class instances
+and closure heap-cells.
+
+**ISA changes (version 0x0001 → 0x0002):**
+
+- `.gx` header bytes `0x0E..0x0F` (previously "reserved, must be 0")
+  now carry `heap_base: u16` — the address where the bump allocator
+  starts. `0x0000` means the program declared no heap and `sys alloc`
+  will fault on first call. Old `0x0001` files always read `0x0000`
+  here and load fine; they just can't allocate.
+- New fault vector `0x04` — `heap_exhausted`. Raised when `sys alloc`
+  can't satisfy a request (cursor would collide with the stack,
+  overflow the 16-bit address space, or `heap_base = 0`).
+- New `sys` syscall `0x20` — `alloc`. Reads requested size in bytes
+  from `acu`. On success: returns the freshly-allocated address in
+  `acu` and advances the VM's heap cursor by the requested size. On
+  exhaustion: raises the `heap_exhausted` fault.
+
+**Codegen:**
+
+- `.gx` header emission writes `heap_base = data_cursor` at the end
+  of emission, so the heap starts at the first byte past the static-
+  data region and grows upward toward the stack.
+- `gero.lang.internal.codegen.opcodes.Sys.alloc = 0x20` constant
+  added — internal seam for future PRs (classes #260, closures #259)
+  to emit `mov size, acu; sys 0x20` at allocation sites.
+
+**Out of scope:**
+
+- User-facing language API for raw allocation (no `mem.alloc`
+  builtin in this PR — the allocator is infra-only). Classes and
+  closures will consume it from the codegen side; if a user-facing
+  raw-alloc surface emerges later, it lands as its own design.
+- Free / GC. The bump allocator only grows. A program that exhausts
+  its heap region faults; restarting the VM resets the cursor.
+- Per-bank or per-region heap (the bump cursor is global).

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -540,11 +540,17 @@ silent no-ops. Unknown syscall numbers raise the
 
 | ID    | Name            | Register convention                            |
 |-------|-----------------|------------------------------------------------|
-| `0x01`| `print_str`     | `acu` = address of a null-terminated byte string in memory. Bytes (without the trailing `\0`) are written to `Host.out`. |
-| `0x02`| `print_int`     | `acu` = signed 16-bit value. Written as decimal to `Host.out`. |
-| `0x03`| `print_char`    | low byte of `acu` written directly. |
-| `0x04`| `print_newline` | writes a single `\n` byte. |
-| `0x20`| `alloc`         | bump-allocate `acu` bytes on the heap. On success, sets `acu` to the address of the freshly-allocated block and advances the VM's heap cursor by the requested size. On exhaustion (cursor + size would collide with the stack or fall outside the program's heap region), raises the **heap-exhausted** fault (vector `0x04`). Faults if `heap_base = 0` (program declared no heap). |
+| `0x01`| `print_str`            | `acu` = address of a null-terminated byte string in memory. Bytes (without the trailing `\0`) are written to `Host.out`. |
+| `0x02`| `print_int`            | `acu` = signed 16-bit value. Written as decimal to `Host.out`. |
+| `0x03`| `print_char`           | low byte of `acu` written directly. |
+| `0x04`| `print_newline`        | writes a single `\n` byte. |
+| `0x05`| `print_fixed`          | `acu` = Q8.8 fixed-point value. Formats as `<int>.<3-digit-frac>` decimal — e.g. value `384` (1.5 in Q8.8) prints `1.500`. Negative values get a leading `-`. |
+| `0x10`| `format_str_to_buf`    | `acu` = source str address (null-terminated). `r1` = dst cursor. Copies the bytes (excluding the trailing null) from `[acu]` to `[r1]`, then advances `r1` past the copy. |
+| `0x11`| `format_int_to_buf`    | `acu` = i16 value. `r1` = dst cursor. Appends the signed-decimal representation of `acu` at `[r1]`, then advances `r1`. |
+| `0x12`| `format_char_to_buf`   | `acu` = char value (low byte). `r1` = dst cursor. Writes the low byte to `[r1]`, advances `r1` by 1. |
+| `0x13`| `format_fixed_to_buf`  | `acu` = Q8.8 value. `r1` = dst cursor. Appends the same `<int>.<3-digit-frac>` formatting as `print_fixed` at `[r1]`, then advances `r1`. |
+| `0x14`| `format_terminate_buf` | `r1` = dst cursor. Writes a single null byte at `[r1]` and advances `r1` by 1 (so chained terminators don't stomp the same slot). |
+| `0x20`| `alloc`                | bump-allocate `acu` bytes on the heap. On success, sets `acu` to the address of the freshly-allocated block and advances the VM's heap cursor by the requested size. On exhaustion (cursor + size would collide with the stack or fall outside the program's heap region), raises the **heap-exhausted** fault (vector `0x04`). Faults if `heap_base = 0` (program declared no heap). |
 
 Writer failures (host stdout closed, OOM in the writer's buffer)
 raise the **invalid-opcode** fault as well. The `sys` mechanism is

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -544,6 +544,7 @@ silent no-ops. Unknown syscall numbers raise the
 | `0x02`| `print_int`     | `acu` = signed 16-bit value. Written as decimal to `Host.out`. |
 | `0x03`| `print_char`    | low byte of `acu` written directly. |
 | `0x04`| `print_newline` | writes a single `\n` byte. |
+| `0x20`| `alloc`         | bump-allocate `acu` bytes on the heap. On success, sets `acu` to the address of the freshly-allocated block and advances the VM's heap cursor by the requested size. On exhaustion (cursor + size would collide with the stack or fall outside the program's heap region), raises the **heap-exhausted** fault (vector `0x04`). Faults if `heap_base = 0` (program declared no heap). |
 
 Writer failures (host stdout closed, OOM in the writer's buffer)
 raise the **invalid-opcode** fault as well. The `sys` mechanism is
@@ -567,7 +568,7 @@ Reserved vectors:
 | `0x01` | Invalid opcode fault. |
 | `0x02` | Invalid register fault. |
 | `0x03` | Division by zero (`div` / `divs` with divisor = 0). |
-| `0x04` | Reserved (future). |
+| `0x04` | Heap exhausted (`sys alloc` with cursor + size colliding with the stack, exceeding the heap budget, or `heap_base = 0`). |
 | `0x05` | Arithmetic overflow (currently only emitted by `div` / `divs` when quotient exceeds 16 bits). |
 | `0x06..0x1F` | Reserved (host-defined). |
 | `0x20..0x3F` | Software interrupts (`int N`). |
@@ -625,13 +626,13 @@ metadata.
 | Offset | Field          | Size | Notes |
 |--------|----------------|------|-------|
 | `0x00` | magic          | 4    | `'G' 'E' 'R' 'O'` (`0x47 0x45 0x52 0x4F`) |
-| `0x04` | version        | 2    | u16le format version. Currently `0x0001`. |
+| `0x04` | version        | 2    | u16le format version. Currently `0x0002`. |
 | `0x06` | flags          | 2    | u16le bitfield (see below) |
 | `0x08` | entry_point    | 2    | u16le address `ip` is set to at boot |
 | `0x0A` | image_size     | 2    | u16le base-image size in bytes (`0..65535`; max 65535-byte image — programs needing more use banks) |
 | `0x0C` | bank_count     | 1    | total number of 16KB banks (0..255) |
 | `0x0D` | sram_bank_count| 1    | how many of the **last** banks are battery-backed SRAM (0..255, must be `<= bank_count`); 0 ⇒ no save support |
-| `0x0E` | reserved       | 2    | must be `0x00 0x00` |
+| `0x0E` | heap_base      | 2    | u16le address where the bump allocator's heap starts. Usually the first byte past the end of static data, leaving the gap to `sp` for heap growth. `0x0000` ⇒ no heap (programs that call `sys alloc` will fault). Added in version `0x0002`; files declaring version `0x0001` always read `0x0000` here. |
 
 #### Flags bitfield
 
@@ -709,6 +710,7 @@ the VM halts with a host-visible error code.
 | `0x01` | Invalid opcode (byte read at `ip` is not in the opcode table) |
 | `0x02` | Invalid register (operand register index `>= 0x0F`) |
 | `0x03` | Division by zero (`div` / `divs` with divisor = 0) |
+| `0x04` | Heap exhausted (`sys alloc` overflows past the available heap region) |
 | `0x05` | Arithmetic overflow (`div` / `divs` quotient > 16 bits) |
 
 `mb >= bank_count` and stack over/underflow are **not** faults — they
@@ -718,7 +720,7 @@ behave permissively (read `0xFF`, write dropped; stack wraps).
 
 ## 10. Versioning
 
-This document specifies version `0x0001`. Future ISA changes:
+This document specifies version `0x0002`. Future ISA changes:
 
 - **Patch-level edits to this doc** (clarifying ambiguous behavior,
   fixing typos, documenting reserved bits) do not bump the version.

--- a/src/disasm/header.zig
+++ b/src/disasm/header.zig
@@ -57,7 +57,7 @@ pub const Symbols = struct {
 /// One file's worth of decoded header info + section slices, all
 /// borrowed from the caller's `bytes` buffer.
 pub const Header = struct {
-    /// Bytecode format version — currently `0x0001`.
+    /// Bytecode format version — currently `0x0002`.
     version: u16,
     /// Bit-set per ISA §7.1 (bit 0 = banked, bit 1 = has-debug).
     flags: u16,
@@ -71,6 +71,10 @@ pub const Header = struct {
     bank_count: u8,
     /// Number of trailing bank slots that are SRAM (battery-backed).
     sram_bank_count: u8,
+    /// Bump-allocator heap base — usually the first byte past the
+    /// static-data region. `0` means the program declared no heap.
+    /// Added in version `0x0002`; files declaring `0x0001` read `0`.
+    heap_base: u16,
 
     /// Slice of the base image bytes (length == `image_size`).
     image: []const u8,
@@ -136,8 +140,9 @@ pub fn parseSymbols(allocator: std.mem.Allocator, debug_bytes: []const u8) Symbo
 }
 
 /// Parse `bytes` as a `.gx` archive. Strict: rejects unknown
-/// flag bits and any version != `0x0001`. The returned slices
-/// borrow from the input buffer.
+/// flag bits and any version with a higher major byte than the
+/// VM's loader accepts. The returned slices borrow from the input
+/// buffer.
 pub fn parse(bytes: []const u8) DecodeError!Header {
     const loaded = try gero.vm.parseGx(bytes);
 
@@ -148,6 +153,7 @@ pub fn parse(bytes: []const u8) DecodeError!Header {
         .image_size = loaded.header.image_size,
         .bank_count = loaded.header.bank_count,
         .sram_bank_count = loaded.header.sram_bank_count,
+        .heap_base = loaded.header.heap_base,
         .image = loaded.image,
         .banks = loaded.banks,
         .debug = loaded.debug,

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -15,10 +15,7 @@ const diag_mod = @import("lang/diagnostic.zig");
 const render_mod = @import("lang/render.zig");
 const codegen_mod = @import("lang/codegen.zig");
 
-// Direct submodule imports for the `internal` namespaces below —
-// the parent `typecheck.zig` / `codegen.zig` files don't re-export
-// these (the aliases are private), so the barrel pulls them
-// straight from disk.
+// Direct submodule imports for the `internal` namespace below.
 const tc_mem_builtin = @import("lang/typecheck/mem_builtin.zig");
 const tc_match = @import("lang/typecheck/match.zig");
 const tc_predicates = @import("lang/typecheck/predicates.zig");
@@ -33,12 +30,16 @@ const cg_pattern = @import("lang/codegen/pattern.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 
+// ---------- lexer ----------
+
 /// Re-export: lexer token.
 pub const Token = lexer_mod.Token;
 /// Re-export: lexer output stream.
 pub const TokenStream = lexer_mod.TokenStream;
 /// Re-export: `.gr` tokenizer.
 pub const tokenize = lexer_mod.tokenize;
+
+// ---------- parser ----------
 
 /// Re-export: AST node types.
 pub const ast = ast_mod;
@@ -51,6 +52,8 @@ pub const parse = parser_mod.parse;
 /// Round-trip safe: `parse(print(parse(s))) == parse(s)`.
 pub const print = print_mod.print;
 
+// ---------- typechecker ----------
+
 /// Re-export: typechecker type representation (`Type`, `Primitive`,
 /// `Array`, etc.).
 pub const types = types_mod;
@@ -60,23 +63,50 @@ pub const scope = scope_mod;
 pub const CheckedProgram = typecheck_mod.CheckedProgram;
 /// Re-export: walk an `ast.Program` through the typechecker.
 pub const typecheck = typecheck_mod.typecheck;
+/// Re-export: `mem.*` stdlib builtin signature (lookup return type).
+pub const MemBuiltinSig = tc_mem_builtin.MemBuiltinSig;
+/// Re-export: `mem.X` lookup by builtin name.
+pub const lookupMemBuiltin = tc_mem_builtin.lookupMemBuiltin;
+/// Re-export: rich diagnostic shape carried by `CheckedProgram`.
+pub const Diagnostic = diag_mod.Diagnostic;
+/// Re-export: severity classification on a `Diagnostic`.
+pub const Severity = diag_mod.Severity;
+/// Re-export: diagnostic-rendering primitives (pretty + JSON).
+/// Per `docs/lang-diagnostics.md`.
+pub const render = render_mod;
 
-/// Typechecker barrel — intentional consumer surface plus an
-/// `internal` namespace for the submodule seams.
-pub const typechecker = struct {
-    /// Typechecker output (program + diagnostics).
-    pub const CheckedProgram = typecheck_mod.CheckedProgram;
-    /// Walk an `ast.Program` through the typechecker.
-    pub const typecheck = typecheck_mod.typecheck;
-    /// `mem.*` stdlib builtin signature (lookup return type).
-    pub const MemBuiltinSig = tc_mem_builtin.MemBuiltinSig;
-    /// `mem.X` lookup by builtin name.
-    pub const lookupMemBuiltin = tc_mem_builtin.lookupMemBuiltin;
+// ---------- codegen ----------
 
-    /// Internal — submodule seams exposed for mirror-layout test
-    /// reachability. Members under `internal` are **not** stable
-    /// consumer API and may change in any minor bump.
-    pub const internal = struct {
+/// Re-export: codegen output (`.gx` image + diagnostics).
+pub const Compiled = codegen_mod.Compiled;
+/// Re-export: codegen knobs (`entry_name`, `debug_symbols`).
+pub const CompileOptions = codegen_mod.Options;
+/// Re-export: errors `compile` can return (host-failure family —
+/// semantic errors land in `Compiled.diagnostics`).
+pub const CompileError = codegen_mod.CompileError;
+/// Re-export: walk a `CheckedProgram` through codegen to a `.gx`
+/// image.
+pub const compile = codegen_mod.compile;
+
+/// Codegen-namespaced boot-layout constants per ISA §7.
+pub const codegen = struct {
+    /// IVT base address — first IVT slot.
+    pub const ivt_base = codegen_mod.ivt_base;
+    /// First byte of code emission (above the IVT + low-RAM
+    /// scratch).
+    pub const code_base = codegen_mod.code_base;
+    /// First byte of static-data emission.
+    pub const data_base = codegen_mod.data_base;
+};
+
+// ---------- internal ----------
+
+/// Submodule seams exposed for mirror-layout test reachability.
+/// **Not** stable consumer API — members under `internal` may
+/// change in any minor bump.
+pub const internal = struct {
+    /// Internal — typecheck submodule seams.
+    pub const typechecker = struct {
         /// Internal — stateful resolution + inference walker.
         pub const Checker = typecheck_mod.Checker;
         /// Internal — pure predicates over `types.Type`.
@@ -93,42 +123,9 @@ pub const typechecker = struct {
         /// Internal — `mem.*` stdlib typecheck dispatch.
         pub const mem_builtin = tc_mem_builtin;
     };
-};
 
-/// Re-export: rich diagnostic shape carried by `CheckedProgram`.
-pub const Diagnostic = diag_mod.Diagnostic;
-/// Re-export: severity classification on a `Diagnostic`.
-pub const Severity = diag_mod.Severity;
-/// Re-export: diagnostic-rendering primitives (pretty + JSON).
-/// Per `docs/lang-diagnostics.md`.
-pub const render = render_mod;
-
-/// Codegen barrel — intentional consumer surface (constants
-/// `ivt_base` / `code_base` / `data_base`, the `compile` entry,
-/// the `Compiled` / `Options` / `CompileError` types) plus an
-/// `internal` namespace for the submodule seams.
-pub const codegen = struct {
-    /// Codegen output (`.gx` image + diagnostics).
-    pub const Compiled = codegen_mod.Compiled;
-    /// Codegen knobs (`entry_name`, `debug_symbols`).
-    pub const Options = codegen_mod.Options;
-    /// Errors `compile` can return (host-failure family — semantic
-    /// errors land in `Compiled.diagnostics`).
-    pub const CompileError = codegen_mod.CompileError;
-    /// Walk a `CheckedProgram` through codegen to a `.gx` image.
-    pub const compile = codegen_mod.compile;
-    /// IVT base address (first IVT slot per ISA §7).
-    pub const ivt_base = codegen_mod.ivt_base;
-    /// First byte of code emission (above the IVT + low-RAM
-    /// scratch).
-    pub const code_base = codegen_mod.code_base;
-    /// First byte of static-data emission.
-    pub const data_base = codegen_mod.data_base;
-
-    /// Internal — submodule seams exposed for mirror-layout test
-    /// reachability. Members under `internal` are **not** stable
-    /// consumer API and may change in any minor bump.
-    pub const internal = struct {
+    /// Internal — codegen submodule seams.
+    pub const codegen = struct {
         /// Internal — per-fn codegen state (bytecode buffer,
         /// locals, diagnostic sink).
         pub const Emitter = codegen_mod.Emitter;
@@ -147,8 +144,7 @@ pub const codegen = struct {
         pub const archive = cg_archive;
         /// Internal — `mem.*` stdlib codegen lowering.
         pub const mem_builtin = cg_mem_builtin;
-        /// Internal — string literal pool + interpolation
-        /// lowering.
+        /// Internal — string literal pool + interpolation lowering.
         pub const strings = cg_strings;
         /// Internal — `match` pattern-arm test emission.
         pub const pattern = cg_pattern;
@@ -159,10 +155,3 @@ pub const codegen = struct {
         pub const control_flow = cg_control_flow;
     };
 };
-/// Re-export: codegen output (`.gx` image + diagnostics).
-pub const Compiled = codegen_mod.Compiled;
-/// Re-export: codegen knobs (`entry_name`, `debug_symbols`).
-pub const CompileOptions = codegen_mod.Options;
-/// Re-export: walk a `CheckedProgram` through codegen to a `.gx`
-/// image.
-pub const compile = codegen_mod.compile;

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -15,6 +15,24 @@ const diag_mod = @import("lang/diagnostic.zig");
 const render_mod = @import("lang/render.zig");
 const codegen_mod = @import("lang/codegen.zig");
 
+// Direct submodule imports for the `internal` namespaces below —
+// the parent `typecheck.zig` / `codegen.zig` files don't re-export
+// these (the aliases are private), so the barrel pulls them
+// straight from disk.
+const tc_mem_builtin = @import("lang/typecheck/mem_builtin.zig");
+const tc_match = @import("lang/typecheck/match.zig");
+const tc_predicates = @import("lang/typecheck/predicates.zig");
+const tc_annotations = @import("lang/typecheck/annotations.zig");
+const tc_relations = @import("lang/typecheck/relations.zig");
+const tc_flow = @import("lang/typecheck/flow.zig");
+const cg_opcodes = @import("lang/codegen/opcodes.zig");
+const cg_archive = @import("lang/codegen/archive.zig");
+const cg_mem_builtin = @import("lang/codegen/mem_builtin.zig");
+const cg_strings = @import("lang/codegen/strings.zig");
+const cg_pattern = @import("lang/codegen/pattern.zig");
+const cg_expr_emit = @import("lang/codegen/expr.zig");
+const cg_control_flow = @import("lang/codegen/control_flow.zig");
+
 /// Re-export: lexer token.
 pub const Token = lexer_mod.Token;
 /// Re-export: lexer output stream.
@@ -51,9 +69,9 @@ pub const typechecker = struct {
     /// Walk an `ast.Program` through the typechecker.
     pub const typecheck = typecheck_mod.typecheck;
     /// `mem.*` stdlib builtin signature (lookup return type).
-    pub const MemBuiltinSig = typecheck_mod.MemBuiltinSig;
+    pub const MemBuiltinSig = tc_mem_builtin.MemBuiltinSig;
     /// `mem.X` lookup by builtin name.
-    pub const lookupMemBuiltin = typecheck_mod.lookupMemBuiltin;
+    pub const lookupMemBuiltin = tc_mem_builtin.lookupMemBuiltin;
 
     /// Internal — submodule seams exposed for mirror-layout test
     /// reachability. Members under `internal` are **not** stable
@@ -62,18 +80,18 @@ pub const typechecker = struct {
         /// Internal — stateful resolution + inference walker.
         pub const Checker = typecheck_mod.Checker;
         /// Internal — pure predicates over `types.Type`.
-        pub const predicates = typecheck_mod.predicates;
+        pub const predicates = tc_predicates;
         /// Internal — §3.7 annotation validation pipeline.
-        pub const annotations = typecheck_mod.annotations;
+        pub const annotations = tc_annotations;
         /// Internal — assignability + cast convertibility relations.
-        pub const relations = typecheck_mod.relations;
+        pub const relations = tc_relations;
         /// Internal — flow-sensitive helpers (ident name, body
         /// exits, named-type / field finders).
-        pub const flow = typecheck_mod.flow;
+        pub const flow = tc_flow;
         /// Internal — `match` exhaustiveness + reachability checks.
-        pub const match = typecheck_mod.match;
+        pub const match = tc_match;
         /// Internal — `mem.*` stdlib typecheck dispatch.
-        pub const mem_builtin = typecheck_mod.mem_builtin;
+        pub const mem_builtin = tc_mem_builtin;
     };
 };
 
@@ -124,21 +142,21 @@ pub const codegen = struct {
         pub const LoopFrame = codegen_mod.LoopFrame;
         /// Internal — opcode / register / syscall byte tables
         /// (mirror of `src/vm/opcodes.zig`).
-        pub const opcodes = codegen_mod.opcodes;
+        pub const opcodes = cg_opcodes;
         /// Internal — `.gx` archive layout + small pure helpers.
-        pub const archive = codegen_mod.archive;
+        pub const archive = cg_archive;
         /// Internal — `mem.*` stdlib codegen lowering.
-        pub const mem_builtin = codegen_mod.mem_builtin;
+        pub const mem_builtin = cg_mem_builtin;
         /// Internal — string literal pool + interpolation
         /// lowering.
-        pub const strings = codegen_mod.strings;
+        pub const strings = cg_strings;
         /// Internal — `match` pattern-arm test emission.
-        pub const pattern = codegen_mod.pattern;
+        pub const pattern = cg_pattern;
         /// Internal — expression lowering helpers.
-        pub const expr_emit = codegen_mod.expr_emit;
+        pub const expr_emit = cg_expr_emit;
         /// Internal — control-flow lowering (if / while / for /
         /// match / break / continue / defer).
-        pub const control_flow = codegen_mod.control_flow;
+        pub const control_flow = cg_control_flow;
     };
 };
 /// Re-export: codegen output (`.gx` image + diagnostics).

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -42,10 +42,40 @@ pub const scope = scope_mod;
 pub const CheckedProgram = typecheck_mod.CheckedProgram;
 /// Re-export: walk an `ast.Program` through the typechecker.
 pub const typecheck = typecheck_mod.typecheck;
-/// Re-export: typechecker module barrel — `gero.lang.typecheck`
-/// already names the entry-point function so sub-module access
-/// goes through this alias.
-pub const typechecker = typecheck_mod;
+
+/// Typechecker barrel — intentional consumer surface plus an
+/// `internal` namespace for the submodule seams.
+pub const typechecker = struct {
+    /// Typechecker output (program + diagnostics).
+    pub const CheckedProgram = typecheck_mod.CheckedProgram;
+    /// Walk an `ast.Program` through the typechecker.
+    pub const typecheck = typecheck_mod.typecheck;
+    /// `mem.*` stdlib builtin signature (lookup return type).
+    pub const MemBuiltinSig = typecheck_mod.MemBuiltinSig;
+    /// `mem.X` lookup by builtin name.
+    pub const lookupMemBuiltin = typecheck_mod.lookupMemBuiltin;
+
+    /// Internal — submodule seams exposed for mirror-layout test
+    /// reachability. Members under `internal` are **not** stable
+    /// consumer API and may change in any minor bump.
+    pub const internal = struct {
+        /// Internal — stateful resolution + inference walker.
+        pub const Checker = typecheck_mod.Checker;
+        /// Internal — pure predicates over `types.Type`.
+        pub const predicates = typecheck_mod.predicates;
+        /// Internal — §3.7 annotation validation pipeline.
+        pub const annotations = typecheck_mod.annotations;
+        /// Internal — assignability + cast convertibility relations.
+        pub const relations = typecheck_mod.relations;
+        /// Internal — flow-sensitive helpers (ident name, body
+        /// exits, named-type / field finders).
+        pub const flow = typecheck_mod.flow;
+        /// Internal — `match` exhaustiveness + reachability checks.
+        pub const match = typecheck_mod.match;
+        /// Internal — `mem.*` stdlib typecheck dispatch.
+        pub const mem_builtin = typecheck_mod.mem_builtin;
+    };
+};
 
 /// Re-export: rich diagnostic shape carried by `CheckedProgram`.
 pub const Diagnostic = diag_mod.Diagnostic;
@@ -55,9 +85,62 @@ pub const Severity = diag_mod.Severity;
 /// Per `docs/lang-diagnostics.md`.
 pub const render = render_mod;
 
-/// Re-export: codegen module (constants `ivt_base`, `code_base`,
-/// `data_base`).
-pub const codegen = codegen_mod;
+/// Codegen barrel — intentional consumer surface (constants
+/// `ivt_base` / `code_base` / `data_base`, the `compile` entry,
+/// the `Compiled` / `Options` / `CompileError` types) plus an
+/// `internal` namespace for the submodule seams.
+pub const codegen = struct {
+    /// Codegen output (`.gx` image + diagnostics).
+    pub const Compiled = codegen_mod.Compiled;
+    /// Codegen knobs (`entry_name`, `debug_symbols`).
+    pub const Options = codegen_mod.Options;
+    /// Errors `compile` can return (host-failure family — semantic
+    /// errors land in `Compiled.diagnostics`).
+    pub const CompileError = codegen_mod.CompileError;
+    /// Walk a `CheckedProgram` through codegen to a `.gx` image.
+    pub const compile = codegen_mod.compile;
+    /// IVT base address (first IVT slot per ISA §7).
+    pub const ivt_base = codegen_mod.ivt_base;
+    /// First byte of code emission (above the IVT + low-RAM
+    /// scratch).
+    pub const code_base = codegen_mod.code_base;
+    /// First byte of static-data emission.
+    pub const data_base = codegen_mod.data_base;
+
+    /// Internal — submodule seams exposed for mirror-layout test
+    /// reachability. Members under `internal` are **not** stable
+    /// consumer API and may change in any minor bump.
+    pub const internal = struct {
+        /// Internal — per-fn codegen state (bytecode buffer,
+        /// locals, diagnostic sink).
+        pub const Emitter = codegen_mod.Emitter;
+        /// Internal — unresolved `call addr` site shape.
+        pub const CallPatch = codegen_mod.CallPatch;
+        /// Internal — one lexical block tracked at codegen time
+        /// (owns the LIFO `defer` list).
+        pub const Block = codegen_mod.Block;
+        /// Internal — one enclosing loop tracked while emitting the
+        /// body (carries break / continue patches).
+        pub const LoopFrame = codegen_mod.LoopFrame;
+        /// Internal — opcode / register / syscall byte tables
+        /// (mirror of `src/vm/opcodes.zig`).
+        pub const opcodes = codegen_mod.opcodes;
+        /// Internal — `.gx` archive layout + small pure helpers.
+        pub const archive = codegen_mod.archive;
+        /// Internal — `mem.*` stdlib codegen lowering.
+        pub const mem_builtin = codegen_mod.mem_builtin;
+        /// Internal — string literal pool + interpolation
+        /// lowering.
+        pub const strings = codegen_mod.strings;
+        /// Internal — `match` pattern-arm test emission.
+        pub const pattern = codegen_mod.pattern;
+        /// Internal — expression lowering helpers.
+        pub const expr_emit = codegen_mod.expr_emit;
+        /// Internal — control-flow lowering (if / while / for /
+        /// match / break / continue / defer).
+        pub const control_flow = codegen_mod.control_flow;
+    };
+};
 /// Re-export: codegen output (`.gx` image + diagnostics).
 pub const Compiled = codegen_mod.Compiled;
 /// Re-export: codegen knobs (`entry_name`, `debug_symbols`).

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -209,7 +209,7 @@ pub fn compile(
     @memset(base_image, 0);
     @memcpy(base_image[code_base..][0..emitter.code.items.len], emitter.code.items);
 
-    const image = try buildArchive(allocator, base_image, code_base, &emitter.banks);
+    const image = try buildArchive(allocator, base_image, code_base, emitter.data_cursor, &emitter.banks);
     allocator.free(base_image);
 
     return .{

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -47,27 +47,13 @@ const ast = @import("ast.zig");
 const types_mod = @import("types.zig");
 const typecheck_mod = @import("typecheck.zig");
 const diag_mod = @import("diagnostic.zig");
-/// Re-exported codegen sub-modules — tests reach internal files
-/// through the public barrel so the lint mirror rule resolves.
-pub const opcodes = @import("codegen/opcodes.zig");
-/// `.gx` archive layout + small pure helpers (escape decode,
-/// power-of-two alignment, bank-tag comparison).
-pub const archive = @import("codegen/archive.zig");
-/// `mem.*` stdlib builtin lowering — typed peek / poke,
-/// memcpy / memset, addr-of.
-pub const mem_builtin = @import("codegen/mem_builtin.zig");
-/// String literal pool + interpolation lowering — `InternedString`,
-/// `StringPatch`, the interp buffer reservation, and the per-part
-/// fill helpers.
-pub const strings = @import("codegen/strings.zig");
-/// `match` pattern-arm test emission.
-pub const pattern = @import("codegen/pattern.zig");
-/// Expression lowering — `emitExpr` and the per-shape helpers.
-pub const expr_emit = @import("codegen/expr.zig");
-/// Control-flow lowering — if / while / for / repeat / match /
-/// break / continue / defer + the block / loop-frame stack
-/// helpers.
-pub const control_flow = @import("codegen/control_flow.zig");
+const opcodes = @import("codegen/opcodes.zig");
+const archive = @import("codegen/archive.zig");
+const mem_builtin = @import("codegen/mem_builtin.zig");
+const strings = @import("codegen/strings.zig");
+const pattern = @import("codegen/pattern.zig");
+const expr_emit = @import("codegen/expr.zig");
+const control_flow = @import("codegen/control_flow.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const CheckedProgram = typecheck_mod.CheckedProgram;

--- a/src/lang/codegen/archive.zig
+++ b/src/lang/codegen/archive.zig
@@ -10,7 +10,7 @@ const std = @import("std");
 /// 4-byte ASCII magic at the top of every `.gx` archive.
 pub const gx_magic = [4]u8{ 'G', 'E', 'R', 'O' };
 /// Format version stored in bytes 4-5 of the header.
-pub const gx_version: u16 = 0x0001;
+pub const gx_version: u16 = 0x0002;
 /// Fixed header size in bytes — every archive starts with this
 /// many bytes before the base image.
 pub const gx_header_size: usize = 16;
@@ -36,6 +36,7 @@ pub fn buildArchive(
     allocator: std.mem.Allocator,
     base_image: []const u8,
     entry_point: u16,
+    heap_base: u16,
     banks: *const std.AutoHashMapUnmanaged(u8, std.ArrayList(u8)),
 ) ![]u8 {
     // Bank count = max bank index + 1 (banks are 0-indexed). 0 if
@@ -67,7 +68,7 @@ pub fn buildArchive(
     // safety: bank_count ≤ 256 by construction.
     out[12] = @intCast(bank_count);
     out[13] = 0; // sram_bank_count
-    writeU16Le(out[14..16], 0); // reserved
+    writeU16Le(out[14..16], heap_base);
 
     @memcpy(out[gx_header_size..][0..base_image.len], base_image);
 

--- a/src/lang/codegen/opcodes.zig
+++ b/src/lang/codegen/opcodes.zig
@@ -169,4 +169,9 @@ pub const Sys = struct {
     /// `format_terminate_buf` — write a trailing null byte at the
     /// current cursor of the buffer pointed to by `r1`.
     pub const format_terminate_buf: u8 = 0x14;
+
+    /// `alloc` — bump-allocate `acu` bytes on the heap. Returns
+    /// the freshly-allocated address in `acu`; faults
+    /// `heap_exhausted` (vector `0x04`) on out-of-heap.
+    pub const alloc: u8 = 0x20;
 };

--- a/src/lang/codegen/opcodes.zig
+++ b/src/lang/codegen/opcodes.zig
@@ -8,134 +8,134 @@
 /// the matching instruction; subsequent bytes carry operands per
 /// ISA §5.
 pub const Op = struct {
-    // allow-strict: byte-table mirror of VM opcodes — trailing-comment commentary is the canonical doc.
-    pub const mov_imm16_reg: u8 = 0x10; // mov imm16, reg
-    // allow-strict: byte-table mirror.
-    pub const mov_reg_reg: u8 = 0x11; // mov src, dst
-    // allow-strict: byte-table mirror.
-    pub const mov_reg_offset_reg: u8 = 0x1C; // load:  reg ← [base + ofs]
-    // allow-strict: byte-table mirror.
-    pub const mov_reg_reg_offset: u8 = 0x1D; // store: [base + ofs] ← reg
-    // allow-strict: byte-table mirror.
-    pub const mov_reg_to_addr: u8 = 0x12; // store: [addr] ← reg (word)
-    // allow-strict: byte-table mirror.
-    pub const mov_addr_to_reg: u8 = 0x13; // load:  reg ← [addr] (word)
-    // allow-strict: byte-table mirror.
-    pub const mov_reg_to_zp: u8 = 0x19; // store: [zp] ← reg (word)
-    // allow-strict: byte-table mirror.
-    pub const mov_zp_to_reg: u8 = 0x1A; // load:  reg ← [zp] (word)
-    // allow-strict: byte-table mirror.
-    pub const mov_ptr_to_reg: u8 = 0x15; // load:  reg ← [ptr_reg] (word)
-    // allow-strict: byte-table mirror.
-    pub const mov_reg_to_ptr: u8 = 0x16; // store: [ptr_reg] ← reg (word)
-    // allow-strict: byte-table mirror.
-    pub const mov8_addr_to_reg: u8 = 0x22; // load:  reg ← byte [addr]
-    // allow-strict: byte-table mirror.
-    pub const mov8_reg_to_ptr: u8 = 0x23; // store: [ptr_reg] ← reg.lo (byte)
-    // allow-strict: byte-table mirror.
-    pub const mov8_ptr_to_reg: u8 = 0x24; // load:  reg ← byte [ptr_reg]
-    // allow-strict: byte-table mirror.
-    pub const mov8_zp_to_reg: u8 = 0x29; // load:  reg ← byte [zp]
-    // allow-strict: byte-table mirror.
-    pub const movl_reg_to_addr: u8 = 0x27; // store: [addr] ← reg.lo  (byte store)
-    // allow-strict: byte-table mirror.
-    pub const movl_reg_to_zp: u8 = 0x2B; // store: [zp]   ← reg.lo  (byte store)
+    /// `mov imm16, reg` — load 16-bit immediate into reg.
+    pub const mov_imm16_reg: u8 = 0x10;
+    /// `mov src, dst` — copy register.
+    pub const mov_reg_reg: u8 = 0x11;
+    /// load: reg ← [base + ofs] (word).
+    pub const mov_reg_offset_reg: u8 = 0x1C;
+    /// store: [base + ofs] ← reg (word).
+    pub const mov_reg_reg_offset: u8 = 0x1D;
+    /// store: [addr] ← reg (word).
+    pub const mov_reg_to_addr: u8 = 0x12;
+    /// load: reg ← [addr] (word).
+    pub const mov_addr_to_reg: u8 = 0x13;
+    /// store: [zp] ← reg (word).
+    pub const mov_reg_to_zp: u8 = 0x19;
+    /// load: reg ← [zp] (word).
+    pub const mov_zp_to_reg: u8 = 0x1A;
+    /// load: reg ← [ptr_reg] (word).
+    pub const mov_ptr_to_reg: u8 = 0x15;
+    /// store: [ptr_reg] ← reg (word).
+    pub const mov_reg_to_ptr: u8 = 0x16;
+    /// load: reg ← byte [addr].
+    pub const mov8_addr_to_reg: u8 = 0x22;
+    /// store: [ptr_reg] ← reg.lo (byte).
+    pub const mov8_reg_to_ptr: u8 = 0x23;
+    /// load: reg ← byte [ptr_reg].
+    pub const mov8_ptr_to_reg: u8 = 0x24;
+    /// load: reg ← byte [zp].
+    pub const mov8_zp_to_reg: u8 = 0x29;
+    /// store: [addr] ← reg.lo (byte store).
+    pub const movl_reg_to_addr: u8 = 0x27;
+    /// store: [zp] ← reg.lo (byte store).
+    pub const movl_reg_to_zp: u8 = 0x2B;
 
-    // allow-strict: byte-table mirror.
-    pub const push_reg: u8 = 0x31; // push reg
-    // allow-strict: byte-table mirror.
-    pub const pop_reg: u8 = 0x32; // pop reg
+    /// `push reg` — push register onto the stack.
+    pub const push_reg: u8 = 0x31;
+    /// `pop reg` — pop top of stack into register.
+    pub const pop_reg: u8 = 0x32;
 
-    // allow-strict: byte-table mirror.
-    pub const add_imm16_reg: u8 = 0x40; // add imm, reg
-    // allow-strict: byte-table mirror.
-    pub const add_reg_acu: u8 = 0x42; // acu ← acu + reg
-    // allow-strict: byte-table mirror.
-    pub const sub_imm16_reg: u8 = 0x43; // sub imm, reg
-    // allow-strict: byte-table mirror.
-    pub const sub_reg_acu: u8 = 0x45; // acu ← acu - reg
-    // allow-strict: byte-table mirror.
-    pub const mul_reg_reg: u8 = 0x47; // dst ← dst * src
-    // allow-strict: byte-table mirror.
-    pub const neg_reg: u8 = 0x4A; // reg ← -reg
-    // allow-strict: byte-table mirror.
-    pub const divs_reg_reg: u8 = 0x4E; // dst ← dst / src (signed)
+    /// `add imm, reg` — reg ← reg + imm.
+    pub const add_imm16_reg: u8 = 0x40;
+    /// `add reg, acu` — acu ← acu + reg.
+    pub const add_reg_acu: u8 = 0x42;
+    /// `sub imm, reg` — reg ← reg - imm.
+    pub const sub_imm16_reg: u8 = 0x43;
+    /// `sub reg, acu` — acu ← acu - reg.
+    pub const sub_reg_acu: u8 = 0x45;
+    /// `mul dst, src` — dst ← dst * src.
+    pub const mul_reg_reg: u8 = 0x47;
+    /// `neg reg` — reg ← -reg.
+    pub const neg_reg: u8 = 0x4A;
+    /// `divs dst, src` — dst ← dst / src (signed).
+    pub const divs_reg_reg: u8 = 0x4E;
 
-    // allow-strict: byte-table mirror.
-    pub const and_reg_reg: u8 = 0x61; // dst ← dst & src
-    // allow-strict: byte-table mirror.
-    pub const or_reg_reg: u8 = 0x63; // dst ← dst | src
-    // allow-strict: byte-table mirror.
-    pub const xor_reg_reg: u8 = 0x65; // dst ← dst ^ src
-    // allow-strict: byte-table mirror.
-    pub const not_reg: u8 = 0x66; // reg ← ~reg
-    // allow-strict: byte-table mirror.
-    pub const shl_reg_reg: u8 = 0x71; // dst ← dst << src
-    // allow-strict: byte-table mirror.
-    pub const shr_reg_reg: u8 = 0x73; // dst ← dst >> src
+    /// `and dst, src` — dst ← dst & src.
+    pub const and_reg_reg: u8 = 0x61;
+    /// `or dst, src` — dst ← dst | src.
+    pub const or_reg_reg: u8 = 0x63;
+    /// `xor dst, src` — dst ← dst ^ src.
+    pub const xor_reg_reg: u8 = 0x65;
+    /// `not reg` — reg ← ~reg.
+    pub const not_reg: u8 = 0x66;
+    /// `shl dst, src` — dst ← dst << src.
+    pub const shl_reg_reg: u8 = 0x71;
+    /// `shr dst, src` — dst ← dst >> src (logical).
+    pub const shr_reg_reg: u8 = 0x73;
 
-    // allow-strict: byte-table mirror.
-    pub const shl_reg_imm8: u8 = 0x70; // reg ← reg << imm
-    // allow-strict: byte-table mirror.
-    pub const shr_reg_imm8: u8 = 0x72; // reg ← reg >> imm (logical / unsigned)
-    // allow-strict: byte-table mirror.
-    pub const asr_reg_imm8: u8 = 0x74; // reg ← reg >>a imm (arithmetic / signed)
+    /// `shl reg, imm` — reg ← reg << imm.
+    pub const shl_reg_imm8: u8 = 0x70;
+    /// `shr reg, imm` — reg ← reg >> imm (logical / unsigned).
+    pub const shr_reg_imm8: u8 = 0x72;
+    /// `asr reg, imm` — reg ← reg >>a imm (arithmetic / signed).
+    pub const asr_reg_imm8: u8 = 0x74;
 
-    // allow-strict: byte-table mirror.
-    pub const cmp_reg_imm16: u8 = 0x80; // flags ← reg - imm
-    // allow-strict: byte-table mirror.
-    pub const cmp_reg_reg: u8 = 0x81; // flags ← dst - src
+    /// `cmp reg, imm` — flags ← reg - imm.
+    pub const cmp_reg_imm16: u8 = 0x80;
+    /// `cmp dst, src` — flags ← dst - src.
+    pub const cmp_reg_reg: u8 = 0x81;
 
-    // allow-strict: byte-table mirror.
-    pub const jmp_addr: u8 = 0x90; // unconditional jump
-    // allow-strict: byte-table mirror.
-    pub const jeq_addr: u8 = 0x92; // jump on Z = 1
-    // allow-strict: byte-table mirror.
-    pub const jne_addr: u8 = 0x93; // jump on Z = 0
-    // allow-strict: byte-table mirror.
-    pub const jlt_addr: u8 = 0x94; // signed less
-    // allow-strict: byte-table mirror.
-    pub const jle_addr: u8 = 0x95; // signed ≤
-    // allow-strict: byte-table mirror.
-    pub const jgt_addr: u8 = 0x96; // signed >
-    // allow-strict: byte-table mirror.
-    pub const jge_addr: u8 = 0x97; // signed ≥
+    /// `jmp addr` — unconditional jump.
+    pub const jmp_addr: u8 = 0x90;
+    /// `jeq addr` — jump on Z = 1.
+    pub const jeq_addr: u8 = 0x92;
+    /// `jne addr` — jump on Z = 0.
+    pub const jne_addr: u8 = 0x93;
+    /// `jlt addr` — signed less-than.
+    pub const jlt_addr: u8 = 0x94;
+    /// `jle addr` — signed ≤.
+    pub const jle_addr: u8 = 0x95;
+    /// `jgt addr` — signed greater-than.
+    pub const jgt_addr: u8 = 0x96;
+    /// `jge addr` — signed ≥.
+    pub const jge_addr: u8 = 0x97;
 
-    // allow-strict: byte-table mirror.
-    pub const bcpy: u8 = 0x2C; // bcpy dst, src, len — memcpy via 3 regs
-    // allow-strict: byte-table mirror.
-    pub const bfill: u8 = 0x2D; // bfill addr, len, val — memset via 3 regs
+    /// `bcpy dst, src, len` — memcpy via 3 regs.
+    pub const bcpy: u8 = 0x2C;
+    /// `bfill addr, len, val` — memset via 3 regs.
+    pub const bfill: u8 = 0x2D;
 
-    // allow-strict: byte-table mirror.
-    pub const call_addr: u8 = 0xA0; // call abs addr
-    // allow-strict: byte-table mirror.
-    pub const call_reg: u8 = 0xA1; // call [reg]
-    // allow-strict: byte-table mirror.
-    pub const ret_op: u8 = 0xA2; // ret
+    /// `call addr` — call absolute address.
+    pub const call_addr: u8 = 0xA0;
+    /// `call [reg]` — call via register.
+    pub const call_reg: u8 = 0xA1;
+    /// `ret` — return from call.
+    pub const ret_op: u8 = 0xA2;
 
-    // allow-strict: byte-table mirror.
-    pub const sys: u8 = 0xFB; // host-callback syscall
-    // allow-strict: byte-table mirror.
-    pub const hlt: u8 = 0xFF; // terminal halt
+    /// `sys id` — host-callback syscall.
+    pub const sys: u8 = 0xFB;
+    /// `hlt` — terminal halt.
+    pub const hlt: u8 = 0xFF;
 };
 
 /// VM register byte values per `src/vm/registers.zig`. The
 /// codegen reads / writes through these indices in operand
 /// positions that expect a `Reg`.
 pub const Reg = struct {
-    // allow-strict: register-index mirror.
+    /// Accumulator — return-value and host-syscall arg register.
     pub const acu: u8 = 0x01;
-    // allow-strict: register-index mirror.
+    /// General-purpose register 1.
     pub const r1: u8 = 0x02;
-    // allow-strict: register-index mirror.
+    /// General-purpose register 2.
     pub const r2: u8 = 0x03;
-    // allow-strict: register-index mirror.
+    /// General-purpose register 3.
     pub const r3: u8 = 0x04;
-    // allow-strict: register-index mirror.
+    /// Stack pointer.
     pub const sp: u8 = 0x0A;
-    // allow-strict: register-index mirror.
+    /// Frame pointer.
     pub const fp: u8 = 0x0B;
-    // allow-strict: register-index mirror.
+    /// Memory-bank selector — selects the active SRAM bank window.
     pub const mb: u8 = 0x0C;
 };
 
@@ -143,25 +143,30 @@ pub const Reg = struct {
 /// The `sys` opcode reads one of these as its immediate operand
 /// and routes to the matching host-callback handler.
 pub const Sys = struct {
-    // allow-strict: syscall-id mirror.
+    /// `print_str` — write a null-terminated string from `[acu]`.
     pub const print_str: u8 = 0x01;
-    // allow-strict: syscall-id mirror.
+    /// `print_int` — write `acu` as decimal.
     pub const print_int: u8 = 0x02;
-    // allow-strict: syscall-id mirror.
+    /// `print_char` — write `acu.lo` as a single byte.
     pub const print_char: u8 = 0x03;
-    // allow-strict: syscall-id mirror.
+    /// `print_newline` — write `\n`.
     pub const print_newline: u8 = 0x04;
-    // allow-strict: syscall-id mirror.
+    /// `print_fixed` — write `acu` as Q-format fixed-point.
     pub const print_fixed: u8 = 0x05;
 
-    // allow-strict: syscall-id mirror.
+    /// `format_str_to_buf` — append `[acu]` (null-terminated str)
+    /// to the buffer pointed to by `r1`.
     pub const format_str_to_buf: u8 = 0x10;
-    // allow-strict: syscall-id mirror.
+    /// `format_int_to_buf` — append `acu` as decimal to the buffer
+    /// pointed to by `r1`.
     pub const format_int_to_buf: u8 = 0x11;
-    // allow-strict: syscall-id mirror.
+    /// `format_char_to_buf` — append `acu.lo` as a single byte to
+    /// the buffer pointed to by `r1`.
     pub const format_char_to_buf: u8 = 0x12;
-    // allow-strict: syscall-id mirror.
+    /// `format_fixed_to_buf` — append `acu` as Q-format fixed-
+    /// point to the buffer pointed to by `r1`.
     pub const format_fixed_to_buf: u8 = 0x13;
-    // allow-strict: syscall-id mirror.
+    /// `format_terminate_buf` — write a trailing null byte at the
+    /// current cursor of the buffer pointed to by `r1`.
     pub const format_terminate_buf: u8 = 0x14;
 };

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -170,6 +170,9 @@ pub const predicates = @import("typecheck/predicates.zig");
 /// Annotation validation (§3.7) — target bit-flags, spec table,
 /// per-decl walker, and the `@no_capture` predicate.
 pub const annotations = @import("typecheck/annotations.zig");
+/// Type-to-type relations — assignability (return / let-init /
+/// assignment / call-arg) and cast convertibility (§3.5.1).
+pub const relations = @import("typecheck/relations.zig");
 
 /// Re-export: target bit-flag namespace used by every decl-walker
 /// that calls into `annotations.validateAnnotations`.
@@ -612,7 +615,7 @@ pub const Checker = struct {
         else
             null;
         if (ann_ty != null and init_ty != null) {
-            if (!assignable(init_ty.?.*, ann_ty.?.*)) {
+            if (!relations.assignable(init_ty.?.*, ann_ty.?.*)) {
                 try self.emitMismatch(d.init.?.span(), ann_ty.?, init_ty.?);
             }
         }
@@ -706,7 +709,7 @@ pub const Checker = struct {
             null;
         const init_ty = try self.inferExpr(d.init, ann_ty);
         const final = ann_ty orelse init_ty;
-        if (ann_ty != null and init_ty != null and !assignable(init_ty.?.*, ann_ty.?.*)) {
+        if (ann_ty != null and init_ty != null and !relations.assignable(init_ty.?.*, ann_ty.?.*)) {
             try self.emitMismatch(d.init.span(), ann_ty.?, init_ty.?);
         }
         if (final) |t| {
@@ -731,7 +734,7 @@ pub const Checker = struct {
         // Compound `op=` is sugar for `target = target op value`; the
         // target's type is the hint for the rhs in either form.
         const val_ty = try self.inferExpr(a.value, tgt_ty);
-        if (tgt_ty != null and val_ty != null and !assignable(val_ty.?.*, tgt_ty.?.*)) {
+        if (tgt_ty != null and val_ty != null and !relations.assignable(val_ty.?.*, tgt_ty.?.*)) {
             try self.emitMismatch(a.value.span(), tgt_ty.?, val_ty.?);
         }
     }
@@ -881,7 +884,7 @@ pub const Checker = struct {
             try self.checkReturnStackLifetime(v);
             const v_ty = try self.inferExpr(v, self.current_ret_ty);
             if (self.current_ret_ty) |rt| if (v_ty) |vt| {
-                if (!assignable(vt.*, rt.*) and !predicates.isNilType(rt.*)) {
+                if (!relations.assignable(vt.*, rt.*) and !predicates.isNilType(rt.*)) {
                     try self.emitMismatch(v.span(), rt, vt);
                 }
             };
@@ -1626,7 +1629,7 @@ pub const Checker = struct {
                     null;
                 const skip = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
                 const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-                if (!skip and param_ty != null and arg_ty != null and !assignable(arg_ty.?.*, param_ty.?.*)) {
+                if (!skip and param_ty != null and arg_ty != null and !relations.assignable(arg_ty.?.*, param_ty.?.*)) {
                     try self.emitMismatch(arg.span(), param_ty.?, arg_ty.?);
                 }
             }
@@ -1683,7 +1686,7 @@ pub const Checker = struct {
             };
             const expected_ty = try self.resolveType(decl_field.type_ann);
             const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
-            if (actual_ty) |at| if (!assignable(at.*, expected_ty.*)) {
+            if (actual_ty) |at| if (!relations.assignable(at.*, expected_ty.*)) {
                 try self.emitMismatch(lit_field.value.span(), expected_ty, at);
             };
             _ = try seen.put(self.arena, field_name, {});
@@ -1719,7 +1722,7 @@ pub const Checker = struct {
                 continue;
             }
             const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
-            if (expected_ty) |et| if (actual_ty) |at| if (!assignable(at.*, et.*)) {
+            if (expected_ty) |et| if (actual_ty) |at| if (!relations.assignable(at.*, et.*)) {
                 try self.emitMismatch(lit_field.value.span(), et, at);
             };
         }
@@ -1991,7 +1994,7 @@ pub const Checker = struct {
         const inner_ty = try self.inferExpr(c.inner, null);
         const target_ty = try self.resolveType(c.target_type);
         if (inner_ty) |it| {
-            if (!canCast(it.*, target_ty.*)) {
+            if (!relations.canCast(it.*, target_ty.*)) {
                 const from_s = try types.render(self.arena, it.*);
                 const to_s = try types.render(self.arena, target_ty.*);
                 const msg = try std.fmt.allocPrint(
@@ -2055,7 +2058,7 @@ pub const Checker = struct {
             // those params accept any caller-supplied type.
             const skip = predicates.isNilType(param_ty.*);
             const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-            if (!skip and arg_ty != null and !assignable(arg_ty.?.*, param_ty.*)) {
+            if (!skip and arg_ty != null and !relations.assignable(arg_ty.?.*, param_ty.*)) {
                 try self.emitMismatch(arg.span(), param_ty, arg_ty.?);
             }
         }
@@ -2102,7 +2105,7 @@ pub const Checker = struct {
             const param_ty = f.params[i];
             const skip = predicates.isNilType(param_ty.*);
             const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-            if (!skip and arg_ty != null and !assignable(arg_ty.?.*, param_ty.*)) {
+            if (!skip and arg_ty != null and !relations.assignable(arg_ty.?.*, param_ty.*)) {
                 try self.emitMismatch(arg.span(), param_ty, arg_ty.?);
             }
         }
@@ -2112,7 +2115,7 @@ pub const Checker = struct {
             const arg_ty = try self.inferExpr(arg, pivot);
             const at = arg_ty orelse continue;
             if (pivot) |p| {
-                if (!assignable(at.*, p.*)) {
+                if (!relations.assignable(at.*, p.*)) {
                     const exp_s = try types.render(self.arena, p.*);
                     const got_s = try types.render(self.arena, at.*);
                     const msg = try std.fmt.allocPrint(
@@ -2266,48 +2269,4 @@ fn isPlaceExpr(e: *const ast.Expr) bool {
         .paren => |p| isPlaceExpr(p.inner),
         else => false,
     };
-}
-
-// ---------- assignability ----------
-
-/// `true` when an `actual` typed value can be stored / returned /
-/// passed into an `expected` slot. Wider than `Type.eql` — allows
-/// `T → T?` (non-nil to nullable) and recurses into tuples for
-/// per-slot assignability. Used by return / let-init / assignment
-/// / call-arg checks; operator arms keep strict equality.
-fn assignable(actual: types.Type, expected: types.Type) bool {
-    if (actual.eql(expected)) return true;
-    if (expected == .optional) {
-        if (actual == .primitive and actual.primitive == .nil_) return true;
-        if (assignable(actual, expected.optional.*)) return true;
-    }
-    if (expected == .tuple and actual == .tuple and expected.tuple.len == actual.tuple.len) {
-        for (expected.tuple, actual.tuple) |e, a| {
-            if (!assignable(a.*, e.*)) return false;
-        }
-        return true;
-    }
-    return false;
-}
-
-// ---------- cast convertibility (§3.5.1) ----------
-
-/// Spec §3.5.1 conversion table. Allows integer ↔ integer (any
-/// width / sign), bool ↔ integer, fixed ↔ integer, u8 ↔ char, and
-/// any same-primitive identity cast. Rejects everything else
-/// (class casts, function-pointer reinterpret, reference casts).
-fn canCast(from: types.Type, to: types.Type) bool {
-    if (from != .primitive or to != .primitive) return false;
-    const f = from.primitive;
-    const t = to.primitive;
-    if (f == t) return true;
-    const f_int = predicates.isIntegerPrimitive(f);
-    const t_int = predicates.isIntegerPrimitive(t);
-    if (f_int and t_int) return true;
-    if (f == .bool_ and t_int) return true;
-    if (f_int and t == .bool_) return true;
-    if (f == .fixed and t_int) return true;
-    if (f_int and t == .fixed) return true;
-    if ((f == .u8 and t == .char) or (f == .char and t == .u8)) return true;
-    return false;
 }

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -157,36 +157,14 @@ pub fn typecheck(
     };
 }
 
-/// `mem.*` stdlib builtin lowering — signatures, lookup, and
-/// the two typechecker dispatch entry points.
-pub const mem_builtin = @import("typecheck/mem_builtin.zig");
-/// `match` typechecking — pattern walks, exhaustiveness +
-/// reachability checks, variant-path utilities.
-pub const match = @import("typecheck/match.zig");
-/// Pure predicates over `types.Type` / `types.Primitive` /
-/// `ast.BinaryOp` — integer / numeric / bool / nil / bakeable
-/// checks plus diagnostic-string formatters.
-pub const predicates = @import("typecheck/predicates.zig");
-/// Annotation validation (§3.7) — target bit-flags, spec table,
-/// per-decl walker, and the `@no_capture` predicate.
-pub const annotations = @import("typecheck/annotations.zig");
-/// Type-to-type relations — assignability (return / let-init /
-/// assignment / call-arg) and cast convertibility (§3.5.1).
-pub const relations = @import("typecheck/relations.zig");
-/// Flow-sensitive helpers — ident-name extraction, body-exits
-/// check, named-type lookup, struct/class field finders.
-pub const flow = @import("typecheck/flow.zig");
+const mem_builtin = @import("typecheck/mem_builtin.zig");
+const match = @import("typecheck/match.zig");
+const predicates = @import("typecheck/predicates.zig");
+const annotations = @import("typecheck/annotations.zig");
+const relations = @import("typecheck/relations.zig");
+const flow = @import("typecheck/flow.zig");
 
-/// Re-export: target bit-flag namespace used by every decl-walker
-/// that calls into `annotations.validateAnnotations`.
 const T = annotations.T;
-
-/// `mem.*` stdlib builtin signature (re-exported from the
-/// sub-module for callers that just want the lookup type).
-pub const MemBuiltinSig = mem_builtin.MemBuiltinSig;
-
-/// `mem.X` lookup (re-exported convenience).
-pub const lookupMemBuiltin = mem_builtin.lookupMemBuiltin;
 
 /// Stateful walker that runs resolution + inference + checking
 /// across the program. Sub-modules under `typecheck/` take a

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -173,6 +173,9 @@ pub const annotations = @import("typecheck/annotations.zig");
 /// Type-to-type relations — assignability (return / let-init /
 /// assignment / call-arg) and cast convertibility (§3.5.1).
 pub const relations = @import("typecheck/relations.zig");
+/// Flow-sensitive helpers — ident-name extraction, body-exits
+/// check, named-type lookup, struct/class field finders.
+pub const flow = @import("typecheck/flow.zig");
 
 /// Re-export: target bit-flag namespace used by every decl-walker
 /// that calls into `annotations.validateAnnotations`.
@@ -291,8 +294,8 @@ pub const Checker = struct {
         if (cond.* != .binary) return null;
         const b = cond.binary;
         if (b.op != .eq and b.op != .neq) return null;
-        const lhs_ident = identName(self, b.lhs);
-        const rhs_ident = identName(self, b.rhs);
+        const lhs_ident = flow.identName(self, b.lhs);
+        const rhs_ident = flow.identName(self, b.rhs);
         const lhs_nil = b.lhs.* == .nil_lit;
         const rhs_nil = b.rhs.* == .nil_lit;
         if (lhs_ident) |n| if (rhs_nil) return .{ .name = n, .is_neq = b.op == .neq };
@@ -592,7 +595,7 @@ pub const Checker = struct {
         const arm = is_.arms[0];
         const cond = arm.cond orelse return null;
         const nc = self.matchNilCheck(cond) orelse return null;
-        if (!bodyAlwaysExits(arm.body)) return null;
+        if (!flow.bodyAlwaysExits(arm.body)) return null;
         if (nc.is_neq) {
             // Multi-return: bail when err != nil. After the bail
             // err is statically nil, so its correlated sibling
@@ -766,7 +769,7 @@ pub const Checker = struct {
     fn checkNoCaptureMutation(self: *Checker, target: *const ast.Expr) WalkError!void {
         if (!self.in_no_capture) return;
         const locals = self.lambda_locals orelse return;
-        const name = identName(self, target) orelse return;
+        const name = flow.identName(self, target) orelse return;
         if (locals.contains(name)) return;
         const msg = try std.fmt.allocPrint(
             self.arena,
@@ -784,7 +787,7 @@ pub const Checker = struct {
         // Flow analysis is applied only when there is exactly one
         // arm — the simple `if cond then BODY [else …] end` shape.
         // Multi-arm `elif` chains skip the bookkeeping.
-        const flow: ?NilCheck = if (arms.len == 1 and arms[0].cond != null)
+        const nil_flow: ?NilCheck = if (arms.len == 1 and arms[0].cond != null)
             self.matchNilCheck(arms[0].cond.?)
         else
             null;
@@ -794,8 +797,8 @@ pub const Checker = struct {
             if (arm.let_expr) |e| _ = try self.inferExpr(e, null);
             if (arm.let_guard) |g| _ = try self.inferExpr(g, null);
 
-            const arm_gain: ?[]const u8 = if (i == 0 and flow != null and flow.?.is_neq)
-                flow.?.name
+            const arm_gain: ?[]const u8 = if (i == 0 and nil_flow != null and nil_flow.?.is_neq)
+                nil_flow.?.name
             else
                 null;
             const added = if (arm_gain) |n| try self.pushNonNil(n) else false;
@@ -806,8 +809,8 @@ pub const Checker = struct {
         if (else_body) |eb| {
             // The else-arm fires when the `if` cond was false, so
             // `x == nil` confers non-nil in the else.
-            const else_gain: ?[]const u8 = if (flow != null and !flow.?.is_neq)
-                flow.?.name
+            const else_gain: ?[]const u8 = if (nil_flow != null and !nil_flow.?.is_neq)
+                nil_flow.?.name
             else
                 null;
             const added = if (else_gain) |n| try self.pushNonNil(n) else false;
@@ -898,7 +901,7 @@ pub const Checker = struct {
     fn checkReturnStackLifetime(self: *Checker, v: *const ast.Expr) WalkError!void {
         if (v.* != .ref_of) return;
         const inner = v.ref_of.inner;
-        const name = identName(self, inner) orelse return;
+        const name = flow.identName(self, inner) orelse return;
         const locals = self.fn_locals orelse return;
         if (!locals.contains(name)) return;
         const msg = try std.fmt.allocPrint(
@@ -1398,7 +1401,7 @@ pub const Checker = struct {
     ) WalkError!void {
         const rt = recv_ty orelse return;
         if (rt.* != .optional) return;
-        if (identName(self, receiver)) |name| {
+        if (flow.identName(self, receiver)) |name| {
             if (self.non_nil.contains(name)) return;
         }
         const ty_s = try types.render(self.arena, rt.*);
@@ -1525,7 +1528,7 @@ pub const Checker = struct {
         recv_ty: ?*const types.Type,
     ) WalkError!?*const types.Type {
         const rt = recv_ty orelse return null;
-        const named_name = namedNameOf(rt.*) orelse return null;
+        const named_name = flow.namedNameOf(rt.*) orelse return null;
         const field_name = self.lexeme(f.field);
         if (self.struct_registry.get(named_name)) |sd| {
             for (sd.fields) |fld| {
@@ -1587,7 +1590,7 @@ pub const Checker = struct {
             for (m.args) |a| _ = try self.inferExpr(a, null);
             return null;
         };
-        const named_name = namedNameOf(rt.*) orelse {
+        const named_name = flow.namedNameOf(rt.*) orelse {
             for (m.args) |a| _ = try self.inferExpr(a, null);
             return null;
         };
@@ -1679,7 +1682,7 @@ pub const Checker = struct {
         defer seen.deinit(self.arena);
         for (sl.fields) |lit_field| {
             const field_name = self.lexeme(lit_field.name);
-            const decl_field = findStructField(self, decl_fields, field_name) orelse {
+            const decl_field = flow.findStructField(self, decl_fields, field_name) orelse {
                 try self.emitUndefinedField(type_name, field_name, lit_field.name);
                 _ = try self.inferExpr(lit_field.value, null);
                 continue;
@@ -1716,7 +1719,7 @@ pub const Checker = struct {
             // Search the inheritance chain. Class fields are
             // optional-typed, so an untyped field accepts anything.
             const expected_ty: ?*const types.Type = try self.lookupClassFieldType(cd, field_name);
-            if (expected_ty == null and findClassField(self, cd, field_name) == null) {
+            if (expected_ty == null and flow.findClassField(self, cd, field_name) == null) {
                 try self.emitUndefinedField(type_name, field_name, lit_field.name);
                 _ = try self.inferExpr(lit_field.value, null);
                 continue;
@@ -2191,71 +2194,18 @@ fn structLitMentions(c: *const Checker, fields: []const ast.StructLitField, name
 /// wrapped in `paren`). Used by call-site rules that need to find
 /// the underlying decl (bake-call check, variadic detection).
 fn directCalleeName(c: *const Checker, callee: *const ast.Expr) ?[]const u8 {
-    return identName(c, callee);
+    return flow.identName(c, callee);
 }
 
 /// When `callee` resolves to a `def` decl whose last param is
 /// variadic, return that decl. Returns `null` otherwise — callers
 /// fall back to the regular fixed-arity path.
 fn variadicCalleeDecl(c: *const Checker, callee: *const ast.Expr) ?*const ast.DefDecl {
-    const name = identName(c, callee) orelse return null;
+    const name = flow.identName(c, callee) orelse return null;
     const decl = c.def_registry.get(name) orelse return null;
     if (decl.params.len == 0) return null;
     if (!decl.params[decl.params.len - 1].variadic) return null;
     return decl;
-}
-
-// ---------- flow-analysis helpers ----------
-
-/// Extract the source-buffer lexeme when `e` is a bare ident
-/// (possibly wrapped in `paren`). Returns `null` otherwise — used
-/// by nil-check pattern matching and by flow-sensitive deref
-/// lookups.
-fn identName(c: *const Checker, e: *const ast.Expr) ?[]const u8 {
-    return switch (e.*) {
-        .ident => |i| c.lexeme(i.span),
-        .paren => |p| identName(c, p.inner),
-        else => null,
-    };
-}
-
-/// `true` when the last statement of `body` is `return` / `break` /
-/// `continue` — used by the `if x == nil then return end`
-/// fall-through detector.
-fn bodyAlwaysExits(body: []const ast.Statement) bool {
-    if (body.len == 0) return false;
-    return switch (body[body.len - 1]) {
-        .return_stmt, .break_stmt, .continue_stmt => true,
-        else => false,
-    };
-}
-
-/// Lexeme of a `Named` type, or `null` for other type shapes.
-fn namedNameOf(t: types.Type) ?[]const u8 {
-    return switch (t) {
-        .named => |n| n.name,
-        else => null,
-    };
-}
-
-/// Locate a field on a struct decl by name.
-fn findStructField(c: *const Checker, fields: []const ast.StructField, name: []const u8) ?*const ast.StructField {
-    for (fields) |*f| {
-        if (std.mem.eql(u8, c.lexeme(f.name), name)) return f;
-    }
-    return null;
-}
-
-/// Locate a field on a class decl by name (walks the inheritance
-/// chain). Returns the first hit.
-fn findClassField(c: *const Checker, cd: *const ast.ClassDecl, name: []const u8) ?*const ast.ClassField {
-    for (cd.fields) |*f| {
-        if (std.mem.eql(u8, c.lexeme(f.name), name)) return f;
-    }
-    if (cd.extends) |ext| if (c.class_registry.get(c.lexeme(ext))) |parent| {
-        return findClassField(c, parent, name);
-    };
-    return null;
 }
 
 // ---------- place expression check ----------

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -163,6 +163,10 @@ pub const mem_builtin = @import("typecheck/mem_builtin.zig");
 /// `match` typechecking — pattern walks, exhaustiveness +
 /// reachability checks, variant-path utilities.
 pub const match = @import("typecheck/match.zig");
+/// Pure predicates over `types.Type` / `types.Primitive` /
+/// `ast.BinaryOp` — integer / numeric / bool / nil / bakeable
+/// checks plus diagnostic-string formatters.
+pub const predicates = @import("typecheck/predicates.zig");
 
 /// `mem.*` stdlib builtin signature (re-exported from the
 /// sub-module for callers that just want the lookup type).
@@ -828,7 +832,7 @@ pub const Checker = struct {
         try self.checkNoCaptureMutation(id.target);
         const tgt_ty = try self.inferExpr(id.target, null);
         if (tgt_ty) |t| {
-            if (!isIntegerType(t.*)) {
+            if (!predicates.isIntegerType(t.*)) {
                 const ty_s = try types.render(self.arena, t.*);
                 const msg = try std.fmt.allocPrint(
                     self.arena,
@@ -965,7 +969,7 @@ pub const Checker = struct {
             try self.checkReturnStackLifetime(v);
             const v_ty = try self.inferExpr(v, self.current_ret_ty);
             if (self.current_ret_ty) |rt| if (v_ty) |vt| {
-                if (!assignable(vt.*, rt.*) and !isNilType(rt.*)) {
+                if (!assignable(vt.*, rt.*) and !predicates.isNilType(rt.*)) {
                     try self.emitMismatch(v.span(), rt, vt);
                 }
             };
@@ -1024,7 +1028,7 @@ pub const Checker = struct {
         // are runtime-only.
         if (d.is_bake) if (d.ret_type) |r| {
             const rt = try self.resolveType(r);
-            if (!isBakeableType(rt.*)) {
+            if (!predicates.isBakeableType(rt.*)) {
                 const ty_s = try types.render(self.arena, rt.*);
                 const msg = try std.fmt.allocPrint(
                     self.arena,
@@ -1708,7 +1712,7 @@ pub const Checker = struct {
                     try self.resolveType(t)
                 else
                     null;
-                const skip = if (param_ty) |pt| isNilType(pt.*) else true;
+                const skip = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
                 const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
                 if (!skip and param_ty != null and arg_ty != null and !assignable(arg_ty.?.*, param_ty.?.*)) {
                     try self.emitMismatch(arg.span(), param_ty.?, arg_ty.?);
@@ -1868,12 +1872,12 @@ pub const Checker = struct {
         // primitive. Range-check the literal against the pinned width.
         if (hint) |h| if (h.* == .primitive) {
             const p = h.primitive;
-            if (isIntegerPrimitive(p)) {
-                if (!intLitFits(lit.value, p)) {
+            if (predicates.isIntegerPrimitive(p)) {
+                if (!predicates.intLitFits(lit.value, p)) {
                     const msg = try std.fmt.allocPrint(
                         self.arena,
                         "literal `{d}` does not fit in `{s}`",
-                        .{ lit.value, primitiveName(p) },
+                        .{ lit.value, predicates.primitiveName(p) },
                     );
                     try self.emitSpan("E_TYPE_MISMATCH", lit.span, msg);
                 }
@@ -1933,21 +1937,21 @@ pub const Checker = struct {
         const ot = operand_ty.?;
         switch (u.op) {
             .neg => {
-                if (!isNumericType(ot.*)) {
+                if (!predicates.isNumericType(ot.*)) {
                     try self.emitOperatorRequires(u.span, "negation `-`", "a numeric type", ot);
                     return null;
                 }
                 return ot;
             },
             .log_not => {
-                if (!isBoolType(ot.*)) {
+                if (!predicates.isBoolType(ot.*)) {
                     try self.emitOperatorRequires(u.span, "logical `not`", "`bool`", ot);
                     return null;
                 }
                 return try self.primitive(.bool_);
             },
             .bit_not => {
-                if (!isIntegerType(ot.*)) {
+                if (!predicates.isIntegerType(ot.*)) {
                     try self.emitOperatorRequires(u.span, "bitwise `~`", "an integer type", ot);
                     return null;
                 }
@@ -1973,15 +1977,15 @@ pub const Checker = struct {
         const rhs_ty = try self.inferExpr(b.rhs, rhs_hint);
         if (lhs_ty == null or rhs_ty == null) return lhs_ty orelse rhs_ty;
         // String concatenation: only `+`, both sides `str`.
-        if (b.op == .add and isStrType(lhs_ty.?.*) and isStrType(rhs_ty.?.*)) {
+        if (b.op == .add and predicates.isStrType(lhs_ty.?.*) and predicates.isStrType(rhs_ty.?.*)) {
             return try self.primitive(.str);
         }
-        if (!isNumericType(lhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, opLexeme(b.op), "a numeric type", lhs_ty.?);
+        if (!predicates.isNumericType(lhs_ty.?.*)) {
+            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "a numeric type", lhs_ty.?);
             return null;
         }
-        if (!isNumericType(rhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, opLexeme(b.op), "a numeric type", rhs_ty.?);
+        if (!predicates.isNumericType(rhs_ty.?.*)) {
+            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "a numeric type", rhs_ty.?);
             return null;
         }
         if (!lhs_ty.?.eql(rhs_ty.?.*)) {
@@ -1995,12 +1999,12 @@ pub const Checker = struct {
         // Shift count is itself an integer; default to u8-ish via i16 (no specific hint).
         const rhs_ty = try self.inferExpr(b.rhs, null);
         if (lhs_ty == null or rhs_ty == null) return lhs_ty;
-        if (!isIntegerType(lhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, opLexeme(b.op), "an integer type", lhs_ty.?);
+        if (!predicates.isIntegerType(lhs_ty.?.*)) {
+            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "an integer type", lhs_ty.?);
             return null;
         }
-        if (!isIntegerType(rhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, opLexeme(b.op), "an integer shift count", rhs_ty.?);
+        if (!predicates.isIntegerType(rhs_ty.?.*)) {
+            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "an integer shift count", rhs_ty.?);
             return null;
         }
         return lhs_ty;
@@ -2011,12 +2015,12 @@ pub const Checker = struct {
         const rhs_hint = lhs_ty orelse hint;
         const rhs_ty = try self.inferExpr(b.rhs, rhs_hint);
         if (lhs_ty == null or rhs_ty == null) return lhs_ty orelse rhs_ty;
-        if (!isIntegerType(lhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, opLexeme(b.op), "an integer type", lhs_ty.?);
+        if (!predicates.isIntegerType(lhs_ty.?.*)) {
+            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "an integer type", lhs_ty.?);
             return null;
         }
-        if (!isIntegerType(rhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, opLexeme(b.op), "an integer type", rhs_ty.?);
+        if (!predicates.isIntegerType(rhs_ty.?.*)) {
+            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "an integer type", rhs_ty.?);
             return null;
         }
         if (!lhs_ty.?.eql(rhs_ty.?.*)) {
@@ -2032,7 +2036,7 @@ pub const Checker = struct {
             // Allow nil-comparison (`x != nil` / `nil == p`) — the
             // canonical nullable idiom per §3.4.1. Strict-equality
             // only when neither side is the nil literal.
-            const either_is_nil = isNilType(lhs_ty.?.*) or isNilType(rhs_ty.?.*);
+            const either_is_nil = predicates.isNilType(lhs_ty.?.*) or predicates.isNilType(rhs_ty.?.*);
             if (!either_is_nil and !lhs_ty.?.eql(rhs_ty.?.*)) {
                 try self.emitMismatch(b.rhs.span(), lhs_ty.?, rhs_ty.?);
             }
@@ -2044,11 +2048,11 @@ pub const Checker = struct {
         const bool_ty = try self.primitive(.bool_);
         const lhs_ty = try self.inferExpr(b.lhs, bool_ty);
         const rhs_ty = try self.inferExpr(b.rhs, bool_ty);
-        if (lhs_ty) |t| if (!isBoolType(t.*)) {
-            try self.emitOperatorRequires(b.span, opLexeme(b.op), "`bool`", t);
+        if (lhs_ty) |t| if (!predicates.isBoolType(t.*)) {
+            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "`bool`", t);
         };
-        if (rhs_ty) |t| if (!isBoolType(t.*)) {
-            try self.emitOperatorRequires(b.span, opLexeme(b.op), "`bool`", t);
+        if (rhs_ty) |t| if (!predicates.isBoolType(t.*)) {
+            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "`bool`", t);
         };
         return bool_ty;
     }
@@ -2137,7 +2141,7 @@ pub const Checker = struct {
             // Skip the type check when the param's type is the
             // `nil_` placeholder used for unannotated `def` params —
             // those params accept any caller-supplied type.
-            const skip = isNilType(param_ty.*);
+            const skip = predicates.isNilType(param_ty.*);
             const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
             if (!skip and arg_ty != null and !assignable(arg_ty.?.*, param_ty.*)) {
                 try self.emitMismatch(arg.span(), param_ty, arg_ty.?);
@@ -2184,7 +2188,7 @@ pub const Checker = struct {
         // Fixed params: standard per-arg type check.
         for (c.args[0..fixed_count], 0..) |arg, i| {
             const param_ty = f.params[i];
-            const skip = isNilType(param_ty.*);
+            const skip = predicates.isNilType(param_ty.*);
             const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
             if (!skip and arg_ty != null and !assignable(arg_ty.?.*, param_ty.*)) {
                 try self.emitMismatch(arg.span(), param_ty, arg_ty.?);
@@ -2339,121 +2343,12 @@ fn findClassField(c: *const Checker, cd: *const ast.ClassDecl, name: []const u8)
     return null;
 }
 
-// ---------- type predicates ----------
-
-fn isIntegerPrimitive(p: types.Primitive) bool {
-    return switch (p) {
-        .i8, .u8, .i16, .u16 => true,
-        else => false,
-    };
-}
-
-fn isIntegerType(t: types.Type) bool {
-    return switch (t) {
-        .primitive => |p| isIntegerPrimitive(p),
-        else => false,
-    };
-}
-
-fn isNumericType(t: types.Type) bool {
-    return switch (t) {
-        .primitive => |p| isIntegerPrimitive(p) or p == .fixed,
-        else => false,
-    };
-}
-
-fn isBoolType(t: types.Type) bool {
-    return switch (t) {
-        .primitive => |p| p == .bool_,
-        else => false,
-    };
-}
-
-fn isStrType(t: types.Type) bool {
-    return switch (t) {
-        .primitive => |p| p == .str,
-        else => false,
-    };
-}
-
 /// `true` when `d` carries a `@no_capture` annotation.
 fn defHasNoCapture(c: *const Checker, d: ast.DefDecl) bool {
     for (d.annotations) |ann| {
         if (std.mem.eql(u8, c.lexeme(ann.name), "no_capture")) return true;
     }
     return false;
-}
-
-fn isNilType(t: types.Type) bool {
-    return switch (t) {
-        .primitive => |p| p == .nil_,
-        else => false,
-    };
-}
-
-/// `true` when a type is representable as static data — i.e. safe
-/// as the return type or output of a `bake` context. `Vec(T)` and
-/// references live in the runtime allocator / borrow domain and
-/// therefore can't be baked.
-fn isBakeableType(t: types.Type) bool {
-    return switch (t) {
-        .primitive => true,
-        .array => |a| isBakeableType(a.elem.*),
-        .tuple => |xs| blk: {
-            for (xs) |e| if (!isBakeableType(e.*)) break :blk false;
-            break :blk true;
-        },
-        .optional => |inner| isBakeableType(inner.*),
-        .named => true,
-        .vec, .reference, .function => false,
-    };
-}
-
-fn primitiveName(p: types.Primitive) []const u8 {
-    return switch (p) {
-        .i8 => "i8",
-        .u8 => "u8",
-        .i16 => "i16",
-        .u16 => "u16",
-        .bool_ => "bool",
-        .nil_ => "nil",
-        .str => "str",
-        .fixed => "fixed",
-        .char => "char",
-    };
-}
-
-fn intLitFits(value: i32, p: types.Primitive) bool {
-    return switch (p) {
-        .i8 => value >= -128 and value <= 127,
-        .u8 => value >= 0 and value <= 255,
-        .i16 => value >= -32768 and value <= 32767,
-        .u16 => value >= 0 and value <= 65535,
-        else => false,
-    };
-}
-
-fn opLexeme(op: ast.BinaryOp) []const u8 {
-    return switch (op) {
-        .add => "`+`",
-        .sub => "`-`",
-        .mul => "`*`",
-        .div => "`/`",
-        .mod => "`%`",
-        .shl => "`<<`",
-        .shr => "`>>`",
-        .bit_and => "`&`",
-        .bit_or => "`|`",
-        .bit_xor => "`^`",
-        .eq => "`==`",
-        .neq => "`!=`",
-        .lt => "`<`",
-        .lte => "`<=`",
-        .gt => "`>`",
-        .gte => "`>=`",
-        .log_and => "`and`",
-        .log_or => "`or`",
-    };
 }
 
 // ---------- place expression check ----------
@@ -2597,8 +2492,8 @@ fn canCast(from: types.Type, to: types.Type) bool {
     const f = from.primitive;
     const t = to.primitive;
     if (f == t) return true;
-    const f_int = isIntegerPrimitive(f);
-    const t_int = isIntegerPrimitive(t);
+    const f_int = predicates.isIntegerPrimitive(f);
+    const t_int = predicates.isIntegerPrimitive(t);
     if (f_int and t_int) return true;
     if (f == .bool_ and t_int) return true;
     if (f_int and t == .bool_) return true;

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -167,6 +167,13 @@ pub const match = @import("typecheck/match.zig");
 /// `ast.BinaryOp` — integer / numeric / bool / nil / bakeable
 /// checks plus diagnostic-string formatters.
 pub const predicates = @import("typecheck/predicates.zig");
+/// Annotation validation (§3.7) — target bit-flags, spec table,
+/// per-decl walker, and the `@no_capture` predicate.
+pub const annotations = @import("typecheck/annotations.zig");
+
+/// Re-export: target bit-flag namespace used by every decl-walker
+/// that calls into `annotations.validateAnnotations`.
+const T = annotations.T;
 
 /// `mem.*` stdlib builtin signature (re-exported from the
 /// sub-module for callers that just want the lookup type).
@@ -356,101 +363,6 @@ pub const Checker = struct {
         return self.source[span.start..span.end];
     }
 
-    // ---------- annotation validation (§3.7) ----------
-
-    /// Validate every annotation attached to a decl. `target` is
-    /// the decl's target bit (see the `T` namespace). Emits
-    /// `E_ANN_UNKNOWN` / `E_ANN_BAD_TARGET` / `E_ANN_BAD_ARG` /
-    /// `E_ANN_CONFLICT` per the rules in the annotation spec
-    /// table.
-    fn validateAnnotations(self: *Checker, anns: []const ast.Annotation, target: u32) WalkError!void {
-        for (anns) |ann| {
-            const name = self.lexeme(ann.name);
-            const spec = findAnnotationSpec(name) orelse {
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "unknown annotation `@{s}`",
-                    .{name},
-                );
-                try self.emitSpan("E_ANN_UNKNOWN", ann.name, msg);
-                continue;
-            };
-            if ((spec.targets & target) == 0) {
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "annotation `@{s}` cannot be applied to a {s}",
-                    .{ name, targetLabel(target) },
-                );
-                try self.emitSpan("E_ANN_BAD_TARGET", ann.name, msg);
-            }
-            try self.validateAnnotationArgs(ann, spec);
-        }
-        // Conflict pairs — second loop so we only emit each conflict
-        // once and so we don't false-positive when an earlier
-        // annotation was already rejected.
-        for (anns, 0..) |a, i| {
-            const a_spec = findAnnotationSpec(self.lexeme(a.name)) orelse continue;
-            for (anns[i + 1 ..]) |b| {
-                const b_name = self.lexeme(b.name);
-                for (a_spec.conflicts_with) |c| {
-                    if (std.mem.eql(u8, c, b_name)) {
-                        const msg = try std.fmt.allocPrint(
-                            self.arena,
-                            "annotations `@{s}` and `@{s}` cannot be combined",
-                            .{ self.lexeme(a.name), b_name },
-                        );
-                        try self.emitSpan("E_ANN_CONFLICT", b.name, msg);
-                    }
-                }
-            }
-        }
-    }
-
-    fn validateAnnotationArgs(self: *Checker, ann: ast.Annotation, spec: *const AnnotationSpec) WalkError!void {
-        switch (spec.args) {
-            .none => {
-                if (ann.args.len != 0) {
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "annotation `@{s}` does not take arguments",
-                        .{spec.name},
-                    );
-                    try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
-                }
-            },
-            .int_lit => {
-                if (ann.args.len != 1 or ann.args[0].* != .int_lit) {
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "annotation `@{s}` expects a single integer literal",
-                        .{spec.name},
-                    );
-                    try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
-                }
-            },
-            .int_lit_pow2 => {
-                if (ann.args.len != 1 or ann.args[0].* != .int_lit) {
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "annotation `@{s}` expects a single integer literal",
-                        .{spec.name},
-                    );
-                    try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
-                    return;
-                }
-                const v = ann.args[0].int_lit.value;
-                if (v <= 0 or (v & (v - 1)) != 0) {
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "annotation `@{s}` requires a power-of-two value, got {d}",
-                        .{ spec.name, v },
-                    );
-                    try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
-                }
-            },
-        }
-    }
-
     // ---------- Pass 1: top-level decl registration ----------
 
     fn registerTopLevel(self: *Checker, s: ast.Statement) WalkError!void {
@@ -621,8 +533,8 @@ pub const Checker = struct {
             },
             .def_decl => |d| try self.checkDefDecl(d),
             .class_decl => |c| try self.checkClassDecl(c),
-            .struct_decl => |sd| try self.validateAnnotations(sd.annotations, T.STRUCT),
-            .enum_decl => |ed| try self.validateAnnotations(ed.annotations, T.ENUM),
+            .struct_decl => |sd| try annotations.validateAnnotations(self, sd.annotations, T.STRUCT),
+            .enum_decl => |ed| try annotations.validateAnnotations(self, ed.annotations, T.ENUM),
             .use_decl, .local_decl => {},
             .asm_stmt => |as_| if (self.in_bake) {
                 try self.emitSpan("E_BAKE_ASM_INSIDE", as_.span, "`asm` is not allowed inside a `bake` context — compile-time interpretation cannot run host bytecode");
@@ -688,7 +600,7 @@ pub const Checker = struct {
     }
 
     fn checkLetDecl(self: *Checker, d: ast.LetDecl) WalkError!void {
-        try self.validateAnnotations(d.annotations, T.LET);
+        try annotations.validateAnnotations(self, d.annotations, T.LET);
         const ann_ty: ?*const types.Type = if (d.type_ann) |t|
             try self.resolveType(t)
         else
@@ -787,7 +699,7 @@ pub const Checker = struct {
     }
 
     fn checkConstDecl(self: *Checker, d: ast.ConstDecl) WalkError!void {
-        try self.validateAnnotations(d.annotations, T.CONST);
+        try annotations.validateAnnotations(self, d.annotations, T.CONST);
         const ann_ty: ?*const types.Type = if (d.type_ann) |t|
             try self.resolveType(t)
         else
@@ -995,7 +907,7 @@ pub const Checker = struct {
     }
 
     fn checkDefDecl(self: *Checker, d: ast.DefDecl) WalkError!void {
-        try self.validateAnnotations(d.annotations, T.DEF);
+        try annotations.validateAnnotations(self, d.annotations, T.DEF);
         try self.checkVariadicPosition(d);
         const saved_scope = self.current_scope;
         var fn_scope: Scope = .init(self.arena, saved_scope);
@@ -1021,7 +933,7 @@ pub const Checker = struct {
         // must not mutate captured bindings. Nested `def`s inherit
         // the flag so a closure two levels deep still flags.
         const saved_nc = self.in_no_capture;
-        self.in_no_capture = saved_nc or defHasNoCapture(self, d);
+        self.in_no_capture = saved_nc or annotations.defHasNoCapture(self, d);
         defer self.in_no_capture = saved_nc;
 
         // Bake fn return type must be bakeable. `Vec(T)` and `&T`
@@ -1069,7 +981,7 @@ pub const Checker = struct {
     }
 
     fn checkClassDecl(self: *Checker, d: ast.ClassDecl) WalkError!void {
-        try self.validateAnnotations(d.annotations, T.CLASS);
+        try annotations.validateAnnotations(self, d.annotations, T.CLASS);
         const saved = self.current_scope;
         var class_scope: Scope = .init(self.arena, saved);
         self.current_scope = &class_scope;
@@ -1084,7 +996,7 @@ pub const Checker = struct {
         defer self.current_class_name = saved_name;
 
         for (d.fields) |f| {
-            try self.validateAnnotations(f.annotations, T.CLASS_FIELD);
+            try annotations.validateAnnotations(self, f.annotations, T.CLASS_FIELD);
             const ty: ?*const types.Type = if (f.type_ann) |t|
                 try self.resolveType(t)
             else
@@ -2343,14 +2255,6 @@ fn findClassField(c: *const Checker, cd: *const ast.ClassDecl, name: []const u8)
     return null;
 }
 
-/// `true` when `d` carries a `@no_capture` annotation.
-fn defHasNoCapture(c: *const Checker, d: ast.DefDecl) bool {
-    for (d.annotations) |ann| {
-        if (std.mem.eql(u8, c.lexeme(ann.name), "no_capture")) return true;
-    }
-    return false;
-}
-
 // ---------- place expression check ----------
 
 /// `true` when `e` is a valid assignment target — `ident`, `field`,
@@ -2361,101 +2265,6 @@ fn isPlaceExpr(e: *const ast.Expr) bool {
         .ident, .field, .index => true,
         .paren => |p| isPlaceExpr(p.inner),
         else => false,
-    };
-}
-
-// ---------- annotation validation (§3.7) ----------
-
-/// Bit flags for annotation `targets:` — which decl kinds an
-/// annotation may attach to.
-const T = struct {
-    const LET: u32 = 1 << 0;
-    const CONST: u32 = 1 << 1;
-    const DEF: u32 = 1 << 2;
-    const CLASS: u32 = 1 << 3;
-    const STRUCT: u32 = 1 << 4;
-    const ENUM: u32 = 1 << 5;
-    const CLASS_FIELD: u32 = 1 << 6;
-};
-
-/// Shape an annotation's args must take.
-const ArgRule = enum {
-    none, // no args (marker)
-    int_lit, // single int literal
-    int_lit_pow2, // single int literal, power of two
-};
-
-const AnnotationSpec = struct {
-    name: []const u8,
-    targets: u32,
-    args: ArgRule,
-    /// Annotation names that conflict with this one when both are
-    /// applied to the same decl.
-    conflicts_with: []const []const u8 = &.{},
-};
-
-/// Spec inventory per `docs/gero-lang.md` §3.7.
-const annotation_specs = [_]AnnotationSpec{
-    // Memory placement (§3.7.1)
-    .{ .name = "bank", .targets = T.DEF | T.LET | T.CONST, .args = .int_lit },
-    .{ .name = "zero_page", .targets = T.LET, .args = .none },
-    .{ .name = "addr", .targets = T.LET, .args = .int_lit },
-    .{ .name = "volatile", .targets = T.LET, .args = .none },
-    .{ .name = "align", .targets = T.LET | T.CONST | T.STRUCT, .args = .int_lit_pow2 },
-    // Codegen control (§3.7.2)
-    .{ .name = "inline", .targets = T.DEF, .args = .none },
-    .{ .name = "cold", .targets = T.DEF, .args = .none },
-    .{ .name = "no_capture", .targets = T.DEF, .args = .none },
-    // Misc
-    .{ .name = "noreturn", .targets = T.DEF, .args = .none },
-    .{ .name = "interrupt", .targets = T.DEF, .args = .int_lit },
-    .{ .name = "test", .targets = T.DEF, .args = .none },
-    .{ .name = "bench", .targets = T.DEF, .args = .none },
-    // OOP (§6)
-    .{
-        .name = "override",
-        .targets = T.DEF,
-        .args = .none,
-        .conflicts_with = &.{ "final", "abstract" },
-    },
-    .{
-        .name = "final",
-        .targets = T.DEF | T.CLASS,
-        .args = .none,
-        .conflicts_with = &.{ "override", "abstract" },
-    },
-    .{
-        .name = "abstract",
-        .targets = T.DEF | T.CLASS,
-        .args = .none,
-        .conflicts_with = &.{ "override", "final", "static" },
-    },
-    .{
-        .name = "static",
-        .targets = T.DEF,
-        .args = .none,
-        .conflicts_with = &.{ "abstract", "override" },
-    },
-    .{ .name = "private", .targets = T.DEF | T.LET | T.CLASS_FIELD, .args = .none },
-};
-
-fn findAnnotationSpec(name: []const u8) ?*const AnnotationSpec {
-    for (&annotation_specs) |*s| {
-        if (std.mem.eql(u8, s.name, name)) return s;
-    }
-    return null;
-}
-
-fn targetLabel(target: u32) []const u8 {
-    return switch (target) {
-        T.LET => "let",
-        T.CONST => "const",
-        T.DEF => "def",
-        T.CLASS => "class",
-        T.STRUCT => "struct",
-        T.ENUM => "enum",
-        T.CLASS_FIELD => "class field",
-        else => "decl",
     };
 }
 

--- a/src/lang/typecheck/annotations.zig
+++ b/src/lang/typecheck/annotations.zig
@@ -49,7 +49,9 @@ pub const AnnotationSpec = struct {
     conflicts_with: []const []const u8 = &.{},
 };
 
-/// Spec inventory per `docs/gero-lang.md` §3.7.
+/// Spec inventory per `docs/gero-lang.md` §3.7. Comptime array —
+/// iterate with `&annotation_specs` to keep slot pointers stable
+/// across element copies.
 pub const annotation_specs = [_]AnnotationSpec{
     // Memory placement (§3.7.1)
     .{ .name = "bank", .targets = T.DEF | T.LET | T.CONST, .args = .int_lit },

--- a/src/lang/typecheck/annotations.zig
+++ b/src/lang/typecheck/annotations.zig
@@ -1,0 +1,221 @@
+/// Annotation validation per `docs/gero-lang.md` §3.7 — the
+/// `T` target bit-flags, the `AnnotationSpec` table, and the
+/// `validateAnnotations` / `validateAnnotationArgs` walkers
+/// invoked from every decl-registration site. Also hosts
+/// `defHasNoCapture`, the small predicate that scans a `def`'s
+/// annotation list for `@no_capture`.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const typecheck = @import("../typecheck.zig");
+
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+/// Bit flags for annotation `targets:` — which decl kinds an
+/// annotation may attach to. Combined with `|` in the spec table.
+pub const T = struct {
+    /// `let` decl.
+    pub const LET: u32 = 1 << 0;
+    /// `const` decl.
+    pub const CONST: u32 = 1 << 1;
+    /// `def` (function) decl.
+    pub const DEF: u32 = 1 << 2;
+    /// `class` decl.
+    pub const CLASS: u32 = 1 << 3;
+    /// `struct` decl.
+    pub const STRUCT: u32 = 1 << 4;
+    /// `enum` decl.
+    pub const ENUM: u32 = 1 << 5;
+    /// Field inside a `class` decl.
+    pub const CLASS_FIELD: u32 = 1 << 6;
+};
+
+/// Shape an annotation's args must take.
+pub const ArgRule = enum {
+    none, // no args (marker)
+    int_lit, // single int literal
+    int_lit_pow2, // single int literal, power of two
+};
+
+/// Specification for one annotation: which targets it may attach
+/// to, what arg shape it expects, and which sibling annotations
+/// it conflicts with.
+pub const AnnotationSpec = struct {
+    name: []const u8,
+    targets: u32,
+    args: ArgRule,
+    /// Annotation names that conflict with this one when both are
+    /// applied to the same decl.
+    conflicts_with: []const []const u8 = &.{},
+};
+
+/// Spec inventory per `docs/gero-lang.md` §3.7.
+pub const annotation_specs = [_]AnnotationSpec{
+    // Memory placement (§3.7.1)
+    .{ .name = "bank", .targets = T.DEF | T.LET | T.CONST, .args = .int_lit },
+    .{ .name = "zero_page", .targets = T.LET, .args = .none },
+    .{ .name = "addr", .targets = T.LET, .args = .int_lit },
+    .{ .name = "volatile", .targets = T.LET, .args = .none },
+    .{ .name = "align", .targets = T.LET | T.CONST | T.STRUCT, .args = .int_lit_pow2 },
+    // Codegen control (§3.7.2)
+    .{ .name = "inline", .targets = T.DEF, .args = .none },
+    .{ .name = "cold", .targets = T.DEF, .args = .none },
+    .{ .name = "no_capture", .targets = T.DEF, .args = .none },
+    // Misc
+    .{ .name = "noreturn", .targets = T.DEF, .args = .none },
+    .{ .name = "interrupt", .targets = T.DEF, .args = .int_lit },
+    .{ .name = "test", .targets = T.DEF, .args = .none },
+    .{ .name = "bench", .targets = T.DEF, .args = .none },
+    // OOP (§6)
+    .{
+        .name = "override",
+        .targets = T.DEF,
+        .args = .none,
+        .conflicts_with = &.{ "final", "abstract" },
+    },
+    .{
+        .name = "final",
+        .targets = T.DEF | T.CLASS,
+        .args = .none,
+        .conflicts_with = &.{ "override", "abstract" },
+    },
+    .{
+        .name = "abstract",
+        .targets = T.DEF | T.CLASS,
+        .args = .none,
+        .conflicts_with = &.{ "override", "final", "static" },
+    },
+    .{
+        .name = "static",
+        .targets = T.DEF,
+        .args = .none,
+        .conflicts_with = &.{ "abstract", "override" },
+    },
+    .{ .name = "private", .targets = T.DEF | T.LET | T.CLASS_FIELD, .args = .none },
+};
+
+/// Look up a spec by annotation name. Returns `null` for unknown
+/// annotations — callers emit `E_ANN_UNKNOWN` in that case.
+pub fn findAnnotationSpec(name: []const u8) ?*const AnnotationSpec {
+    for (&annotation_specs) |*s| {
+        if (std.mem.eql(u8, s.name, name)) return s;
+    }
+    return null;
+}
+
+/// Human-readable label for a target bit — used in
+/// `E_ANN_BAD_TARGET` messages.
+pub fn targetLabel(target: u32) []const u8 {
+    return switch (target) {
+        T.LET => "let",
+        T.CONST => "const",
+        T.DEF => "def",
+        T.CLASS => "class",
+        T.STRUCT => "struct",
+        T.ENUM => "enum",
+        T.CLASS_FIELD => "class field",
+        else => "decl",
+    };
+}
+
+/// Validate every annotation attached to a decl. `target` is the
+/// decl's target bit (see the `T` namespace). Emits
+/// `E_ANN_UNKNOWN` / `E_ANN_BAD_TARGET` / `E_ANN_BAD_ARG` /
+/// `E_ANN_CONFLICT` per the rules in the annotation spec table.
+pub fn validateAnnotations(self: *Checker, anns: []const ast.Annotation, target: u32) WalkError!void {
+    for (anns) |ann| {
+        const name = self.lexeme(ann.name);
+        const spec = findAnnotationSpec(name) orelse {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "unknown annotation `@{s}`",
+                .{name},
+            );
+            try self.emitSpan("E_ANN_UNKNOWN", ann.name, msg);
+            continue;
+        };
+        if ((spec.targets & target) == 0) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "annotation `@{s}` cannot be applied to a {s}",
+                .{ name, targetLabel(target) },
+            );
+            try self.emitSpan("E_ANN_BAD_TARGET", ann.name, msg);
+        }
+        try validateAnnotationArgs(self, ann, spec);
+    }
+    // Conflict pairs — second loop so we only emit each conflict
+    // once and so we don't false-positive when an earlier
+    // annotation was already rejected.
+    for (anns, 0..) |a, i| {
+        const a_spec = findAnnotationSpec(self.lexeme(a.name)) orelse continue;
+        for (anns[i + 1 ..]) |b| {
+            const b_name = self.lexeme(b.name);
+            for (a_spec.conflicts_with) |c| {
+                if (std.mem.eql(u8, c, b_name)) {
+                    const msg = try std.fmt.allocPrint(
+                        self.arena,
+                        "annotations `@{s}` and `@{s}` cannot be combined",
+                        .{ self.lexeme(a.name), b_name },
+                    );
+                    try self.emitSpan("E_ANN_CONFLICT", b.name, msg);
+                }
+            }
+        }
+    }
+}
+
+/// Check a single annotation's arguments against its spec's
+/// `ArgRule`. Emits `E_ANN_BAD_ARG` on shape or value violations.
+pub fn validateAnnotationArgs(self: *Checker, ann: ast.Annotation, spec: *const AnnotationSpec) WalkError!void {
+    switch (spec.args) {
+        .none => {
+            if (ann.args.len != 0) {
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "annotation `@{s}` does not take arguments",
+                    .{spec.name},
+                );
+                try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
+            }
+        },
+        .int_lit => {
+            if (ann.args.len != 1 or ann.args[0].* != .int_lit) {
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "annotation `@{s}` expects a single integer literal",
+                    .{spec.name},
+                );
+                try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
+            }
+        },
+        .int_lit_pow2 => {
+            if (ann.args.len != 1 or ann.args[0].* != .int_lit) {
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "annotation `@{s}` expects a single integer literal",
+                    .{spec.name},
+                );
+                try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
+                return;
+            }
+            const v = ann.args[0].int_lit.value;
+            if (v <= 0 or (v & (v - 1)) != 0) {
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "annotation `@{s}` requires a power-of-two value, got {d}",
+                    .{ spec.name, v },
+                );
+                try self.emitSpan("E_ANN_BAD_ARG", ann.span, msg);
+            }
+        },
+    }
+}
+
+/// `true` when `d` carries a `@no_capture` annotation.
+pub fn defHasNoCapture(c: *const Checker, d: ast.DefDecl) bool {
+    for (d.annotations) |ann| {
+        if (std.mem.eql(u8, c.lexeme(ann.name), "no_capture")) return true;
+    }
+    return false;
+}

--- a/src/lang/typecheck/flow.zig
+++ b/src/lang/typecheck/flow.zig
@@ -1,0 +1,62 @@
+/// Small, heterogeneous helpers consumed by flow-sensitive
+/// inference and decl-resolution paths in the typechecker.
+/// Grouped here because each is too small to warrant its own
+/// file and they share the common shape of "lookup or shape
+/// inspection that doesn't drive its own pass".
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const typecheck = @import("../typecheck.zig");
+
+const Checker = typecheck.Checker;
+
+/// Extract the source-buffer lexeme when `e` is a bare ident
+/// (possibly wrapped in `paren`). Returns `null` otherwise — used
+/// by nil-check pattern matching and by flow-sensitive deref
+/// lookups.
+pub fn identName(c: *const Checker, e: *const ast.Expr) ?[]const u8 {
+    return switch (e.*) {
+        .ident => |i| c.lexeme(i.span),
+        .paren => |p| identName(c, p.inner),
+        else => null,
+    };
+}
+
+/// `true` when the last statement of `body` is `return` / `break` /
+/// `continue` — used by the `if x == nil then return end`
+/// fall-through detector.
+pub fn bodyAlwaysExits(body: []const ast.Statement) bool {
+    if (body.len == 0) return false;
+    return switch (body[body.len - 1]) {
+        .return_stmt, .break_stmt, .continue_stmt => true,
+        else => false,
+    };
+}
+
+/// Lexeme of a `Named` type, or `null` for other type shapes.
+pub fn namedNameOf(t: types.Type) ?[]const u8 {
+    return switch (t) {
+        .named => |n| n.name,
+        else => null,
+    };
+}
+
+/// Locate a field on a struct decl by name.
+pub fn findStructField(c: *const Checker, fields: []const ast.StructField, name: []const u8) ?*const ast.StructField {
+    for (fields) |*f| {
+        if (std.mem.eql(u8, c.lexeme(f.name), name)) return f;
+    }
+    return null;
+}
+
+/// Locate a field on a class decl by name (walks the inheritance
+/// chain). Returns the first hit.
+pub fn findClassField(c: *const Checker, cd: *const ast.ClassDecl, name: []const u8) ?*const ast.ClassField {
+    for (cd.fields) |*f| {
+        if (std.mem.eql(u8, c.lexeme(f.name), name)) return f;
+    }
+    if (cd.extends) |ext| if (c.class_registry.get(c.lexeme(ext))) |parent| {
+        return findClassField(c, parent, name);
+    };
+    return null;
+}

--- a/src/lang/typecheck/predicates.zig
+++ b/src/lang/typecheck/predicates.zig
@@ -1,0 +1,137 @@
+/// Pure predicates over `types.Type` / `types.Primitive` /
+/// `ast.BinaryOp`. No `Checker` state — every helper is a total
+/// function from its inputs, so they're safe to call from any
+/// inference / checking site. Used heavily by the binary-operator
+/// arm-checks, integer-literal fitting, and `bake` return-type
+/// validation.
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+
+/// `true` for fixed-width integer primitives (`i8` / `u8` / `i16`
+/// / `u16`). Excludes `fixed` (a Q-format scaled int), `bool`,
+/// `nil`, `str`, `char`.
+pub fn isIntegerPrimitive(p: types.Primitive) bool {
+    return switch (p) {
+        .i8, .u8, .i16, .u16 => true,
+        else => false,
+    };
+}
+
+/// `true` when `t` is a primitive integer (see
+/// `isIntegerPrimitive`). Aggregate / reference / named types
+/// return `false`.
+pub fn isIntegerType(t: types.Type) bool {
+    return switch (t) {
+        .primitive => |p| isIntegerPrimitive(p),
+        else => false,
+    };
+}
+
+/// `true` when `t` is an integer or `fixed` — i.e. anything that
+/// participates in `+ - * / %` and comparison arms.
+pub fn isNumericType(t: types.Type) bool {
+    return switch (t) {
+        .primitive => |p| isIntegerPrimitive(p) or p == .fixed,
+        else => false,
+    };
+}
+
+/// `true` when `t` is the `bool` primitive. Used by logical-op
+/// and condition checks.
+pub fn isBoolType(t: types.Type) bool {
+    return switch (t) {
+        .primitive => |p| p == .bool_,
+        else => false,
+    };
+}
+
+/// `true` when `t` is the `str` primitive. Used by the `+`
+/// concatenation arm.
+pub fn isStrType(t: types.Type) bool {
+    return switch (t) {
+        .primitive => |p| p == .str,
+        else => false,
+    };
+}
+
+/// `true` when `t` is the `nil` primitive. Used by nullable
+/// initialization, nil-equality, and call-arg nil-propagation
+/// paths.
+pub fn isNilType(t: types.Type) bool {
+    return switch (t) {
+        .primitive => |p| p == .nil_,
+        else => false,
+    };
+}
+
+/// `true` when a type is representable as static data — i.e. safe
+/// as the return type or output of a `bake` context. `Vec(T)` and
+/// references live in the runtime allocator / borrow domain and
+/// therefore can't be baked.
+pub fn isBakeableType(t: types.Type) bool {
+    return switch (t) {
+        .primitive => true,
+        .array => |a| isBakeableType(a.elem.*),
+        .tuple => |xs| blk: {
+            for (xs) |e| if (!isBakeableType(e.*)) break :blk false;
+            break :blk true;
+        },
+        .optional => |inner| isBakeableType(inner.*),
+        .named => true,
+        .vec, .reference, .function => false,
+    };
+}
+
+/// Display name for a primitive — used in diagnostic messages
+/// (e.g. `"value 257 doesn't fit in u8"`).
+pub fn primitiveName(p: types.Primitive) []const u8 {
+    return switch (p) {
+        .i8 => "i8",
+        .u8 => "u8",
+        .i16 => "i16",
+        .u16 => "u16",
+        .bool_ => "bool",
+        .nil_ => "nil",
+        .str => "str",
+        .fixed => "fixed",
+        .char => "char",
+    };
+}
+
+/// `true` when `value` is representable in `p` (only meaningful
+/// for the four integer primitives — other primitives always
+/// return `false`).
+pub fn intLitFits(value: i32, p: types.Primitive) bool {
+    return switch (p) {
+        .i8 => value >= -128 and value <= 127,
+        .u8 => value >= 0 and value <= 255,
+        .i16 => value >= -32768 and value <= 32767,
+        .u16 => value >= 0 and value <= 65535,
+        else => false,
+    };
+}
+
+/// Backtick-quoted display form for a binary operator — used in
+/// the `operator X requires Y` diagnostic family.
+pub fn opLexeme(op: ast.BinaryOp) []const u8 {
+    return switch (op) {
+        .add => "`+`",
+        .sub => "`-`",
+        .mul => "`*`",
+        .div => "`/`",
+        .mod => "`%`",
+        .shl => "`<<`",
+        .shr => "`>>`",
+        .bit_and => "`&`",
+        .bit_or => "`|`",
+        .bit_xor => "`^`",
+        .eq => "`==`",
+        .neq => "`!=`",
+        .lt => "`<`",
+        .lte => "`<=`",
+        .gt => "`>`",
+        .gte => "`>=`",
+        .log_and => "`and`",
+        .log_or => "`or`",
+    };
+}

--- a/src/lang/typecheck/relations.zig
+++ b/src/lang/typecheck/relations.zig
@@ -1,0 +1,46 @@
+/// Type-to-type relations: assignability (used by return /
+/// let-init / assignment / call-arg checks) and cast
+/// convertibility (used by the `as` expression). Both are pure
+/// functions over `types.Type` pairs — no `Checker` state.
+const types = @import("../types.zig");
+const predicates = @import("predicates.zig");
+
+/// `true` when an `actual` typed value can be stored / returned /
+/// passed into an `expected` slot. Wider than `Type.eql` — allows
+/// `T → T?` (non-nil to nullable) and recurses into tuples for
+/// per-slot assignability. Used by return / let-init / assignment
+/// / call-arg checks; operator arms keep strict equality.
+pub fn assignable(actual: types.Type, expected: types.Type) bool {
+    if (actual.eql(expected)) return true;
+    if (expected == .optional) {
+        if (actual == .primitive and actual.primitive == .nil_) return true;
+        if (assignable(actual, expected.optional.*)) return true;
+    }
+    if (expected == .tuple and actual == .tuple and expected.tuple.len == actual.tuple.len) {
+        for (expected.tuple, actual.tuple) |e, a| {
+            if (!assignable(a.*, e.*)) return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+/// Spec §3.5.1 conversion table. Allows integer ↔ integer (any
+/// width / sign), bool ↔ integer, fixed ↔ integer, u8 ↔ char, and
+/// any same-primitive identity cast. Rejects everything else
+/// (class casts, function-pointer reinterpret, reference casts).
+pub fn canCast(from: types.Type, to: types.Type) bool {
+    if (from != .primitive or to != .primitive) return false;
+    const f = from.primitive;
+    const t = to.primitive;
+    if (f == t) return true;
+    const f_int = predicates.isIntegerPrimitive(f);
+    const t_int = predicates.isIntegerPrimitive(t);
+    if (f_int and t_int) return true;
+    if (f == .bool_ and t_int) return true;
+    if (f_int and t == .bool_) return true;
+    if (f == .fixed and t_int) return true;
+    if (f_int and t == .fixed) return true;
+    if ((f == .u8 and t == .char) or (f == .char and t == .u8)) return true;
+    return false;
+}

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -33,6 +33,10 @@ pub const Vector = enum(u8) {
     invalid_register = 0x02,
     /// Division by zero.
     div_by_zero = 0x03,
+    /// Heap exhausted — `sys alloc` couldn't satisfy a request
+    /// because the bump cursor would have collided with the stack
+    /// or fallen outside the program's heap region.
+    heap_exhausted = 0x04,
     /// Arithmetic overflow (e.g. `div` quotient > 16 bits).
     arith_overflow = 0x05,
     _,

--- a/src/vm/handlers/system.zig
+++ b/src/vm/handlers/system.zig
@@ -159,6 +159,15 @@ pub const SyscallId = enum(u8) {
     /// stomp the same slot).
     format_terminate_buf = 0x14,
 
+    /// `acu` = requested size in bytes. On success: `acu` ← the
+    /// address of the freshly-allocated block, and the VM's bump
+    /// cursor advances by the requested size. Raises the
+    /// `heap_exhausted` fault when the cursor is 0 (program
+    /// declared no heap), when the request overflows the 16-bit
+    /// address space, or when the new cursor would collide with
+    /// the stack (`new_cursor > sp`).
+    alloc = 0x20,
+
     /// Open-enum tail — unknown syscall ids coerce here and the
     /// `sys` handler routes them to the `invalid_opcode` fault.
     _,
@@ -187,10 +196,28 @@ pub fn sys(vm: *VM) StepResult {
         .format_char_to_buf => formatCharToBuf(vm),
         .format_fixed_to_buf => formatFixedToBuf(vm) catch return fault(vm, .invalid_opcode),
         .format_terminate_buf => formatTerminateBuf(vm),
+        .alloc => return allocSyscall(vm),
         // Unknown id — open-enum coercion picks this up; future
         // syscall ids should add an arm above.
         _ => return fault(vm, .invalid_opcode),
     }
+    return ok;
+}
+
+/// `sys alloc` (0x20) — bump-allocate `acu` bytes on the heap.
+/// Returns the freshly-allocated address in `acu` and advances
+/// `vm.heap_cursor` by the requested size. Faults on out-of-heap.
+fn allocSyscall(vm: *VM) StepResult {
+    const cursor = vm.heap_cursor;
+    if (cursor == 0) return fault(vm, .heap_exhausted);
+    const size = vm.regs.read(.acu);
+    // @as: widen both u16 operands to u32 so the overflow check sees the real sum, not the wrapped low 16 bits.
+    const new_cursor: u32 = @as(u32, cursor) + @as(u32, size);
+    if (new_cursor > 0xFFFF) return fault(vm, .heap_exhausted);
+    if (new_cursor > vm.regs.read(.sp)) return fault(vm, .heap_exhausted);
+    // @as: u32 fits in u16 here — the check above proved it.
+    vm.heap_cursor = @intCast(new_cursor);
+    vm.regs.write(.acu, cursor);
     return ok;
 }
 

--- a/src/vm/loader.zig
+++ b/src/vm/loader.zig
@@ -10,7 +10,7 @@ pub const magic: [4]u8 = .{ 'G', 'E', 'R', 'O' };
 /// ISA version this loader accepts (high byte = major, low =
 /// minor). Files with a higher major are rejected; same major
 /// + higher minor are accepted (backwards-compatible additions).
-pub const version_target: u16 = 0x0001;
+pub const version_target: u16 = 0x0002;
 
 /// Header bytes — fixed 16-byte prefix.
 pub const header_size: usize = 16;
@@ -34,8 +34,7 @@ pub const LoaderError = error{
     BadMagic,
     /// Major version exceeds what this loader supports.
     UnsupportedVersion,
-    /// `flags` has a reserved bit set, or the trailing
-    /// `reserved` field is non-zero.
+    /// `flags` has a reserved bit set.
     ReservedBitsSet,
     /// `sram_bank_count > bank_count`.
     InvalidSramCount,
@@ -54,6 +53,11 @@ pub const Header = struct {
     image_size: u16,
     bank_count: u8,
     sram_bank_count: u8,
+    /// Address where the bump-allocator heap starts. `0` means the
+    /// program declared no heap and `sys alloc` will fault on first
+    /// call. Files declaring version `0x0001` always read `0` here
+    /// (the field was added in `0x0002`).
+    heap_base: u16,
 
     /// `true` when the file carries a bank-pool section.
     pub fn isBanked(self: Header) bool {
@@ -98,8 +102,11 @@ pub fn parse(bytes: []const u8) LoaderError!LoadedProgram {
     const image_size = readU16Le(bytes, 0x0A);
     const bank_count = bytes[0x0C];
     const sram_bank_count = bytes[0x0D];
-    const reserved = readU16Le(bytes, 0x0E);
-    if (reserved != 0) return error.ReservedBitsSet;
+    // 0x0E..0x0F is `heap_base` from version 0x0002 onward. Files
+    // declaring version 0x0001 still pass — the field reads as 0,
+    // which means "no heap" and the alloc syscall faults on first
+    // use. Older files never called `sys alloc` anyway.
+    const heap_base = readU16Le(bytes, 0x0E);
     if (sram_bank_count > bank_count) return error.InvalidSramCount;
 
     const image_start = header_size;
@@ -135,6 +142,7 @@ pub fn parse(bytes: []const u8) LoaderError!LoadedProgram {
             .image_size = image_size,
             .bank_count = bank_count,
             .sram_bank_count = sram_bank_count,
+            .heap_base = heap_base,
         },
         .image = image,
         .banks = banks,

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -107,6 +107,12 @@ pub const VM = struct {
     /// silent no-ops — fine for tests / headless smoke runs that
     /// don't care about output.
     host: Host,
+    /// Bump-allocator cursor — next address `sys alloc` returns.
+    /// Initialized from `loaded.header.heap_base` at boot;
+    /// advances forward by the requested size on each allocation.
+    /// `0` means "no heap" (program declared none) and `sys alloc`
+    /// faults on first call.
+    heap_cursor: u16,
 
     /// Construct a fresh VM with default boot state. `ip` is left
     /// at 0; the loader sets it to the program's entry point. The
@@ -119,6 +125,7 @@ pub const VM = struct {
             .banks = null,
             .cycles = 0,
             .host = .{},
+            .heap_cursor = 0,
         };
         vm.bootInitRegisters();
         return vm;
@@ -182,6 +189,7 @@ pub const VM = struct {
     ) (std.mem.Allocator.Error || BanksError)!void {
         @memcpy(self.mmap.mem.bytes[0..loaded.image.len], loaded.image);
         self.regs.write(.ip, loaded.header.entry_point);
+        self.heap_cursor = loaded.header.heap_base;
         if (loaded.header.bank_count > 0) {
             try self.installBanksWithImage(
                 allocator,

--- a/tests/disasm/header.test.zig
+++ b/tests/disasm/header.test.zig
@@ -39,9 +39,19 @@ test "header: minimal valid cart exposes fields" {
     try std.testing.expectEqual(@as(u16, 3), h.image_size);
     try std.testing.expectEqual(@as(u8, 0), h.bank_count);
     try std.testing.expectEqual(@as(u8, 0), h.sram_bank_count);
+    try std.testing.expectEqual(@as(u16, 0), h.heap_base);
     try std.testing.expectEqualSlices(u8, &.{ 0xFF, 0xFF, 0xFF }, h.image);
     try std.testing.expectEqual(@as(usize, 0), h.banks.len);
     try std.testing.expectEqual(@as(usize, 0), h.debug.len);
+}
+
+test "header: heap_base parses from bytes 0x0E..0x0F (little-endian)" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0, 0x1100, 0, 0, 0);
+    buf[0x0E] = 0x34;
+    buf[0x0F] = 0x12;
+    const h = try gero.disasm.parseHeader(&buf);
+    try std.testing.expectEqual(@as(u16, 0x1234), h.heap_base);
 }
 
 test "header: bad magic rejected" {

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1222,6 +1222,40 @@ test "codegen: format-spec `$(x:d)` is rejected with E_CODEGEN_UNSUPPORTED" {
     try std.testing.expect(found);
 }
 
+test "codegen: diagnostic message slices outlive `compile`" {
+    // Regression: `Diagnostic.message` strings allocated by
+    // `Emitter.unsupported` live on `Compiled.diag_arena`. A prior
+    // shape kept them on a scratch arena that deinit'd before
+    // `compile` returned, leaving the slices dangling. This test
+    // reads `.message` AFTER `compile` returns to prove the arena
+    // outlives the call.
+    const source =
+        \\def main()
+        \\  let x: i16 = 1
+        \\  let s: str = "$(x:d)"
+        \\  print s
+        \\end
+    ;
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    var compiled = try gero.lang.compile(alloc, source, &checked, .{});
+    defer compiled.deinit();
+
+    var checked_message = false;
+    for (compiled.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_CODEGEN_UNSUPPORTED")) {
+            try std.testing.expect(std.mem.indexOf(u8, d.message, "format specs") != null);
+            checked_message = true;
+        }
+    }
+    try std.testing.expect(checked_message);
+}
+
 test "codegen: zero-page overflow emits E_CODEGEN_ZP_OVERFLOW" {
     // 130 `@zero_page` u16 globals = 260 bytes — exceeds the 256-byte
     // zero-page budget at the 129th binding (which would push the

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -37,6 +37,29 @@ test "codegen: empty `def main() end` compiles to a valid .gx" {
     try std.testing.expectEqual(@as(u8, 0xFF), loaded.image[gero.lang.codegen.code_base]);
 }
 
+test "codegen: emitted .gx header carries heap_base = end of data region" {
+    // Source with no globals — data region empty, so heap_base sits
+    // at data_base (the start of the dynamic data area).
+    var compiled = try compileSource(
+        \\def main() end
+    );
+    defer compiled.deinit();
+    const loaded = try gero.vm.parseGx(compiled.image);
+    try std.testing.expectEqual(gero.lang.codegen.data_base, loaded.header.heap_base);
+}
+
+test "codegen: heap_base advances past static globals" {
+    // Two u16 globals in the data region → heap_base = data_base + 4.
+    var compiled = try compileSource(
+        \\let a: u16 = 0
+        \\let b: u16 = 0
+        \\def main() end
+    );
+    defer compiled.deinit();
+    const loaded = try gero.vm.parseGx(compiled.image);
+    try std.testing.expectEqual(@as(u16, gero.lang.codegen.data_base + 4), loaded.header.heap_base);
+}
+
 test "codegen: produced .gx boots and halts on the VM" {
     var compiled = try compileSource(
         \\def main() end

--- a/tests/lang/codegen/archive.test.zig
+++ b/tests/lang/codegen/archive.test.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const gero = @import("gero");
-const archive = gero.lang.codegen.internal.archive;
+const archive = gero.lang.internal.codegen.archive;
 
 test "archive: alignUpU16 rounds to the next power-of-two multiple" {
     try std.testing.expectEqual(@as(u16, 0), archive.alignUpU16(0, 16));

--- a/tests/lang/codegen/archive.test.zig
+++ b/tests/lang/codegen/archive.test.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const gero = @import("gero");
-const archive = gero.lang.codegen.archive;
+const archive = gero.lang.codegen.internal.archive;
 
 test "archive: alignUpU16 rounds to the next power-of-two multiple" {
     try std.testing.expectEqual(@as(u16, 0), archive.alignUpU16(0, 16));

--- a/tests/lang/codegen/control_flow.test.zig
+++ b/tests/lang/codegen/control_flow.test.zig
@@ -6,5 +6,5 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "codegen/control_flow: module compiles through the barrel" {
-    _ = gero.lang.codegen.internal.control_flow;
+    _ = gero.lang.internal.codegen.control_flow;
 }

--- a/tests/lang/codegen/control_flow.test.zig
+++ b/tests/lang/codegen/control_flow.test.zig
@@ -6,5 +6,5 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "codegen/control_flow: module compiles through the barrel" {
-    _ = gero.lang.codegen.control_flow;
+    _ = gero.lang.codegen.internal.control_flow;
 }

--- a/tests/lang/codegen/expr.test.zig
+++ b/tests/lang/codegen/expr.test.zig
@@ -5,5 +5,5 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "codegen/expr: module compiles through the barrel" {
-    _ = gero.lang.codegen.expr_emit;
+    _ = gero.lang.codegen.internal.expr_emit;
 }

--- a/tests/lang/codegen/expr.test.zig
+++ b/tests/lang/codegen/expr.test.zig
@@ -5,5 +5,5 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "codegen/expr: module compiles through the barrel" {
-    _ = gero.lang.codegen.internal.expr_emit;
+    _ = gero.lang.internal.codegen.expr_emit;
 }

--- a/tests/lang/codegen/mem_builtin.test.zig
+++ b/tests/lang/codegen/mem_builtin.test.zig
@@ -6,5 +6,5 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "mem_builtin: module compiles through the codegen barrel" {
-    _ = gero.lang.codegen.mem_builtin;
+    _ = gero.lang.codegen.internal.mem_builtin;
 }

--- a/tests/lang/codegen/mem_builtin.test.zig
+++ b/tests/lang/codegen/mem_builtin.test.zig
@@ -6,5 +6,5 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "mem_builtin: module compiles through the codegen barrel" {
-    _ = gero.lang.codegen.internal.mem_builtin;
+    _ = gero.lang.internal.codegen.mem_builtin;
 }

--- a/tests/lang/codegen/opcodes.test.zig
+++ b/tests/lang/codegen/opcodes.test.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const gero = @import("gero");
-const opcodes = gero.lang.codegen.opcodes;
+const opcodes = gero.lang.codegen.internal.opcodes;
 
 test "opcodes: Op.mov_imm16_reg matches the VM dispatch table entry" {
     try std.testing.expectEqual(@as(u8, 0x10), opcodes.Op.mov_imm16_reg);

--- a/tests/lang/codegen/opcodes.test.zig
+++ b/tests/lang/codegen/opcodes.test.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const gero = @import("gero");
-const opcodes = gero.lang.codegen.internal.opcodes;
+const opcodes = gero.lang.internal.codegen.opcodes;
 
 test "opcodes: Op.mov_imm16_reg matches the VM dispatch table entry" {
     try std.testing.expectEqual(@as(u8, 0x10), opcodes.Op.mov_imm16_reg);

--- a/tests/lang/codegen/pattern.test.zig
+++ b/tests/lang/codegen/pattern.test.zig
@@ -6,5 +6,5 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "codegen/pattern: module compiles through the barrel" {
-    _ = gero.lang.codegen.pattern;
+    _ = gero.lang.codegen.internal.pattern;
 }

--- a/tests/lang/codegen/pattern.test.zig
+++ b/tests/lang/codegen/pattern.test.zig
@@ -6,5 +6,5 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "codegen/pattern: module compiles through the barrel" {
-    _ = gero.lang.codegen.internal.pattern;
+    _ = gero.lang.internal.codegen.pattern;
 }

--- a/tests/lang/codegen/strings.test.zig
+++ b/tests/lang/codegen/strings.test.zig
@@ -7,9 +7,9 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "codegen/strings: module compiles through the barrel" {
-    _ = gero.lang.codegen.strings;
+    _ = gero.lang.codegen.internal.strings;
 }
 
 test "codegen/strings: interp_buffer_size is the documented 64 bytes" {
-    try std.testing.expectEqual(@as(u16, 64), gero.lang.codegen.strings.interp_buffer_size);
+    try std.testing.expectEqual(@as(u16, 64), gero.lang.codegen.internal.strings.interp_buffer_size);
 }

--- a/tests/lang/codegen/strings.test.zig
+++ b/tests/lang/codegen/strings.test.zig
@@ -7,9 +7,9 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "codegen/strings: module compiles through the barrel" {
-    _ = gero.lang.codegen.internal.strings;
+    _ = gero.lang.internal.codegen.strings;
 }
 
 test "codegen/strings: interp_buffer_size is the documented 64 bytes" {
-    try std.testing.expectEqual(@as(u16, 64), gero.lang.codegen.internal.strings.interp_buffer_size);
+    try std.testing.expectEqual(@as(u16, 64), gero.lang.internal.codegen.strings.interp_buffer_size);
 }

--- a/tests/lang/typecheck/annotations.test.zig
+++ b/tests/lang/typecheck/annotations.test.zig
@@ -1,8 +1,296 @@
-/// Mirror-layout placeholder. Real coverage of annotation
-/// validation — unknown / bad-target / bad-arg / pow2 / conflict
-/// arms — is gero-qa's design space.
+/// Specs for `typecheck/annotations` — the §3.7 annotation
+/// validation pipeline. Pure helpers (`findAnnotationSpec`,
+/// `targetLabel`, spec-table sanity) get direct unit calls; the
+/// arm coverage for `validateAnnotations` / `validateAnnotationArgs`
+/// (unknown / bad-target / bad-arg / pow2 / conflict) runs E2E
+/// through `gero.lang.typecheck` because each helper takes a
+/// `*Checker` plus parsed source. `defHasNoCapture` also rides on
+/// the E2E surface — its observable effect is whether the
+/// `@no_capture` body emits `E_ANN_CAPTURE_VIOLATION`.
+const std = @import("std");
 const gero = @import("gero");
 
+const annotations = gero.lang.typechecker.annotations;
+const alloc = std.testing.allocator;
+
+// ---------- E2E helpers ----------
+
+/// Assert the typechecker produces zero diagnostics on a
+/// self-contained source.
+fn expectClean(source: []const u8) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tree.errors.len);
+
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+    if (checked.diagnostics.len > 0) {
+        std.debug.print("unexpected typecheck diagnostics for `{s}`:\n", .{source});
+        for (checked.diagnostics) |d| std.debug.print("  - {s}: {s}\n", .{ d.code, d.message });
+    }
+    try std.testing.expectEqual(@as(usize, 0), checked.diagnostics.len);
+}
+
+/// Assert at least one diagnostic with `code` fires.
+fn expectCode(source: []const u8, code: []const u8) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    for (checked.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, code)) return;
+    }
+    std.debug.print("missing diagnostic `{s}` for `{s}`; got:\n", .{ code, source });
+    for (checked.diagnostics) |d| {
+        std.debug.print("  - {s}: {s}\n", .{ d.code, d.message });
+    }
+    return error.MissingDiagnosticCode;
+}
+
+// ---------- module reachability ----------
+
 test "typecheck/annotations: module compiles through the barrel" {
-    _ = gero.lang.typechecker.annotations;
+    _ = annotations;
+}
+
+// ---------- findAnnotationSpec (pure) ----------
+
+test "typecheck/annotations: findAnnotationSpec returns a spec for every documented annotation" {
+    inline for (.{
+        "bank",   "zero_page", "addr",       "volatile", "align",
+        "inline", "cold",      "no_capture", "noreturn", "interrupt",
+        "test",   "bench",     "override",   "final",    "abstract",
+        "static", "private",
+    }) |name| {
+        const spec = annotations.findAnnotationSpec(name);
+        try std.testing.expect(spec != null);
+        try std.testing.expectEqualStrings(name, spec.?.name);
+    }
+}
+
+test "typecheck/annotations: findAnnotationSpec returns null for unknown names" {
+    try std.testing.expect(annotations.findAnnotationSpec("not_a_real_annotation") == null);
+    try std.testing.expect(annotations.findAnnotationSpec("") == null);
+    // Case-sensitive lookup — `Bank` is not the same as `bank`.
+    try std.testing.expect(annotations.findAnnotationSpec("Bank") == null);
+}
+
+test "typecheck/annotations: annotation_specs table is self-consistent" {
+    // Every entry has a non-empty name and every name in `conflicts_with`
+    // resolves back through `findAnnotationSpec` — catches typos in the
+    // conflict-pair table.
+    for (&annotations.annotation_specs) |spec| {
+        try std.testing.expect(spec.name.len > 0);
+        for (spec.conflicts_with) |other| {
+            const peer = annotations.findAnnotationSpec(other);
+            try std.testing.expect(peer != null);
+        }
+    }
+}
+
+// ---------- targetLabel (pure) ----------
+
+test "typecheck/annotations: targetLabel maps each single-bit target to its lexeme" {
+    const T = annotations.T;
+    try std.testing.expectEqualStrings("let", annotations.targetLabel(T.LET));
+    try std.testing.expectEqualStrings("const", annotations.targetLabel(T.CONST));
+    try std.testing.expectEqualStrings("def", annotations.targetLabel(T.DEF));
+    try std.testing.expectEqualStrings("class", annotations.targetLabel(T.CLASS));
+    try std.testing.expectEqualStrings("struct", annotations.targetLabel(T.STRUCT));
+    try std.testing.expectEqualStrings("enum", annotations.targetLabel(T.ENUM));
+    try std.testing.expectEqualStrings("class field", annotations.targetLabel(T.CLASS_FIELD));
+}
+
+test "typecheck/annotations: targetLabel falls back to `decl` for unknown / combined bits" {
+    const T = annotations.T;
+    // Combined bits don't map cleanly to a single label.
+    try std.testing.expectEqualStrings("decl", annotations.targetLabel(T.LET | T.CONST));
+    // 0 and out-of-range bits also fall through.
+    try std.testing.expectEqualStrings("decl", annotations.targetLabel(0));
+    try std.testing.expectEqualStrings("decl", annotations.targetLabel(1 << 20));
+}
+
+// ---------- validateAnnotations: E_ANN_UNKNOWN ----------
+
+test "typecheck/annotations: unknown annotation on def errors with E_ANN_UNKNOWN" {
+    try expectCode(
+        \\@nope
+        \\def f()
+        \\end
+    , "E_ANN_UNKNOWN");
+}
+
+test "typecheck/annotations: unknown annotation on let errors with E_ANN_UNKNOWN" {
+    try expectCode(
+        \\@nope
+        \\let x: i16 = 0
+    , "E_ANN_UNKNOWN");
+}
+
+// ---------- validateAnnotations: E_ANN_BAD_TARGET ----------
+
+test "typecheck/annotations: @inline on let errors with E_ANN_BAD_TARGET" {
+    // `inline` is DEF-only.
+    try expectCode(
+        \\@inline
+        \\let x: i16 = 0
+    , "E_ANN_BAD_TARGET");
+}
+
+test "typecheck/annotations: @zero_page on def errors with E_ANN_BAD_TARGET" {
+    // `zero_page` is LET-only.
+    try expectCode(
+        \\@zero_page
+        \\def f()
+        \\end
+    , "E_ANN_BAD_TARGET");
+}
+
+test "typecheck/annotations: @bank on let accepts (multi-target spec)" {
+    // `bank` allows DEF | LET | CONST — exercises the multi-bit `targets`
+    // path positively so a regression that drops one bit gets caught.
+    try expectClean(
+        \\@bank 1
+        \\let x: i16 = 0
+    );
+}
+
+// ---------- validateAnnotationArgs: ArgRule.none ----------
+
+test "typecheck/annotations: marker annotation with args errors with E_ANN_BAD_ARG" {
+    try expectCode(
+        \\@inline 5
+        \\def f()
+        \\end
+    , "E_ANN_BAD_ARG");
+}
+
+// ---------- validateAnnotationArgs: ArgRule.int_lit ----------
+
+test "typecheck/annotations: @bank without args errors with E_ANN_BAD_ARG" {
+    try expectCode(
+        \\@bank
+        \\def f()
+        \\end
+    , "E_ANN_BAD_ARG");
+}
+
+test "typecheck/annotations: @bank with non-int-lit arg errors with E_ANN_BAD_ARG" {
+    try expectCode(
+        \\@bank "one"
+        \\def f()
+        \\end
+    , "E_ANN_BAD_ARG");
+}
+
+// ---------- validateAnnotationArgs: ArgRule.int_lit_pow2 ----------
+
+test "typecheck/annotations: @align with power-of-two value accepts" {
+    try expectClean(
+        \\@align 4
+        \\let x: i16 = 0
+    );
+}
+
+test "typecheck/annotations: @align with non-power-of-two errors with E_ANN_BAD_ARG" {
+    try expectCode(
+        \\@align 6
+        \\let x: i16 = 0
+    , "E_ANN_BAD_ARG");
+}
+
+test "typecheck/annotations: @align with zero errors with E_ANN_BAD_ARG" {
+    // The pow2 rule rejects 0 explicitly (`v <= 0` arm), even though
+    // bit-trick would accept it. Boundary check.
+    try expectCode(
+        \\@align 0
+        \\let x: i16 = 0
+    , "E_ANN_BAD_ARG");
+}
+
+test "typecheck/annotations: @align without args errors with E_ANN_BAD_ARG" {
+    try expectCode(
+        \\@align
+        \\let x: i16 = 0
+    , "E_ANN_BAD_ARG");
+}
+
+test "typecheck/annotations: @align with non-int-lit arg errors with E_ANN_BAD_ARG" {
+    try expectCode(
+        \\@align "8"
+        \\let x: i16 = 0
+    , "E_ANN_BAD_ARG");
+}
+
+// ---------- conflict detection ----------
+
+test "typecheck/annotations: @final + @override conflict errors with E_ANN_CONFLICT" {
+    try expectCode(
+        \\class A
+        \\  @final
+        \\  @override
+        \\  def m()
+        \\  end
+        \\end
+    , "E_ANN_CONFLICT");
+}
+
+test "typecheck/annotations: @abstract + @static conflict errors with E_ANN_CONFLICT" {
+    try expectCode(
+        \\class A
+        \\  @abstract
+        \\  @static
+        \\  def m()
+        \\  end
+        \\end
+    , "E_ANN_CONFLICT");
+}
+
+test "typecheck/annotations: @final alone on a def accepts" {
+    // Negative-of-conflict: lone @final emits no E_ANN_CONFLICT.
+    try expectClean(
+        \\class A
+        \\  @final
+        \\  def m()
+        \\  end
+        \\end
+    );
+}
+
+// ---------- defHasNoCapture (observed via E_ANN_CAPTURE_VIOLATION) ----------
+
+test "typecheck/annotations: defHasNoCapture true ⇒ @no_capture mutation flags E_ANN_CAPTURE_VIOLATION" {
+    // The predicate itself is one line; its observable effect is
+    // whether the checker arms the no-capture state for the body.
+    // A successful flag means `defHasNoCapture(d)` returned `true`
+    // for this def.
+    try expectCode(
+        \\@no_capture
+        \\def f()
+        \\  let x: i16 = 0
+        \\  let g = lambda ()
+        \\    x = x + 1
+        \\  end
+        \\end
+    , "E_ANN_CAPTURE_VIOLATION");
+}
+
+test "typecheck/annotations: defHasNoCapture false ⇒ same body accepts without the annotation" {
+    // Without `@no_capture`, the same closure shape must clean —
+    // confirms `defHasNoCapture` is reading the annotation list and
+    // not unconditionally arming the flag.
+    try expectClean(
+        \\def f()
+        \\  let x: i16 = 0
+        \\  let g = lambda ()
+        \\    x = x + 1
+        \\  end
+        \\end
+    );
 }

--- a/tests/lang/typecheck/annotations.test.zig
+++ b/tests/lang/typecheck/annotations.test.zig
@@ -1,0 +1,8 @@
+/// Mirror-layout placeholder. Real coverage of annotation
+/// validation — unknown / bad-target / bad-arg / pow2 / conflict
+/// arms — is gero-qa's design space.
+const gero = @import("gero");
+
+test "typecheck/annotations: module compiles through the barrel" {
+    _ = gero.lang.typechecker.annotations;
+}

--- a/tests/lang/typecheck/annotations.test.zig
+++ b/tests/lang/typecheck/annotations.test.zig
@@ -10,7 +10,7 @@
 const std = @import("std");
 const gero = @import("gero");
 
-const annotations = gero.lang.typechecker.annotations;
+const annotations = gero.lang.typechecker.internal.annotations;
 const alloc = std.testing.allocator;
 
 // ---------- E2E helpers ----------

--- a/tests/lang/typecheck/annotations.test.zig
+++ b/tests/lang/typecheck/annotations.test.zig
@@ -10,7 +10,7 @@
 const std = @import("std");
 const gero = @import("gero");
 
-const annotations = gero.lang.typechecker.internal.annotations;
+const annotations = gero.lang.internal.typechecker.annotations;
 const alloc = std.testing.allocator;
 
 // ---------- E2E helpers ----------

--- a/tests/lang/typecheck/flow.test.zig
+++ b/tests/lang/typecheck/flow.test.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const gero = @import("gero");
 
-const flow = gero.lang.typechecker.internal.flow;
+const flow = gero.lang.internal.typechecker.flow;
 const ast = gero.lang.ast;
 const types = gero.lang.types;
 

--- a/tests/lang/typecheck/flow.test.zig
+++ b/tests/lang/typecheck/flow.test.zig
@@ -1,7 +1,281 @@
-/// Mirror-layout placeholder. Behavior coverage is gero-qa's
-/// design space.
+/// Specs for `typecheck/flow` — the heterogeneous bag of helpers
+/// for flow-sensitive inference and decl resolution. Pure helpers
+/// over plain AST / type values (`bodyAlwaysExits`, `namedNameOf`)
+/// get direct unit calls; the Checker-dependent helpers
+/// (`identName`, `findStructField`, `findClassField`) ride the
+/// E2E surface, observing their effects through the diagnostics
+/// they enable / suppress.
+const std = @import("std");
 const gero = @import("gero");
 
+const flow = gero.lang.typechecker.flow;
+const ast = gero.lang.ast;
+const types = gero.lang.types;
+
+const alloc = std.testing.allocator;
+
+// ---------- E2E helpers ----------
+
+fn expectClean(source: []const u8) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tree.errors.len);
+
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+    if (checked.diagnostics.len > 0) {
+        std.debug.print("unexpected typecheck diagnostics for `{s}`:\n", .{source});
+        for (checked.diagnostics) |d| std.debug.print("  - {s}: {s}\n", .{ d.code, d.message });
+    }
+    try std.testing.expectEqual(@as(usize, 0), checked.diagnostics.len);
+}
+
+fn expectCode(source: []const u8, code: []const u8) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    for (checked.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, code)) return;
+    }
+    std.debug.print("missing diagnostic `{s}` for `{s}`; got:\n", .{ code, source });
+    for (checked.diagnostics) |d| {
+        std.debug.print("  - {s}: {s}\n", .{ d.code, d.message });
+    }
+    return error.MissingDiagnosticCode;
+}
+
+// ---------- module reachability ----------
+
 test "typecheck/flow: module compiles through the barrel" {
-    _ = gero.lang.typechecker.flow;
+    _ = flow;
+}
+
+// ---------- bodyAlwaysExits (pure over AST) ----------
+
+test "typecheck/flow: bodyAlwaysExits returns false for empty body" {
+    const empty: []const ast.Statement = &.{};
+    try std.testing.expect(!flow.bodyAlwaysExits(empty));
+}
+
+test "typecheck/flow: bodyAlwaysExits returns true when last statement is return" {
+    const stmts = [_]ast.Statement{
+        .{ .return_stmt = .{ .value = null, .span = .{ .start = 0, .end = 6 } } },
+    };
+    try std.testing.expect(flow.bodyAlwaysExits(&stmts));
+}
+
+test "typecheck/flow: bodyAlwaysExits returns true when last statement is break" {
+    const stmts = [_]ast.Statement{
+        .{ .break_stmt = .{ .label = null, .span = .{ .start = 0, .end = 5 } } },
+    };
+    try std.testing.expect(flow.bodyAlwaysExits(&stmts));
+}
+
+test "typecheck/flow: bodyAlwaysExits returns true when last statement is continue" {
+    const stmts = [_]ast.Statement{
+        .{ .continue_stmt = .{ .label = null, .span = .{ .start = 0, .end = 8 } } },
+    };
+    try std.testing.expect(flow.bodyAlwaysExits(&stmts));
+}
+
+test "typecheck/flow: bodyAlwaysExits returns false when last statement is non-exit" {
+    // Statement-expr (a fallthrough) — last statement isn't a flow
+    // terminator, so body doesn't exit.
+    var dummy_ident = ast.Expr{ .ident = .{ .span = .{ .start = 0, .end = 1 } } };
+    const stmts = [_]ast.Statement{
+        .{ .expr_stmt = .{ .expr = &dummy_ident, .span = .{ .start = 0, .end = 1 } } },
+    };
+    try std.testing.expect(!flow.bodyAlwaysExits(&stmts));
+}
+
+test "typecheck/flow: bodyAlwaysExits inspects only the last statement" {
+    // Earlier statements that exit don't matter — only the tail counts.
+    // A body that returns at index 0 then runs a non-exit statement is
+    // dead-code, but bodyAlwaysExits reports false because the tail is
+    // not an exit.
+    var dummy_ident = ast.Expr{ .ident = .{ .span = .{ .start = 0, .end = 1 } } };
+    const stmts = [_]ast.Statement{
+        .{ .return_stmt = .{ .value = null, .span = .{ .start = 0, .end = 6 } } },
+        .{ .expr_stmt = .{ .expr = &dummy_ident, .span = .{ .start = 0, .end = 1 } } },
+    };
+    try std.testing.expect(!flow.bodyAlwaysExits(&stmts));
+}
+
+// ---------- bodyAlwaysExits (observable E2E effect) ----------
+
+test "typecheck/flow: deref after `if x == nil then return end` accepts (bodyAlwaysExits=true on if-body)" {
+    // The fall-through detector consults bodyAlwaysExits on the
+    // if-body to decide whether the deref past the if is reachable
+    // with `s` proven non-nil.
+    try expectClean(
+        \\def f(s: str?)
+        \\  if s == nil
+        \\    return
+        \\  end
+        \\  let n = s.len
+        \\end
+    );
+}
+
+test "typecheck/flow: deref after `if x == nil` with no exit errors with E_NULL_DEREF" {
+    // bodyAlwaysExits=false ⇒ control may fall through with `s` still
+    // possibly nil ⇒ the post-if deref must reject.
+    try expectCode(
+        \\def f(s: str?)
+        \\  if s == nil
+        \\    let x = 0
+        \\  end
+        \\  let n = s.len
+        \\end
+    , "E_NULL_DEREF");
+}
+
+// ---------- namedNameOf (pure over types.Type) ----------
+
+test "typecheck/flow: namedNameOf returns the lexeme for a named type" {
+    const t = types.Type{ .named = .{ .name = "Player", .span = .{ .start = 0, .end = 6 } } };
+    try std.testing.expectEqualStrings("Player", flow.namedNameOf(t).?);
+}
+
+test "typecheck/flow: namedNameOf returns null for non-named types" {
+    try std.testing.expect(flow.namedNameOf(.{ .primitive = .i16 }) == null);
+
+    const inner = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(inner);
+    try std.testing.expect(flow.namedNameOf(.{ .vec = inner }) == null);
+    try std.testing.expect(flow.namedNameOf(.{ .reference = inner }) == null);
+    try std.testing.expect(flow.namedNameOf(.{ .optional = inner }) == null);
+    try std.testing.expect(flow.namedNameOf(.{ .array = .{ .elem = inner, .len = 4 } }) == null);
+}
+
+// ---------- identName (observable through nil-check pattern) ----------
+
+test "typecheck/flow: identName matches bare ident — `if x == nil then return end` proves x non-nil" {
+    // identName must extract `s` from the bare-ident lhs of `s == nil`
+    // for the nil-narrowing flow analysis to register. If it returned
+    // null here, the post-if deref would error.
+    try expectClean(
+        \\def f(s: str?)
+        \\  if s == nil
+        \\    return
+        \\  end
+        \\  print s.len
+        \\end
+    );
+}
+
+test "typecheck/flow: identName unwraps `paren` — `(s) == nil` still narrows" {
+    // The paren-unwrap branch of identName must let `(s)` flow through.
+    try expectClean(
+        \\def f(s: str?)
+        \\  if (s) == nil
+        \\    return
+        \\  end
+        \\  print s.len
+        \\end
+    );
+}
+
+// ---------- findStructField (observable through field access + literal) ----------
+
+test "typecheck/flow: findStructField hit — `s.hp` on known field accepts" {
+    try expectClean(
+        \\struct Stats
+        \\  hp: i16
+        \\  mp: i16
+        \\end
+        \\
+        \\let s = Stats { hp: 10, mp: 5 }
+        \\let x = s.hp
+    );
+}
+
+test "typecheck/flow: findStructField miss on field access errors with E_TYPE_UNDEFINED_FIELD" {
+    try expectCode(
+        \\struct Stats
+        \\  hp: i16
+        \\end
+        \\
+        \\let s = Stats { hp: 0 }
+        \\let x = s.bogus
+    , "E_TYPE_UNDEFINED_FIELD");
+}
+
+test "typecheck/flow: findStructField miss on struct literal field errors with E_TYPE_UNDEFINED_FIELD" {
+    // The struct-literal path also walks findStructField to validate
+    // each key — a typo there must surface.
+    try expectCode(
+        \\struct Stats
+        \\  hp: i16
+        \\end
+        \\
+        \\let s = Stats { hp: 0, foo: 1 }
+    , "E_TYPE_UNDEFINED_FIELD");
+}
+
+// ---------- findClassField (observable via self.<field> resolution) ----------
+
+test "typecheck/flow: findClassField hit on own field accepts" {
+    try expectClean(
+        \\class Player
+        \\  let hp: i16
+        \\
+        \\  def get_hp(self) -> i16
+        \\    return self.hp
+        \\  end
+        \\end
+    );
+}
+
+test "typecheck/flow: findClassField walks the inheritance chain — inherited field resolves" {
+    try expectClean(
+        \\class Entity
+        \\  let hp: i16
+        \\end
+        \\
+        \\class Player extends Entity
+        \\  let mp: i16
+        \\
+        \\  def total(self) -> i16
+        \\    return self.hp + self.mp
+        \\  end
+        \\end
+    );
+}
+
+test "typecheck/flow: findClassField miss on unknown field errors with E_TYPE_UNDEFINED_FIELD" {
+    try expectCode(
+        \\class Player
+        \\  let hp: i16
+        \\
+        \\  def bad(self) -> i16
+        \\    return self.bogus
+        \\  end
+        \\end
+    , "E_TYPE_UNDEFINED_FIELD");
+}
+
+test "typecheck/flow: findClassField miss after walking the chain errors with E_TYPE_UNDEFINED_FIELD" {
+    // Field exists on neither the class nor its parent — recursion
+    // terminates with null, surfaces as undefined-field.
+    try expectCode(
+        \\class Entity
+        \\  let hp: i16
+        \\end
+        \\
+        \\class Player extends Entity
+        \\  let mp: i16
+        \\
+        \\  def bad(self) -> i16
+        \\    return self.bogus
+        \\  end
+        \\end
+    , "E_TYPE_UNDEFINED_FIELD");
 }

--- a/tests/lang/typecheck/flow.test.zig
+++ b/tests/lang/typecheck/flow.test.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const gero = @import("gero");
 
-const flow = gero.lang.typechecker.flow;
+const flow = gero.lang.typechecker.internal.flow;
 const ast = gero.lang.ast;
 const types = gero.lang.types;
 

--- a/tests/lang/typecheck/flow.test.zig
+++ b/tests/lang/typecheck/flow.test.zig
@@ -1,0 +1,7 @@
+/// Mirror-layout placeholder. Behavior coverage is gero-qa's
+/// design space.
+const gero = @import("gero");
+
+test "typecheck/flow: module compiles through the barrel" {
+    _ = gero.lang.typechecker.flow;
+}

--- a/tests/lang/typecheck/match.test.zig
+++ b/tests/lang/typecheck/match.test.zig
@@ -6,15 +6,15 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "typecheck/match: module compiles through the barrel" {
-    _ = gero.lang.typechecker.internal.match;
+    _ = gero.lang.internal.typechecker.match;
 }
 
 test "typecheck/match: splitPath splits `Enum.Variant` correctly" {
-    const result = gero.lang.typechecker.internal.match.splitPath("Color.Red");
+    const result = gero.lang.internal.typechecker.match.splitPath("Color.Red");
     try std.testing.expectEqualStrings("Color", result.head);
     try std.testing.expectEqualStrings("Red", result.tail);
 
-    const no_dot = gero.lang.typechecker.internal.match.splitPath("Lone");
+    const no_dot = gero.lang.internal.typechecker.match.splitPath("Lone");
     try std.testing.expectEqualStrings("", no_dot.head);
     try std.testing.expectEqualStrings("Lone", no_dot.tail);
 }

--- a/tests/lang/typecheck/match.test.zig
+++ b/tests/lang/typecheck/match.test.zig
@@ -6,15 +6,15 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "typecheck/match: module compiles through the barrel" {
-    _ = gero.lang.typechecker.match;
+    _ = gero.lang.typechecker.internal.match;
 }
 
 test "typecheck/match: splitPath splits `Enum.Variant` correctly" {
-    const result = gero.lang.typechecker.match.splitPath("Color.Red");
+    const result = gero.lang.typechecker.internal.match.splitPath("Color.Red");
     try std.testing.expectEqualStrings("Color", result.head);
     try std.testing.expectEqualStrings("Red", result.tail);
 
-    const no_dot = gero.lang.typechecker.match.splitPath("Lone");
+    const no_dot = gero.lang.typechecker.internal.match.splitPath("Lone");
     try std.testing.expectEqualStrings("", no_dot.head);
     try std.testing.expectEqualStrings("Lone", no_dot.tail);
 }

--- a/tests/lang/typecheck/mem_builtin.test.zig
+++ b/tests/lang/typecheck/mem_builtin.test.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "typecheck/mem_builtin: module compiles through the barrel" {
-    _ = gero.lang.typechecker.mem_builtin;
+    _ = gero.lang.typechecker.internal.mem_builtin;
 }
 
 test "typecheck/mem_builtin: lookupMemBuiltin recognizes every entry" {
@@ -18,7 +18,7 @@ test "typecheck/mem_builtin: lookupMemBuiltin recognizes every entry" {
         "addr_of",
     };
     for (names) |name| {
-        try std.testing.expect(gero.lang.typechecker.mem_builtin.lookupMemBuiltin(name) != null);
+        try std.testing.expect(gero.lang.typechecker.internal.mem_builtin.lookupMemBuiltin(name) != null);
     }
-    try std.testing.expect(gero.lang.typechecker.mem_builtin.lookupMemBuiltin("nonexistent") == null);
+    try std.testing.expect(gero.lang.typechecker.internal.mem_builtin.lookupMemBuiltin("nonexistent") == null);
 }

--- a/tests/lang/typecheck/mem_builtin.test.zig
+++ b/tests/lang/typecheck/mem_builtin.test.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const gero = @import("gero");
 
 test "typecheck/mem_builtin: module compiles through the barrel" {
-    _ = gero.lang.typechecker.internal.mem_builtin;
+    _ = gero.lang.internal.typechecker.mem_builtin;
 }
 
 test "typecheck/mem_builtin: lookupMemBuiltin recognizes every entry" {
@@ -18,7 +18,7 @@ test "typecheck/mem_builtin: lookupMemBuiltin recognizes every entry" {
         "addr_of",
     };
     for (names) |name| {
-        try std.testing.expect(gero.lang.typechecker.internal.mem_builtin.lookupMemBuiltin(name) != null);
+        try std.testing.expect(gero.lang.internal.typechecker.mem_builtin.lookupMemBuiltin(name) != null);
     }
-    try std.testing.expect(gero.lang.typechecker.internal.mem_builtin.lookupMemBuiltin("nonexistent") == null);
+    try std.testing.expect(gero.lang.internal.typechecker.mem_builtin.lookupMemBuiltin("nonexistent") == null);
 }

--- a/tests/lang/typecheck/predicates.test.zig
+++ b/tests/lang/typecheck/predicates.test.zig
@@ -6,14 +6,14 @@
 const std = @import("std");
 const gero = @import("gero");
 
-const predicates = gero.lang.typechecker.predicates;
+const predicates = gero.lang.typechecker.internal.predicates;
 const types = gero.lang.types;
 const ast = gero.lang.ast;
 
 const alloc = std.testing.allocator;
 
 test "typecheck/predicates: module compiles through the barrel" {
-    _ = gero.lang.typechecker.predicates;
+    _ = gero.lang.typechecker.internal.predicates;
 }
 
 // ---------- isIntegerPrimitive ----------

--- a/tests/lang/typecheck/predicates.test.zig
+++ b/tests/lang/typecheck/predicates.test.zig
@@ -6,14 +6,14 @@
 const std = @import("std");
 const gero = @import("gero");
 
-const predicates = gero.lang.typechecker.internal.predicates;
+const predicates = gero.lang.internal.typechecker.predicates;
 const types = gero.lang.types;
 const ast = gero.lang.ast;
 
 const alloc = std.testing.allocator;
 
 test "typecheck/predicates: module compiles through the barrel" {
-    _ = gero.lang.typechecker.internal.predicates;
+    _ = gero.lang.internal.typechecker.predicates;
 }
 
 // ---------- isIntegerPrimitive ----------

--- a/tests/lang/typecheck/predicates.test.zig
+++ b/tests/lang/typecheck/predicates.test.zig
@@ -1,0 +1,31 @@
+/// Smoke that the `predicates` typecheck sub-module is reachable
+/// through the public barrel. Concrete behavior coverage —
+/// integer/numeric arms, `bakeable` recursion, op-lexeme table
+/// completeness — lives in `tests/lang/typecheck.test.zig` and is
+/// filled in by gero-qa.
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/predicates: module compiles through the barrel" {
+    _ = gero.lang.typechecker.predicates;
+}
+
+test "typecheck/predicates: isIntegerPrimitive accepts every integer width" {
+    _ = std.testing.expect; // placeholder — gero-qa fills the case
+}
+
+test "typecheck/predicates: isNumericType includes fixed but excludes bool" {
+    _ = std.testing.expect; // placeholder — gero-qa fills the case
+}
+
+test "typecheck/predicates: isBakeableType rejects vec / reference / function" {
+    _ = std.testing.expect; // placeholder — gero-qa fills the case
+}
+
+test "typecheck/predicates: intLitFits enforces signed and unsigned bounds" {
+    _ = std.testing.expect; // placeholder — gero-qa fills the case
+}
+
+test "typecheck/predicates: opLexeme covers every BinaryOp variant" {
+    _ = std.testing.expect; // placeholder — gero-qa fills the case
+}

--- a/tests/lang/typecheck/predicates.test.zig
+++ b/tests/lang/typecheck/predicates.test.zig
@@ -1,31 +1,313 @@
-/// Smoke that the `predicates` typecheck sub-module is reachable
-/// through the public barrel. Concrete behavior coverage —
-/// integer/numeric arms, `bakeable` recursion, op-lexeme table
-/// completeness — lives in `tests/lang/typecheck.test.zig` and is
-/// filled in by gero-qa.
+/// Specs for the pure `typecheck/predicates` sub-module — happy +
+/// failure path per fallible predicate. Concrete behavior coverage
+/// (integer/numeric arms, `bakeable` recursion, op-lexeme table
+/// completeness) lives here; integration coverage is in
+/// `tests/lang/typecheck.test.zig`.
 const std = @import("std");
 const gero = @import("gero");
+
+const predicates = gero.lang.typechecker.predicates;
+const types = gero.lang.types;
+const ast = gero.lang.ast;
+
+const alloc = std.testing.allocator;
 
 test "typecheck/predicates: module compiles through the barrel" {
     _ = gero.lang.typechecker.predicates;
 }
 
+// ---------- isIntegerPrimitive ----------
+
 test "typecheck/predicates: isIntegerPrimitive accepts every integer width" {
-    _ = std.testing.expect; // placeholder — gero-qa fills the case
+    try std.testing.expect(predicates.isIntegerPrimitive(.i8));
+    try std.testing.expect(predicates.isIntegerPrimitive(.u8));
+    try std.testing.expect(predicates.isIntegerPrimitive(.i16));
+    try std.testing.expect(predicates.isIntegerPrimitive(.u16));
 }
 
+test "typecheck/predicates: isIntegerPrimitive rejects non-integer primitives" {
+    try std.testing.expect(!predicates.isIntegerPrimitive(.fixed));
+    try std.testing.expect(!predicates.isIntegerPrimitive(.bool_));
+    try std.testing.expect(!predicates.isIntegerPrimitive(.nil_));
+    try std.testing.expect(!predicates.isIntegerPrimitive(.str));
+    try std.testing.expect(!predicates.isIntegerPrimitive(.char));
+}
+
+// ---------- isIntegerType ----------
+
+test "typecheck/predicates: isIntegerType is true for integer primitives" {
+    try std.testing.expect(predicates.isIntegerType(.{ .primitive = .i8 }));
+    try std.testing.expect(predicates.isIntegerType(.{ .primitive = .u8 }));
+    try std.testing.expect(predicates.isIntegerType(.{ .primitive = .i16 }));
+    try std.testing.expect(predicates.isIntegerType(.{ .primitive = .u16 }));
+}
+
+test "typecheck/predicates: isIntegerType rejects fixed and other primitives" {
+    try std.testing.expect(!predicates.isIntegerType(.{ .primitive = .fixed }));
+    try std.testing.expect(!predicates.isIntegerType(.{ .primitive = .bool_ }));
+    try std.testing.expect(!predicates.isIntegerType(.{ .primitive = .str }));
+}
+
+test "typecheck/predicates: isIntegerType rejects aggregate and reference shapes" {
+    const elem = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(elem);
+    const arr = types.Type{ .array = .{ .elem = elem, .len = 4 } };
+    try std.testing.expect(!predicates.isIntegerType(arr));
+
+    const vec = types.Type{ .vec = elem };
+    try std.testing.expect(!predicates.isIntegerType(vec));
+
+    const ref = types.Type{ .reference = elem };
+    try std.testing.expect(!predicates.isIntegerType(ref));
+
+    const opt = types.Type{ .optional = elem };
+    try std.testing.expect(!predicates.isIntegerType(opt));
+
+    const named = types.Type{ .named = .{ .name = "Player", .span = .{ .start = 0, .end = 6 } } };
+    try std.testing.expect(!predicates.isIntegerType(named));
+}
+
+// ---------- isNumericType ----------
+
 test "typecheck/predicates: isNumericType includes fixed but excludes bool" {
-    _ = std.testing.expect; // placeholder — gero-qa fills the case
+    try std.testing.expect(predicates.isNumericType(.{ .primitive = .i8 }));
+    try std.testing.expect(predicates.isNumericType(.{ .primitive = .u8 }));
+    try std.testing.expect(predicates.isNumericType(.{ .primitive = .i16 }));
+    try std.testing.expect(predicates.isNumericType(.{ .primitive = .u16 }));
+    try std.testing.expect(predicates.isNumericType(.{ .primitive = .fixed }));
+
+    try std.testing.expect(!predicates.isNumericType(.{ .primitive = .bool_ }));
+    try std.testing.expect(!predicates.isNumericType(.{ .primitive = .nil_ }));
+    try std.testing.expect(!predicates.isNumericType(.{ .primitive = .str }));
+    try std.testing.expect(!predicates.isNumericType(.{ .primitive = .char }));
+}
+
+test "typecheck/predicates: isNumericType rejects non-primitive shapes" {
+    const elem = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(elem);
+    const vec = types.Type{ .vec = elem };
+    try std.testing.expect(!predicates.isNumericType(vec));
+}
+
+// ---------- isBoolType ----------
+
+test "typecheck/predicates: isBoolType accepts bool, rejects others" {
+    try std.testing.expect(predicates.isBoolType(.{ .primitive = .bool_ }));
+
+    try std.testing.expect(!predicates.isBoolType(.{ .primitive = .i16 }));
+    try std.testing.expect(!predicates.isBoolType(.{ .primitive = .nil_ }));
+    try std.testing.expect(!predicates.isBoolType(.{ .primitive = .str }));
+}
+
+test "typecheck/predicates: isBoolType rejects non-primitive shapes" {
+    const inner = try types.mkPrimitive(alloc, .bool_);
+    defer alloc.destroy(inner);
+    const opt = types.Type{ .optional = inner };
+    try std.testing.expect(!predicates.isBoolType(opt));
+}
+
+// ---------- isStrType ----------
+
+test "typecheck/predicates: isStrType accepts str, rejects others" {
+    try std.testing.expect(predicates.isStrType(.{ .primitive = .str }));
+
+    try std.testing.expect(!predicates.isStrType(.{ .primitive = .char }));
+    try std.testing.expect(!predicates.isStrType(.{ .primitive = .i16 }));
+    try std.testing.expect(!predicates.isStrType(.{ .primitive = .bool_ }));
+}
+
+test "typecheck/predicates: isStrType rejects optional/reference wrappers around str" {
+    const inner = try types.mkPrimitive(alloc, .str);
+    defer alloc.destroy(inner);
+    const opt = types.Type{ .optional = inner };
+    try std.testing.expect(!predicates.isStrType(opt));
+    const ref = types.Type{ .reference = inner };
+    try std.testing.expect(!predicates.isStrType(ref));
+}
+
+// ---------- isNilType ----------
+
+test "typecheck/predicates: isNilType accepts nil, rejects others" {
+    try std.testing.expect(predicates.isNilType(.{ .primitive = .nil_ }));
+
+    try std.testing.expect(!predicates.isNilType(.{ .primitive = .bool_ }));
+    try std.testing.expect(!predicates.isNilType(.{ .primitive = .i16 }));
+    try std.testing.expect(!predicates.isNilType(.{ .primitive = .str }));
+}
+
+test "typecheck/predicates: isNilType does not propagate through optional" {
+    // An `optional` wrapping nil isn't itself nil — the predicate
+    // matches only the bare nil primitive, used by nil-equality and
+    // nil-propagation paths.
+    const inner = try types.mkPrimitive(alloc, .nil_);
+    defer alloc.destroy(inner);
+    const opt = types.Type{ .optional = inner };
+    try std.testing.expect(!predicates.isNilType(opt));
+}
+
+// ---------- isBakeableType ----------
+
+test "typecheck/predicates: isBakeableType accepts every primitive" {
+    inline for (.{ .i8, .u8, .i16, .u16, .bool_, .nil_, .str, .fixed, .char }) |p| {
+        try std.testing.expect(predicates.isBakeableType(.{ .primitive = p }));
+    }
+}
+
+test "typecheck/predicates: isBakeableType accepts named types" {
+    const named = types.Type{ .named = .{ .name = "Color", .span = .{ .start = 0, .end = 5 } } };
+    try std.testing.expect(predicates.isBakeableType(named));
 }
 
 test "typecheck/predicates: isBakeableType rejects vec / reference / function" {
-    _ = std.testing.expect; // placeholder — gero-qa fills the case
+    const elem = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(elem);
+    const vec = types.Type{ .vec = elem };
+    try std.testing.expect(!predicates.isBakeableType(vec));
+
+    const ref = types.Type{ .reference = elem };
+    try std.testing.expect(!predicates.isBakeableType(ref));
+
+    const fun = types.Type{ .function = .{ .params = &.{}, .ret = elem } };
+    try std.testing.expect(!predicates.isBakeableType(fun));
 }
 
-test "typecheck/predicates: intLitFits enforces signed and unsigned bounds" {
-    _ = std.testing.expect; // placeholder — gero-qa fills the case
+test "typecheck/predicates: isBakeableType recurses into array and propagates non-bakeable" {
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+    const arr_ok = types.Type{ .array = .{ .elem = u8t, .len = 8 } };
+    try std.testing.expect(predicates.isBakeableType(arr_ok));
+
+    // [Vec(u8); 4] — non-bakeable element ⇒ non-bakeable array.
+    const inner_vec = types.Type{ .vec = u8t };
+    const arr_bad = types.Type{ .array = .{ .elem = &inner_vec, .len = 4 } };
+    try std.testing.expect(!predicates.isBakeableType(arr_bad));
 }
+
+test "typecheck/predicates: isBakeableType recurses into tuple — fails on first non-bakeable elem" {
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+    const i16t = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(i16t);
+
+    const tup_ok_elems = [_]*const types.Type{ u8t, i16t };
+    const tup_ok = types.Type{ .tuple = &tup_ok_elems };
+    try std.testing.expect(predicates.isBakeableType(tup_ok));
+
+    // (u8, Vec(u8)) — second element non-bakeable ⇒ tuple non-bakeable.
+    const inner_vec = types.Type{ .vec = u8t };
+    const tup_bad_elems = [_]*const types.Type{ u8t, &inner_vec };
+    const tup_bad = types.Type{ .tuple = &tup_bad_elems };
+    try std.testing.expect(!predicates.isBakeableType(tup_bad));
+}
+
+test "typecheck/predicates: isBakeableType recurses into optional" {
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+    const opt_ok = types.Type{ .optional = u8t };
+    try std.testing.expect(predicates.isBakeableType(opt_ok));
+
+    const inner_vec = types.Type{ .vec = u8t };
+    const opt_bad = types.Type{ .optional = &inner_vec };
+    try std.testing.expect(!predicates.isBakeableType(opt_bad));
+}
+
+// ---------- primitiveName ----------
+
+test "typecheck/predicates: primitiveName covers every primitive variant" {
+    try std.testing.expectEqualStrings("i8", predicates.primitiveName(.i8));
+    try std.testing.expectEqualStrings("u8", predicates.primitiveName(.u8));
+    try std.testing.expectEqualStrings("i16", predicates.primitiveName(.i16));
+    try std.testing.expectEqualStrings("u16", predicates.primitiveName(.u16));
+    try std.testing.expectEqualStrings("bool", predicates.primitiveName(.bool_));
+    try std.testing.expectEqualStrings("nil", predicates.primitiveName(.nil_));
+    try std.testing.expectEqualStrings("str", predicates.primitiveName(.str));
+    try std.testing.expectEqualStrings("fixed", predicates.primitiveName(.fixed));
+    try std.testing.expectEqualStrings("char", predicates.primitiveName(.char));
+}
+
+// ---------- intLitFits ----------
+
+test "typecheck/predicates: intLitFits accepts in-range values for every integer width" {
+    try std.testing.expect(predicates.intLitFits(0, .i8));
+    try std.testing.expect(predicates.intLitFits(-128, .i8));
+    try std.testing.expect(predicates.intLitFits(127, .i8));
+
+    try std.testing.expect(predicates.intLitFits(0, .u8));
+    try std.testing.expect(predicates.intLitFits(255, .u8));
+
+    try std.testing.expect(predicates.intLitFits(-32768, .i16));
+    try std.testing.expect(predicates.intLitFits(32767, .i16));
+
+    try std.testing.expect(predicates.intLitFits(0, .u16));
+    try std.testing.expect(predicates.intLitFits(65535, .u16));
+}
+
+test "typecheck/predicates: intLitFits rejects i8 overflow on both sides" {
+    try std.testing.expect(!predicates.intLitFits(128, .i8));
+    try std.testing.expect(!predicates.intLitFits(-129, .i8));
+}
+
+test "typecheck/predicates: intLitFits rejects u8 overflow and negative values" {
+    try std.testing.expect(!predicates.intLitFits(256, .u8));
+    try std.testing.expect(!predicates.intLitFits(-1, .u8));
+}
+
+test "typecheck/predicates: intLitFits rejects i16 overflow on both sides" {
+    try std.testing.expect(!predicates.intLitFits(32768, .i16));
+    try std.testing.expect(!predicates.intLitFits(-32769, .i16));
+}
+
+test "typecheck/predicates: intLitFits rejects u16 overflow and negative values" {
+    try std.testing.expect(!predicates.intLitFits(65536, .u16));
+    try std.testing.expect(!predicates.intLitFits(-1, .u16));
+}
+
+test "typecheck/predicates: intLitFits returns false for non-integer primitives" {
+    // Documented contract: only meaningful for the four integer
+    // primitives. Everything else returns false even for value 0.
+    try std.testing.expect(!predicates.intLitFits(0, .bool_));
+    try std.testing.expect(!predicates.intLitFits(0, .nil_));
+    try std.testing.expect(!predicates.intLitFits(0, .str));
+    try std.testing.expect(!predicates.intLitFits(0, .fixed));
+    try std.testing.expect(!predicates.intLitFits(0, .char));
+}
+
+test "typecheck/predicates: intLitFits handles i32 extremes safely" {
+    // Boundary safety — predicate accepts an i32 input, so the
+    // largest and smallest legal i32 values must produce `false`
+    // without overflowing the comparison.
+    try std.testing.expect(!predicates.intLitFits(std.math.maxInt(i32), .u16));
+    try std.testing.expect(!predicates.intLitFits(std.math.minInt(i32), .i16));
+}
+
+// ---------- opLexeme ----------
 
 test "typecheck/predicates: opLexeme covers every BinaryOp variant" {
-    _ = std.testing.expect; // placeholder — gero-qa fills the case
+    try std.testing.expectEqualStrings("`+`", predicates.opLexeme(.add));
+    try std.testing.expectEqualStrings("`-`", predicates.opLexeme(.sub));
+    try std.testing.expectEqualStrings("`*`", predicates.opLexeme(.mul));
+    try std.testing.expectEqualStrings("`/`", predicates.opLexeme(.div));
+    try std.testing.expectEqualStrings("`%`", predicates.opLexeme(.mod));
+    try std.testing.expectEqualStrings("`<<`", predicates.opLexeme(.shl));
+    try std.testing.expectEqualStrings("`>>`", predicates.opLexeme(.shr));
+    try std.testing.expectEqualStrings("`&`", predicates.opLexeme(.bit_and));
+    try std.testing.expectEqualStrings("`|`", predicates.opLexeme(.bit_or));
+    try std.testing.expectEqualStrings("`^`", predicates.opLexeme(.bit_xor));
+    try std.testing.expectEqualStrings("`==`", predicates.opLexeme(.eq));
+    try std.testing.expectEqualStrings("`!=`", predicates.opLexeme(.neq));
+    try std.testing.expectEqualStrings("`<`", predicates.opLexeme(.lt));
+    try std.testing.expectEqualStrings("`<=`", predicates.opLexeme(.lte));
+    try std.testing.expectEqualStrings("`>`", predicates.opLexeme(.gt));
+    try std.testing.expectEqualStrings("`>=`", predicates.opLexeme(.gte));
+    try std.testing.expectEqualStrings("`and`", predicates.opLexeme(.log_and));
+    try std.testing.expectEqualStrings("`or`", predicates.opLexeme(.log_or));
+}
+
+test "typecheck/predicates: opLexeme table is exhaustive — sanity-check by enum field count" {
+    // If a new BinaryOp variant is added without a lexeme entry,
+    // Zig's exhaustive switch in `opLexeme` won't compile and this
+    // test will fail to build. The count guard catches the inverse:
+    // a stale spec that hasn't been updated when a variant is added.
+    const variant_count = @typeInfo(ast.BinaryOp).@"enum".fields.len;
+    try std.testing.expectEqual(@as(usize, 18), variant_count);
 }

--- a/tests/lang/typecheck/relations.test.zig
+++ b/tests/lang/typecheck/relations.test.zig
@@ -7,7 +7,7 @@
 const std = @import("std");
 const gero = @import("gero");
 
-const relations = gero.lang.typechecker.internal.relations;
+const relations = gero.lang.internal.typechecker.relations;
 const types = gero.lang.types;
 
 const alloc = std.testing.allocator;

--- a/tests/lang/typecheck/relations.test.zig
+++ b/tests/lang/typecheck/relations.test.zig
@@ -7,7 +7,7 @@
 const std = @import("std");
 const gero = @import("gero");
 
-const relations = gero.lang.typechecker.relations;
+const relations = gero.lang.typechecker.internal.relations;
 const types = gero.lang.types;
 
 const alloc = std.testing.allocator;

--- a/tests/lang/typecheck/relations.test.zig
+++ b/tests/lang/typecheck/relations.test.zig
@@ -1,7 +1,267 @@
-/// Mirror-layout placeholder. Behavior coverage is gero-qa's
-/// design space.
+/// Specs for `typecheck/relations` — `assignable` and `canCast`.
+/// Both are pure functions over `types.Type` pairs with no
+/// `Checker` state, so every spec is a direct unit call. Covers
+/// the structural-assignability matrix (primitive identity,
+/// nil-to-optional, T-to-T?, per-slot tuple recursion) and the
+/// §3.5.1 cast conversion table.
+const std = @import("std");
 const gero = @import("gero");
 
+const relations = gero.lang.typechecker.relations;
+const types = gero.lang.types;
+
+const alloc = std.testing.allocator;
+
+// ---------- small constructors for fixture types ----------
+
+fn prim(p: types.Primitive) types.Type {
+    return .{ .primitive = p };
+}
+
+// ---------- module reachability ----------
+
 test "typecheck/relations: module compiles through the barrel" {
-    _ = gero.lang.typechecker.relations;
+    _ = relations;
+}
+
+// ---------- assignable: identity ----------
+
+test "typecheck/relations: assignable accepts identical primitives" {
+    try std.testing.expect(relations.assignable(prim(.i16), prim(.i16)));
+    try std.testing.expect(relations.assignable(prim(.bool_), prim(.bool_)));
+    try std.testing.expect(relations.assignable(prim(.str), prim(.str)));
+}
+
+test "typecheck/relations: assignable rejects different-width integers" {
+    // §3.5: no implicit narrowing OR widening. Cast required.
+    try std.testing.expect(!relations.assignable(prim(.i8), prim(.i16)));
+    try std.testing.expect(!relations.assignable(prim(.i16), prim(.i8)));
+    try std.testing.expect(!relations.assignable(prim(.u8), prim(.u16)));
+}
+
+test "typecheck/relations: assignable rejects signed/unsigned mix at same width" {
+    try std.testing.expect(!relations.assignable(prim(.i16), prim(.u16)));
+    try std.testing.expect(!relations.assignable(prim(.u8), prim(.i8)));
+}
+
+test "typecheck/relations: assignable rejects across primitive classes" {
+    try std.testing.expect(!relations.assignable(prim(.bool_), prim(.i16)));
+    try std.testing.expect(!relations.assignable(prim(.i16), prim(.bool_)));
+    try std.testing.expect(!relations.assignable(prim(.str), prim(.i16)));
+    try std.testing.expect(!relations.assignable(prim(.fixed), prim(.i16)));
+    try std.testing.expect(!relations.assignable(prim(.char), prim(.u8)));
+}
+
+// ---------- assignable: nil → optional ----------
+
+test "typecheck/relations: assignable accepts nil into a nullable slot" {
+    const inner = try types.mkPrimitive(alloc, .str);
+    defer alloc.destroy(inner);
+    const opt = types.Type{ .optional = inner };
+    try std.testing.expect(relations.assignable(prim(.nil_), opt));
+}
+
+test "typecheck/relations: assignable rejects nil into a non-nullable slot" {
+    // The nil-to-optional path is the *only* widening assignable
+    // grants over identity. Bare nil-into-str must reject.
+    try std.testing.expect(!relations.assignable(prim(.nil_), prim(.str)));
+    try std.testing.expect(!relations.assignable(prim(.nil_), prim(.i16)));
+}
+
+// ---------- assignable: T → T? ----------
+
+test "typecheck/relations: assignable accepts T into T? when inner matches" {
+    const inner = try types.mkPrimitive(alloc, .str);
+    defer alloc.destroy(inner);
+    const opt = types.Type{ .optional = inner };
+    try std.testing.expect(relations.assignable(prim(.str), opt));
+}
+
+test "typecheck/relations: assignable rejects T into T? when inner differs" {
+    const inner = try types.mkPrimitive(alloc, .str);
+    defer alloc.destroy(inner);
+    const opt = types.Type{ .optional = inner };
+    // `i16` is not assignable to `str?` — the inner types must match.
+    try std.testing.expect(!relations.assignable(prim(.i16), opt));
+}
+
+test "typecheck/relations: assignable rejects optional → non-optional (no auto-unwrap)" {
+    const inner = try types.mkPrimitive(alloc, .str);
+    defer alloc.destroy(inner);
+    const opt = types.Type{ .optional = inner };
+    try std.testing.expect(!relations.assignable(opt, prim(.str)));
+}
+
+// ---------- assignable: tuple per-slot recursion ----------
+
+test "typecheck/relations: assignable on tuples requires same arity and per-slot assignable" {
+    const i16t = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(i16t);
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+
+    const a_elems = [_]*const types.Type{ i16t, u8t };
+    const b_elems = [_]*const types.Type{ i16t, u8t };
+    const a = types.Type{ .tuple = &a_elems };
+    const b = types.Type{ .tuple = &b_elems };
+    try std.testing.expect(relations.assignable(a, b));
+}
+
+test "typecheck/relations: assignable on tuples rejects arity mismatch" {
+    const i16t = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(i16t);
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+
+    const a_elems = [_]*const types.Type{ i16t, u8t };
+    const b_elems = [_]*const types.Type{i16t};
+    const a = types.Type{ .tuple = &a_elems };
+    const b = types.Type{ .tuple = &b_elems };
+    try std.testing.expect(!relations.assignable(a, b));
+}
+
+test "typecheck/relations: assignable on tuples rejects slot type mismatch" {
+    const i16t = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(i16t);
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+    const strt = try types.mkPrimitive(alloc, .str);
+    defer alloc.destroy(strt);
+
+    const expected_elems = [_]*const types.Type{ i16t, u8t };
+    const actual_elems = [_]*const types.Type{ i16t, strt };
+    const expected = types.Type{ .tuple = &expected_elems };
+    const actual = types.Type{ .tuple = &actual_elems };
+    try std.testing.expect(!relations.assignable(actual, expected));
+}
+
+test "typecheck/relations: assignable allows nil in a tuple slot when expected is nullable" {
+    // (nil, u8) assignable to (str?, u8) — slot recursion runs the
+    // nil-to-optional path per-element.
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+    const strt = try types.mkPrimitive(alloc, .str);
+    defer alloc.destroy(strt);
+    const opt_str = types.Type{ .optional = strt };
+    const nil_t = try types.mkPrimitive(alloc, .nil_);
+    defer alloc.destroy(nil_t);
+
+    const expected_elems = [_]*const types.Type{ &opt_str, u8t };
+    const actual_elems = [_]*const types.Type{ nil_t, u8t };
+    const expected = types.Type{ .tuple = &expected_elems };
+    const actual = types.Type{ .tuple = &actual_elems };
+    try std.testing.expect(relations.assignable(actual, expected));
+}
+
+// ---------- assignable: aggregate / reference rejections ----------
+
+test "typecheck/relations: assignable rejects vec/reference/function pairs without identity" {
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+    const i16t = try types.mkPrimitive(alloc, .i16);
+    defer alloc.destroy(i16t);
+
+    const vec_u8 = types.Type{ .vec = u8t };
+    const vec_i16 = types.Type{ .vec = i16t };
+    try std.testing.expect(!relations.assignable(vec_u8, vec_i16));
+
+    const ref_u8 = types.Type{ .reference = u8t };
+    const ref_i16 = types.Type{ .reference = i16t };
+    try std.testing.expect(!relations.assignable(ref_u8, ref_i16));
+}
+
+test "typecheck/relations: assignable rejects across named types with different lexemes" {
+    const a = types.Type{ .named = .{ .name = "Player", .span = .{ .start = 0, .end = 6 } } };
+    const b = types.Type{ .named = .{ .name = "Enemy", .span = .{ .start = 0, .end = 5 } } };
+    try std.testing.expect(!relations.assignable(a, b));
+}
+
+// ---------- canCast: identity ----------
+
+test "typecheck/relations: canCast accepts same-primitive identity for every primitive" {
+    inline for (.{ .i8, .u8, .i16, .u16, .bool_, .nil_, .str, .fixed, .char }) |p| {
+        try std.testing.expect(relations.canCast(prim(p), prim(p)));
+    }
+}
+
+// ---------- canCast: integer ↔ integer ----------
+
+test "typecheck/relations: canCast accepts every integer ↔ integer pair" {
+    const ints = .{ .i8, .u8, .i16, .u16 };
+    inline for (ints) |from| {
+        inline for (ints) |to| {
+            try std.testing.expect(relations.canCast(prim(from), prim(to)));
+        }
+    }
+}
+
+// ---------- canCast: bool ↔ integer ----------
+
+test "typecheck/relations: canCast accepts bool ↔ integer" {
+    try std.testing.expect(relations.canCast(prim(.bool_), prim(.i8)));
+    try std.testing.expect(relations.canCast(prim(.bool_), prim(.u16)));
+    try std.testing.expect(relations.canCast(prim(.i16), prim(.bool_)));
+    try std.testing.expect(relations.canCast(prim(.u8), prim(.bool_)));
+}
+
+// ---------- canCast: fixed ↔ integer ----------
+
+test "typecheck/relations: canCast accepts fixed ↔ integer" {
+    try std.testing.expect(relations.canCast(prim(.fixed), prim(.i16)));
+    try std.testing.expect(relations.canCast(prim(.fixed), prim(.u8)));
+    try std.testing.expect(relations.canCast(prim(.i8), prim(.fixed)));
+    try std.testing.expect(relations.canCast(prim(.u16), prim(.fixed)));
+}
+
+// ---------- canCast: u8 ↔ char ----------
+
+test "typecheck/relations: canCast accepts u8 ↔ char" {
+    try std.testing.expect(relations.canCast(prim(.u8), prim(.char)));
+    try std.testing.expect(relations.canCast(prim(.char), prim(.u8)));
+}
+
+// ---------- canCast: rejections ----------
+
+test "typecheck/relations: canCast rejects str ↔ anything except itself" {
+    try std.testing.expect(!relations.canCast(prim(.str), prim(.i16)));
+    try std.testing.expect(!relations.canCast(prim(.str), prim(.u8)));
+    try std.testing.expect(!relations.canCast(prim(.i16), prim(.str)));
+    try std.testing.expect(!relations.canCast(prim(.str), prim(.char)));
+}
+
+test "typecheck/relations: canCast rejects nil ↔ anything except itself" {
+    try std.testing.expect(!relations.canCast(prim(.nil_), prim(.i16)));
+    try std.testing.expect(!relations.canCast(prim(.nil_), prim(.bool_)));
+    try std.testing.expect(!relations.canCast(prim(.i16), prim(.nil_)));
+}
+
+test "typecheck/relations: canCast rejects bool ↔ fixed (must transit through integer)" {
+    // §3.5.1 — fixed is only convertible with integers, not bool directly.
+    try std.testing.expect(!relations.canCast(prim(.bool_), prim(.fixed)));
+    try std.testing.expect(!relations.canCast(prim(.fixed), prim(.bool_)));
+}
+
+test "typecheck/relations: canCast rejects char ↔ non-u8 integer/primitive" {
+    // char ↔ u8 is special-cased; char ↔ i16, char ↔ bool, etc. don't qualify.
+    try std.testing.expect(!relations.canCast(prim(.char), prim(.i16)));
+    try std.testing.expect(!relations.canCast(prim(.char), prim(.bool_)));
+    try std.testing.expect(!relations.canCast(prim(.i16), prim(.char)));
+}
+
+test "typecheck/relations: canCast rejects non-primitive pairs" {
+    const u8t = try types.mkPrimitive(alloc, .u8);
+    defer alloc.destroy(u8t);
+
+    const vec = types.Type{ .vec = u8t };
+    const ref = types.Type{ .reference = u8t };
+    const arr = types.Type{ .array = .{ .elem = u8t, .len = 4 } };
+    const named = types.Type{ .named = .{ .name = "Player", .span = .{ .start = 0, .end = 6 } } };
+
+    try std.testing.expect(!relations.canCast(vec, prim(.i16)));
+    try std.testing.expect(!relations.canCast(prim(.i16), ref));
+    try std.testing.expect(!relations.canCast(arr, prim(.u8)));
+    try std.testing.expect(!relations.canCast(named, prim(.i16)));
+    // Even named-to-itself (different instance) doesn't qualify — canCast
+    // requires both ends to be `.primitive`.
+    try std.testing.expect(!relations.canCast(named, named));
 }

--- a/tests/lang/typecheck/relations.test.zig
+++ b/tests/lang/typecheck/relations.test.zig
@@ -1,0 +1,7 @@
+/// Mirror-layout placeholder. Behavior coverage is gero-qa's
+/// design space.
+const gero = @import("gero");
+
+test "typecheck/relations: module compiles through the barrel" {
+    _ = gero.lang.typechecker.relations;
+}

--- a/tests/vm/handlers/system.test.zig
+++ b/tests/vm/handlers/system.test.zig
@@ -483,3 +483,33 @@ test "sys 0xFB alloc 0x20: size that would overflow u16 raises heap_exhausted" {
     try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
     try std.testing.expectEqual(@as(u16, 0xFF00), vm.heap_cursor);
 }
+
+test "sys 0xFB alloc 0x20: boundary cursor + size == sp succeeds (no fault)" {
+    // The OOH check is `new_cursor > sp`, so allocating exactly up
+    // to (and including) sp is allowed. One byte past would fault.
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.heap_cursor = 0x3000;
+    vm.regs.write(.sp, 0x3010);
+    vm.regs.write(.acu, 0x10);
+    loadProgram(&vm, &.{ 0xFB, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.acu));
+    try std.testing.expectEqual(@as(u16, 0x3010), vm.heap_cursor);
+    // ip advances past the 2-byte sys instruction — no fault path.
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+}
+
+test "sys 0xFB alloc 0x20: one byte past sp raises heap_exhausted" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.heap_cursor = 0x3000;
+    vm.regs.write(.sp, 0x3010);
+    vm.mmap.writeWord(gero.vm.ivtSlot(.heap_exhausted), 0x5000);
+    // 0x3000 + 0x11 = 0x3011 > sp (0x3010) → fault.
+    vm.regs.write(.acu, 0x11);
+    loadProgram(&vm, &.{ 0xFB, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.heap_cursor);
+}

--- a/tests/vm/handlers/system.test.zig
+++ b/tests/vm/handlers/system.test.zig
@@ -402,3 +402,84 @@ test "sys 0xFB: with host.out = null, output syscalls are silent no-ops" {
     try std.testing.expectEqual(gero.vm.StepResult.cont, gero.vm.step(&vm));
     try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
 }
+
+// ---------- sys alloc (0x20) ----------
+
+test "sys 0xFB alloc 0x20: returns heap_base on first call, advances cursor by size" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.heap_cursor = 0x3000;
+    vm.regs.write(.acu, 16);
+    loadProgram(&vm, &.{ 0xFB, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.acu));
+    try std.testing.expectEqual(@as(u16, 0x3010), vm.heap_cursor);
+    try std.testing.expectEqual(@as(u16, 0x1102), vm.regs.read(.ip));
+}
+
+test "sys 0xFB alloc 0x20: second call returns previous cursor" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.heap_cursor = 0x3000;
+    // First alloc: 8 bytes.
+    vm.regs.write(.acu, 8);
+    loadProgram(&vm, &.{ 0xFB, 0x20, 0xFB, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.acu));
+    // Second alloc: 4 bytes — cursor moved past the first block.
+    vm.regs.write(.acu, 4);
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x3008), vm.regs.read(.acu));
+    try std.testing.expectEqual(@as(u16, 0x300C), vm.heap_cursor);
+}
+
+test "sys 0xFB alloc 0x20: zero-size allocation returns cursor without advancing" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.heap_cursor = 0x3000;
+    vm.regs.write(.acu, 0);
+    loadProgram(&vm, &.{ 0xFB, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.regs.read(.acu));
+    try std.testing.expectEqual(@as(u16, 0x3000), vm.heap_cursor);
+}
+
+test "sys 0xFB alloc 0x20: heap_cursor = 0 raises heap_exhausted fault" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    // heap_cursor defaults to 0 (no heap declared).
+    vm.mmap.writeWord(gero.vm.ivtSlot(.heap_exhausted), 0x5000);
+    vm.regs.write(.acu, 8);
+    loadProgram(&vm, &.{ 0xFB, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+}
+
+test "sys 0xFB alloc 0x20: cursor + size colliding with sp raises heap_exhausted" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.heap_cursor = 0xFFF0;
+    vm.regs.write(.sp, 0xFFF8);
+    vm.mmap.writeWord(gero.vm.ivtSlot(.heap_exhausted), 0x5000);
+    // Allocating 16 bytes would push cursor to 0x10000, past sp.
+    vm.regs.write(.acu, 16);
+    loadProgram(&vm, &.{ 0xFB, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+    // Cursor must be unchanged — failed allocation doesn't consume.
+    try std.testing.expectEqual(@as(u16, 0xFFF0), vm.heap_cursor);
+}
+
+test "sys 0xFB alloc 0x20: size that would overflow u16 raises heap_exhausted" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.heap_cursor = 0xFF00;
+    vm.regs.write(.sp, 0xFFFE);
+    vm.mmap.writeWord(gero.vm.ivtSlot(.heap_exhausted), 0x5000);
+    // cursor (0xFF00) + size (0x0200) = 0x10100 — exceeds u16.
+    vm.regs.write(.acu, 0x0200);
+    loadProgram(&vm, &.{ 0xFB, 0x20 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0x5000), vm.regs.read(.ip));
+    try std.testing.expectEqual(@as(u16, 0xFF00), vm.heap_cursor);
+}

--- a/tests/vm/loader.test.zig
+++ b/tests/vm/loader.test.zig
@@ -60,11 +60,20 @@ test "loader: rejects reserved flag bits" {
     try std.testing.expectError(error.ReservedBitsSet, gero.vm.parseGx(&buf));
 }
 
-test "loader: rejects non-zero reserved field at 0x0E" {
+test "loader: parses heap_base from bytes 0x0E..0x0F (little-endian)" {
+    var buf: [16]u8 = undefined;
+    _ = buildGx(&buf, 0x0002, 0, 0x1100, 0, 0, 0);
+    buf[0x0E] = 0x34;
+    buf[0x0F] = 0x12;
+    const loaded = try gero.vm.parseGx(&buf);
+    try std.testing.expectEqual(@as(u16, 0x1234), loaded.header.heap_base);
+}
+
+test "loader: heap_base defaults to 0 when bytes 0x0E..0x0F are zero" {
     var buf: [16]u8 = undefined;
     _ = buildGx(&buf, 0x0001, 0, 0x1100, 0, 0, 0);
-    buf[0x0E] = 0x42;
-    try std.testing.expectError(error.ReservedBitsSet, gero.vm.parseGx(&buf));
+    const loaded = try gero.vm.parseGx(&buf);
+    try std.testing.expectEqual(@as(u16, 0), loaded.header.heap_base);
 }
 
 test "loader: rejects sram_bank_count > bank_count" {


### PR DESCRIPTION
## Summary

Two scopes in one PR per the team-mode-not-preferred recovery:

**M3b chunk 0 — VM bump allocator** (shared infrastructure for the upcoming class instances #260 and closure heap-cells #259). New PR commits:

- `feat(vm)` — bump bytecode format `0x0001`→`0x0002`, new header field `heap_base: u16` at bytes `0x0E..0x0F`, new fault vector `0x04 heap_exhausted`, new `sys alloc = 0x20` syscall (read size from `acu`, return pointer in `acu`, advance `vm.heap_cursor`).
- `feat(lang/codegen)` — `buildArchive` writes `heap_base = emitter.data_cursor` final into the header; new `Sys.alloc` constant for future codegen consumers.
- `test(vm,disasm)` — 8 syscall tests (happy + sp-boundary + sp+1 fault + zero-size + u16-overflow + no-heap), 2 loader tests, 2 disasm header tests, 2 codegen header tests.
- ISA spec §7.1 header, §6.1 vectors, §5.13.1 syscall table (synced with reality — previously-undocumented `print_fixed` + `format_*_to_buf` family also added), §9 faults, §10 versioning all updated.
- Changeset `.changeset/vm-heap-allocator.md` (bump: minor).

**M3a review-fix rattrapage** (14 commits) — the typecheck.zig split campaign + the review-fix work that didn't make it into the merged #273. Lands here so M3b builds on the intended M3a state:

- 4 typecheck split commits (`predicates`, `annotations`, `relations`, `flow`) + their 4 qa-designed test suites (91 specs total).
- 6 review-fix commits per the original #273 review:
  - `internal` namespace pattern routes the ~60-symbol submodule seam through `gero.lang.internal.{typechecker,codegen}.X` instead of leaving them in the consumer surface.
  - Diag-arena lifetime regression test (the fix shipped in #273 had no test reading `compiled.diagnostics[i].message` after `compile` returned).
  - `codegen/opcodes.zig` doc-comment rewrite (drops ~50 cargo-cult `// allow-strict:` lines, promotes the trailing-mnemonic comments to leading `///` docs).
  - `annotation_specs` comptime-array contract note.
  - Submodule re-export shims dropped from `typecheck.zig` / `codegen.zig` (parent files now hold the references for their own use only; the barrel imports submodules directly).
  - Public barrel flatten — single source of truth per symbol, one `pub const internal = struct` umbrella instead of split `typechecker.internal` + `codegen.internal`.

## Out of scope

- User-facing language API for raw allocation — `mem.alloc(N)` builtin not in this PR. The allocator is infra only; classes (#260) and closures (#259) will consume it from the codegen side. If a user-facing raw-alloc surface emerges later, it lands as its own design.
- Free / GC. The bump allocator only grows. A program that exhausts its heap region faults; restarting the VM resets the cursor.
- Per-bank or per-region heap (the bump cursor is global).

## Test plan

- [x] `zig build verify` green
- [x] `zig build test-modes` green (Debug + ReleaseSafe + ReleaseFast + ReleaseSmall)
- [x] `zig build test-all` green (linux-x64 + macos-arm + win-x64 + win-arm + wasi)
- [x] `zig build ci` green
- [x] Self-review pass per CLAUDE.md 4-step — all gates + hygiene checks clean, three surfaced gaps closed in `793c681`
- [x] No AI attribution in commit history
- [x] Conventional-commit scopes valid on every commit