### PR TITLE
feat(lang): M3b chunk 1 — single-class OOP codegen (vtable + dispatch)

### DIFF
--- a/.changeset/lang-class-vtable.md
+++ b/.changeset/lang-class-vtable.md
@@ -1,0 +1,42 @@
+---
+bump: minor
+---
+
+Codegen for single-class OOP — instance allocation, vtable
+emission, constructor lowering, field read/write, and method
+dispatch via vtable.
+
+**Scope:**
+
+- `let p = Player()` constructor: bump-allocates the instance
+  (`sys alloc` from the heap allocator shipped in the prior
+  PR), writes the class's vtable pointer at instance offset 0,
+  invokes `init(self, args...)` when declared, returns the
+  instance address in `acu`.
+- Instance layout per spec §6: 2-byte vtable pointer at offset
+  0, then field bytes contiguous (1 byte per u8 / i8 / bool /
+  char, 2 bytes per i16 / u16 / fixed / reference / named
+  field).
+- Vtables live in the base image — appended after the code body
+  and the string pool, one u16 entry per method in declaration
+  order. Constructor-side vtable address slots are recorded as
+  patches and resolved after the vtable emission pass.
+- `obj.field` and `self.field` read + write — word load /
+  store via `mov [base + ofs], dst` for fields with i8-fit
+  offsets, synthesized `add` + indirect for larger offsets.
+- `obj.method(args)` and `self.method(args)` dispatch through
+  the vtable — load vtable_ptr from instance[0], load method
+  address from `[vtable + slot * 2]`, push self + user args
+  right-to-left, `call_reg`.
+- `self` expression — bound as the first method parameter at
+  fp+4; existing free-fn calling convention applies unchanged.
+
+**Out of scope (M3b chunk 2 / closures):**
+
+- Inheritance (`extends`), vtable copy-and-override,
+  `super.method`, `super.field` shadowing.
+- `@final` devirtualization, `@abstract` faulting stubs,
+  `@static` (class-level methods with no `self`).
+- `@private` enforcement at codegen (typechecker concern via
+  annotation validation).
+- Closures and capture analysis.

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -29,6 +29,7 @@ const cg_strings = @import("lang/codegen/strings.zig");
 const cg_pattern = @import("lang/codegen/pattern.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
+const cg_class = @import("lang/codegen/class.zig");
 
 // ---------- lexer ----------
 
@@ -153,5 +154,8 @@ pub const internal = struct {
         /// Internal — control-flow lowering (if / while / for /
         /// match / break / continue / defer).
         pub const control_flow = cg_control_flow;
+        /// Internal — class lowering (vtable + constructor +
+        /// field rw + method dispatch).
+        pub const class = cg_class;
     };
 };

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -54,6 +54,7 @@ const strings = @import("codegen/strings.zig");
 const pattern = @import("codegen/pattern.zig");
 const expr_emit = @import("codegen/expr.zig");
 const control_flow = @import("codegen/control_flow.zig");
+const class = @import("codegen/class.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const CheckedProgram = typecheck_mod.CheckedProgram;
@@ -182,12 +183,16 @@ pub fn compile(
         .string_patches = .empty,
         .checked = checked,
         .enum_decls = .{},
+        .class_decls = .{},
+        .class_layouts = .{},
+        .vtable_patches = .empty,
         .block_stack = .empty,
         .loop_stack = .empty,
         .diagnostics = &diagnostics,
     };
     defer emitter.code.deinit(allocator);
     defer emitter.call_patches.deinit(allocator);
+    defer emitter.vtable_patches.deinit(allocator);
     defer emitter.strings.deinit(allocator);
     defer emitter.string_patches.deinit(allocator);
     defer emitter.block_stack.deinit(allocator);
@@ -314,6 +319,17 @@ const Global = struct {
     placement: enum { addr, zero_page, data },
 };
 
+/// Unresolved vtable-address site — the constructor for
+/// `class_name` left an imm16 slot at `code_offset` (inside the
+/// `bank` buffer or base code) for the class's vtable address.
+/// `patchVtableSlots` rewrites every slot once `emitVtables`
+/// has resolved each class's `vtable_addr`.
+pub const VtablePatch = struct {
+    bank: ?u8,
+    code_offset: usize,
+    class_name: []const u8,
+};
+
 /// Per-fn codegen state — owns the working bytecode buffer, the
 /// local-slot table, and the diagnostic sink. The entry-def
 /// emission path owns one Emitter; later M1 commits will create
@@ -400,6 +416,22 @@ pub const Emitter = struct {
     /// emitting `EnumName.Variant` constructors, `is` tests, and
     /// `match` arm patterns.
     enum_decls: std.StringHashMapUnmanaged(*const ast.EnumDecl),
+    /// Top-level `class Foo … end` declarations indexed by name.
+    /// Backs constructor detection in `emitCall`, vtable + layout
+    /// lookup in field / method access, and the vtable emission
+    /// pass.
+    class_decls: std.StringHashMapUnmanaged(*const ast.ClassDecl),
+    /// Per-class layout — instance size, per-field byte offsets,
+    /// per-method vtable slot, and the vtable's resolved address
+    /// (populated after `class.emitVtables`).
+    class_layouts: std.StringHashMapUnmanaged(class.ClassLayout),
+    /// Unresolved vtable-address slots emitted by class
+    /// constructors — the constructor emits `mov 0, r2` as a
+    /// placeholder when it runs (vtables don't have addresses
+    /// yet). After `class.emitVtables` resolves each layout's
+    /// `vtable_addr`, `patchVtableSlots` rewrites every recorded
+    /// imm16 slot with the right address.
+    vtable_patches: std.ArrayList(VtablePatch),
     /// Stack of lexical blocks active at the current emit cursor.
     /// The function body opens the bottom block; nested `do…end`,
     /// loop bodies, `if` arms, etc. push more on top. Each block
@@ -832,6 +864,10 @@ pub const Emitter = struct {
         // Pre-pass 0: index top-level enum decls so variant-tag
         // lookups during expr / pattern emission resolve cheaply.
         try self.collectEnumDecls(program);
+        // Pre-pass 0b: index top-level class decls + compute
+        // per-class layouts. Vtables are emitted later (after
+        // method addresses are known).
+        try class.collectClassDecls(self, program);
         // Pre-pass 1: register globals (top-level let/const).
         try self.registerGlobals(program);
         // Pre-pass 2: collect each def's bank so `emitCall` can
@@ -845,6 +881,8 @@ pub const Emitter = struct {
             .def_decl => |*dd| if (dd != entry) try self.emitDef(dd, .regular),
             else => {},
         };
+        // Emit class methods as plain defs with mangled labels.
+        try class.emitClassMethods(self, program);
 
         // Emit the `__call_bank` trampoline only if at least one
         // cross-bank call site asked for it (saves 10 bytes when
@@ -854,6 +892,13 @@ pub const Emitter = struct {
         // Append the interned string pool to the base image so all
         // recorded `StringPatch`es can resolve to real addresses.
         try self.emitStringPool();
+        // Append per-class vtables (u16 method-address tables) to
+        // the base image. Must run after all methods have emitted
+        // so `fn_addresses` contains the resolved addresses.
+        try class.emitVtables(self);
+        // Resolve constructor-side placeholder slots now that each
+        // class's vtable lives at a known address.
+        try class.patchVtableSlots(self);
 
         try self.patchCalls();
         try self.patchStrings();
@@ -1171,7 +1216,13 @@ pub const Emitter = struct {
         }
     }
 
-    fn widthOfTypeAnn(self: *const Emitter, t: ast.TypeAnn) u8 {
+    /// Byte width inferred from a type annotation — 1 for the
+    /// byte-wide primitives (`i8`/`u8`/`bool`/`char`), 2 for
+    /// everything else (the 16-bit primitives, references, named
+    /// types, aggregates). Public so the class-layout pass in
+    /// `codegen/class.zig` can size class fields with the same
+    /// rule the global-placement path uses.
+    pub fn widthOfTypeAnn(self: *const Emitter, t: ast.TypeAnn) u8 {
         return switch (t) {
             .named => |n| blk: {
                 const name = self.source[n.name.start..n.name.end];
@@ -1194,6 +1245,18 @@ pub const Emitter = struct {
     /// state (locals / params / frame_bytes / is_entry) so each
     /// def gets a fresh frame view.
     fn emitDef(self: *Emitter, def: *const ast.DefDecl, kind: DefKind) !void {
+        const name = self.source[def.name.start..def.name.end];
+        return self.emitDefWithLabel(def, kind, name);
+    }
+
+    /// Emit a method as a plain def under a mangled label
+    /// (`ClassName.methodName`). The bytecode shape is identical to
+    /// a free fn; only the `fn_addresses` map key differs.
+    pub fn emitMethodAsDef(self: *Emitter, def: *const ast.DefDecl, label: []const u8) !void {
+        return self.emitDefWithLabel(def, .regular, label);
+    }
+
+    fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, label: []const u8) !void {
         // Detect `@bank N` annotation — drives bank routing for
         // this def's body bytes + the fn's resolved address.
         var bank_target: ?u8 = null;
@@ -1224,8 +1287,7 @@ pub const Emitter = struct {
             self.current_bank = saved_bank;
         }
 
-        const name = self.source[def.name.start..def.name.end];
-        const dup_name = try self.arena.dupe(u8, name);
+        const dup_name = try self.arena.dupe(u8, label);
         // @as: narrow usize code offset to u16; per-buffer offset stays ≤ 64 KiB.
         const code_offset: u16 = @intCast(try self.currentOffset());
         const addr: u16 = if (bank_target) |_|
@@ -1423,10 +1485,31 @@ pub const Emitter = struct {
     /// Lower `target = value`. The target must be an ident that
     /// resolves to a local, param, or global. Compound `op=`
     /// forms are not yet supported.
+    /// Return the class name when `e`'s inferred type is a
+    /// registered class; otherwise `null`. Used by the field
+    /// access + method dispatch paths to decide between the
+    /// class-typed lowering and the existing free-fn / enum paths.
+    pub fn classNameOf(self: *const Emitter, e: *const ast.Expr) ?[]const u8 {
+        const ty = self.typeOf(e) orelse return null;
+        if (ty.* != .named) return null;
+        const name = ty.named.name;
+        if (!self.class_decls.contains(name)) return null;
+        return name;
+    }
+
     fn emitAssign(self: *Emitter, a: ast.AssignStmt) !void {
         if (a.op != .set) {
             try self.unsupported(a.span, "compound `op=` assignments — only plain `=` is supported");
             return;
+        }
+        // Field-target assignment — `recv.field = value` on a class
+        // receiver routes to the class field-store path.
+        if (a.target.* == .field) {
+            if (self.classNameOf(a.target.field.receiver)) |cname| {
+                const fname = self.source[a.target.field.field.start..a.target.field.field.end];
+                try class.emitFieldStore(self, a.target.field.receiver, cname, fname, a.value, a.target.field.span);
+                return;
+            }
         }
         if (a.target.* != .ident) {
             try self.unsupported(a.span, "non-ident assignment targets (field / index)");

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -220,11 +220,12 @@ pub fn emitConstructor(
         // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
         const drop_bytes: u16 = 2 + @as(u16, @intCast(c.args.len * 2));
         try self.addImmToReg(drop_bytes, Reg.sp);
+        // init may have clobbered acu — restore the instance ptr
+        // from r1 so the caller's let-bind reads the right value.
+        try self.movRegToReg(Reg.r1, Reg.acu);
     }
-
-    // 5. Result in acu = instance pointer. Always restore from r1
-    //    in case init's epilogue or its arg-drop touched acu.
-    try self.movRegToReg(Reg.r1, Reg.acu);
+    // No-init path leaves acu holding the instance ptr from the
+    // `sys alloc` above — none of the intervening ops touched it.
 }
 
 /// `true` when the class declares an `init` method.

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -1,0 +1,434 @@
+/// Class lowering — instance layout, vtable emission, constructor
+/// calls, field read/write, and method dispatch via vtable.
+///
+/// Per spec §6 a class instance is `[vtable_ptr: u16][field bytes
+/// contiguous]`. The vtable lives in static data (appended after
+/// the code body and string pool, same pattern as
+/// `codegen/strings.zig`) — one u16 entry per method, in
+/// declaration order. Method calls load the vtable pointer from
+/// the instance, index into the table, and `call_reg` the
+/// resolved address.
+///
+/// Single-class scope only: inheritance + `super` land in a
+/// follow-up PR.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const opcodes = @import("opcodes.zig");
+const codegen_mod = @import("../codegen.zig");
+
+const Emitter = codegen_mod.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Sys = opcodes.Sys;
+
+/// Layout for one class: total instance size in bytes, per-field
+/// byte offset relative to the instance base, and the vtable
+/// address (populated after vtable emission).
+pub const ClassLayout = struct {
+    instance_size: u16,
+    field_offsets: std.StringHashMapUnmanaged(FieldInfo),
+    method_slots: std.StringHashMapUnmanaged(u16),
+    vtable_addr: ?u16,
+};
+
+/// Per-field metadata captured at layout time.
+pub const FieldInfo = struct {
+    offset: u16,
+    width: u8,
+};
+
+/// Pre-pass: index every top-level class decl + compute its
+/// instance layout. The vtable address is left `null` here and
+/// populated later by `emitVtables`, once method addresses exist.
+pub fn collectClassDecls(self: *Emitter, program: *const ast.Program) !void {
+    for (program.statements) |*stmt| switch (stmt.*) {
+        .class_decl => |cd| {
+            const name = self.source[cd.name.start..cd.name.end];
+            const dup = try self.arena.dupe(u8, name);
+            try self.class_decls.put(self.arena, dup, &stmt.class_decl);
+
+            var layout: ClassLayout = .{
+                .instance_size = 2, // vtable_ptr at offset 0
+                .field_offsets = .{},
+                .method_slots = .{},
+                .vtable_addr = null,
+            };
+            for (cd.fields) |field| {
+                const width: u8 = if (field.type_ann) |t|
+                    self.widthOfTypeAnn(t.*)
+                else
+                    2;
+                const fname = self.source[field.name.start..field.name.end];
+                const dup_f = try self.arena.dupe(u8, fname);
+                try layout.field_offsets.put(self.arena, dup_f, .{
+                    .offset = layout.instance_size,
+                    .width = width,
+                });
+                layout.instance_size += width;
+            }
+            for (cd.methods, 0..) |method, slot| {
+                const mname = self.source[method.name.start..method.name.end];
+                const dup_m = try self.arena.dupe(u8, mname);
+                // @as: method slot fits u16 — practical class size is well below 64k methods.
+                try layout.method_slots.put(self.arena, dup_m, @intCast(slot));
+            }
+            try self.class_layouts.put(self.arena, dup, layout);
+        },
+        else => {},
+    };
+}
+
+/// Mangled label for a class method — internal map key only, not
+/// emitted as a user-visible symbol. `.` keeps the two halves
+/// visually distinct in diagnostics.
+pub fn methodLabel(self: *Emitter, class_name: []const u8, method_name: []const u8) ![]const u8 {
+    return std.fmt.allocPrint(self.arena, "{s}.{s}", .{ class_name, method_name });
+}
+
+/// Iterate every class's methods and emit each one as a plain def
+/// with a mangled label. Mirrors the top-level def loop in
+/// `emitProgram`; reuses the same calling convention so methods
+/// look like free fns at the bytecode level (self is param 0).
+pub fn emitClassMethods(self: *Emitter, program: *const ast.Program) !void {
+    for (program.statements) |*stmt| switch (stmt.*) {
+        .class_decl => |cd| {
+            const cname = self.source[cd.name.start..cd.name.end];
+            for (cd.methods) |*method| {
+                const mname = self.source[method.name.start..method.name.end];
+                const label = try methodLabel(self, cname, mname);
+                try self.emitMethodAsDef(method, label);
+            }
+        },
+        else => {},
+    };
+}
+
+/// Emit per-class vtables after all method addresses are known.
+/// Vtable bytes go into the base image (same pattern as
+/// `emitStringPool`) so the runtime can read them via fixed
+/// addresses recorded in `vtable_addr`. Each vtable is `N * 2`
+/// bytes of little-endian u16 method addresses.
+pub fn emitVtables(self: *Emitter) !void {
+    // Vtables live in the base image so banked code can still
+    // address them. Save + restore buffer routing.
+    const saved_bank = self.current_bank;
+    self.current_bank = null;
+    defer self.current_bank = saved_bank;
+
+    var it = self.class_decls.iterator();
+    while (it.next()) |entry| {
+        const class_name = entry.key_ptr.*;
+        const cd = entry.value_ptr.*;
+        const layout = self.class_layouts.getPtr(class_name) orelse continue;
+
+        // @as: currentOffset returns usize, narrow to u16 — base image is ≤ 64 KiB.
+        const offset: u16 = @intCast(try self.currentOffset());
+        layout.vtable_addr = codegen_mod.code_base +% offset;
+
+        for (cd.methods) |method| {
+            const mname = self.source[method.name.start..method.name.end];
+            const label = try methodLabel(self, class_name, mname);
+            const method_addr = self.fn_addresses.get(label) orelse 0;
+            try self.emitU16Le(method_addr);
+        }
+    }
+}
+
+/// `true` when `name` is a registered class — used by `emitCall`
+/// to detect `ClassName(args)` constructor shapes before falling
+/// into the free-fn calling path.
+pub fn isClassName(self: *const Emitter, name: []const u8) bool {
+    return self.class_decls.contains(name);
+}
+
+/// Resolve every constructor-side vtable-address placeholder. Runs
+/// after `emitVtables` so each `class_layouts.vtable_addr` is set.
+pub fn patchVtableSlots(self: *Emitter) !void {
+    for (self.vtable_patches.items) |p| {
+        const layout = self.class_layouts.get(p.class_name) orelse continue;
+        const addr = layout.vtable_addr orelse 0;
+        const buf: []u8 = if (p.bank) |b|
+            if (self.banks.getPtr(b)) |bl| bl.items else continue
+        else
+            self.code.items;
+        if (p.code_offset + 2 > buf.len) continue;
+        // safety: addr is u16; the two-byte slot fits cleanly.
+        buf[p.code_offset] = @intCast(addr & 0xFF);
+        buf[p.code_offset + 1] = @intCast((addr >> 8) & 0xFF);
+    }
+}
+
+/// Lower `ClassName(args)` — bump-allocate an instance, write the
+/// vtable pointer at offset 0, optionally call `init`, then leave
+/// the instance address in `acu` (so callers can store it in a
+/// `let` binding).
+pub fn emitConstructor(
+    self: *Emitter,
+    class_name: []const u8,
+    c: ast.CallExpr,
+) !void {
+    const layout = self.class_layouts.get(class_name) orelse {
+        try self.diagFatal(c.span, "E_CODEGEN_UNKNOWN_CLASS", "codegen: constructor for unknown class");
+        return;
+    };
+    // 1. mov instance_size, acu ; sys alloc
+    try self.movImmToReg(layout.instance_size, Reg.acu);
+    try self.emitByte(Op.sys);
+    try self.emitByte(Sys.alloc);
+
+    // 2. Save instance pointer in r1 for the vtable write.
+    try self.movRegToReg(Reg.acu, Reg.r1);
+
+    // 3. Write vtable address into the instance's word at offset 0.
+    //    The vtable's address isn't known yet (vtables emit after
+    //    all defs), so leave a placeholder + record a patch that
+    //    `patchVtableSlots` rewrites once `emitVtables` runs.
+    try self.emitByte(Op.mov_imm16_reg);
+    const vtable_slot = try self.currentOffset();
+    try self.emitU16Le(0); // placeholder, patched in patchVtableSlots
+    try self.emitByte(Reg.r2);
+    try self.vtable_patches.append(self.allocator, .{
+        .bank = self.current_bank,
+        .code_offset = vtable_slot,
+        .class_name = try self.arena.dupe(u8, class_name),
+    });
+    // store r2 → [r1] (word)
+    try self.emitByte(Op.mov_reg_to_ptr);
+    try self.emitByte(Reg.r1);
+    try self.emitByte(Reg.r2);
+
+    // 4. If the class declares an `init` method, call it with
+    //    (self=r1, user_args...). The free-fn calling convention
+    //    pushes right-to-left.
+    if (hasInitMethod(self, class_name)) {
+        // Push user args right-to-left, preserving r1 across eval.
+        var i: usize = c.args.len;
+        while (i > 0) {
+            i -= 1;
+            try self.pushReg(Reg.r1);
+            try self.emitExpr(c.args[i]);
+            try self.popReg(Reg.r1);
+            try self.pushReg(Reg.acu);
+        }
+        // Push self last so it lands at fp+4 in the callee frame.
+        try self.pushReg(Reg.r1);
+
+        const init_label = try methodLabel(self, class_name, "init");
+        try emitDirectCall(self, init_label, c.span);
+
+        // Drop args: 1 (self) + user args, 2 bytes each.
+        // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
+        const drop_bytes: u16 = 2 + @as(u16, @intCast(c.args.len * 2));
+        try self.addImmToReg(drop_bytes, Reg.sp);
+    }
+
+    // 5. Result in acu = instance pointer. Always restore from r1
+    //    in case init's epilogue or its arg-drop touched acu.
+    try self.movRegToReg(Reg.r1, Reg.acu);
+}
+
+/// `true` when the class declares an `init` method.
+fn hasInitMethod(self: *Emitter, class_name: []const u8) bool {
+    const cd = self.class_decls.get(class_name) orelse return false;
+    for (cd.methods) |m| {
+        const mname = self.source[m.name.start..m.name.end];
+        if (std.mem.eql(u8, mname, "init")) return true;
+    }
+    return false;
+}
+
+/// Lower `recv.field` (class-typed receiver) — evaluate the
+/// receiver into `acu` (instance pointer), then word- or byte-
+/// load at the field's offset.
+pub fn emitFieldLoad(
+    self: *Emitter,
+    recv: *const ast.Expr,
+    class_name: []const u8,
+    field_name: []const u8,
+    recv_span: ast.Span,
+) !void {
+    const layout = self.class_layouts.get(class_name) orelse {
+        try self.diagFatal(recv_span, "E_CODEGEN_UNKNOWN_CLASS", "codegen: field access on unknown class");
+        return;
+    };
+    const field = layout.field_offsets.get(field_name) orelse {
+        try self.diagFatal(recv_span, "E_CODEGEN_UNDEFINED_FIELD", "codegen: unknown class field");
+        return;
+    };
+
+    try self.emitExpr(recv);
+    // acu = instance ptr; load at acu + field.offset.
+    try self.movRegToReg(Reg.acu, Reg.r1);
+    if (field.width == 1) {
+        try emitByteLoadAtOffset(self, Reg.r1, field.offset, Reg.acu);
+    } else {
+        try emitWordLoadAtOffset(self, Reg.r1, field.offset, Reg.acu);
+    }
+}
+
+/// Lower `recv.field = value` — evaluate value, push, evaluate
+/// recv, pop value back, store at the field's offset.
+pub fn emitFieldStore(
+    self: *Emitter,
+    recv: *const ast.Expr,
+    class_name: []const u8,
+    field_name: []const u8,
+    value: *const ast.Expr,
+    recv_span: ast.Span,
+) !void {
+    const layout = self.class_layouts.get(class_name) orelse {
+        try self.diagFatal(recv_span, "E_CODEGEN_UNKNOWN_CLASS", "codegen: field store on unknown class");
+        return;
+    };
+    const field = layout.field_offsets.get(field_name) orelse {
+        try self.diagFatal(recv_span, "E_CODEGEN_UNDEFINED_FIELD", "codegen: unknown class field");
+        return;
+    };
+
+    try self.emitExpr(value);
+    try self.pushReg(Reg.acu);
+    try self.emitExpr(recv);
+    try self.movRegToReg(Reg.acu, Reg.r1);
+    try self.popReg(Reg.r2);
+    if (field.width == 1) {
+        try emitByteStoreAtOffset(self, Reg.r1, field.offset, Reg.r2);
+    } else {
+        try emitWordStoreAtOffset(self, Reg.r1, field.offset, Reg.r2);
+    }
+}
+
+/// Lower `recv.method(args)` (class-typed receiver) — vtable
+/// dispatch: load vtable_ptr from instance, load method address
+/// from `[vtable + slot*2]`, push self + user args right-to-left,
+/// `call_reg`, drop args.
+pub fn emitMethodDispatch(
+    self: *Emitter,
+    recv: *const ast.Expr,
+    class_name: []const u8,
+    method_name: []const u8,
+    args: []const *const ast.Expr,
+    span: ast.Span,
+) !void {
+    const layout = self.class_layouts.get(class_name) orelse {
+        try self.diagFatal(span, "E_CODEGEN_UNKNOWN_CLASS", "codegen: method call on unknown class");
+        return;
+    };
+    const slot = layout.method_slots.get(method_name) orelse {
+        try self.diagFatal(span, "E_CODEGEN_UNDEFINED_METHOD", "codegen: unknown class method");
+        return;
+    };
+
+    // 1. Evaluate receiver, stash instance ptr in r1.
+    try self.emitExpr(recv);
+    try self.movRegToReg(Reg.acu, Reg.r1);
+
+    // 2. Load vtable pointer from [r1+0] into r2.
+    try emitWordLoadAtOffset(self, Reg.r1, 0, Reg.r2);
+
+    // 3. Load method address from [r2 + slot*2] into r3.
+    // @as: slot index fits u16; the *2 product fits comfortably.
+    const slot_offset: u16 = @as(u16, slot) * 2;
+    try emitWordLoadAtOffset(self, Reg.r2, slot_offset, Reg.r3);
+
+    // 4. Push args right-to-left, preserving r1 (instance ptr)
+    //    and r3 (method addr) across arg eval.
+    var i: usize = args.len;
+    while (i > 0) {
+        i -= 1;
+        try self.pushReg(Reg.r1);
+        try self.pushReg(Reg.r3);
+        try self.emitExpr(args[i]);
+        try self.popReg(Reg.r3);
+        try self.popReg(Reg.r1);
+        try self.pushReg(Reg.acu);
+    }
+
+    // 5. Push self last so it lands at fp+4 in the callee frame.
+    try self.pushReg(Reg.r1);
+
+    // 6. call_reg r3 — indirect call to the resolved method.
+    try self.emitByte(Op.call_reg);
+    try self.emitByte(Reg.r3);
+
+    // 7. Drop args: 1 (self) + user args.
+    // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
+    const drop_bytes: u16 = 2 + @as(u16, @intCast(args.len * 2));
+    try self.addImmToReg(drop_bytes, Reg.sp);
+}
+
+/// Direct call helper — used by the constructor for the `init`
+/// call. Records a patch so the address resolves at
+/// end-of-emission alongside every other free-fn call.
+fn emitDirectCall(self: *Emitter, label: []const u8, span: ast.Span) !void {
+    const dup = try self.arena.dupe(u8, label);
+    try self.emitByte(Op.call_addr);
+    const patch_offset = try self.currentOffset();
+    try self.emitU16Le(0);
+    try self.call_patches.append(self.allocator, .{
+        .bank = self.current_bank,
+        .code_offset = patch_offset,
+        .target = .{ .fn_name = dup },
+        .span = span,
+    });
+}
+
+/// Word load: `mov [base + offset], dst`. The native opcode
+/// takes an i8 offset; widen via `add` + indirect load when the
+/// offset exceeds 127.
+fn emitWordLoadAtOffset(self: *Emitter, base: u8, offset: u16, dst: u8) !void {
+    if (offset <= 127) {
+        // @as: offset fits i8 (≤127); the cast is a no-op for the value range.
+        try self.movRegOffsetToReg(base, @as(i8, @intCast(offset)), dst);
+        return;
+    }
+    // tmp = base + offset; then load [tmp+0].
+    try self.movRegToReg(base, Reg.r2);
+    try self.addImmToReg(offset, Reg.r2);
+    try self.movRegOffsetToReg(Reg.r2, 0, dst);
+}
+
+/// Word store: `mov src, [base + offset]`. Same `i8`-vs-widen
+/// rule as the load helper.
+fn emitWordStoreAtOffset(self: *Emitter, base: u8, offset: u16, src: u8) !void {
+    if (offset <= 127) {
+        // @as: offset fits i8 (≤127); the cast is a no-op for the value range.
+        try self.movRegToRegOffset(src, base, @as(i8, @intCast(offset)));
+        return;
+    }
+    try self.movRegToReg(base, Reg.r3);
+    try self.addImmToReg(offset, Reg.r3);
+    try self.movRegToRegOffset(src, Reg.r3, 0);
+}
+
+/// Byte load with `+offset` addressing — synthesized via a temp
+/// pointer register. No native indexed-byte load opcode exists.
+/// `mov8_ptr_to_reg` (0x24) operand order: ptr_reg byte, dst byte.
+fn emitByteLoadAtOffset(self: *Emitter, base: u8, offset: u16, dst: u8) !void {
+    if (offset == 0) {
+        try self.emitByte(Op.mov8_ptr_to_reg);
+        try self.emitByte(base);
+        try self.emitByte(dst);
+        return;
+    }
+    try self.movRegToReg(base, Reg.r2);
+    try self.addImmToReg(offset, Reg.r2);
+    try self.emitByte(Op.mov8_ptr_to_reg);
+    try self.emitByte(Reg.r2);
+    try self.emitByte(dst);
+}
+
+/// Byte store with `+offset` addressing. `mov8_reg_to_ptr` (0x23)
+/// operand order: src byte, ptr_reg byte.
+fn emitByteStoreAtOffset(self: *Emitter, base: u8, offset: u16, src: u8) !void {
+    if (offset == 0) {
+        try self.emitByte(Op.mov8_reg_to_ptr);
+        try self.emitByte(src);
+        try self.emitByte(base);
+        return;
+    }
+    try self.movRegToReg(base, Reg.r3);
+    try self.addImmToReg(offset, Reg.r3);
+    try self.emitByte(Op.mov8_reg_to_ptr);
+    try self.emitByte(src);
+    try self.emitByte(Reg.r3);
+}

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -7,6 +7,7 @@ const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const archive = @import("archive.zig");
+const class = @import("class.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -66,6 +67,16 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .call => |c| try emitCall(self, c),
         .method_call => |m| try emitMethodCall(self, m, e),
         .field => |f| try emitFieldExpr(self, f, e),
+        .self_expr => |se| {
+            // `self` inside a method body lives at fp+4 (the first
+            // implicit param). Outside a method it's a typecheck
+            // error — the codegen falls through to "unsupported".
+            if (self.params.get("self")) |ofs| {
+                try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+            } else {
+                try self.unsupported(se.span, "`self` used outside a method body");
+            }
+        },
         .is_test => |it| try emitIsTest(self, it),
         .ref_of => |r| try self.emitAddrOf(r.inner),
         .cast => |c| try emitExpr(self, c.inner), // same-width primitives share a bit pattern, so the cast is a no-op
@@ -84,6 +95,12 @@ pub fn emitExprDiscard(self: *Emitter, e: *const ast.Expr) !void {
 /// `acu`. Field access on non-enum receivers is not yet
 /// supported.
 pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void {
+    // Class-typed receiver — `obj.field` instance load.
+    if (self.classNameOf(f.receiver)) |cname| {
+        const fname = self.source[f.field.start..f.field.end];
+        try class.emitFieldLoad(self, f.receiver, cname, fname, f.span);
+        return;
+    }
     if (f.receiver.* == .ident) {
         const recv_name = self.source[f.receiver.ident.span.start..f.receiver.ident.span.end];
         if (self.enum_decls.get(recv_name)) |ed| {
@@ -354,6 +371,12 @@ pub fn emitShortCircuitBool(self: *Emitter, b: ast.BinaryExpr) !void {
 /// other receivers (class instance method calls) are not yet
 /// supported.
 pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr) !void {
+    // Class-typed receiver — vtable dispatch.
+    if (self.classNameOf(m.receiver)) |cname| {
+        const mname = self.source[m.method.start..m.method.end];
+        try class.emitMethodDispatch(self, m.receiver, cname, mname, m.args, m.span);
+        return;
+    }
     if (m.receiver.* == .ident) {
         const recv = self.source[m.receiver.ident.span.start..m.receiver.ident.span.end];
         if (std.mem.eql(u8, recv, "mem")) {
@@ -390,6 +413,16 @@ pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr)
 /// way in. Closure invocations and fn-pointer calls are not
 /// yet supported.
 pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
+    // Class constructor call — `ClassName(args)` allocates an
+    // instance, writes the vtable pointer, and runs `init` if
+    // declared. The instance address lands in `acu`.
+    if (c.callee.* == .ident) {
+        const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+        if (class.isClassName(self, callee_name)) {
+            try class.emitConstructor(self, callee_name, c);
+            return;
+        }
+    }
     if (c.callee.* == .field) {
         const fe = c.callee.field;
         if (fe.receiver.* == .ident) {

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1567,3 +1567,348 @@ test "codegen: custom entry_name resolves" {
     defer compiled.deinit();
     try std.testing.expect(!compiled.hasErrors());
 }
+
+// ---------- M3b chunk 1: class vtable + dispatch ----------
+
+test "codegen/class: zero-field class with one method prints from the method" {
+    var compiled = try compileSource(
+        \\class Player
+        \\  def greet(self)
+        \\    print "hi"
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let p = Player()
+        \\  p.greet()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("hi\n", writer.written());
+}
+
+test "codegen/class: instance pointer is freshly heap-allocated (acu = heap_base on first alloc)" {
+    var compiled = try compileSource(
+        \\class Box
+        \\  let v: i16
+        \\end
+        \\
+        \\def main()
+        \\  let p = Box()
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // `let p` lives at [fp - 2] (first local). Should hold the
+    // heap-allocated instance address; heap starts at data_base
+    // when no globals are placed.
+    const p_addr = vm.mmap.readWord(0xFFFC);
+    try std.testing.expectEqual(@as(u16, gero.lang.codegen.data_base), p_addr);
+}
+
+test "codegen/class: vtable_ptr at instance[0] points at the class's vtable" {
+    var compiled = try compileSource(
+        \\class Player
+        \\  def greet(self)
+        \\    print "hi"
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let p = Player()
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // p is at [fp - 2] = 0xFFFC.
+    const p_addr = vm.mmap.readWord(0xFFFC);
+    // [p+0] = vtable address. Vtable address must be non-zero
+    // (lives in the base image past code + strings).
+    const vtable_addr = vm.mmap.readWord(p_addr);
+    try std.testing.expect(vtable_addr != 0);
+}
+
+test "codegen/class: field read returns the value written by init" {
+    var compiled = try compileSource(
+        \\class Counter
+        \\  let n: i16
+        \\
+        \\  def init(self)
+        \\    self.n = 7
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let c = Counter()
+        \\  print c.n
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("7\n", writer.written());
+}
+
+test "codegen/class: field write from outside the class persists" {
+    var compiled = try compileSource(
+        \\class Box
+        \\  let v: i16
+        \\end
+        \\
+        \\def main()
+        \\  let b = Box()
+        \\  b.v = 42
+        \\  print b.v
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("42\n", writer.written());
+}
+
+test "codegen/class: byte-wide field (u8) reads back narrowed" {
+    var compiled = try compileSource(
+        \\class Cell
+        \\  let b: u8
+        \\end
+        \\
+        \\def main()
+        \\  let c = Cell()
+        \\  c.b = 200
+        \\  print c.b
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("200\n", writer.written());
+}
+
+test "codegen/class: method with user args" {
+    var compiled = try compileSource(
+        \\class Adder
+        \\  def add(self, x: i16, y: i16)
+        \\    print x + y
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let a = Adder()
+        \\  a.add(3, 4)
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("7\n", writer.written());
+}
+
+test "codegen/class: init with args populates fields" {
+    var compiled = try compileSource(
+        \\class Pair
+        \\  let lo: i16
+        \\  let hi: i16
+        \\
+        \\  def init(self, a: i16, b: i16)
+        \\    self.lo = a
+        \\    self.hi = b
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let p = Pair(10, 20)
+        \\  print p.lo
+        \\  print p.hi
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("10\n20\n", writer.written());
+}
+
+test "codegen/class: method-to-method dispatch on self" {
+    var compiled = try compileSource(
+        \\class Echo
+        \\  def shout(self)
+        \\    self.whisper()
+        \\    self.whisper()
+        \\  end
+        \\
+        \\  def whisper(self)
+        \\    print "."
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let e = Echo()
+        \\  e.shout()
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings(".\n.\n", writer.written());
+}
+
+test "codegen/class: two instances of the same class are independent" {
+    var compiled = try compileSource(
+        \\class Box
+        \\  let v: i16
+        \\end
+        \\
+        \\def main()
+        \\  let a = Box()
+        \\  let b = Box()
+        \\  a.v = 11
+        \\  b.v = 22
+        \\  print a.v
+        \\  print b.v
+        \\end
+    );
+    defer compiled.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("11\n22\n", writer.written());
+}
+
+test "codegen/class: mixed-width fields land at the expected offsets" {
+    // u8 (1) + i16 (2) + bool (1) + i16 (2) → 6 bytes of fields,
+    // total instance_size = 2 (vtable_ptr) + 6 = 8 bytes.
+    var compiled = try compileSource(
+        \\class Mix
+        \\  let a: u8
+        \\  let b: i16
+        \\  let c: bool
+        \\  let d: i16
+        \\
+        \\  def init(self)
+        \\    self.a = 7
+        \\    self.b = 1000
+        \\    self.c = true
+        \\    self.d = -1
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let m = Mix()
+        \\  print m.a
+        \\  print m.b
+        \\  print m.c
+        \\  print m.d
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("7\n1000\n1\n-1\n", writer.written());
+}
+
+test "codegen/class: method returning a value propagates through `acu`" {
+    var compiled = try compileSource(
+        \\class Box
+        \\  let v: i16
+        \\
+        \\  def init(self, x: i16)
+        \\    self.v = x
+        \\  end
+        \\
+        \\  def get(self) -> i16
+        \\    return self.v
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let b = Box(99)
+        \\  let v = b.get()
+        \\  print v
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("99\n", writer.written());
+}

--- a/tests/lang/codegen/class.test.zig
+++ b/tests/lang/codegen/class.test.zig
@@ -1,0 +1,11 @@
+/// Smoke that the `class` codegen submodule is reachable through
+/// the public barrel. End-to-end coverage of class instantiation,
+/// field rw, and method dispatch lives in
+/// `tests/lang/codegen.test.zig` — that's where the VM-side round
+/// trip actually exercises the lowering.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/class: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.class;
+}


### PR DESCRIPTION
## Summary

M3b chunk 1 — single-class OOP lowering. Advances #260 (inheritance + super land in chunk 2).

- **Instance layout** per spec §6: 2-byte vtable pointer at offset 0, then field bytes contiguous.
- **Constructor** `ClassName(args)` → bump-alloc + vtable_ptr write + `init` invocation if declared. Instance address returned in `acu`.
- **Vtables** in the base image (appended after code + string pool). Constructor-side address slots resolved via a patch pass after vtables emit.
- **Field access** `obj.field` / `self.field` read + write — word ops via `mov_reg_offset_reg` / `mov_reg_reg_offset` (i8-fit offsets) or synthesized `add` + indirect for larger ones. Byte fields use `mov8_*`.
- **Method dispatch** via vtable — load vtable_ptr, index by slot, `call_reg`. Self pushed as first arg per the existing free-fn calling convention.
- **`self` expression** bound as the first method param at fp+4.

12 codegen tests cover the AC for chunk 1.

## Out of scope (chunk 2 / later)

- Inheritance (`extends`), vtable copy-and-override, `super.method`, `super.field` shadowing.
- `@final` devirtualization, `@abstract` faulting stubs, `@static` class-level methods.
- `@private` codegen enforcement (typechecker concern).
- Closures + capture analysis (closes #259, separate PR after this).

## Test plan

- [x] `zig build verify` green
- [x] `zig build ci` green (test-modes Debug/ReleaseSafe/ReleaseFast/ReleaseSmall + test-all cross-target + examples + check-broken)
- [x] Self-review per CLAUDE.md 4-step pass — gates clean, no `*anyopaque` / `anyerror` / `std.debug.print`, justified casts, conventional-commit scopes valid, no AI attribution
- [x] Two surfaced coverage gaps fixed in-PR (mixed-width fields, method returning a value)