### PR TITLE
feat(lang): M3b chunk 2 — class inheritance (closes #260)

### DIFF
--- a/.changeset/lang-class-inheritance.md
+++ b/.changeset/lang-class-inheritance.md
@@ -1,0 +1,51 @@
+---
+bump: minor
+---
+
+Codegen for class inheritance — `extends`, vtable override,
+`super.method`, `super.field` with shadowing. Closes #260.
+
+**Layout** — single inheritance:
+
+- Child instance layout = parent's instance layout (inherited
+  field offsets preserved) + child's own fields appended at the
+  tail. Shadowing creates a separate slot — the parent's field
+  stays addressable via `super.field` while the child's
+  `self.field` resolves to the new appended slot.
+- Child vtable = parent's vtable copied; overrides reuse the
+  parent's slot index; brand-new methods append at fresh slots.
+  Vtable emit walks `method_order` per class so the bytes land
+  in slot order.
+- Layouts are computed in a separate `computeLayouts` pass
+  (memoized + chain-recursive on `extends`) so a child whose
+  parent isn't yet laid out resolves the parent first.
+
+**Constructor** — `Child()` walks the method-owner chain to find
+the closest `init` definition (own or inherited) and direct-calls
+that class's mangled label. A child with no own init but a
+parent that defines one gets the parent's init for free.
+
+**`super.method(args)`** — bypasses the vtable. The codegen
+finds the closest ancestor that owns the method (walking
+`parent_name` from the enclosing method's class) and emits a
+direct call to `Ancestor.method`. Self is loaded from `fp+4`
+(the current method's implicit param).
+
+**`super.field`** — loads `self`, then word/byte-loads at the
+parent-side field offset (walking the parent chain to find the
+slot the parent's own `self.field` would use). The shadowed
+parent slot stays in instance memory exactly because the
+inherited layout never recycled it.
+
+**Out of scope** (M3b finishing touches after closures):
+
+- `@final` devirtualization
+- `@abstract` faulting stubs
+- `@static` (class-level methods with no `self`)
+- `@private` codegen enforcement (typechecker concern)
+
+Eight new codegen tests cover inherited method (no override),
+child override via vtable, `super.method` bypass, inherited
+fields, shadowed field + `super.field`, child-without-init
+reuses parent's init, three-level chain, and dynamic vtable
+dispatch on shared slots.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,276 +1,429 @@
 # Gero — Claude Guidelines
 
-## Project Overview
+Gero is a 16-bit VM + assembler + disassembler + Lua-style language
+compiler, all pure Zig. Public barrel: `src/gero.zig`, imported as
+`@import("gero")`. Designed for native + `wasm32-wasi`; zero runtime
+deps; built on [knit](https://github.com/salty-max/knit) for the
+parser-combinator layer (asm + lang).
 
-Gero is a hobby ecosystem in Zig: a 16-bit virtual machine, an
-assembler and disassembler for its bytecode, and a Lua-style language
-that compiles to that bytecode. The fantasy-console (gtx-16) and web
-playground (gero-lab) are out of scope for this repo — they live or
-will live elsewhere and consume gero as a library.
+The fantasy-console (gtx-16) and web playground live elsewhere and
+consume gero as a library — out of scope for this repo.
 
-The library is **gero**. Package name in `build.zig.zon` is `.gero`,
-module is `@import("gero")`, public barrel is `src/gero.zig`.
+---
 
-What gero **is**:
+## When in doubt, read the specs
 
-- A VM kernel + asm/disasm + language compiler, all pure Zig
-- Designed for native + `wasm32-wasi` (web shells consume the WASM)
-- Built on top of [knit](https://github.com/salty-max/knit) for the
-  parser-combinator layer (asm + lang use it)
+The `docs/` folder is the source of truth for everything language-,
+ISA-, or CLI-shaped. **If my mental model disagrees with a spec,
+the spec wins** — go read it before changing code that touches the
+contract, before answering a "how does X work?" question, before
+designing a new feature. Don't reconstruct rules from memory or
+guess from the codebase shape when the spec defines them.
 
-What gero **is not**:
+| Doc | Owns |
+|---|---|
+| [`isa.md`](docs/isa.md) | Bytecode ISA — opcodes, registers, memory map, `.gx` header, faults, interrupts. The contract between VM / asm / disasm. |
+| [`asm.md`](docs/asm.md) | Asm language spec — surface syntax, directives, addressing modes, label rules. Targets the ISA above. |
+| [`gero-lang.md`](docs/gero-lang.md) | High-level language spec — types, statements, expressions, classes (§6), annotations (§3.7), the works. The lang compiler targets the ISA. |
+| [`lang-diagnostics.md`](docs/lang-diagnostics.md) | Diagnostic shape + every error code the parser / typecheck / codegen can emit. The contract for E\_-codes. |
+| [`cli.md`](docs/cli.md) | `gero` CLI — subcommands (`gero check` / `compile` / `disasm` / `asm` / etc.), flags, exit codes. |
+| [`tooling.md`](docs/tooling.md) | Project setup — installing the CLI, wiring editors, CI integration. |
+| [`asm-cookbook.md`](docs/asm-cookbook.md) | Working asm recipes — boot, IVT, banks, syscalls, etc. Reference for "how do I do X in asm?". |
+| [`gtx-16.md`](docs/gtx-16.md) | Fantasy-console spec — consumes Gero as its CPU/VM. Out-of-repo, but the contract lives here. |
 
-- A general-purpose VM — the ISA is custom and bounded to 16-bit
-- A self-hosting compiler — the lang compiler is in Zig
-- A graphics / IO runtime — that lives in the gtx-16 shell
+These specs follow the "complete designs, no deferral" rule:
+they describe the **final shape** of the language / ISA / tooling
+from day one. Implementation stages across PRs; the spec describes
+what the system IS, not what it WILL be.
 
-## Workflow Contract
+- ❌ "Status: design draft", "TBD", "deferred to later",
+  "v0.X feature", "Ranges work, custom iterables come later"
+- ✅ Either it's in the design with full shape (helpers, edge
+  cases, semantics) or explicitly "out of scope" with rationale
 
-**Issue → branch → PR → wait for merge signal → next issue.**
-Never batch issues into a single PR. Never start the next issue
-before the current one is explicitly merged. The maintainer
-controls cadence; the implementer waits for the go-ahead.
+When a spec change is needed, the spec edit lands in the same PR
+as the implementation — never after.
 
-When the issue body lists acceptance criteria, treat them as the
-definition of done — not green CI. Re-read them before declaring
-the work finished (see [Self-Review](#self-review-before-declaring-done)).
+---
 
-## Tech Stack
+## The contract
 
-- **Zig 0.16.0** minimum (pinned in `build.zig.zon`)
-- **Zero runtime deps** — pure Zig, no C deps, no FFI (the language
-  layer bridges to whatever the host exposes; the core has no I/O)
-- **Build / test / lint / release tooling**: `build.zig` is the task
-  runner. Every dev command is `zig build <step>`. No Makefile, no
-  shell wrapper. Run `zig build --help` to list every step.
-- **Format**: `zig fmt` (driven via `zig build fmt` / `fmt-check`)
-- **Lint**: single Zig binary at `tools/lint/main.zig`, built as
-  `zig-out/bin/gero-lint`, runs every rule against the in-memory
-  source tree in ~2-3s
-- **Git hooks**: [lefthook](https://github.com/evilmartians/lefthook)
-- **Conventional commits**: [convco](https://github.com/convco/convco)
-  — scope-enum enforced via `.versionrc`
-- **Changesets**: manual `.changeset/*.md` format with shell scripts
+**Workflow:** one issue → one branch → one PR → wait for explicit
+merge signal → next issue. Never batch issues. Never start the next
+one before the current is merged. PR diff past ~400 lines → stop
+and split.
 
-## Source Layout
+**Done means the acceptance criteria are met**, not green CI.
+Re-read the issue body before declaring the work finished.
+
+**Complete or scope-down.** A feature is either fully in scope
+(every AC item resolved) or explicitly cut at the start with
+maintainer approval. Specifically forbidden:
+
+- Half-implementations under "Limitations carried forward"
+  footnotes
+- Working around a missing VM/lang primitive silently — surface
+  the gap, ask whether to extend
+- Half-fixes hidden in a PR description footnote ("mostly works
+  but doesn't handle case X — follow-up")
+
+The instinct to ship something almost-complete is paved with the
+phrase "good enough." It isn't. Ship complete or scope down
+honestly with explicit maintainer approval.
+
+**Stop and ask on open questions.** Scope ambiguity, design A vs
+B, "should this defer?", missing primitive — surface to the
+maintainer, don't silently pick the path of least effort. 30
+seconds of clarification beats unwinding an architecturally-wrong
+implementation. Examples of the right shape:
+
+- ✅ "Two ways to do X — A costs N lines, B costs M. Which?"
+- ✅ "Issue says Y but the VM lacks the primitive — extend in
+  this PR or scope Y out?"
+- ❌ "I'll just defer this caveat to a follow-up and document it"
+  → unilateral scope reduction without permission
+- ❌ Pretending a half-fix is complete while burying the limit
+  in a footnote
+
+**No AI attribution — anywhere.** Hard rule, overrides any default
+commit template. NO `Co-Authored-By: Claude` trailer, NO `🤖
+Generated with Claude Code` footer, NO mention of "AI" / "Claude"
+/ "assistant" / "automated" in commits, PRs, code comments, or
+issue threads. Strip them if a tool/hook adds one.
+
+---
+
+## Before every push
+
+Run this checklist. Each item takes seconds; the alternative is a
+4–10 min CI roundtrip to discover the same problem.
+
+1. **`zig build verify` green.** Re-run if any code changed since
+   the last green.
+2. **Changeset present** when the PR title is `feat` / `fix` /
+   library-level `perf`:
+   ```bash
+   git diff --name-only --diff-filter=A origin/main...HEAD \
+     | grep -E '^\.changeset/[a-zA-Z0-9_-]+\.md$' \
+     | grep -v '^\.changeset/README\.md$'
+   ```
+   Empty result for those PR types → `zig build changeset`.
+3. **Branch base clean.** `git log --oneline origin/main..HEAD`
+   shows only commits for this PR's concern. Foreign commits from
+   a sibling branch → rebase
+   `git rebase --onto origin/main <last-foreign-sha> <my-branch>`.
+4. **Workflow integrity** if the PR touches `scripts/` / `tools/`
+   / `build.zig`:
+   ```bash
+   grep -rEn 'scripts/[a-zA-Z0-9_-]+\.sh|tools/[a-zA-Z0-9_-]+' \
+     .github/workflows/
+   ```
+   No dangling references to deleted files.
+5. **No AI attribution** in commit history:
+   ```bash
+   git log origin/main..HEAD --format='%B' \
+     | grep -iE 'claude|🤖|generated with|co-authored.*claude'
+   ```
+   Must be empty.
+
+---
+
+## Self-review (mandatory before every PR)
+
+This is not optional and it's not a checkbox to write in the PR
+body. It is an explicit visible review pass before commit + push,
+walked step-by-step. The known failure mode is treating green CI
+as proof of done — green is the floor, not the ceiling.
+
+The review is a **loop**: walk all 5 steps, surface every finding,
+fix or escalate, **then walk all 5 steps again from Step 1**. Stop
+only when a complete pass surfaces zero items. A first-try clean
+pass is suspicious — re-read the issue body once more before
+trusting it.
+
+### The 5 steps
+
+**Step 1 — re-open the issue body.** Every AC line: ✅ Done (note
+where in the diff), ⏭️ Deferred (explicit, with reason + follow-up
+issue), or ❌ Missed (fix it).
+
+**Step 2 — technical gates.** `zig build ci` clean across all
+release modes + cross-targets. Lint clean.
+
+**Step 3 — explicit acceptance checks.**
+
+- Public API diff vs `src/gero.zig` (and the relevant barrel:
+  `src/lang.zig`, `src/vm.zig`, etc.) — every visible export
+  intentional, no `*anyopaque` / `anyerror` leaks
+- Docs propagation — new public export → README's API list, new
+  convention → CLAUDE.md
+- Changeset present at the right level for `feat` / `fix` / `perf`
+  / breaking PRs
+
+**Step 4 — hygiene.**
+
+- No leftover `std.debug.print`, `unreachable` without comment,
+  commented-out code, unused imports
+- No `// TODO` pointing at an issue number
+- Conventional-commit headers valid with scope on every commit
+- No AI attribution
+- Diff scope matches what the issue says it should
+
+**Step 5 — code quality.** Read the diff like a reviewer who
+didn't write it. Look for:
+
+- **Naming** — does each new symbol read right at the call site?
+  Tighten anything that needs surrounding context to make sense.
+- **Dead code / duplication** — drop unused helpers; consolidate
+  if the same shape was written twice (three similar lines beats
+  a premature abstraction, but six identical lines should
+  collapse).
+- **Premature abstraction** — does every new parameter / branch
+  / helper have a current caller for every shape it accepts? If
+  a branch is "in case someone wants X later", delete it.
+- **Comments WHAT vs WHY** — every `//` should say WHY, not WHAT.
+  Strip any inline that just restates what the next line does.
+- **Function size** — body past ~40 lines or branching on
+  multiple state shapes → split.
+- **Error paths** — every `try` site readable; the caller has a
+  sensible response to each error in the set; no unjustified
+  `catch unreachable`.
+- **Test shape** — every new test asserts on the actual behavior,
+  not on incidental implementation details that will change on
+  the next refactor.
+- **Magic values** — every literal in the diff has a name or a
+  comment justifying it. No bare `0xFF`, `42`, `0x4000` without
+  context.
+
+### Loop discipline — no David GoodEnough
+
+Every finding from any step gets one of two responses, never
+"noted in the PR body":
+
+- **Fix in this PR.** Default. Then loop back to Step 1. Whether
+  the finding is a blocker or a nit doesn't change this — there
+  is no scope-reduction tier for things I noticed myself.
+- **Escalate to the maintainer with a concrete question.** Use
+  this when the fix is genuinely a separate design decision (e.g.
+  "the clean fix is to extend the VM with opcode X — that's its
+  own PR, do I split or absorb?"). Don't escalate to dodge a fix
+  this PR could easily absorb.
+
+**Specifically forbidden** in the review report:
+
+- "Findings I chose not to address" / "Gaps surfaced but skipped"
+- "LGTM with the following caveats"
+- "Belt-and-suspenders, skippable"
+- "Preexisting drift, out of scope"
+- "Edge case, minor"
+- Any phrasing that ships self-noted holes
+
+The loop ends in one of two shapes only:
+
+- **LGTM** — clean pass, zero items, ready to push
+- **BLOCKED on <specific question for maintainer>** — concrete
+  decision needed before continuing
+
+Never a third "LGTM with footnotes" shape.
+
+---
+
+## Source layout
 
 ```
 src/
 ├── gero.zig               # Public barrel
-├── vm/                    # Bytecode interpreter (registers, memory, dispatch)
-├── asm/                   # Assembler (text → bytecode); consumes knit
-├── disasm/                # Disassembler (bytecode → text)
-├── lang/                  # Gero language compiler (text → bytecode); consumes knit
+├── vm/                    # Bytecode interpreter
+├── asm/                   # Assembler (consumes knit)
+├── disasm/                # Disassembler
+├── lang/                  # Gero language compiler (consumes knit)
 └── common/                # Shared types: Value, Bytecode, Span
 
 tests/
 ├── util.zig               # Shared test helpers
 ├── gero.test.zig          # Public-surface smoke tests
-├── vm/<file>.test.zig     # Mirrors src/vm/<file>.zig
-├── asm/<file>.test.zig    # Mirrors src/asm/<file>.zig
-└── …
+└── <mod>/<file>.test.zig  # Mirrors src/<mod>/<file>.zig
 
-apps/                      # CLIs land here when needed
-docs/                      # ISA spec + lang spec live here
-editors/                   # Editor tooling — tree-sitter grammar + VS Code ext (submodules)
-tools/                     # Single-binary dev utilities (lint, etc.)
-scripts/                   # Bash helpers for build.zig + lefthook (slim — most logic in tools/)
-.changeset/                # *.md changeset files
-.github/                   # workflows + templates
-.gitmodules                # Submodule pinning
+apps/         # CLIs
+docs/         # ISA spec + lang spec
+editors/      # Tree-sitter grammar + VS Code ext (submodules)
+tools/        # Single-binary dev utilities (lint, etc.)
+scripts/      # Bash helpers for build.zig + lefthook
+.changeset/   # *.md changeset files
+.github/      # Workflows + templates
 ```
 
-The `src/gero.zig` barrel and any `src/<module>.zig` (top-level
-module barrel) are exempt from the mirror rule. Every file deeper
-(`src/vm/foo.zig`, `src/asm/codegen.zig`, …) requires a matching
-`tests/vm/foo.test.zig` etc. — the lint binary enforces this.
+**Mirror rule:** every `src/<mod>/<file>.zig` requires a matching
+`tests/<mod>/<file>.test.zig` — lint-enforced. Exempt:
+`src/gero.zig` and any top-level module barrel (e.g. `src/lang.zig`).
 
 `internal.zig` colocated with a module dir is the convention for
-private helpers — exempt from the mirror rule, must not be re-exported
-through `src/gero.zig`, exercised through its consuming modules' tests.
+private helpers — exempt from the mirror rule, must not be
+re-exported through `src/gero.zig`, exercised through its
+consuming modules' tests.
 
-## Design Principles
+**Imports:** single-level relative only. `../foo.zig` or `./foo.zig`
+— anything deeper (`../../...`) is rejected by the lint binary.
+Public consumers (and tests) import only `gero`:
 
-### Small, composable units
+```zig
+const gero = @import("gero");
+```
 
-Each file does one thing. If a function's body grows past ~40 lines or
-branches on more than a couple of state shapes, split it.
+Tests can also import `../util.zig` (one level) for shared helpers.
 
-### No hidden state
+---
 
-Modules are pure functions of their inputs (or transparent state
-machines documented at the boundary). Never close over module-level
-mutable state, never read globals.
+## Code rules
 
-### Carry types through
+### Structure
 
-No `*anyopaque` in public signatures. No `anyerror` — explicit error
-sets only. The lint binary enforces both.
+- **One concern per file.** Split early. Function body past ~40
+  lines, or branching on multiple state shapes → split.
+- **No hidden state.** Modules are pure functions of their inputs
+  (or transparent state machines documented at the boundary).
+  Never close over module-level mutable state; never read globals.
 
-### Justified casts
+### Types
 
-`@as`, `@ptrCast`, `@alignCast`, `@bitCast` require a one-line
-`// @as: <reason>` or `// safety: <reason>` comment directly above
-the call.
+- No `anyerror`, no `*anyopaque` / `*const anyopaque` in any
+  signature. Explicit error sets only.
+- `@as` / `@ptrCast` / `@alignCast` / `@bitCast` require a
+  one-line `// @as: <reason>` or `// safety: <reason>` directly
+  above the call.
+- `Span { start, end }` from `common` for source positions —
+  don't reinvent.
 
-### Spans are first-class
+### Comments
 
-When source positions matter (asm errors, lang diagnostics), use the
-`Span { start, end }` shape from `common`. Don't reinvent.
+- `///` doc on every exported declaration. One-line description;
+  param/return blurb when names alone aren't self-explanatory;
+  2–4 line example for non-trivial functions.
+- `//` inline = WHY, not WHAT. Single-line only. Skip on obvious
+  code.
+- `//!` file-level doc reserved for `src/gero.zig` only.
+- `std.debug.print` forbidden in `src/`. Allowed in tests behind a
+  local debug flag (`if (debug_dump) std.debug.print(...)`).
 
-### Complete designs, no deferral
+**Forbidden in any comment (`///` or `//`):**
 
-When proposing or reviewing a design — especially in user-facing
-specs (`docs/gero-lang.md`, `docs/isa.md`, public API surface) —
-ship the **complete** design. Helpers, edge cases, integration
-points, failure semantics: all decided up front.
+- **Issue numbers** (`#NNN`, `see #189`, `closes #142`) — those
+  belong in commit messages / PR descriptions / changesets only.
+  The code surface is for readers; the issue tracker is project
+  metadata.
+- **Version markers** (`v0.X`, `Phase Y`, `Roadmap:`) — code
+  describes what works today, factually. Versioning lives in
+  CHANGELOG / git tags / project board.
+- **AI attribution** (see "The contract").
 
-- ❌ "Status: design draft", "TBD", "deferred to later", "v0.X feature"
-- ❌ "Ranges work, custom iterables come later"
-- ✅ Either it's in the design (with full shape) or explicitly
-  "out of scope" (a non-feature with rationale)
+### Tests
 
-Implementation can stage across PRs; the **spec** describes the
-final shape from day one.
+- One spec per source file (mirror layout, lint-enforced).
+- Naming: `<file>.test.zig`, `test "<symbol>: <behavior>" { ... }`.
+- Shared helpers in `tests/util.zig` — don't reinvent per-spec.
+- No snapshot tests.
+- Coverage isn't a target; **failure paths are.** Happy +  at
+  least one failure per fallible function.
+- All four release modes pass: `zig build test-modes` runs Debug,
+  ReleaseSafe, ReleaseFast, ReleaseSmall. A test passing only in
+  Debug isn't done.
+- Cross-target gate: `zig build test-all` covers linux-x64,
+  macos-aarch64, windows-x64, windows-aarch64, wasm32-wasi.
+- **Asm layer:** golden-file or VM-state-at-hlt tests only. No
+  `@test`/`assert_eq` directives. Structured spec tests live in
+  the lang layer.
+- **Refactor commits:** the mirror test file gets only the bare
+  minimum the lint rule demands (one placeholder test). Pre-named
+  `test "<symbol>: <behavior>"` stubs that hint at what should be
+  covered are over-scope — test design is a separate concern from
+  refactor. For a series of similar refactor splits, batch them
+  all before writing the consolidated test suite (rather than
+  pipelining test-on-slice-1 with refactor-of-slice-2).
 
-### No half-features, no "David GoodEnough"
+---
 
-When an issue is scoped, **finish it.** A feature is either fully
-implemented or explicitly cut from scope at the start — not half-
-implemented and shipped under a "Limitations carried forward"
-section in the changeset / PR.
+## Strict-mode lint (`gero-lint`)
 
-Specifically forbidden:
+Single Zig binary at `tools/lint/main.zig`, built as
+`zig-out/bin/gero-lint`, runs in ~2–3s. Fails on any of these in
+`src/`:
 
-- ❌ "It mostly works but doesn't handle case X — that's a follow-
-  up." If case X is in the issue's AC, do it. If it shouldn't be,
-  argue for cutting it from the AC before starting work.
-- ❌ "There's a VM gap, so I emit suboptimal bytecode. Documented."
-  If the VM gap blocks a clean implementation, extend the VM in
-  the same PR (or split honestly with the user's go-ahead).
-- ❌ "Trampolines are complex — the user can manually set
-  the register before calling." If the spec promises automatic
-  behavior, deliver it.
-
-The instinct to ship something almost-complete is paved with the
-phrase "good enough." It isn't. Ship complete or scope down
-honestly with explicit user approval.
-
-### Stop and ask, don't assume
-
-When you hit an open question — scope, design choice, whether a
-limitation is acceptable, whether to defer something — **stop and
-ask.** Do not silently choose the path of least effort and ship a
-half-feature.
-
-- ❌ "I'll just defer this caveat to a follow-up and document it
-  in the changeset." That's unilateral scope reduction without
-  permission.
-- ❌ "The VM doesn't have this opcode, so I'll work around it."
-  Surface the gap, ask whether to extend the VM.
-- ❌ Pretending a half-fix is complete in the PR description while
-  burying the limitation in a "carried forward" footnote.
-- ✅ "I see two ways to do X: A or B. A costs N lines, B costs M.
-  Which one?"
-- ✅ "Issue says Y, but the VM lacks the primitive for Y. Do I
-  extend the VM in this PR or scope Y out?"
-
-The cost of a 30-second clarifying question is much smaller than
-the cost of an architecturally-wrong implementation that ships and
-has to be unwound later.
-
-## Imports
-
-- **Single-level relative imports** — `../foo.zig` or `./foo.zig`.
-  Anything past one parent (`@import("../../...")`) is rejected by
-  the lint binary.
-- **Public consumers** import only `gero`:
-  ```zig
-  const gero = @import("gero");
-  ```
-- Tests use `@import("gero")` for the public API plus
-  `@import("../util.zig")` (one level) for helpers.
-
-## Strict Compiler Configuration
-
-Strictness up front pays back downstream — gero is the foundation
-for gtx-16 native + future web shells. A leaky type or silent UB
-here propagates everywhere.
-
-### Build modes
-
-`zig build test-modes` runs **all four**: Debug, ReleaseSafe,
-ReleaseFast, ReleaseSmall. A test passing only in Debug isn't done.
-
-### Forbidden in `src/`
-
-The lint binary fails on any of:
-
-- `anyerror` — use explicit error sets
-- `*anyopaque` or `*const anyopaque` anywhere
-- `@as(`, `@ptrCast(`, `@alignCast(`, `@bitCast(` without a
-  `// @as: <reason>` or `// safety: <reason>` comment directly above
-- `unreachable` and `@compileError("TODO")` without a justifying
+- `anyerror`, `*anyopaque` / `*const anyopaque`
+- `@as(` / `@ptrCast(` / `@alignCast(` / `@bitCast(` without
+  `// @as:` / `// safety:` justification directly above
+- `unreachable` / `@compileError("TODO")` without a justifying
   comment
-- `std.debug.print` outside test code (debug-only seams that need
-  printing should be opt-in via a flag)
+- `std.debug.print` outside test code
 - `catch unreachable` without `// allow-strict: <invariant>`
 - `catch |x| return x` — use `try` instead
 - `std.heap.page_allocator` direct use — accept allocators from
   callers
 - `usingnamespace`
-- `//!` (file-level doc comment) anywhere except the top-level barrel
+- `//!` file-level doc anywhere except the top barrel
+- Issue numbers / version markers in any comment
+- Mirror-layout violations
+- Multi-level relative imports (`../../`)
+- Naming: `pub fn Foo(...) type` must be PascalCase;
+  `pub fn foo(...) <other>` must be camelCase
+- Public declarations without `///` doc comments
 
-Allowlist a violation by adding `// allow-strict: <reason>` directly
-above the line. Reviewer-gated.
+Allowlist a violation with `// allow-strict: <reason>` directly
+above the line. Reviewer-gated — bring a real reason.
 
-### Cross-target gate
-
-`zig build test-all` compiles tests for Linux x86_64, macOS aarch64,
-Windows x86_64 + aarch64, and `wasm32-wasi` on every PR. A change that
-breaks any target fails CI.
-
-### Naming convention
-
-The lint binary enforces:
-
-- `pub fn Foo(...) type` → **PascalCase**
-- `pub fn foo(...) <other>` → **camelCase**
-
-`pub const` naming is not enforced — convention is PascalCase for
-types (`pub const Foo = struct {...}`) and snake_case for values
+`pub const` naming is convention-only (not enforced): PascalCase
+for types (`pub const Foo = struct {...}`), snake_case for values
 (`pub const max_count = 42`).
 
-## Testing
+---
 
-- `zig build test` runs every native test in Debug
-- One spec per source file, mirror layout (lint-enforced)
-- Naming: `<file>.test.zig`, `test "<symbol>: <behavior>" { ... }`
-- Helpers in `tests/util.zig`. Don't invent per-spec helpers when a
-  shared one exists.
-- No snapshot tests
-- Coverage isn't a target; **failure paths** are. A function with
-  100% line coverage but no failure case is undertested.
+## Build commands (gates)
 
-## Branching
+Three layered gates. Warm-cache numbers; cold cache adds ~30s–1m
+for the Zig build itself.
 
-- `feat/<short-desc>` — new module, new public API
-- `fix/<short-desc>` — bug fix
-- `perf/<short-desc>` — measurable performance improvement
-- `chore/<short-desc>` — tooling, deps, CI, build
-- `docs/<short-desc>` — docs-only change
-- `refactor/<short-desc>` — internal restructuring with no behavior
-  change
+```bash
+zig build quick   # inner loop (~1s) — fmt-check + Debug test.
+                  # Use between edits while iterating.
 
-Branch from `main`. One issue → one branch → one PR. If a PR is
-growing past ~400 lines of diff, stop and split.
+zig build verify  # pre-push (~3s) — quick + lint + asm example
+                  # gates. REQUIRED green before pushing.
 
-## Commit Convention
+zig build ci      # full matrix (~4s warm / ~2m cold) — verify
+                  # + test-modes (Debug/Safe/Fast/Small)
+                  # + test-all (linux/macos/windows/wasi)
+                  # + test-examples (asm round-trip + stdout diff).
+                  # Mirrors GitHub Actions. Required before tagging
+                  # a release; optional before PR push.
+```
 
-Conventional commits enforced by **convco** with a strict scope-enum
-(`.versionrc`).
+GitHub Actions runs `ci` on every push — don't gate every commit
+on it locally, but `verify` green is required before pushing.
 
-### Allowed scopes
+---
+
+## Branches + commits + changesets
+
+**Branches:**
+
+- `feat/<short>` — new module, new public API
+- `fix/<short>` — bug fix
+- `perf/<short>` — measurable performance improvement
+- `chore/<short>` — tooling, deps, CI, build
+- `docs/<short>` — docs-only change
+- `refactor/<short>` — internal restructure, no behavior change
+
+Branch from `main`. One issue → one branch → one PR.
+
+**Commits:** Conventional Commits enforced by **convco** with a
+strict scope-enum from `.versionrc`.
+
+- No scope-less commits (`feat: add x` → rejected)
+- Multi-concern changes split into multiple commits in the PR
+- `fixup!` for review feedback, then `--autosquash`
+- Tooling-only `perf` → use `chore(tooling)` (changeset gate
+  auto-skips). Library API perf wins stay `perf(<scope>)`.
+
+**Allowed scopes:**
 
 ```
 vm                  → src/vm/*
@@ -280,242 +433,52 @@ lang                → src/lang/*
 common              → src/common/*
 tooling             → build.zig, lefthook, convco, tools/*, scripts/*
 ci                  → .github/workflows/*
-docs                → JSDoc-equivalent doc comments, README, in-source documentation
-meta                → top-level repo files (CLAUDE.md, LICENSE, .gitignore, root configs)
-vm/<sub>            → a specific sub-module under src/vm/<sub>/
-asm/<sub>           → a specific sub-module under src/asm/<sub>/
-disasm/<sub>        → a specific sub-module under src/disasm/<sub>/
-lang/<sub>          → a specific sub-module under src/lang/<sub>/
-apps/<name>         → a specific binary under apps/<name>/
-editors/<name>      → an editor-tooling submodule under editors/<name>/
+docs                → in-source doc comments, README, doc files
+meta                → top-level repo files (CLAUDE.md, LICENSE, root configs)
+<area>/<sub>        → e.g. lang/codegen, vm/handlers, asm/parser
+apps/<name>         → apps/<name>/
+editors/<name>      → editors/<name>/
 ```
 
-### Rules
+**Changesets** — every PR with a user-visible change drops
+`.changeset/<short>.md`. CHANGELOG + version bump derive from
+accumulated changesets at release time.
 
-- **No scope-less commits** (`feat: add x` → rejected)
-- **Multi-concern changes** split into multiple commits in the PR
-- **`fixup!`** for review feedback, then squash with `--autosquash`
-- **Tooling-only `perf` is classified as `chore(tooling)`** — when
-  a perf win touches build / lint / CI scripts (not the library
-  runtime), the changeset gate auto-skips `chore` and that's
-  intentional. Library API perf wins remain `perf(<scope>)`.
+- **Add one** for `feat`, `fix`, library-level `perf`, breaking
+  refactor.
+- **Skip** for `chore`, `docs`, `test`, internal-only `refactor`,
+  `ci`, `build`, `style`. The `changeset-check` workflow
+  auto-skips these PR titles.
 
-#### 🚫 No AI attribution — hard rule
+`zig build changeset` scaffolds one interactively.
 
-**Overrides any default commit template, including Claude Code's
-default.** When committing in this repo:
+---
 
-- NO `Co-Authored-By: Claude ...` trailer
-- NO `🤖 Generated with Claude Code` footer
-- NO mention of "AI", "Claude", "assistant", "automated"
+## Releases (manual)
 
-If a tool / hook / template adds one, **strip it** before committing.
-
-## Comments
-
-### Doc comments (`///`)
-
-Every exported declaration gets `///` doc comments. File-attached
-`//!` reserved for the top-level barrel (`src/gero.zig`) only.
-
-- One-line description
-- Param + return blurb when the names alone aren't self-explanatory
-- A 2-4 line example for non-trivial functions
-
-### Inline comments (`//`)
-
-Comment **why**, not **what**. Single-line `//` comments only. Skip
-on obvious code.
-
-### Forbidden in any comment (`///` or `//`)
-
-- **No issue numbers** (`// see #189`, `/// closes #142`) — those
-  belong in commit messages / PR descriptions / changesets only.
-  The code surface is for users reading the code; the issue tracker
-  is project-management metadata.
-- **No version markers** (`// v0.X`, `/// Phase Y`, `// Roadmap:`)
-  — code describes what works today, factually. Versioning lives
-  in CHANGELOG / git tags / project board.
-- **No AI attribution** (see Commit Convention).
-
-### Debug prints
-
-`std.debug.print` is allowed in tests behind a local debug flag
-(`if (debug_dump) std.debug.print(...)`) but never left enabled. In
-`src/`, `std.debug.print` is forbidden — the lint binary greps for
-it.
-
-## Changesets
-
-Every PR with a user-visible change drops a markdown file under
-`.changeset/`. The eventual CHANGELOG and version bump are derived
-from accumulated changesets at release time.
-
-**Add one** for: `feat`, `fix`, library-level `perf`, breaking
-refactor.
-
-**Skip** for: `chore`, `docs`, `test`, `refactor` (internal-only),
-`ci`, `build`, `style`. The `changeset-check` workflow auto-skips
-these PR titles.
-
-Run `zig build changeset` to scaffold one interactively.
-
-## Releasing
-
-Releases are **manual** by design. Multiple merged PRs accumulate
-changesets on `main`; the maintainer cuts a release when several are
-worth a coherent semver bump. Pushing to `main` runs CI but **never**
-publishes — only pushing a `vX.Y.Z` tag triggers `release.yml`.
-
-### Runbook
+Releases are cut manually. Multiple merged PRs accumulate
+changesets on `main`; the maintainer cuts a release when several
+are worth a coherent semver bump. Pushing to `main` runs CI but
+**never** publishes — only pushing a `vX.Y.Z` tag triggers
+`release.yml`.
 
 ```bash
 git checkout main && git pull
-
 zig build version           # consume changesets, bump version, prepend CHANGELOG
-
-git diff
+git diff                    # review the generated CHANGELOG, edit by hand if needed
 git add . && git commit -m "chore(meta): release vX.Y.Z"
 git tag vX.Y.Z
 git push origin main --tags
 ```
 
-If `zig build version` produces a CHANGELOG you don't want, edit it
-by hand before tagging — that's the canonical workflow.
+---
 
-## Local Gates
+## Tech stack (one-liner reference)
 
-Three layered gates with different speed / coverage trade-offs.
-Warm-cache numbers; cold cache adds ~30s-1m for the Zig build itself.
-
-```bash
-zig build quick     # inner loop (~1s)
-                    # fmt-check + test (Debug only). No lint.
-                    # Use between edits while iterating.
-
-zig build verify    # pre-push (~3s)
-                    # quick + lint + asm example gates. Required
-                    # green before pushing.
-
-zig build ci        # full matrix (~4s warm / ~2m cold)
-                    # verify + test-modes (ReleaseSafe / Fast / Small)
-                    #        + test-all (cross-target: linux / macos
-                    #          / windows / wasi)
-                    #        + test-examples (full asm + run + stdout
-                    #          diff + round-trip)
-                    # Mirrors what GitHub Actions runs. Required
-                    # before tagging a release; optional before PR push.
-```
-
-GitHub Actions runs `ci` on every push, so you don't have to gate
-every commit on it locally — but `verify` green is required before
-pushing.
-
-## Before Push
-
-Before every `git push` to a feature branch, run this checklist.
-Each item takes seconds; the alternative is a 4-10 min CI roundtrip
-to discover the same problem.
-
-1. **`zig build verify`** — must be green. Re-run if any code
-   changed since the last green.
-2. **Changeset present** if the PR title will be `feat` / `fix` /
-   library-level `perf`:
-   ```bash
-   git diff --name-only --diff-filter=A origin/main...HEAD \
-     | grep -E '^\.changeset/[a-zA-Z0-9_-]+\.md$' \
-     | grep -v '^\.changeset/README\.md$'
-   ```
-   If empty and the title is `feat` / `fix` / `perf`, run
-   `zig build changeset`.
-3. **Branch base is clean**:
-   ```bash
-   git log --oneline origin/main..HEAD
-   ```
-   Every commit listed must belong to this PR's concern only. Foreign
-   commits from a sibling branch → rebase
-   `git rebase --onto origin/main <last-foreign-sha> <my-branch>`.
-4. **Workflow integrity** if this PR touches `scripts/` / `tools/` /
-   `build.zig`:
-   ```bash
-   grep -rEn 'scripts/[a-zA-Z0-9_-]+\.sh|tools/[a-zA-Z0-9_-]+' \
-     .github/workflows/
-   ```
-   No dangling references to deleted files.
-5. **No AI attribution**:
-   ```bash
-   git log origin/main..HEAD --format='%B' \
-     | grep -iE 'claude|🤖|generated with|co-authored.*claude'
-   ```
-   Must be empty.
-
-## Self-Review Before Declaring Done
-
-When the work on an issue is finished, **don't declare done
-immediately**. Run a self-review pass, fix what you find, and loop
-until the review is clean.
-
-> **The known failure mode** is treating green CI as proof of done.
-> `zig build ci` clean is **necessary but not sufficient**. Issues
-> list explicit acceptance criteria that go beyond CI: docs updates,
-> type / error-set tightness, downstream consumer impact, changeset,
-> README export list.
-
-### Step 1 — re-open the issue body
-
-Re-read every acceptance criterion line by line. For each: ✅ Done
-(note where in the diff), ⏭️ Deferred (note explicitly, with reason
-and follow-up issue), or ❌ Missed (fix it).
-
-### Step 2 — technical gates
-
-Run `zig build ci` (or rely on a recent GitHub Actions run). All
-green is the floor, not the ceiling.
-
-### Step 3 — explicit acceptance checks
-
-- **Public API impact** — diff against `src/gero.zig` to confirm every
-  visible export is intentional. No `*anyopaque` leaks; no `anyerror`
-  introductions.
-- **Docs** — every doc-affecting change must propagate. New public
-  export → README's API list MUST include it. New convention →
-  CLAUDE.md.
-- **Changeset** — added at the appropriate level for `feat` / `fix` /
-  `perf` / breaking PRs.
-
-### Step 4 — hygiene
-
-- No leftover `std.debug.print`, `unreachable` without comment,
-  commented-out code, unused imports
-- No `// TODO` referencing an issue number (TODO must describe
-  what's missing, not point at a tracker)
-- Conventional-commit headers valid; every commit has a scope
-- No AI attribution
-- Diff scope matches what the issue says it should
-
-### Loop
-
-If any step finds an issue, fix it and run **all four steps again**.
-Stop only when a complete pass surfaces zero items. A first-try clean
-pass is suspicious — re-read the issue body once more before trusting
-it.
-
-## Key Rules Summary
-
-1. **Issue → branch → PR → wait for merge signal → next issue**
-2. **One concern per file** — split early
-3. **Complete designs, no deferral** in specs and public surfaces
-4. **No `*anyopaque` / no `anyerror`** in public exports
-5. **Justified casts** — `@as`/`@ptrCast`/`@bitCast` need a why-comment
-6. **Spans are first-class** for diagnostics
-7. **Test the failure path** — happy + at least one failure per spec,
-   all four release modes
-8. **Mirror layout** — every `src/<mod>/<file>.zig` has a
-   `tests/<mod>/<file>.test.zig`
-9. **Single-level relative imports** — no deep `../../`
-10. **Strict scope-enum** — every commit has a scope from the convco
-    enum
-11. **No issue numbers or version markers in `///` / `//` comments**
-12. **No AI attribution** — never in commits, PRs, or issue comments
-13. **Before-push checklist** — 5 items, 10 seconds, saves CI roundtrips
-14. **Self-review loop** — fix until LGTM before declaring done
+Zig 0.16.0 minimum (pinned in `build.zig.zon`), zero runtime deps,
+`build.zig` is the task runner (no Makefile, no shell wrapper —
+`zig build --help` lists every step), `zig fmt` via
+`zig build fmt`/`fmt-check`, lint via `zig build lint`, git hooks
+via [lefthook](https://github.com/evilmartians/lefthook),
+commits via [convco](https://github.com/convco/convco), changesets
+as manual `.changeset/*.md` files.

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -185,6 +185,7 @@ pub fn compile(
         .enum_decls = .{},
         .class_decls = .{},
         .class_layouts = .{},
+        .current_class_name = null,
         .vtable_patches = .empty,
         .block_stack = .empty,
         .loop_stack = .empty,
@@ -425,6 +426,10 @@ pub const Emitter = struct {
     /// per-method vtable slot, and the vtable's resolved address
     /// (populated after `class.emitVtables`).
     class_layouts: std.StringHashMapUnmanaged(class.ClassLayout),
+    /// Name of the class whose method body we're currently
+    /// emitting — drives `super` resolution. `null` outside any
+    /// method body. Saved + restored per `emitMethodAsDef` call.
+    current_class_name: ?[]const u8,
     /// Unresolved vtable-address slots emitted by class
     /// constructors — the constructor emits `mov 0, r2` as a
     /// placeholder when it runs (vtables don't have addresses
@@ -865,9 +870,11 @@ pub const Emitter = struct {
         // lookups during expr / pattern emission resolve cheaply.
         try self.collectEnumDecls(program);
         // Pre-pass 0b: index top-level class decls + compute
-        // per-class layouts. Vtables are emitted later (after
-        // method addresses are known).
+        // per-class layouts (with parent-chain resolution for
+        // inherited fields + methods). Vtables emit later, once
+        // method addresses exist.
         try class.collectClassDecls(self, program);
+        try class.computeLayouts(self);
         // Pre-pass 1: register globals (top-level let/const).
         try self.registerGlobals(program);
         // Pre-pass 2: collect each def's bank so `emitCall` can
@@ -1251,8 +1258,14 @@ pub const Emitter = struct {
 
     /// Emit a method as a plain def under a mangled label
     /// (`ClassName.methodName`). The bytecode shape is identical to
-    /// a free fn; only the `fn_addresses` map key differs.
-    pub fn emitMethodAsDef(self: *Emitter, def: *const ast.DefDecl, label: []const u8) !void {
+    /// a free fn; only the `fn_addresses` map key differs. Saves +
+    /// restores `current_class_name` around the body emit so
+    /// `super` lookups inside the body resolve to the right
+    /// class's parent.
+    pub fn emitMethodAsDef(self: *Emitter, def: *const ast.DefDecl, class_name: []const u8, label: []const u8) !void {
+        const saved = self.current_class_name;
+        self.current_class_name = class_name;
+        defer self.current_class_name = saved;
         return self.emitDefWithLabel(def, .regular, label);
     }
 

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -1,16 +1,20 @@
 /// Class lowering — instance layout, vtable emission, constructor
 /// calls, field read/write, and method dispatch via vtable.
+/// Handles single inheritance via `extends`: a child class
+/// inherits the parent's field layout (own fields appended;
+/// shadowed names occupy distinct slots and `super.field` reaches
+/// the parent's), and the child's vtable copies the parent's
+/// method addresses, overrides re-declared slots, and appends
+/// brand-new methods at fresh slot indices.
 ///
 /// Per spec §6 a class instance is `[vtable_ptr: u16][field bytes
 /// contiguous]`. The vtable lives in static data (appended after
 /// the code body and string pool, same pattern as
-/// `codegen/strings.zig`) — one u16 entry per method, in
-/// declaration order. Method calls load the vtable pointer from
-/// the instance, index into the table, and `call_reg` the
-/// resolved address.
-///
-/// Single-class scope only: inheritance + `super` land in a
-/// follow-up PR.
+/// `codegen/strings.zig`) — one u16 entry per method, in slot
+/// order. Method calls load the vtable pointer from the instance,
+/// index into the table, and `call_reg` the resolved address.
+/// `super.method(args)` bypasses the vtable and emits a direct
+/// call to the parent's mangled label.
 const std = @import("std");
 const ast = @import("../ast.zig");
 const opcodes = @import("opcodes.zig");
@@ -22,12 +26,31 @@ const Reg = opcodes.Reg;
 const Sys = opcodes.Sys;
 
 /// Layout for one class: total instance size in bytes, per-field
-/// byte offset relative to the instance base, and the vtable
-/// address (populated after vtable emission).
+/// byte offset relative to the instance base, per-method vtable
+/// slot, method-by-slot order for vtable emission, the parent
+/// class name (for `super` resolution), and the vtable address
+/// (populated after vtable emission).
 pub const ClassLayout = struct {
     instance_size: u16,
     field_offsets: std.StringHashMapUnmanaged(FieldInfo),
+    /// Method name → slot index inside this class's vtable.
+    /// Inherited methods sit at the parent's slot indices;
+    /// overrides reuse those slots; brand-new methods append at
+    /// the tail.
     method_slots: std.StringHashMapUnmanaged(u16),
+    /// Method name → name of the class that actually defines this
+    /// method (after inheritance + override resolution). Drives
+    /// the `ClassName.methodName` label lookup at vtable-emit time
+    /// and at `super.method` direct-call sites.
+    method_owners: std.StringHashMapUnmanaged([]const u8),
+    /// Method names in slot order. `method_order.items[N]` is the
+    /// method that occupies slot N — the vtable emits its address
+    /// in that order.
+    method_order: std.ArrayListUnmanaged([]const u8),
+    /// Parent class name when this class `extends` something;
+    /// `null` for root classes. Drives `super.method` direct call
+    /// and `super.field` parent-shadowed access.
+    parent_name: ?[]const u8,
     vtable_addr: ?u16,
 };
 
@@ -37,45 +60,110 @@ pub const FieldInfo = struct {
     width: u8,
 };
 
-/// Pre-pass: index every top-level class decl + compute its
-/// instance layout. The vtable address is left `null` here and
-/// populated later by `emitVtables`, once method addresses exist.
+/// Pre-pass: index every top-level class decl by name. Layouts
+/// (which need to walk parents first) get computed in the
+/// follow-up `computeLayouts` pass.
 pub fn collectClassDecls(self: *Emitter, program: *const ast.Program) !void {
     for (program.statements) |*stmt| switch (stmt.*) {
         .class_decl => |cd| {
             const name = self.source[cd.name.start..cd.name.end];
             const dup = try self.arena.dupe(u8, name);
             try self.class_decls.put(self.arena, dup, &stmt.class_decl);
-
-            var layout: ClassLayout = .{
-                .instance_size = 2, // vtable_ptr at offset 0
-                .field_offsets = .{},
-                .method_slots = .{},
-                .vtable_addr = null,
-            };
-            for (cd.fields) |field| {
-                const width: u8 = if (field.type_ann) |t|
-                    self.widthOfTypeAnn(t.*)
-                else
-                    2;
-                const fname = self.source[field.name.start..field.name.end];
-                const dup_f = try self.arena.dupe(u8, fname);
-                try layout.field_offsets.put(self.arena, dup_f, .{
-                    .offset = layout.instance_size,
-                    .width = width,
-                });
-                layout.instance_size += width;
-            }
-            for (cd.methods, 0..) |method, slot| {
-                const mname = self.source[method.name.start..method.name.end];
-                const dup_m = try self.arena.dupe(u8, mname);
-                // @as: method slot fits u16 — practical class size is well below 64k methods.
-                try layout.method_slots.put(self.arena, dup_m, @intCast(slot));
-            }
-            try self.class_layouts.put(self.arena, dup, layout);
         },
         else => {},
     };
+}
+
+/// Compute layouts for every indexed class. Single-pass with
+/// recursive parent resolution — `computeLayout` is memoized so a
+/// chain `A ← B ← C` collapses to one walk per class.
+pub fn computeLayouts(self: *Emitter) !void {
+    var it = self.class_decls.iterator();
+    while (it.next()) |entry| {
+        _ = try computeLayout(self, entry.key_ptr.*);
+    }
+}
+
+/// Compute one class's layout, recursing to the parent first when
+/// the class `extends`. Memoized via `class_layouts.contains` so
+/// the same layout never gets built twice.
+fn computeLayout(self: *Emitter, class_name: []const u8) !void {
+    if (self.class_layouts.contains(class_name)) return;
+    const cd = self.class_decls.get(class_name) orelse return;
+
+    var layout: ClassLayout = .{
+        .instance_size = 2, // vtable_ptr at offset 0
+        .field_offsets = .{},
+        .method_slots = .{},
+        .method_owners = .{},
+        .method_order = .empty,
+        .parent_name = null,
+        .vtable_addr = null,
+    };
+
+    // Inherit from parent — fields + methods seed the layout
+    // before this class's own additions get applied on top.
+    if (cd.extends) |ext_span| {
+        const parent_name = self.source[ext_span.start..ext_span.end];
+        try computeLayout(self, parent_name);
+        if (self.class_layouts.getPtr(parent_name)) |parent_layout| {
+            layout.parent_name = try self.arena.dupe(u8, parent_name);
+            layout.instance_size = parent_layout.instance_size;
+            var fit = parent_layout.field_offsets.iterator();
+            while (fit.next()) |e| {
+                try layout.field_offsets.put(self.arena, e.key_ptr.*, e.value_ptr.*);
+            }
+            var mit = parent_layout.method_slots.iterator();
+            while (mit.next()) |e| {
+                try layout.method_slots.put(self.arena, e.key_ptr.*, e.value_ptr.*);
+            }
+            var oit = parent_layout.method_owners.iterator();
+            while (oit.next()) |e| {
+                try layout.method_owners.put(self.arena, e.key_ptr.*, e.value_ptr.*);
+            }
+            for (parent_layout.method_order.items) |mname| {
+                try layout.method_order.append(self.arena, mname);
+            }
+        }
+    }
+
+    // Own fields — shadowing replaces the inherited entry in
+    // `field_offsets` so `self.X` resolves to the child's slot.
+    // The parent's slot remains in memory (instance_size already
+    // counted it) and stays reachable via `super.X`.
+    for (cd.fields) |field| {
+        const width: u8 = if (field.type_ann) |t|
+            self.widthOfTypeAnn(t.*)
+        else
+            2;
+        const fname = self.source[field.name.start..field.name.end];
+        const dup_f = try self.arena.dupe(u8, fname);
+        try layout.field_offsets.put(self.arena, dup_f, .{
+            .offset = layout.instance_size,
+            .width = width,
+        });
+        layout.instance_size += width;
+    }
+
+    // Own methods — overrides reuse the parent's slot (same name
+    // already in `method_slots`); brand-new methods append.
+    const dup_class = try self.arena.dupe(u8, class_name);
+    for (cd.methods) |method| {
+        const mname = self.source[method.name.start..method.name.end];
+        const dup_m = try self.arena.dupe(u8, mname);
+        if (layout.method_slots.get(mname) != null) {
+            // Override — slot stays, only the owner changes.
+            try layout.method_owners.put(self.arena, dup_m, dup_class);
+        } else {
+            // @as: method slot fits u16; practical caps are well below 32k.
+            const slot: u16 = @intCast(layout.method_order.items.len);
+            try layout.method_slots.put(self.arena, dup_m, slot);
+            try layout.method_owners.put(self.arena, dup_m, dup_class);
+            try layout.method_order.append(self.arena, dup_m);
+        }
+    }
+
+    try self.class_layouts.put(self.arena, dup_class, layout);
 }
 
 /// Mangled label for a class method — internal map key only, not
@@ -96,7 +184,7 @@ pub fn emitClassMethods(self: *Emitter, program: *const ast.Program) !void {
             for (cd.methods) |*method| {
                 const mname = self.source[method.name.start..method.name.end];
                 const label = try methodLabel(self, cname, mname);
-                try self.emitMethodAsDef(method, label);
+                try self.emitMethodAsDef(method, cname, label);
             }
         },
         else => {},
@@ -118,16 +206,18 @@ pub fn emitVtables(self: *Emitter) !void {
     var it = self.class_decls.iterator();
     while (it.next()) |entry| {
         const class_name = entry.key_ptr.*;
-        const cd = entry.value_ptr.*;
         const layout = self.class_layouts.getPtr(class_name) orelse continue;
 
         // @as: currentOffset returns usize, narrow to u16 — base image is ≤ 64 KiB.
         const offset: u16 = @intCast(try self.currentOffset());
         layout.vtable_addr = codegen_mod.code_base +% offset;
 
-        for (cd.methods) |method| {
-            const mname = self.source[method.name.start..method.name.end];
-            const label = try methodLabel(self, class_name, mname);
+        // Iterate in slot order — each slot's address comes from
+        // the class that actually owns the method (inherited
+        // methods → parent's label; overrides → child's label).
+        for (layout.method_order.items) |mname| {
+            const owner = layout.method_owners.get(mname) orelse class_name;
+            const label = try methodLabel(self, owner, mname);
             const method_addr = self.fn_addresses.get(label) orelse 0;
             try self.emitU16Le(method_addr);
         }
@@ -200,7 +290,7 @@ pub fn emitConstructor(
     // 4. If the class declares an `init` method, call it with
     //    (self=r1, user_args...). The free-fn calling convention
     //    pushes right-to-left.
-    if (hasInitMethod(self, class_name)) {
+    if (initOwner(self, class_name)) |owner| {
         // Push user args right-to-left, preserving r1 across eval.
         var i: usize = c.args.len;
         while (i > 0) {
@@ -213,7 +303,9 @@ pub fn emitConstructor(
         // Push self last so it lands at fp+4 in the callee frame.
         try self.pushReg(Reg.r1);
 
-        const init_label = try methodLabel(self, class_name, "init");
+        // Direct-call the inheritance-resolved `init` — may live
+        // on an ancestor when the child doesn't define its own.
+        const init_label = try methodLabel(self, owner, "init");
         try emitDirectCall(self, init_label, c.span);
 
         // Drop args: 1 (self) + user args, 2 bytes each.
@@ -228,14 +320,49 @@ pub fn emitConstructor(
     // `sys alloc` above — none of the intervening ops touched it.
 }
 
-/// `true` when the class declares an `init` method.
-fn hasInitMethod(self: *Emitter, class_name: []const u8) bool {
-    const cd = self.class_decls.get(class_name) orelse return false;
-    for (cd.methods) |m| {
-        const mname = self.source[m.name.start..m.name.end];
-        if (std.mem.eql(u8, mname, "init")) return true;
+/// Look up which class actually owns `init` for this class
+/// (walking the inheritance chain). Returns `null` when no
+/// ancestor declares `init`.
+fn initOwner(self: *Emitter, class_name: []const u8) ?[]const u8 {
+    const layout = self.class_layouts.get(class_name) orelse return null;
+    return layout.method_owners.get("init");
+}
+
+/// Look up a class's parent name (one level up the chain).
+pub fn parentOf(self: *const Emitter, class_name: []const u8) ?[]const u8 {
+    const layout = self.class_layouts.get(class_name) orelse return null;
+    return layout.parent_name;
+}
+
+/// Find the closest ancestor of `class_name` whose own layout
+/// declares `field_name` (i.e. resolves `super.field`). Returns
+/// the field info or `null` if no ancestor field matches.
+fn findInheritedField(
+    self: *const Emitter,
+    class_name: []const u8,
+    field_name: []const u8,
+) ?FieldInfo {
+    var cur = self.class_layouts.get(class_name) orelse return null;
+    var parent = cur.parent_name orelse return null;
+    while (true) {
+        const player = self.class_layouts.get(parent) orelse return null;
+        if (player.field_offsets.get(field_name)) |fi| {
+            // The inherited entry sits at the parent's own offset
+            // (before any further shadowing in deeper chains).
+            const cd = self.class_decls.get(parent) orelse return fi;
+            // Walk the parent's own fields to find the actual
+            // offset that parent's `self.field` would use — same
+            // entry the parent's layout has at its own slot.
+            for (cd.fields) |f| {
+                if (std.mem.eql(u8, self.source[f.name.start..f.name.end], field_name)) {
+                    return fi;
+                }
+            }
+            // Field was inherited by parent too — keep walking up.
+        }
+        parent = player.parent_name orelse return null;
+        cur = player;
     }
-    return false;
 }
 
 /// Lower `recv.field` (class-typed receiver) — evaluate the
@@ -355,6 +482,102 @@ pub fn emitMethodDispatch(
     // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
     const drop_bytes: u16 = 2 + @as(u16, @intCast(args.len * 2));
     try self.addImmToReg(drop_bytes, Reg.sp);
+}
+
+/// Lower `super.method(args)` — direct call to the named method
+/// on the parent of the enclosing method's class. Bypasses vtable
+/// lookup entirely (the dispatch is static at compile time).
+/// `enclosing_class` is the class whose method body we're inside
+/// (tracked on `Emitter.current_class_name` by `emitMethodAsDef`).
+pub fn emitSuperMethodCall(
+    self: *Emitter,
+    enclosing_class: []const u8,
+    method_name: []const u8,
+    args: []const *const ast.Expr,
+    span: ast.Span,
+) !void {
+    const parent = parentOf(self, enclosing_class) orelse {
+        try self.diagFatal(span, "E_CODEGEN_NO_PARENT", "codegen: `super` used in a class with no parent");
+        return;
+    };
+    // Resolve the actual ancestor that defines this method — walk
+    // up from the parent until we find a class that owns it. Lets
+    // `super.foo` skip past parents that inherited foo themselves.
+    const owner = findMethodOwnerFrom(self, parent, method_name) orelse {
+        try self.diagFatal(span, "E_CODEGEN_UNDEFINED_METHOD", "codegen: `super.method` resolves to no ancestor method");
+        return;
+    };
+
+    // self for the super call is the current method's self (fp+4).
+    // Load it into r1 first so arg eval can clobber acu freely.
+    if (self.params.get("self")) |ofs| {
+        try self.movRegOffsetToReg(Reg.fp, ofs, Reg.r1);
+    } else {
+        try self.diagFatal(span, "E_CODEGEN_NO_SELF", "codegen: `super.method` used outside a method body");
+        return;
+    }
+
+    // Push args right-to-left, preserving r1 across eval.
+    var i: usize = args.len;
+    while (i > 0) {
+        i -= 1;
+        try self.pushReg(Reg.r1);
+        try self.emitExpr(args[i]);
+        try self.popReg(Reg.r1);
+        try self.pushReg(Reg.acu);
+    }
+    // Push self last so it lands at fp+4 in the callee frame.
+    try self.pushReg(Reg.r1);
+
+    const label = try methodLabel(self, owner, method_name);
+    try emitDirectCall(self, label, span);
+
+    // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
+    const drop_bytes: u16 = 2 + @as(u16, @intCast(args.len * 2));
+    try self.addImmToReg(drop_bytes, Reg.sp);
+}
+
+/// Lower `super.field` read — load `self`, then read at the
+/// parent-side field offset (the shadowed slot from before the
+/// child's own redefinition).
+pub fn emitSuperFieldLoad(
+    self: *Emitter,
+    enclosing_class: []const u8,
+    field_name: []const u8,
+    span: ast.Span,
+) !void {
+    const field = findInheritedField(self, enclosing_class, field_name) orelse {
+        try self.diagFatal(span, "E_CODEGEN_UNDEFINED_FIELD", "codegen: `super.field` resolves to no ancestor field");
+        return;
+    };
+
+    if (self.params.get("self")) |ofs| {
+        try self.movRegOffsetToReg(Reg.fp, ofs, Reg.r1);
+    } else {
+        try self.diagFatal(span, "E_CODEGEN_NO_SELF", "codegen: `super.field` used outside a method body");
+        return;
+    }
+    if (field.width == 1) {
+        try emitByteLoadAtOffset(self, Reg.r1, field.offset, Reg.acu);
+    } else {
+        try emitWordLoadAtOffset(self, Reg.r1, field.offset, Reg.acu);
+    }
+}
+
+/// Walk the chain from `start_class` upward looking for the first
+/// ancestor that defines a method named `method_name`. Returns
+/// the ancestor's class name, or `null` if no ancestor declares it.
+fn findMethodOwnerFrom(
+    self: *const Emitter,
+    start_class: []const u8,
+    method_name: []const u8,
+) ?[]const u8 {
+    var cur = start_class;
+    while (true) {
+        const layout = self.class_layouts.get(cur) orelse return null;
+        if (layout.method_owners.get(method_name)) |owner| return owner;
+        cur = layout.parent_name orelse return null;
+    }
 }
 
 /// Direct call helper — used by the constructor for the `init`

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -77,6 +77,12 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
                 try self.unsupported(se.span, "`self` used outside a method body");
             }
         },
+        .super_expr => |se| {
+            // Bare `super` is never a valid value — it must be
+            // followed by `.method(...)` or `.field`. Both shapes
+            // intercept before they reach this fallthrough arm.
+            try self.unsupported(se.span, "`super` must be followed by `.method(...)` or `.field`");
+        },
         .is_test => |it| try emitIsTest(self, it),
         .ref_of => |r| try self.emitAddrOf(r.inner),
         .cast => |c| try emitExpr(self, c.inner), // same-width primitives share a bit pattern, so the cast is a no-op
@@ -95,6 +101,16 @@ pub fn emitExprDiscard(self: *Emitter, e: *const ast.Expr) !void {
 /// `acu`. Field access on non-enum receivers is not yet
 /// supported.
 pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void {
+    // `super.field` — read parent-side shadowed slot.
+    if (f.receiver.* == .super_expr) {
+        if (self.current_class_name) |cname| {
+            const fname = self.source[f.field.start..f.field.end];
+            try class.emitSuperFieldLoad(self, cname, fname, f.span);
+            return;
+        }
+        try self.unsupported(f.span, "`super.field` used outside a method body");
+        return;
+    }
     // Class-typed receiver — `obj.field` instance load.
     if (self.classNameOf(f.receiver)) |cname| {
         const fname = self.source[f.field.start..f.field.end];
@@ -371,6 +387,17 @@ pub fn emitShortCircuitBool(self: *Emitter, b: ast.BinaryExpr) !void {
 /// other receivers (class instance method calls) are not yet
 /// supported.
 pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr) !void {
+    // `super.method(args)` — direct call to parent's method,
+    // bypassing the vtable.
+    if (m.receiver.* == .super_expr) {
+        if (self.current_class_name) |cname| {
+            const mname = self.source[m.method.start..m.method.end];
+            try class.emitSuperMethodCall(self, cname, mname, m.args, m.span);
+            return;
+        }
+        try self.unsupported(m.span, "`super.method` used outside a method body");
+        return;
+    }
     // Class-typed receiver — vtable dispatch.
     if (self.classNameOf(m.receiver)) |cname| {
         const mname = self.source[m.method.start..m.method.end];

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1912,3 +1912,277 @@ test "codegen/class: method returning a value propagates through `acu`" {
 
     try std.testing.expectEqualStrings("99\n", writer.written());
 }
+
+// ---------- M3b chunk 2: inheritance + super ----------
+
+test "codegen/class: child inherits parent method (no override)" {
+    var compiled = try compileSource(
+        \\class Parent
+        \\  def greet(self)
+        \\    print "parent"
+        \\  end
+        \\end
+        \\
+        \\class Child extends Parent
+        \\end
+        \\
+        \\def main()
+        \\  let c = Child()
+        \\  c.greet()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("parent\n", writer.written());
+}
+
+test "codegen/class: child override dispatches to child via vtable" {
+    var compiled = try compileSource(
+        \\class Parent
+        \\  def speak(self)
+        \\    print "parent"
+        \\  end
+        \\end
+        \\
+        \\class Child extends Parent
+        \\  def speak(self)
+        \\    print "child"
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let c = Child()
+        \\  c.speak()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("child\n", writer.written());
+}
+
+test "codegen/class: super.method bypasses the vtable" {
+    var compiled = try compileSource(
+        \\class Parent
+        \\  def speak(self)
+        \\    print "parent"
+        \\  end
+        \\end
+        \\
+        \\class Child extends Parent
+        \\  def speak(self)
+        \\    super.speak()
+        \\    print "child"
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let c = Child()
+        \\  c.speak()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // super.speak runs parent's body ("parent"), then child's
+    // body resumes and prints "child".
+    try std.testing.expectEqualStrings("parent\nchild\n", writer.written());
+}
+
+test "codegen/class: child inherits parent fields and reads them via self" {
+    var compiled = try compileSource(
+        \\class Parent
+        \\  let n: i16
+        \\
+        \\  def init(self, x: i16)
+        \\    self.n = x
+        \\  end
+        \\end
+        \\
+        \\class Child extends Parent
+        \\end
+        \\
+        \\def main()
+        \\  let c = Child(42)
+        \\  print c.n
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("42\n", writer.written());
+}
+
+test "codegen/class: shadowed field — self.X reads child's, super.X reads parent's" {
+    var compiled = try compileSource(
+        \\class Parent
+        \\  let value: i16
+        \\
+        \\  def init(self)
+        \\    self.value = 10
+        \\  end
+        \\end
+        \\
+        \\class Child extends Parent
+        \\  let value: i16
+        \\
+        \\  def init(self)
+        \\    super.init()
+        \\    self.value = 20
+        \\  end
+        \\
+        \\  def report(self)
+        \\    print self.value
+        \\    print super.value
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let c = Child()
+        \\  c.report()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("20\n10\n", writer.written());
+}
+
+test "codegen/class: child without init reuses parent's init via inheritance" {
+    var compiled = try compileSource(
+        \\class Parent
+        \\  let n: i16
+        \\
+        \\  def init(self)
+        \\    self.n = 99
+        \\  end
+        \\end
+        \\
+        \\class Child extends Parent
+        \\end
+        \\
+        \\def main()
+        \\  let c = Child()
+        \\  print c.n
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("99\n", writer.written());
+}
+
+test "codegen/class: vtable dispatch is dynamic — same slot, different bodies" {
+    // The vtable copy + override mechanism gives polymorphism for
+    // free: two classes that share a method slot dispatch to their
+    // own override at runtime. This test allocates a Parent and a
+    // Child, calls speak() on each, and checks each prints its own
+    // body — not whichever class was syntactically named at the
+    // call site.
+    var compiled = try compileSource(
+        \\class Parent
+        \\  def speak(self)
+        \\    print "P"
+        \\  end
+        \\end
+        \\
+        \\class Child extends Parent
+        \\  def speak(self)
+        \\    print "C"
+        \\  end
+        \\end
+        \\
+        \\def main()
+        \\  let p = Parent()
+        \\  let c = Child()
+        \\  p.speak()
+        \\  c.speak()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("P\nC\n", writer.written());
+}
+
+test "codegen/class: three-level inheritance — Grandparent ← Parent ← Child" {
+    var compiled = try compileSource(
+        \\class Grandparent
+        \\  def name(self)
+        \\    print "G"
+        \\  end
+        \\end
+        \\
+        \\class Parent extends Grandparent
+        \\end
+        \\
+        \\class Child extends Parent
+        \\end
+        \\
+        \\def main()
+        \\  let c = Child()
+        \\  c.name()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("G\n", writer.written());
+}


### PR DESCRIPTION
## Summary

M3b chunk 2 — closes #260. Adds single-inheritance support on top of the chunk-1 single-class codegen.

- **Layout** — Child inherits parent's field offsets + appends own fields. Shadowed names occupy distinct slots (parent slot reachable via `super.field`). Vtable inherits parent's slots; overrides reuse; new methods append.
- **Constructor** — walks method-owner chain for `init`. Child without own init reuses parent's init.
- **`super.method(args)`** — direct call to closest ancestor's mangled label. Bypasses vtable.
- **`super.field`** — walks parent chain for first ancestor that owns the field, loads at that slot's offset.

`Emitter.current_class_name` (set + restored per `emitMethodAsDef`) carries the enclosing class so super lookups know where to start.

8 new codegen tests cover: inherited method (no override), child override via vtable, super.method bypass, inherited fields, shadowed field + super.field, child-without-init reuses parent's init, three-level chain, dynamic vtable dispatch on shared slots.

## Out of scope (M3b finishing touches)

- `@final` devirtualization
- `@abstract` faulting stubs
- `@static` class-level methods
- `@private` codegen enforcement (typechecker concern)

## Test plan

- [x] `zig build verify` green
- [x] `zig build ci` green (verify + test-modes 4 modes + test-all 5 cross-targets + examples + check-broken)
- [x] Lint EXIT=0
- [x] Self-review per CLAUDE.md 4-step walkthrough — gates clean, no `std.debug.print` / `unreachable` / `anyerror` / `*anyopaque` added, justified casts via lint pass, no AI attribution, public API surface (`src/gero.zig` + `src/lang.zig`) untouched — all changes under existing `internal.codegen.class`
- [x] One surfaced gap closed in-PR: polymorphism test (dynamic vtable dispatch on shared slots)