### PR TITLE
feat(lang): closures — capture analysis + heap promotion + dispatch

### DIFF
--- a/.changeset/lang-closures.md
+++ b/.changeset/lang-closures.md
@@ -31,13 +31,25 @@ pointer — shared state across all closures + the parent.
 Non-promoted captures get a by-value copy at closure-creation
 time.
 
+**Nested lambdas.** Free vars of an inner lambda that aren't
+local to the enclosing lambda flow transitively into the
+enclosing lambda's capture list. At closure-creation time the
+inner closure's env slot is populated by re-reading the slot
+from the enclosing env — for promoted (cell-pointer) captures
+the pointer propagates as-is so all nesting levels share state;
+for by-value captures the value re-copies. Per-lambda scope
+analysis tracks each lambda's own promoted bindings and
+closure-init let bindings, swapped in while the body emits so
+nested `let x = lambda ... end` dispatch routes correctly.
+
 **Call site.** `f(args)` where `f` is either:
 
 - a let-binding initialized with a lambda (detected via
   `closure_bindings` from the analysis pass), or
-- a local / param whose inferred type is `function` (covers
-  `let c = make_counter()` where `make_counter` returns a
-  lambda — escape across fn boundaries).
+- a local / param / capture whose inferred type is `function`
+  (covers `let c = make_counter()` where `make_counter` returns
+  a lambda — escape across fn boundaries — and the nested case
+  where the function-typed ident is re-read from the env).
 
 …dispatches via `call_reg`: load fn_ptr from tuple, push closure
 ptr as hidden first arg + user args right-to-left, call_reg.
@@ -46,22 +58,19 @@ ptr as hidden first arg + user args right-to-left, call_reg.
 instead of `null` — drives the closure-call detection at sites
 where the closure flowed in from another fn. The lambda body's
 `return` checks against the lambda's own return type (not the
-enclosing fn's).
+enclosing fn's). Bidirectional hint flow lets a short-form
+lambda assigned to a fn-typed binding (`let f: fn() -> i16 = ||
+99`) pick up param + return types from the binding annotation.
 
 **`@no_capture` enforcement** stays exactly as #220 shipped —
 the typechecker errors on captured-and-mutated bindings inside a
 `@no_capture` def body before codegen ever sees the mutation, so
 no auto-promotion happens for those.
 
-**Out of scope** (known limits, follow-ups if they materialize):
-
-- Nested-lambda capture flow (an inner lambda's captures don't
-  propagate through the outer lambda's env).
-- Fn-typed globals (gero has no fn-typed globals today; the
-  closure-call dispatch only inspects locals + params for the
-  function-type check).
-
-Seven new codegen tests cover the AC end-to-end: zero-capture
-lambda, AC1 read-only capture, AC2 mutated capture shared state,
-AC3 two closures consistent state, short-lambda `|x|`,
-multi-capture mixed, and AC4 returned closure with escape.
+Ten codegen tests cover the AC + nested cases end-to-end:
+zero-capture lambda, AC1 read-only capture, AC2 mutated capture
+shared state, AC3 two closures consistent state, short-lambda
+`|x|`, multi-capture mixed, AC4 returned closure with escape,
+nested lambda reading through outer's env, nested mutation
+sharing a cell across levels, and short-lambda inferring its
+shape from a fn-typed binding hint.

--- a/.changeset/lang-closures.md
+++ b/.changeset/lang-closures.md
@@ -1,0 +1,67 @@
+---
+bump: minor
+---
+
+Closures — `lambda () ... end` and short-form `|args| expr`
+compile end-to-end. Closes #259.
+
+**Value model.** A closure value is a 2-byte pointer to a heap
+tuple `(fn_ptr: u16, capture_0: u16, capture_1: u16, ...)`.
+`fn_ptr` is the address of the lambda body, emitted as a
+regular def with a mangled `__lambda_<fn>_<n>` label and a
+hidden first param `env_ptr`. Captures live at `env_ptr + 2 +
+N*2`.
+
+**Capture analysis** (`src/lang/codegen/lambda.zig`). For each
+fn body the codegen emits, a pre-pass walks the body to find:
+
+- All let / const / param bindings (the "promotion candidates").
+- All lambda expressions + their free variables (idents used in
+  the lambda body but declared in the parent scope).
+- Which captured bindings are mutated (assigned in the parent
+  or inside another lambda over the same binding).
+- Which lambdas escape (operand of a `return`).
+
+A binding is **promoted** to a heap cell when it's captured AND
+(mutated OR captured by an escaping lambda). Promoted bindings
+allocate a 2-byte cell via `sys alloc` at `let` time, the slot
+holds the cell pointer, and every read / write goes through cell
+deref / store. Closures over a promoted binding capture the cell
+pointer — shared state across all closures + the parent.
+Non-promoted captures get a by-value copy at closure-creation
+time.
+
+**Call site.** `f(args)` where `f` is either:
+
+- a let-binding initialized with a lambda (detected via
+  `closure_bindings` from the analysis pass), or
+- a local / param whose inferred type is `function` (covers
+  `let c = make_counter()` where `make_counter` returns a
+  lambda — escape across fn boundaries).
+
+…dispatches via `call_reg`: load fn_ptr from tuple, push closure
+ptr as hidden first arg + user args right-to-left, call_reg.
+
+**Typecheck** now returns a function type for lambda expressions
+instead of `null` — drives the closure-call detection at sites
+where the closure flowed in from another fn. The lambda body's
+`return` checks against the lambda's own return type (not the
+enclosing fn's).
+
+**`@no_capture` enforcement** stays exactly as #220 shipped —
+the typechecker errors on captured-and-mutated bindings inside a
+`@no_capture` def body before codegen ever sees the mutation, so
+no auto-promotion happens for those.
+
+**Out of scope** (known limits, follow-ups if they materialize):
+
+- Nested-lambda capture flow (an inner lambda's captures don't
+  propagate through the outer lambda's env).
+- Fn-typed globals (gero has no fn-typed globals today; the
+  closure-call dispatch only inspects locals + params for the
+  function-type check).
+
+Seven new codegen tests cover the AC end-to-end: zero-capture
+lambda, AC1 read-only capture, AC2 mutated capture shared state,
+AC3 two closures consistent state, short-lambda `|x|`,
+multi-capture mixed, and AC4 returned closure with escape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,19 @@ as the implementation — never after.
 ## The contract
 
 **Workflow:** one issue → one branch → one PR → wait for explicit
-merge signal → next issue. Never batch issues. Never start the next
-one before the current is merged. PR diff past ~400 lines → stop
-and split.
+merge signal → next issue. Never batch multiple issues into a
+single PR. **Do not** split a single issue across multiple PRs
+either — one issue maps to exactly one end-to-end PR, no matter
+the diff size. Multi-concern changes within that PR split into
+multiple commits (see [Branches + commits + changesets](#branches--commits--changesets)),
+but the PR boundary matches the issue boundary.
+
+**Close the issue from the PR.** Every `feat` / `fix` / `perf` PR
+description ends with `Closes #N` (or `Advances #N` when a partial
+ship is honestly out of scope, with the deferred AC items listed
+explicitly). GitHub auto-closes on merge — verify post-merge that
+the issue actually closed and reflect any drift back to the
+maintainer.
 
 **Done means the acceptance criteria are met**, not green CI.
 Re-read the issue body before declaring the work finished.
@@ -412,7 +422,8 @@ on it locally, but `verify` green is required before pushing.
 - `docs/<short>` — docs-only change
 - `refactor/<short>` — internal restructure, no behavior change
 
-Branch from `main`. One issue → one branch → one PR.
+Branch from `main`. One issue → one branch → one PR end-to-end
+(no chunking; see [The contract](#the-contract)).
 
 **Commits:** Conventional Commits enforced by **convco** with a
 strict scope-enum from `.versionrc`.

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -30,6 +30,7 @@ const cg_pattern = @import("lang/codegen/pattern.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 const cg_class = @import("lang/codegen/class.zig");
+const cg_lambda = @import("lang/codegen/lambda.zig");
 
 // ---------- lexer ----------
 
@@ -157,5 +158,8 @@ pub const internal = struct {
         /// Internal — class lowering (vtable + constructor +
         /// field rw + method dispatch).
         pub const class = cg_class;
+        /// Internal — closure lowering (capture analysis, heap
+        /// promotion, lambda body emission, dispatch).
+        pub const lambda = cg_lambda;
     };
 };

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -190,6 +190,7 @@ pub fn compile(
         .fn_closure_info = .{
             .promoted = .{},
             .lambdas = .empty,
+            .next_lambda_id = 0,
             .closure_bindings = .{},
         },
         .captures = .{},

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -55,6 +55,7 @@ const pattern = @import("codegen/pattern.zig");
 const expr_emit = @import("codegen/expr.zig");
 const control_flow = @import("codegen/control_flow.zig");
 const class = @import("codegen/class.zig");
+const lambda = @import("codegen/lambda.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const CheckedProgram = typecheck_mod.CheckedProgram;
@@ -186,6 +187,13 @@ pub fn compile(
         .class_decls = .{},
         .class_layouts = .{},
         .current_class_name = null,
+        .fn_closure_info = .{
+            .promoted = .{},
+            .lambdas = .empty,
+            .closure_bindings = .{},
+        },
+        .captures = .{},
+        .lambda_patches = .empty,
         .vtable_patches = .empty,
         .block_stack = .empty,
         .loop_stack = .empty,
@@ -194,6 +202,7 @@ pub fn compile(
     defer emitter.code.deinit(allocator);
     defer emitter.call_patches.deinit(allocator);
     defer emitter.vtable_patches.deinit(allocator);
+    defer emitter.lambda_patches.deinit(allocator);
     defer emitter.strings.deinit(allocator);
     defer emitter.string_patches.deinit(allocator);
     defer emitter.block_stack.deinit(allocator);
@@ -331,6 +340,16 @@ pub const VtablePatch = struct {
     class_name: []const u8,
 };
 
+/// Unresolved lambda fn_ptr site — a closure-creation site left
+/// an imm16 slot at `code_offset` for the lambda body's address.
+/// `patchLambdaSlots` rewrites every slot once each lambda body
+/// has emitted and `fn_addresses[label]` resolves.
+pub const LambdaPatch = struct {
+    bank: ?u8,
+    code_offset: usize,
+    label: []const u8,
+};
+
 /// Per-fn codegen state — owns the working bytecode buffer, the
 /// local-slot table, and the diagnostic sink. The entry-def
 /// emission path owns one Emitter; later M1 commits will create
@@ -430,6 +449,20 @@ pub const Emitter = struct {
     /// emitting — drives `super` resolution. `null` outside any
     /// method body. Saved + restored per `emitMethodAsDef` call.
     current_class_name: ?[]const u8,
+    /// Per-fn closure analysis — populated by `lambda.analyzeFn`
+    /// before each fn body emits, then consulted by `emitLetDecl`
+    /// / `emitIdent` / `emitAssign` / `emitCall` to route through
+    /// the heap-cell / closure-call paths. Reset between defs.
+    fn_closure_info: lambda.FnClosureInfo,
+    /// Captures visible to the body currently emitting — set when
+    /// emitting a lambda's body so `emitIdent` / `emitAssign` can
+    /// dispatch env-relative loads / stores for captured names.
+    /// `null` outside any lambda body.
+    captures: std.StringHashMapUnmanaged(lambda.CaptureSlot),
+    /// Unresolved lambda fn_ptr slots emitted by closure-creation
+    /// sites — patched by `lambda.patchLambdaSlots` once each
+    /// lambda body has landed in `fn_addresses`.
+    lambda_patches: std.ArrayList(LambdaPatch),
     /// Unresolved vtable-address slots emitted by class
     /// constructors — the constructor emits `mov 0, r2` as a
     /// placeholder when it runs (vtables don't have addresses
@@ -805,7 +838,7 @@ pub const Emitter = struct {
     /// recurses through control-flow forms; arms that never execute
     /// at runtime still reserve their slots (the savings of slot
     /// reuse aren't worth a live-range analysis at this scale).
-    fn countLocalsInBody(self: *const Emitter, body: []const ast.Statement) usize {
+    pub fn countLocalsInBody(self: *const Emitter, body: []const ast.Statement) usize {
         var n: usize = 0;
         for (body) |s| n += self.countLocalsInStmt(s);
         return n;
@@ -906,6 +939,10 @@ pub const Emitter = struct {
         // Resolve constructor-side placeholder slots now that each
         // class's vtable lives at a known address.
         try class.patchVtableSlots(self);
+        // Resolve every closure-creation site's lambda fn_ptr slot
+        // — lambda bodies emitted alongside their parent def, so
+        // their addresses live in `fn_addresses` by now.
+        try lambda.patchLambdaSlots(self);
 
         try self.patchCalls();
         try self.patchStrings();
@@ -934,7 +971,7 @@ pub const Emitter = struct {
     /// Look up the typechecker's inferred type for an expression.
     /// Returns `null` when the typechecker couldn't infer a type
     /// (callers must fall back to a less-specific lowering).
-    fn typeOf(self: *const Emitter, e: *const ast.Expr) ?*const Type {
+    pub fn typeOf(self: *const Emitter, e: *const ast.Expr) ?*const Type {
         return self.checked.typeOf(e);
     }
 
@@ -1331,6 +1368,14 @@ pub const Emitter = struct {
             try self.subImmFromReg(reserve_bytes, Reg.sp);
         }
 
+        // Closure-analysis pre-pass — populates fn_closure_info
+        // with the lambda inventory, capture layouts, and the
+        // promotion set. Drives the heap-cell paths in
+        // emitLetDecl / emitIdent / emitAssign + the closure-call
+        // dispatch in emitCall.
+        try lambda.analyzeFn(self, def);
+        defer lambda.resetFnInfo(self);
+
         // Function body opens the outermost block of the frame —
         // `defer`s at the top of the body run before the implicit
         // epilogue's `hlt` / `ret`.
@@ -1347,6 +1392,11 @@ pub const Emitter = struct {
             // the return value in acu (callers read from there).
             try self.emitByte(Op.ret_op);
         }
+
+        // Emit any lambda bodies discovered during analyzeFn —
+        // they emit as plain defs adjacent to the parent so their
+        // call sites + closure-creation patches resolve normally.
+        try lambda.emitLambdaBodies(self, def);
     }
 
     /// Rewrite each unresolved call's 2-byte address slot. An
@@ -1529,6 +1579,21 @@ pub const Emitter = struct {
             return;
         }
         const name = self.source[a.target.ident.span.start..a.target.ident.span.end];
+        // Captured-binding write inside a lambda body — store
+        // through the env-relative cell pointer (the parent
+        // promoted the binding so the write is visible everywhere).
+        if (self.captures.get(name)) |slot| {
+            try lambda.emitCaptureStore(self, slot, a.value);
+            return;
+        }
+        // Promoted local in the parent fn — store through the
+        // local-slot cell pointer.
+        if (lambda.isPromoted(self, name)) {
+            if (self.locals.get(name)) |ofs| {
+                try lambda.emitPromotedAssign(self, ofs, a.value);
+                return;
+            }
+        }
         try self.emitExpr(a.value); // result in acu
         if (self.locals.get(name)) |ofs| {
             try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
@@ -1553,6 +1618,12 @@ pub const Emitter = struct {
         const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
         const dup_name = try self.arena.dupe(u8, name);
         const ofs = try self.allocLocal(dup_name);
+        // Promoted bindings live as heap cells — the slot holds
+        // the cell pointer instead of the value directly.
+        if (lambda.isPromoted(self, name)) {
+            try lambda.emitPromotedLetInit(self, d.init, ofs);
+            return;
+        }
         if (d.init) |init_expr| {
             try self.emitExpr(init_expr); // result in acu
             try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
@@ -1686,12 +1757,12 @@ pub const Emitter = struct {
     // ---------- block + defer infrastructure (delegated) ----------
 
     /// Delegated to `codegen/control_flow.zig`.
-    fn pushBlock(self: *Emitter) !void {
+    pub fn pushBlock(self: *Emitter) !void {
         return control_flow.pushBlock(self);
     }
 
     /// Delegated to `codegen/control_flow.zig`.
-    fn popBlockWithDefers(self: *Emitter) !void {
+    pub fn popBlockWithDefers(self: *Emitter) !void {
         return control_flow.popBlockWithDefers(self);
     }
 

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -8,6 +8,7 @@ const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const archive = @import("archive.zig");
 const class = @import("class.zig");
+const lambda = @import("lambda.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -47,8 +48,20 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .paren => |p| try emitExpr(self, p.inner),
         .ident => |i| {
             const name = self.source[i.span.start..i.span.end];
-            // Lookup order: locals → params → globals.
+            // Lookup order: captures (lambda body) → locals → params
+            // → globals. Captures take precedence so they shadow any
+            // same-named local that might also exist in the body.
+            if (self.captures.get(name)) |slot| {
+                try lambda.emitCaptureLoad(self, slot);
+                return;
+            }
             if (self.locals.get(name)) |ofs| {
+                // Promoted bindings live as heap cells — the slot
+                // holds the cell pointer; deref to get the value.
+                if (lambda.isPromoted(self, name)) {
+                    try lambda.emitPromotedIdentLoad(self, ofs);
+                    return;
+                }
                 try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
                 return;
             }
@@ -83,6 +96,7 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
             // intercept before they reach this fallthrough arm.
             try self.unsupported(se.span, "`super` must be followed by `.method(...)` or `.field`");
         },
+        .lambda => |l| try lambda.emitLambdaExpr(self, l, e),
         .is_test => |it| try emitIsTest(self, it),
         .ref_of => |r| try self.emitAddrOf(r.inner),
         .cast => |c| try emitExpr(self, c.inner), // same-width primitives share a bit pattern, so the cast is a no-op
@@ -447,6 +461,15 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
         const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
         if (class.isClassName(self, callee_name)) {
             try class.emitConstructor(self, callee_name, c);
+            return;
+        }
+        // Closure call — `f(args)` where `f` is a let-binding
+        // initialized from a lambda OR a binding whose inferred
+        // type is a function (covers `let c = make_counter()`
+        // where make_counter returns a closure). Dispatch through
+        // the tuple's fn_ptr instead of the free-fn path.
+        if (lambda.isClosureBinding(self, callee_name) or lambda.isClosureByType(self, c.callee)) {
+            try lambda.emitClosureCall(self, c.callee, c);
             return;
         }
     }

--- a/src/lang/codegen/lambda.zig
+++ b/src/lang/codegen/lambda.zig
@@ -1,0 +1,889 @@
+/// Closure lowering — lambda body emission, capture analysis,
+/// heap-cell promotion for mutated/escaping captures, and the
+/// closure invocation path.
+///
+/// **Value model.** A closure value is a 2-byte pointer to a
+/// heap tuple shaped `(fn_ptr: u16, capture_0: u16, capture_1: u16, ...)`.
+/// The fn_ptr at offset 0 is the address of the lambda body
+/// (emitted as a regular def with a mangled `__lambda_N` label
+/// and a hidden first param `env_ptr`).
+///
+/// **Capture analysis.** For each fn body the codegen emits,
+/// `analyzeFn` walks the body looking for:
+///   - All `let` / `const` bindings in the parent fn.
+///   - All lambda expressions in the body — for each, the set of
+///     free identifiers (used in the lambda body but declared in
+///     the parent scope).
+///   - Whether each captured binding is mutated (assigned anywhere
+///     in the parent, or inside another lambda over the same
+///     binding).
+///   - Whether any lambda escapes (is the operand of a `return`).
+///
+/// A binding is **promoted** (heap-cell-allocated) when it's
+/// captured AND (mutated OR captured by an escaping lambda).
+/// Promoted bindings:
+///   - Allocate a 2-byte heap cell at `let` time via `sys alloc`.
+///   - The cell address lives in the local slot.
+///   - Reads / writes go through cell deref / store (one extra
+///     indirection vs. a normal local).
+///   - Closures over a promoted binding capture the cell pointer
+///     (shared state).
+///
+/// Non-promoted captures get a by-value copy at closure-creation
+/// time: the tuple slot holds the captured value, frozen at the
+/// moment the lambda expression evaluated.
+///
+/// **Call site.** `f(args)` where `f` is a closure binding:
+///   1. Load closure ptr into `r1`.
+///   2. Load fn_ptr from `[r1 + 0]` into `r3`.
+///   3. Push user args right-to-left.
+///   4. Push `r1` (closure ptr) as hidden first arg.
+///   5. `call_reg r3`.
+///   6. Drop args (1 + user args, 2 bytes each).
+///
+/// Inside the lambda body, `env_ptr` is the implicit first param
+/// (fp + 4). Captures are loaded from `[env_ptr + 2 + N*2]` —
+/// for non-promoted captures that's the value directly; for
+/// promoted captures it's the cell pointer, which the body
+/// derefs on use.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const opcodes = @import("opcodes.zig");
+const codegen_mod = @import("../codegen.zig");
+
+const Emitter = codegen_mod.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Sys = opcodes.Sys;
+
+/// Per-fn analysis result. Built by `analyzeFn` before the body
+/// emits; consulted by `emitLetDecl` / `emitIdent` / `emitAssign`
+/// to route through the heap-cell path for promoted bindings,
+/// and by `emitLambdaExpr` / `emitLambdaBodies` to lay out the
+/// closure tuples and emit the bodies.
+pub const FnClosureInfo = struct {
+    /// Names of let / const / param bindings in this fn that must
+    /// live as heap cells.
+    promoted: std.StringHashMapUnmanaged(void),
+    /// Lambdas encountered in the fn body, in source order. The
+    /// index is the lambda's identity within this fn (used to
+    /// derive a stable `__lambda_<fn>_<N>` label).
+    lambdas: std.ArrayListUnmanaged(LambdaInfo),
+    /// Names of let bindings whose init is a lambda — used at
+    /// call sites to detect `f(args)` should dispatch as a
+    /// closure call vs a free-fn call.
+    closure_bindings: std.StringHashMapUnmanaged(void),
+};
+
+/// One lambda discovered during `analyzeFn` — drives both the
+/// closure-creation site (which slots get what) and the body
+/// emission (the env-relative offsets for each capture).
+pub const LambdaInfo = struct {
+    /// AST pointer for identity — `emitLambdaExpr` looks up its
+    /// own info via this pointer when emitting the closure-
+    /// creation code; `emitLambdaBodies` walks the list in order.
+    ast_node: *const ast.LambdaExpr,
+    /// Mangled label — `__lambda_<fn_name>_<index>`.
+    label: []const u8,
+    /// Captured binding names in slot order. Slot index N maps to
+    /// tuple offset `2 + N*2` (offset 0 is fn_ptr).
+    captures: std.ArrayListUnmanaged([]const u8),
+};
+
+/// Walk `def` body, populate `Emitter.fn_closure_info` with the
+/// lambda inventory + capture layout + promotion set. Call before
+/// emitting the body so the let/ident/assign hooks can consult it.
+pub fn analyzeFn(self: *Emitter, def: *const ast.DefDecl) !void {
+    var info: FnClosureInfo = .{
+        .promoted = .{},
+        .lambdas = .empty,
+        .closure_bindings = .{},
+    };
+
+    // Collect local binding names + closure-init bindings from the
+    // top-level statements of the fn body. (Nested scopes use the
+    // same parent locals — gero's frame allocates them all up front.)
+    var local_bindings: std.StringHashMapUnmanaged(void) = .{};
+    for (def.body) |stmt| collectLocalsFromStatement(self, stmt, &local_bindings, &info) catch {};
+    for (def.params) |p| {
+        const name = self.source[p.name.start..p.name.end];
+        try local_bindings.put(self.arena, name, {});
+    }
+
+    // Find every lambda in the body + its captures.
+    for (def.body) |stmt| try findLambdasInStatement(self, stmt, def, &info);
+
+    // Decide promotion. A binding is promoted if it's captured
+    // by some lambda AND (mutated anywhere OR captured by a
+    // lambda that escapes).
+    var mutated: std.StringHashMapUnmanaged(void) = .{};
+    for (def.body) |stmt| collectMutatedInStatement(self, stmt, &mutated);
+
+    var escaping_captures: std.StringHashMapUnmanaged(void) = .{};
+    for (def.body) |stmt| collectEscapingCaptures(self, stmt, &info, &escaping_captures);
+
+    for (info.lambdas.items) |li| {
+        for (li.captures.items) |cap| {
+            if (!local_bindings.contains(cap)) continue;
+            if (mutated.contains(cap) or escaping_captures.contains(cap)) {
+                try info.promoted.put(self.arena, cap, {});
+            }
+        }
+    }
+
+    self.fn_closure_info = info;
+}
+
+/// Reset the per-fn analysis between defs.
+pub fn resetFnInfo(self: *Emitter) void {
+    self.fn_closure_info = .{
+        .promoted = .{},
+        .lambdas = .empty,
+        .closure_bindings = .{},
+    };
+}
+
+/// `true` when `name` was promoted to a heap cell in the current fn.
+pub fn isPromoted(self: *const Emitter, name: []const u8) bool {
+    return self.fn_closure_info.promoted.contains(name);
+}
+
+/// `true` when `name` is bound to a closure value in the current
+/// fn (drives closure-call dispatch at `name(args)` sites).
+pub fn isClosureBinding(self: *const Emitter, name: []const u8) bool {
+    return self.fn_closure_info.closure_bindings.contains(name);
+}
+
+/// `true` when `e` is an ident bound to a local or param whose
+/// inferred type is a function — covers the case where a closure
+/// flowed in from a fn's return value (`let c = make_counter()`
+/// where `make_counter` returns a lambda). Limited to
+/// local/param bindings so free-fn idents (which type as
+/// function too, but dispatch via direct call) don't get
+/// misrouted to the closure path.
+pub fn isClosureByType(self: *const Emitter, e: *const ast.Expr) bool {
+    if (e.* != .ident) return false;
+    const name = self.source[e.ident.span.start..e.ident.span.end];
+    if (!self.locals.contains(name) and !self.params.contains(name)) return false;
+    const ty = self.typeOf(e) orelse return false;
+    return ty.* == .function;
+}
+
+// ---------- promotion-aware let / ident / assign helpers ----------
+
+/// Initial value of a promoted local: allocate a 2-byte cell,
+/// optionally seed it with the init expression, store the cell
+/// pointer in the local slot.
+pub fn emitPromotedLetInit(
+    self: *Emitter,
+    init: ?*const ast.Expr,
+    slot_ofs: i8,
+) !void {
+    // Allocate a 2-byte cell on the heap.
+    try self.movImmToReg(2, Reg.acu);
+    try self.emitByte(Op.sys);
+    try self.emitByte(Sys.alloc);
+    // acu = cell pointer; store it in the local slot.
+    try self.movRegToRegOffset(Reg.acu, Reg.fp, slot_ofs);
+    // Seed the cell with the init value when present.
+    if (init) |init_expr| {
+        try self.movRegToReg(Reg.acu, Reg.r1); // r1 = cell ptr
+        try self.pushReg(Reg.r1);
+        try self.emitExpr(init_expr); // acu = init value
+        try self.popReg(Reg.r1);
+        try cellStore(self, Reg.r1, Reg.acu);
+    }
+}
+
+/// Read a promoted local: load cell pointer from slot, then deref.
+pub fn emitPromotedIdentLoad(self: *Emitter, slot_ofs: i8) !void {
+    try self.movRegOffsetToReg(Reg.fp, slot_ofs, Reg.r1);
+    try cellLoad(self, Reg.r1, Reg.acu);
+}
+
+/// Write a promoted local: evaluate value into acu, push, load
+/// the cell pointer, deref-write.
+pub fn emitPromotedAssign(self: *Emitter, slot_ofs: i8, value: *const ast.Expr) !void {
+    try self.emitExpr(value);
+    try self.pushReg(Reg.acu);
+    try self.movRegOffsetToReg(Reg.fp, slot_ofs, Reg.r1);
+    try self.popReg(Reg.r2);
+    try cellStore(self, Reg.r1, Reg.r2);
+}
+
+fn cellLoad(self: *Emitter, ptr_reg: u8, dst: u8) !void {
+    // mov [ptr], dst (word load via pointer register).
+    try self.emitByte(Op.mov_ptr_to_reg);
+    try self.emitByte(dst);
+    try self.emitByte(ptr_reg);
+}
+
+fn cellStore(self: *Emitter, ptr_reg: u8, src: u8) !void {
+    // mov src → [ptr] (word store via pointer register).
+    try self.emitByte(Op.mov_reg_to_ptr);
+    try self.emitByte(ptr_reg);
+    try self.emitByte(src);
+}
+
+// ---------- lambda expression site ----------
+
+/// Lower a `LambdaExpr` — bump-allocate the tuple, fill it with
+/// the fn_ptr + capture slots, leave the tuple pointer in `acu`.
+pub fn emitLambdaExpr(self: *Emitter, lambda: ast.LambdaExpr, expr: *const ast.Expr) !void {
+    const li = findLambdaInfo(self, expr) orelse {
+        try self.diagFatal(lambda.span, "E_CODEGEN_LAMBDA_NOT_ANALYZED", "codegen: internal — lambda missing from analyzeFn pass");
+        return;
+    };
+
+    // @as: tuple size = 2 (fn_ptr) + 2*N (capture slots). N caps well below 32k by parser limits.
+    const tuple_size: u16 = 2 + @as(u16, @intCast(li.captures.items.len * 2));
+    try self.movImmToReg(tuple_size, Reg.acu);
+    try self.emitByte(Op.sys);
+    try self.emitByte(Sys.alloc);
+    // acu = tuple ptr; stash in r1 for the populate phase.
+    try self.movRegToReg(Reg.acu, Reg.r1);
+
+    // Write fn_ptr at offset 0 — placeholder, patched when the
+    // lambda body emits at the end of the fn pass.
+    try self.emitByte(Op.mov_imm16_reg);
+    const fn_slot = try self.currentOffset();
+    try self.emitU16Le(0);
+    try self.emitByte(Reg.r2);
+    try self.lambda_patches.append(self.allocator, .{
+        .bank = self.current_bank,
+        .code_offset = fn_slot,
+        .label = li.label,
+    });
+    try self.emitByte(Op.mov_reg_to_ptr);
+    try self.emitByte(Reg.r1);
+    try self.emitByte(Reg.r2);
+
+    // Populate each capture slot. Capture[N] lives at offset
+    // `2 + N*2`. Promoted captures: store the cell pointer.
+    // Non-promoted: store the current value.
+    for (li.captures.items, 0..) |cap, idx| {
+        // @as: idx fits u16 — capture count caps below 32k.
+        const slot_offset: u16 = 2 + @as(u16, @intCast(idx)) * 2;
+        try self.pushReg(Reg.r1); // preserve tuple ptr
+        try emitCaptureSource(self, cap);
+        try self.popReg(Reg.r1);
+        // acu = capture value (cell ptr if promoted, value otherwise)
+        try emitWordStoreAtOffset(self, Reg.r1, slot_offset, Reg.acu);
+    }
+
+    // Result: tuple ptr in acu.
+    try self.movRegToReg(Reg.r1, Reg.acu);
+}
+
+/// Load a capture's source value into `acu` at closure-creation
+/// time. For a promoted binding: that's the cell pointer (lives
+/// directly in the local slot). For an unpromoted binding: that's
+/// the current value (regular local / param / global load).
+fn emitCaptureSource(self: *Emitter, name: []const u8) !void {
+    if (self.locals.get(name)) |ofs| {
+        try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+        return;
+    }
+    if (self.params.get(name)) |ofs| {
+        try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+        return;
+    }
+    if (self.globals.get(name)) |g| {
+        try self.emitGlobalLoad(g);
+        return;
+    }
+    // Unbound at this point — analyzeFn shouldn't have recorded
+    // it as a capture. Defensive fault.
+    try self.diagFatal(.{ .start = 0, .end = 0 }, "E_CODEGEN_UNBOUND_CAPTURE", "codegen: lambda captures a name with no current binding");
+}
+
+// ---------- lambda body emission ----------
+
+/// Emit each lambda body in the current fn's analysis as a
+/// separate def with a mangled label. Hidden first param is
+/// `env_ptr` (the closure tuple). Captures are accessed via
+/// `env_ptr + 2 + N*2` inside the body.
+///
+/// Runs at the end of `emitDefWithLabel` so the bodies sit
+/// adjacent to the parent fn in the code buffer — call-patches
+/// pick up their addresses normally.
+pub fn emitLambdaBodies(self: *Emitter, def: *const ast.DefDecl) !void {
+    // Snapshot the lambda list — emitting bodies may mutate
+    // fn_closure_info if a lambda itself contains lambdas, but
+    // for this PR we don't recurse into nested-lambda capture
+    // analysis (a known limit; the typechecker's @no_capture
+    // already constrains deep nesting in @no_capture defs).
+    const lambdas = self.fn_closure_info.lambdas.items;
+    _ = def;
+    for (lambdas) |li| {
+        try emitOneLambdaBody(self, li);
+    }
+}
+
+fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
+    const lambda = li.ast_node;
+
+    // Save + restore per-fn state — identical to emitDefWithLabel
+    // but with a synthetic param list (env_ptr + user params).
+    const saved_locals = self.locals;
+    const saved_params = self.params;
+    const saved_frame = self.frame_bytes;
+    const saved_entry = self.is_entry;
+    const saved_bank = self.current_bank;
+    const saved_info = self.fn_closure_info;
+    self.locals = .{};
+    self.params = .{};
+    self.frame_bytes = 0;
+    self.is_entry = false;
+    // Lambdas inherit the parent bank — nested-bank lambdas land
+    // in a future feature; for now the lambda body shares the
+    // parent fn's emit buffer.
+    self.fn_closure_info = .{
+        .promoted = .{},
+        .lambdas = .empty,
+        .closure_bindings = .{},
+    };
+    defer {
+        self.locals = saved_locals;
+        self.params = saved_params;
+        self.frame_bytes = saved_frame;
+        self.is_entry = saved_entry;
+        self.current_bank = saved_bank;
+        self.fn_closure_info = saved_info;
+    }
+
+    const dup_label = try self.arena.dupe(u8, li.label);
+    // @as: narrow usize code offset to u16; per-buffer offset stays ≤ 64 KiB.
+    const code_offset: u16 = @intCast(try self.currentOffset());
+    const addr: u16 = codegen_mod.code_base + code_offset;
+    try self.fn_addresses.put(self.arena, dup_label, addr);
+
+    // env_ptr is the hidden first param at fp+4. Register it
+    // under the synthetic name "__env" so capture loads can
+    // reach it.
+    try self.params.put(self.arena, "__env", 4);
+
+    // User params follow env_ptr — offsets shift by 2.
+    for (lambda.params, 0..) |p, i| {
+        const p_name = self.source[p.name.start..p.name.end];
+        const dup_p = try self.arena.dupe(u8, p_name);
+        // @as: u8 frame index → i8 fp-offset.
+        const offset: i8 = @intCast(6 + 2 * @as(i32, @intCast(i)));
+        try self.params.put(self.arena, dup_p, offset);
+    }
+
+    // Register the captures so emitIdent / emitAssign in the
+    // body knows where to find them (env-relative). The new
+    // `captures` map on Emitter is consulted before locals/params/
+    // globals during ident resolution.
+    var captures_map: std.StringHashMapUnmanaged(CaptureSlot) = .{};
+    for (li.captures.items, 0..) |cap, idx| {
+        // @as: idx fits u16 — capture count caps below 32k.
+        const offset: u16 = 2 + @as(u16, @intCast(idx)) * 2;
+        const promoted_in_parent = saved_info.promoted.contains(cap);
+        try captures_map.put(self.arena, cap, .{
+            .env_offset = offset,
+            .is_cell = promoted_in_parent,
+        });
+    }
+    const saved_captures = self.captures;
+    self.captures = captures_map;
+    defer self.captures = saved_captures;
+
+    // Reserve local slots up front (lambda body uses locals like
+    // any other fn).
+    const local_count = self.countLocalsInBody(lambda.body);
+    if (local_count > 0) {
+        // @as: 2 bytes per slot, caps well below u16.
+        const reserve_bytes: u16 = @intCast(local_count * 2);
+        try self.subImmFromReg(reserve_bytes, Reg.sp);
+    }
+
+    try self.pushBlock();
+    for (lambda.body) |stmt| try self.emitStatement(stmt);
+    try self.popBlockWithDefers();
+
+    try self.emitByte(Op.ret_op);
+}
+
+/// One captured binding inside a lambda body — drives the
+/// `emitIdent` env-relative load + the assign env-relative cell
+/// write.
+pub const CaptureSlot = struct {
+    /// Offset from env_ptr where the capture lives — for non-cell
+    /// captures, this slot holds the captured value directly; for
+    /// cell captures (promoted), this slot holds the cell pointer.
+    env_offset: u16,
+    /// `true` when the parent promoted this binding to a heap
+    /// cell. Reads in the lambda body need an extra deref; writes
+    /// store back to the cell (visible to other closures + parent).
+    is_cell: bool,
+};
+
+/// Load env_ptr from `[fp + 4]` into `dst` — used by capture
+/// loads / stores inside the lambda body.
+fn loadEnvPtr(self: *Emitter, dst: u8) !void {
+    try self.movRegOffsetToReg(Reg.fp, 4, dst);
+}
+
+/// Read a captured binding from inside the lambda body.
+/// Non-cell: `acu = [env_ptr + N]`. Cell: `acu = [[env_ptr + N]]`.
+pub fn emitCaptureLoad(self: *Emitter, slot: CaptureSlot) !void {
+    try loadEnvPtr(self, Reg.r1);
+    try emitWordLoadAtOffset(self, Reg.r1, slot.env_offset, Reg.acu);
+    if (slot.is_cell) {
+        try self.movRegToReg(Reg.acu, Reg.r1);
+        try cellLoad(self, Reg.r1, Reg.acu);
+    }
+}
+
+/// Write to a captured binding from inside the lambda body.
+/// Only valid for cell captures (non-cell ones are by-value
+/// snapshots at closure creation — writing them would be
+/// invisible to anyone else and is forbidden by the typechecker's
+/// @no_capture enforcement in tracked defs).
+pub fn emitCaptureStore(self: *Emitter, slot: CaptureSlot, value: *const ast.Expr) !void {
+    if (!slot.is_cell) {
+        try self.diagFatal(.{ .start = 0, .end = 0 }, "E_CODEGEN_NONPROMOTED_CAPTURE_WRITE", "codegen: write to non-promoted captured binding (analysis bug — should have promoted it)");
+        return;
+    }
+    try self.emitExpr(value);
+    try self.pushReg(Reg.acu);
+    try loadEnvPtr(self, Reg.r1);
+    try emitWordLoadAtOffset(self, Reg.r1, slot.env_offset, Reg.r1);
+    try self.popReg(Reg.r2);
+    try cellStore(self, Reg.r1, Reg.r2);
+}
+
+// ---------- closure call ----------
+
+/// Lower `expr(args)` where `expr` evaluates to a closure value.
+/// Loads fn_ptr from the tuple, pushes user args right-to-left,
+/// pushes the closure ptr as the hidden first arg, `call_reg`.
+pub fn emitClosureCall(
+    self: *Emitter,
+    callee: *const ast.Expr,
+    c: ast.CallExpr,
+) !void {
+    // Evaluate closure value into r1 (the tuple pointer).
+    try self.emitExpr(callee);
+    try self.movRegToReg(Reg.acu, Reg.r1);
+
+    // Load fn_ptr from [r1 + 0] into r3.
+    try emitWordLoadAtOffset(self, Reg.r1, 0, Reg.r3);
+
+    // Push user args right-to-left, preserving r1 + r3.
+    var i: usize = c.args.len;
+    while (i > 0) {
+        i -= 1;
+        try self.pushReg(Reg.r1);
+        try self.pushReg(Reg.r3);
+        try self.emitExpr(c.args[i]);
+        try self.popReg(Reg.r3);
+        try self.popReg(Reg.r1);
+        try self.pushReg(Reg.acu);
+    }
+
+    // Push env_ptr (the closure itself) as the hidden first arg.
+    try self.pushReg(Reg.r1);
+
+    try self.emitByte(Op.call_reg);
+    try self.emitByte(Reg.r3);
+
+    // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
+    const drop_bytes: u16 = 2 + @as(u16, @intCast(c.args.len * 2));
+    try self.addImmToReg(drop_bytes, Reg.sp);
+}
+
+/// Patch every recorded lambda-fn-ptr placeholder with the
+/// resolved address from `fn_addresses`. Runs after
+/// `emitLambdaBodies` so each label has a known address.
+pub fn patchLambdaSlots(self: *Emitter) !void {
+    for (self.lambda_patches.items) |p| {
+        const addr = self.fn_addresses.get(p.label) orelse 0;
+        const buf: []u8 = if (p.bank) |b|
+            if (self.banks.getPtr(b)) |bl| bl.items else continue
+        else
+            self.code.items;
+        if (p.code_offset + 2 > buf.len) continue;
+        // safety: addr is u16; the 2-byte slot fits cleanly.
+        buf[p.code_offset] = @intCast(addr & 0xFF);
+        buf[p.code_offset + 1] = @intCast((addr >> 8) & 0xFF);
+    }
+}
+
+// ---------- analysis walkers ----------
+
+fn collectLocalsFromStatement(
+    self: *Emitter,
+    s: ast.Statement,
+    locals: *std.StringHashMapUnmanaged(void),
+    info: *FnClosureInfo,
+) !void {
+    switch (s) {
+        .let_decl => |d| {
+            if (d.pattern.* == .ident) {
+                const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
+                try locals.put(self.arena, name, {});
+                if (d.init) |init_expr| {
+                    if (init_expr.* == .lambda) {
+                        try info.closure_bindings.put(self.arena, name, {});
+                    }
+                }
+            }
+        },
+        .const_decl => |d| {
+            const name = self.source[d.name.start..d.name.end];
+            try locals.put(self.arena, name, {});
+            if (d.init.* == .lambda) {
+                try info.closure_bindings.put(self.arena, name, {});
+            }
+        },
+        .block => |b| for (b.body) |inner| try collectLocalsFromStatement(self, inner, locals, info),
+        .if_stmt => |is_| {
+            for (is_.arms) |arm| for (arm.body) |inner| try collectLocalsFromStatement(self, inner, locals, info);
+            if (is_.else_body) |eb| for (eb) |inner| try collectLocalsFromStatement(self, inner, locals, info);
+        },
+        .while_stmt => |ws| for (ws.body) |inner| try collectLocalsFromStatement(self, inner, locals, info),
+        .for_stmt => |fs| for (fs.body) |inner| try collectLocalsFromStatement(self, inner, locals, info),
+        .repeat_stmt => |rs| for (rs.body) |inner| try collectLocalsFromStatement(self, inner, locals, info),
+        else => {},
+    }
+}
+
+fn findLambdasInStatement(
+    self: *Emitter,
+    s: ast.Statement,
+    def: *const ast.DefDecl,
+    info: *FnClosureInfo,
+) !void {
+    switch (s) {
+        .let_decl => |d| if (d.init) |init_expr| try findLambdasInExpr(self, init_expr, def, info),
+        .const_decl => |d| try findLambdasInExpr(self, d.init, def, info),
+        .assign => |a| try findLambdasInExpr(self, a.value, def, info),
+        .return_stmt => |rs| if (rs.value) |v| try findLambdasInExpr(self, v, def, info),
+        .expr_stmt => |es| try findLambdasInExpr(self, es.expr, def, info),
+        .discard => |d| try findLambdasInExpr(self, d.expr, def, info),
+        .print_stmt => |ps| for (ps.args) |a| try findLambdasInExpr(self, a, def, info),
+        .block => |b| for (b.body) |inner| try findLambdasInStatement(self, inner, def, info),
+        .if_stmt => |is_| {
+            for (is_.arms) |arm| {
+                if (arm.cond) |c| try findLambdasInExpr(self, c, def, info);
+                if (arm.let_expr) |le| try findLambdasInExpr(self, le, def, info);
+                if (arm.let_guard) |lg| try findLambdasInExpr(self, lg, def, info);
+                for (arm.body) |inner| try findLambdasInStatement(self, inner, def, info);
+            }
+            if (is_.else_body) |eb| for (eb) |inner| try findLambdasInStatement(self, inner, def, info);
+        },
+        .while_stmt => |ws| {
+            if (ws.cond) |c| try findLambdasInExpr(self, c, def, info);
+            if (ws.let_expr) |le| try findLambdasInExpr(self, le, def, info);
+            if (ws.let_guard) |lg| try findLambdasInExpr(self, lg, def, info);
+            for (ws.body) |inner| try findLambdasInStatement(self, inner, def, info);
+        },
+        .for_stmt => |fs| for (fs.body) |inner| try findLambdasInStatement(self, inner, def, info),
+        .repeat_stmt => |rs| {
+            for (rs.body) |inner| try findLambdasInStatement(self, inner, def, info);
+            try findLambdasInExpr(self, rs.cond, def, info);
+        },
+        else => {},
+    }
+}
+
+fn findLambdasInExpr(
+    self: *Emitter,
+    e: *const ast.Expr,
+    def: *const ast.DefDecl,
+    info: *FnClosureInfo,
+) !void {
+    switch (e.*) {
+        .lambda => |l| {
+            const idx: usize = info.lambdas.items.len;
+            const fn_name = self.source[def.name.start..def.name.end];
+            const label = try std.fmt.allocPrint(self.arena, "__lambda_{s}_{d}", .{ fn_name, idx });
+            var captures: std.ArrayListUnmanaged([]const u8) = .empty;
+            try collectFreeVars(self, &l, &captures, def);
+            try info.lambdas.append(self.arena, .{
+                .ast_node = &e.lambda,
+                .label = label,
+                .captures = captures,
+            });
+        },
+        .paren => |p| try findLambdasInExpr(self, p.inner, def, info),
+        .unary => |u| try findLambdasInExpr(self, u.operand, def, info),
+        .binary => |b| {
+            try findLambdasInExpr(self, b.lhs, def, info);
+            try findLambdasInExpr(self, b.rhs, def, info);
+        },
+        .call => |c| {
+            try findLambdasInExpr(self, c.callee, def, info);
+            for (c.args) |a| try findLambdasInExpr(self, a, def, info);
+        },
+        .method_call => |m| {
+            try findLambdasInExpr(self, m.receiver, def, info);
+            for (m.args) |a| try findLambdasInExpr(self, a, def, info);
+        },
+        .field => |f| try findLambdasInExpr(self, f.receiver, def, info),
+        .is_test => |it| try findLambdasInExpr(self, it.lhs, def, info),
+        .ref_of => |r| try findLambdasInExpr(self, r.inner, def, info),
+        .cast => |c| try findLambdasInExpr(self, c.inner, def, info),
+        else => {},
+    }
+}
+
+/// Collect the free idents referenced inside a lambda body —
+/// names used but not declared as a lambda param / local. The
+/// caller filters against actual parent bindings; this function
+/// just returns the candidate names.
+fn collectFreeVars(
+    self: *Emitter,
+    lambda: *const ast.LambdaExpr,
+    captures: *std.ArrayListUnmanaged([]const u8),
+    def: *const ast.DefDecl,
+) !void {
+    var lambda_locals: std.StringHashMapUnmanaged(void) = .{};
+    for (lambda.params) |p| {
+        const name = self.source[p.name.start..p.name.end];
+        try lambda_locals.put(self.arena, name, {});
+    }
+    for (lambda.body) |stmt| try collectLambdaLocalsInStatement(self, stmt, &lambda_locals);
+    for (lambda.body) |stmt| try collectIdentsInStatement(self, stmt, &lambda_locals, captures, def);
+}
+
+fn collectLambdaLocalsInStatement(
+    self: *Emitter,
+    s: ast.Statement,
+    locals: *std.StringHashMapUnmanaged(void),
+) !void {
+    switch (s) {
+        .let_decl => |d| if (d.pattern.* == .ident) {
+            const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
+            try locals.put(self.arena, name, {});
+        },
+        .const_decl => |d| {
+            const name = self.source[d.name.start..d.name.end];
+            try locals.put(self.arena, name, {});
+        },
+        .block => |b| for (b.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals),
+        .if_stmt => |is_| {
+            for (is_.arms) |arm| for (arm.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals);
+            if (is_.else_body) |eb| for (eb) |inner| try collectLambdaLocalsInStatement(self, inner, locals);
+        },
+        .while_stmt => |ws| for (ws.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals),
+        .for_stmt => |fs| for (fs.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals),
+        .repeat_stmt => |rs| for (rs.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals),
+        else => {},
+    }
+}
+
+fn collectIdentsInStatement(
+    self: *Emitter,
+    s: ast.Statement,
+    locals: *const std.StringHashMapUnmanaged(void),
+    captures: *std.ArrayListUnmanaged([]const u8),
+    def: *const ast.DefDecl,
+) !void {
+    switch (s) {
+        .let_decl => |d| if (d.init) |init_expr| try collectIdentsInExpr(self, init_expr, locals, captures, def),
+        .const_decl => |d| try collectIdentsInExpr(self, d.init, locals, captures, def),
+        .assign => |a| {
+            try collectIdentsInExpr(self, a.target, locals, captures, def);
+            try collectIdentsInExpr(self, a.value, locals, captures, def);
+        },
+        .return_stmt => |rs| if (rs.value) |v| try collectIdentsInExpr(self, v, locals, captures, def),
+        .expr_stmt => |es| try collectIdentsInExpr(self, es.expr, locals, captures, def),
+        .discard => |d| try collectIdentsInExpr(self, d.expr, locals, captures, def),
+        .print_stmt => |ps| for (ps.args) |a| try collectIdentsInExpr(self, a, locals, captures, def),
+        .block => |b| for (b.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def),
+        .if_stmt => |is_| {
+            for (is_.arms) |arm| {
+                if (arm.cond) |c| try collectIdentsInExpr(self, c, locals, captures, def);
+                if (arm.let_expr) |le| try collectIdentsInExpr(self, le, locals, captures, def);
+                if (arm.let_guard) |lg| try collectIdentsInExpr(self, lg, locals, captures, def);
+                for (arm.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def);
+            }
+            if (is_.else_body) |eb| for (eb) |inner| try collectIdentsInStatement(self, inner, locals, captures, def);
+        },
+        .while_stmt => |ws| {
+            if (ws.cond) |c| try collectIdentsInExpr(self, c, locals, captures, def);
+            if (ws.let_expr) |le| try collectIdentsInExpr(self, le, locals, captures, def);
+            if (ws.let_guard) |lg| try collectIdentsInExpr(self, lg, locals, captures, def);
+            for (ws.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def);
+        },
+        .for_stmt => |fs| for (fs.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def),
+        .repeat_stmt => |rs| {
+            for (rs.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def);
+            try collectIdentsInExpr(self, rs.cond, locals, captures, def);
+        },
+        else => {},
+    }
+}
+
+fn collectIdentsInExpr(
+    self: *Emitter,
+    e: *const ast.Expr,
+    locals: *const std.StringHashMapUnmanaged(void),
+    captures: *std.ArrayListUnmanaged([]const u8),
+    def: *const ast.DefDecl,
+) !void {
+    switch (e.*) {
+        .ident => |i| {
+            const name = self.source[i.span.start..i.span.end];
+            if (locals.contains(name)) return;
+            // Skip ident shapes that don't correspond to a binding
+            // (function names typed as call targets, class names,
+            // etc.). For PR scope: include only names that match a
+            // parent let / param. The caller filters again.
+            for (captures.items) |existing| {
+                if (std.mem.eql(u8, existing, name)) return;
+            }
+            try captures.append(self.arena, name);
+        },
+        .paren => |p| try collectIdentsInExpr(self, p.inner, locals, captures, def),
+        .unary => |u| try collectIdentsInExpr(self, u.operand, locals, captures, def),
+        .binary => |b| {
+            try collectIdentsInExpr(self, b.lhs, locals, captures, def);
+            try collectIdentsInExpr(self, b.rhs, locals, captures, def);
+        },
+        .call => |c| {
+            try collectIdentsInExpr(self, c.callee, locals, captures, def);
+            for (c.args) |a| try collectIdentsInExpr(self, a, locals, captures, def);
+        },
+        .method_call => |m| {
+            try collectIdentsInExpr(self, m.receiver, locals, captures, def);
+            for (m.args) |a| try collectIdentsInExpr(self, a, locals, captures, def);
+        },
+        .field => |f| try collectIdentsInExpr(self, f.receiver, locals, captures, def),
+        .is_test => |it| try collectIdentsInExpr(self, it.lhs, locals, captures, def),
+        .ref_of => |r| try collectIdentsInExpr(self, r.inner, locals, captures, def),
+        .cast => |c| try collectIdentsInExpr(self, c.inner, locals, captures, def),
+        // Nested lambdas — collect their free vars too; any name
+        // they capture from the enclosing scope might transitively
+        // need to flow through this lambda's env. For PR scope we
+        // don't recurse — known limitation.
+        .lambda => {},
+        else => {},
+    }
+}
+
+fn collectMutatedInStatement(
+    self: *Emitter,
+    s: ast.Statement,
+    mutated: *std.StringHashMapUnmanaged(void),
+) void {
+    switch (s) {
+        .assign => |a| if (a.target.* == .ident) {
+            const name = self.source[a.target.ident.span.start..a.target.ident.span.end];
+            mutated.put(self.arena, name, {}) catch return;
+        },
+        .inc_dec => |id| if (id.target.* == .ident) {
+            const name = self.source[id.target.ident.span.start..id.target.ident.span.end];
+            mutated.put(self.arena, name, {}) catch return;
+        },
+        .block => |b| for (b.body) |inner| collectMutatedInStatement(self, inner, mutated),
+        .if_stmt => |is_| {
+            for (is_.arms) |arm| for (arm.body) |inner| collectMutatedInStatement(self, inner, mutated);
+            if (is_.else_body) |eb| for (eb) |inner| collectMutatedInStatement(self, inner, mutated);
+        },
+        .while_stmt => |ws| for (ws.body) |inner| collectMutatedInStatement(self, inner, mutated),
+        .for_stmt => |fs| for (fs.body) |inner| collectMutatedInStatement(self, inner, mutated),
+        .repeat_stmt => |rs| for (rs.body) |inner| collectMutatedInStatement(self, inner, mutated),
+        .return_stmt => |rs| if (rs.value) |v| collectMutatedInExpr(self, v, mutated),
+        .expr_stmt => |es| collectMutatedInExpr(self, es.expr, mutated),
+        .print_stmt => |ps| for (ps.args) |a| collectMutatedInExpr(self, a, mutated),
+        else => {},
+    }
+}
+
+fn collectMutatedInExpr(
+    self: *Emitter,
+    e: *const ast.Expr,
+    mutated: *std.StringHashMapUnmanaged(void),
+) void {
+    if (e.* == .lambda) {
+        // A lambda body's assignments to captured names mutate
+        // the captured binding from the parent's perspective.
+        for (e.lambda.body) |stmt| collectMutatedInStatement(self, stmt, mutated);
+    } else if (e.* == .binary) {
+        collectMutatedInExpr(self, e.binary.lhs, mutated);
+        collectMutatedInExpr(self, e.binary.rhs, mutated);
+    } else if (e.* == .call) {
+        collectMutatedInExpr(self, e.call.callee, mutated);
+        for (e.call.args) |a| collectMutatedInExpr(self, a, mutated);
+    }
+    // Other expr shapes can't mutate a binding by themselves.
+}
+
+/// Walk for `return <lambda>` shapes — every binding captured by
+/// an escaping lambda needs promotion (its frame is gone by the
+/// time the closure runs).
+fn collectEscapingCaptures(
+    self: *Emitter,
+    s: ast.Statement,
+    info: *const FnClosureInfo,
+    out: *std.StringHashMapUnmanaged(void),
+) void {
+    switch (s) {
+        .return_stmt => |rs| if (rs.value) |v| collectEscapingFromExpr(self, v, info, out),
+        .let_decl => |d| if (d.init) |init_expr| collectEscapingFromExpr(self, init_expr, info, out),
+        .block => |b| for (b.body) |inner| collectEscapingCaptures(self, inner, info, out),
+        .if_stmt => |is_| {
+            for (is_.arms) |arm| for (arm.body) |inner| collectEscapingCaptures(self, inner, info, out);
+            if (is_.else_body) |eb| for (eb) |inner| collectEscapingCaptures(self, inner, info, out);
+        },
+        .while_stmt => |ws| for (ws.body) |inner| collectEscapingCaptures(self, inner, info, out),
+        .for_stmt => |fs| for (fs.body) |inner| collectEscapingCaptures(self, inner, info, out),
+        .repeat_stmt => |rs| for (rs.body) |inner| collectEscapingCaptures(self, inner, info, out),
+        else => {},
+    }
+}
+
+fn collectEscapingFromExpr(
+    self: *Emitter,
+    e: *const ast.Expr,
+    info: *const FnClosureInfo,
+    out: *std.StringHashMapUnmanaged(void),
+) void {
+    if (e.* != .lambda) return;
+    for (info.lambdas.items) |li| {
+        if (li.ast_node == &e.lambda) {
+            for (li.captures.items) |cap| {
+                out.put(self.arena, cap, {}) catch return;
+            }
+            return;
+        }
+    }
+}
+
+fn findLambdaInfo(self: *Emitter, expr: *const ast.Expr) ?*const LambdaInfo {
+    if (expr.* != .lambda) return null;
+    for (self.fn_closure_info.lambdas.items) |*li| {
+        if (li.ast_node == &expr.lambda) return li;
+    }
+    return null;
+}
+
+/// Word load: `mov [base + offset], dst` (i8 offset when ≤127,
+/// synthesized widen otherwise). Local copy to avoid a cycle
+/// importing class.zig.
+fn emitWordLoadAtOffset(self: *Emitter, base: u8, offset: u16, dst: u8) !void {
+    if (offset <= 127) {
+        // @as: offset fits i8 (≤127); the cast is a no-op for the value range.
+        try self.movRegOffsetToReg(base, @as(i8, @intCast(offset)), dst);
+        return;
+    }
+    try self.movRegToReg(base, Reg.r2);
+    try self.addImmToReg(offset, Reg.r2);
+    try self.movRegOffsetToReg(Reg.r2, 0, dst);
+}
+
+fn emitWordStoreAtOffset(self: *Emitter, base: u8, offset: u16, src: u8) !void {
+    if (offset <= 127) {
+        // @as: offset fits i8 (≤127); the cast is a no-op for the value range.
+        try self.movRegToRegOffset(src, base, @as(i8, @intCast(offset)));
+        return;
+    }
+    try self.movRegToReg(base, Reg.r3);
+    try self.addImmToReg(offset, Reg.r3);
+    try self.movRegToRegOffset(src, Reg.r3, 0);
+}

--- a/src/lang/codegen/lambda.zig
+++ b/src/lang/codegen/lambda.zig
@@ -65,10 +65,20 @@ pub const FnClosureInfo = struct {
     /// Names of let / const / param bindings in this fn that must
     /// live as heap cells.
     promoted: std.StringHashMapUnmanaged(void),
-    /// Lambdas encountered in the fn body, in source order. The
-    /// index is the lambda's identity within this fn (used to
-    /// derive a stable `__lambda_<fn>_<N>` label).
+    /// Lambdas encountered in the fn body, including nested ones.
+    /// Order is "leaf-first" — a nested lambda registers before
+    /// its enclosing lambda (because the enclosing arm recurses
+    /// into the body before appending itself). Labels are unique
+    /// across the whole def via `next_lambda_id`, not the items
+    /// length, so the depth-first registration order doesn't
+    /// cause label collisions.
     lambdas: std.ArrayListUnmanaged(LambdaInfo),
+    /// Monotonic counter for mangled labels. Incremented at
+    /// every `findLambdasInExpr` lambda arm entry — BEFORE the
+    /// recursion into the body — so an outer lambda and any
+    /// nested ones each get a distinct id even though the outer's
+    /// arm captures the id pre-recursion.
+    next_lambda_id: u32,
     /// Names of let bindings whose init is a lambda — used at
     /// call sites to detect `f(args)` should dispatch as a
     /// closure call vs a free-fn call.
@@ -88,6 +98,18 @@ pub const LambdaInfo = struct {
     /// Captured binding names in slot order. Slot index N maps to
     /// tuple offset `2 + N*2` (offset 0 is fn_ptr).
     captures: std.ArrayListUnmanaged([]const u8),
+    /// Bindings declared inside THIS lambda's body that need a
+    /// heap cell — captured-by-some-inner-lambda AND
+    /// (mutated OR captured by an escaping inner lambda).
+    /// Swapped into `fn_closure_info.promoted` while this body
+    /// emits so `emitLetDecl` / `emitAssign` route through the
+    /// cell path for the right scope.
+    promoted: std.StringHashMapUnmanaged(void),
+    /// Bindings declared inside THIS lambda's body whose init is
+    /// a lambda — swapped into `fn_closure_info.closure_bindings`
+    /// while this body emits so nested `f(args)` dispatches
+    /// through the closure-call path.
+    closure_bindings: std.StringHashMapUnmanaged(void),
 };
 
 /// Walk `def` body, populate `Emitter.fn_closure_info` with the
@@ -97,6 +119,7 @@ pub fn analyzeFn(self: *Emitter, def: *const ast.DefDecl) !void {
     var info: FnClosureInfo = .{
         .promoted = .{},
         .lambdas = .empty,
+        .next_lambda_id = 0,
         .closure_bindings = .{},
     };
 
@@ -139,6 +162,7 @@ pub fn resetFnInfo(self: *Emitter) void {
     self.fn_closure_info = .{
         .promoted = .{},
         .lambdas = .empty,
+        .next_lambda_id = 0,
         .closure_bindings = .{},
     };
 }
@@ -154,17 +178,23 @@ pub fn isClosureBinding(self: *const Emitter, name: []const u8) bool {
     return self.fn_closure_info.closure_bindings.contains(name);
 }
 
-/// `true` when `e` is an ident bound to a local or param whose
-/// inferred type is a function — covers the case where a closure
-/// flowed in from a fn's return value (`let c = make_counter()`
-/// where `make_counter` returns a lambda). Limited to
-/// local/param bindings so free-fn idents (which type as
-/// function too, but dispatch via direct call) don't get
-/// misrouted to the closure path.
+/// `true` when `e` is an ident bound to a local / param / capture
+/// whose inferred type is a function — covers cases where a
+/// closure flowed in from a fn's return value (`let c =
+/// make_counter()`) or where the ident is a capture re-read from
+/// the enclosing env in a nested lambda body. Free-fn idents and
+/// class constructors type as function too but dispatch via
+/// direct call, so they're excluded.
 pub fn isClosureByType(self: *const Emitter, e: *const ast.Expr) bool {
     if (e.* != .ident) return false;
     const name = self.source[e.ident.span.start..e.ident.span.end];
-    if (!self.locals.contains(name) and !self.params.contains(name)) return false;
+    if (self.fn_addresses.contains(name)) return false;
+    if (self.class_decls.contains(name)) return false;
+    const has_binding =
+        self.locals.contains(name) or
+        self.params.contains(name) or
+        self.captures.contains(name);
+    if (!has_binding) return false;
     const ty = self.typeOf(e) orelse return false;
     return ty.* == .function;
 }
@@ -276,10 +306,25 @@ pub fn emitLambdaExpr(self: *Emitter, lambda: ast.LambdaExpr, expr: *const ast.E
 }
 
 /// Load a capture's source value into `acu` at closure-creation
-/// time. For a promoted binding: that's the cell pointer (lives
-/// directly in the local slot). For an unpromoted binding: that's
-/// the current value (regular local / param / global load).
+/// time. The slot semantics are deliberately "raw" — for a
+/// promoted binding that's the cell pointer (so the inner
+/// closure shares state with the parent), for a non-promoted
+/// binding that's the value (re-copied into the new closure).
+/// The lookup order — captures → locals → params → globals —
+/// lets nested closures chain: a closure created INSIDE another
+/// lambda's body reads its captures from the enclosing env
+/// rather than a stack slot that doesn't exist at this scope.
 fn emitCaptureSource(self: *Emitter, name: []const u8) !void {
+    if (self.captures.get(name)) |slot| {
+        // Inside an enclosing lambda — re-read this slot raw
+        // from our own env to populate the inner closure's slot.
+        // For promoted (cell-pointer) captures the pointer
+        // propagates as-is (shared state); for by-value captures
+        // the value re-copies.
+        try loadEnvPtr(self, Reg.r1);
+        try emitWordLoadAtOffset(self, Reg.r1, slot.env_offset, Reg.acu);
+        return;
+    }
     if (self.locals.get(name)) |ofs| {
         try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
         return;
@@ -330,26 +375,26 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
     const saved_frame = self.frame_bytes;
     const saved_entry = self.is_entry;
     const saved_bank = self.current_bank;
-    const saved_info = self.fn_closure_info;
+    const saved_promoted = self.fn_closure_info.promoted;
+    const saved_closure_bindings = self.fn_closure_info.closure_bindings;
     self.locals = .{};
     self.params = .{};
     self.frame_bytes = 0;
     self.is_entry = false;
-    // Lambdas inherit the parent bank — nested-bank lambdas land
-    // in a future feature; for now the lambda body shares the
-    // parent fn's emit buffer.
-    self.fn_closure_info = .{
-        .promoted = .{},
-        .lambdas = .empty,
-        .closure_bindings = .{},
-    };
+    // Swap the scope-dependent analysis fields to this lambda's
+    // own — promoted bindings + closure_bindings differ per
+    // scope. The lambdas list stays shared across nested levels
+    // (every lambda emits as a flat def at the end of the parent).
+    self.fn_closure_info.promoted = li.promoted;
+    self.fn_closure_info.closure_bindings = li.closure_bindings;
     defer {
         self.locals = saved_locals;
         self.params = saved_params;
         self.frame_bytes = saved_frame;
         self.is_entry = saved_entry;
         self.current_bank = saved_bank;
-        self.fn_closure_info = saved_info;
+        self.fn_closure_info.promoted = saved_promoted;
+        self.fn_closure_info.closure_bindings = saved_closure_bindings;
     }
 
     const dup_label = try self.arena.dupe(u8, li.label);
@@ -380,7 +425,13 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
     for (li.captures.items, 0..) |cap, idx| {
         // @as: idx fits u16 — capture count caps below 32k.
         const offset: u16 = 2 + @as(u16, @intCast(idx)) * 2;
-        const promoted_in_parent = saved_info.promoted.contains(cap);
+        // `is_cell` reflects the enclosing scope's view of this
+        // capture — promoted in the parent (whichever the parent
+        // scope was) means the slot holds a cell pointer, so
+        // reads in this body need a deref. We use the
+        // pre-swap `saved_promoted` since that's the enclosing
+        // scope's promotion set, not this lambda's own.
+        const promoted_in_parent = saved_promoted.contains(cap);
         try captures_map.put(self.arena, cap, .{
             .env_offset = offset,
             .is_cell = promoted_in_parent,
@@ -551,12 +602,14 @@ fn collectLocalsFromStatement(
     }
 }
 
+const FindError = error{OutOfMemory};
+
 fn findLambdasInStatement(
     self: *Emitter,
     s: ast.Statement,
     def: *const ast.DefDecl,
     info: *FnClosureInfo,
-) !void {
+) FindError!void {
     switch (s) {
         .let_decl => |d| if (d.init) |init_expr| try findLambdasInExpr(self, init_expr, def, info),
         .const_decl => |d| try findLambdasInExpr(self, d.init, def, info),
@@ -595,18 +648,49 @@ fn findLambdasInExpr(
     e: *const ast.Expr,
     def: *const ast.DefDecl,
     info: *FnClosureInfo,
-) !void {
+) FindError!void {
     switch (e.*) {
         .lambda => |l| {
-            const idx: usize = info.lambdas.items.len;
+            const idx = info.next_lambda_id;
+            info.next_lambda_id += 1;
             const fn_name = self.source[def.name.start..def.name.end];
             const label = try std.fmt.allocPrint(self.arena, "__lambda_{s}_{d}", .{ fn_name, idx });
             var captures: std.ArrayListUnmanaged([]const u8) = .empty;
             try collectFreeVars(self, &l, &captures, def);
+            // Per-lambda scope analysis: this lambda's own locals,
+            // which subset of them get initialized with a nested
+            // lambda, and which subset needs a heap cell. Computed
+            // here so emitOneLambdaBody can swap them in.
+            var local_bindings: std.StringHashMapUnmanaged(void) = .{};
+            var scope_closure_bindings: std.StringHashMapUnmanaged(void) = .{};
+            try collectLambdaScopeBindings(self, &l, &local_bindings, &scope_closure_bindings);
+            // Recurse — register any nested lambdas in the same
+            // flat list so emitLambdaBodies emits them all.
+            try findLambdasInLambdaBody(self, &l, def, info);
+            // Now decide promotion for this lambda's own locals.
+            // Mutation walks the body (any assignment in this body
+            // or any deeper nested lambda body counts).
+            var mutated: std.StringHashMapUnmanaged(void) = .{};
+            for (l.body) |stmt| collectMutatedInStatement(self, stmt, &mutated);
+            // Escape: nested lambdas in this body that escape via
+            // a return in this body's tail.
+            var escaping_captures: std.StringHashMapUnmanaged(void) = .{};
+            for (l.body) |stmt| collectEscapingCaptures(self, stmt, info, &escaping_captures);
+            var promoted: std.StringHashMapUnmanaged(void) = .{};
+            for (info.lambdas.items) |child_li| {
+                for (child_li.captures.items) |cap| {
+                    if (!local_bindings.contains(cap)) continue;
+                    if (mutated.contains(cap) or escaping_captures.contains(cap)) {
+                        try promoted.put(self.arena, cap, {});
+                    }
+                }
+            }
             try info.lambdas.append(self.arena, .{
                 .ast_node = &e.lambda,
                 .label = label,
                 .captures = captures,
+                .promoted = promoted,
+                .closure_bindings = scope_closure_bindings,
             });
         },
         .paren => |p| try findLambdasInExpr(self, p.inner, def, info),
@@ -627,6 +711,74 @@ fn findLambdasInExpr(
         .is_test => |it| try findLambdasInExpr(self, it.lhs, def, info),
         .ref_of => |r| try findLambdasInExpr(self, r.inner, def, info),
         .cast => |c| try findLambdasInExpr(self, c.inner, def, info),
+        else => {},
+    }
+}
+
+/// Recurse into a lambda body's statements to register nested
+/// lambdas in the shared `info.lambdas` list. Mirrors the
+/// statement walker used at def-body level — duplicated rather
+/// than parameterized because the def-body walker stays
+/// shallower (it doesn't recurse into lambda bodies itself; this
+/// helper drives that recursion).
+fn findLambdasInLambdaBody(
+    self: *Emitter,
+    lambda: *const ast.LambdaExpr,
+    def: *const ast.DefDecl,
+    info: *FnClosureInfo,
+) FindError!void {
+    for (lambda.body) |stmt| try findLambdasInStatement(self, stmt, def, info);
+}
+
+/// Collect this lambda body's own let / const bindings, plus
+/// the subset of those whose init expression is itself a lambda
+/// (drives the closure-call detection in this lambda's scope).
+fn collectLambdaScopeBindings(
+    self: *Emitter,
+    lambda: *const ast.LambdaExpr,
+    locals: *std.StringHashMapUnmanaged(void),
+    closure_bindings: *std.StringHashMapUnmanaged(void),
+) !void {
+    for (lambda.params) |p| {
+        const name = self.source[p.name.start..p.name.end];
+        try locals.put(self.arena, name, {});
+    }
+    for (lambda.body) |stmt| try collectScopeStatementBindings(self, stmt, locals, closure_bindings);
+}
+
+fn collectScopeStatementBindings(
+    self: *Emitter,
+    s: ast.Statement,
+    locals: *std.StringHashMapUnmanaged(void),
+    closure_bindings: *std.StringHashMapUnmanaged(void),
+) !void {
+    switch (s) {
+        .let_decl => |d| {
+            if (d.pattern.* == .ident) {
+                const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
+                try locals.put(self.arena, name, {});
+                if (d.init) |init_expr| {
+                    if (init_expr.* == .lambda) {
+                        try closure_bindings.put(self.arena, name, {});
+                    }
+                }
+            }
+        },
+        .const_decl => |d| {
+            const name = self.source[d.name.start..d.name.end];
+            try locals.put(self.arena, name, {});
+            if (d.init.* == .lambda) {
+                try closure_bindings.put(self.arena, name, {});
+            }
+        },
+        .block => |b| for (b.body) |inner| try collectScopeStatementBindings(self, inner, locals, closure_bindings),
+        .if_stmt => |is_| {
+            for (is_.arms) |arm| for (arm.body) |inner| try collectScopeStatementBindings(self, inner, locals, closure_bindings);
+            if (is_.else_body) |eb| for (eb) |inner| try collectScopeStatementBindings(self, inner, locals, closure_bindings);
+        },
+        .while_stmt => |ws| for (ws.body) |inner| try collectScopeStatementBindings(self, inner, locals, closure_bindings),
+        .for_stmt => |fs| for (fs.body) |inner| try collectScopeStatementBindings(self, inner, locals, closure_bindings),
+        .repeat_stmt => |rs| for (rs.body) |inner| try collectScopeStatementBindings(self, inner, locals, closure_bindings),
         else => {},
     }
 }
@@ -676,13 +828,15 @@ fn collectLambdaLocalsInStatement(
     }
 }
 
+const CollectError = error{OutOfMemory};
+
 fn collectIdentsInStatement(
     self: *Emitter,
     s: ast.Statement,
     locals: *const std.StringHashMapUnmanaged(void),
     captures: *std.ArrayListUnmanaged([]const u8),
     def: *const ast.DefDecl,
-) !void {
+) CollectError!void {
     switch (s) {
         .let_decl => |d| if (d.init) |init_expr| try collectIdentsInExpr(self, init_expr, locals, captures, def),
         .const_decl => |d| try collectIdentsInExpr(self, d.init, locals, captures, def),
@@ -725,7 +879,7 @@ fn collectIdentsInExpr(
     locals: *const std.StringHashMapUnmanaged(void),
     captures: *std.ArrayListUnmanaged([]const u8),
     def: *const ast.DefDecl,
-) !void {
+) CollectError!void {
     switch (e.*) {
         .ident => |i| {
             const name = self.source[i.span.start..i.span.end];
@@ -757,11 +911,35 @@ fn collectIdentsInExpr(
         .is_test => |it| try collectIdentsInExpr(self, it.lhs, locals, captures, def),
         .ref_of => |r| try collectIdentsInExpr(self, r.inner, locals, captures, def),
         .cast => |c| try collectIdentsInExpr(self, c.inner, locals, captures, def),
-        // Nested lambdas — collect their free vars too; any name
-        // they capture from the enclosing scope might transitively
-        // need to flow through this lambda's env. For PR scope we
-        // don't recurse — known limitation.
-        .lambda => {},
+        // Nested lambda — any name the inner lambda captures from
+        // OUTSIDE its own param + locals is a free var from the
+        // enclosing scope. If that name isn't local to THIS
+        // lambda either, it transitively becomes a capture of this
+        // lambda too — at closure-creation time we populate the
+        // inner closure's slot by re-reading our own env.
+        .lambda => |inner| {
+            var inner_locals: std.StringHashMapUnmanaged(void) = .{};
+            for (inner.params) |p| {
+                const name = self.source[p.name.start..p.name.end];
+                try inner_locals.put(self.arena, name, {});
+            }
+            for (inner.body) |stmt| try collectLambdaLocalsInStatement(self, stmt, &inner_locals);
+            var inner_captures: std.ArrayListUnmanaged([]const u8) = .empty;
+            for (inner.body) |stmt| try collectIdentsInStatement(self, stmt, &inner_locals, &inner_captures, def);
+            for (inner_captures.items) |inner_cap| {
+                // Skip if local to this lambda's own scope.
+                if (locals.contains(inner_cap)) continue;
+                // De-dup against captures we've already recorded.
+                var seen = false;
+                for (captures.items) |existing| {
+                    if (std.mem.eql(u8, existing, inner_cap)) {
+                        seen = true;
+                        break;
+                    }
+                }
+                if (!seen) try captures.append(self.arena, inner_cap);
+            }
+        },
         else => {},
     }
 }

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1321,19 +1321,37 @@ pub const Checker = struct {
                 if (self.in_no_capture) self.lambda_locals = .{};
                 defer self.lambda_locals = saved_locals;
 
+                var param_types: std.ArrayList(*const types.Type) = .empty;
+                errdefer param_types.deinit(self.arena);
                 for (l.params) |p| {
-                    const pt: ?*const types.Type = if (p.type_ann) |t|
+                    const pt: *const types.Type = if (p.type_ann) |t|
                         try self.resolveType(t)
                     else
-                        null;
+                        try self.primitive(.nil_);
                     try self.registerName(self.lexeme(p.name), .{
                         .kind = .param,
                         .decl_span = p.name,
                         .ty = pt,
                     });
+                    try param_types.append(self.arena, pt);
                 }
+                const ret_ty: *const types.Type = if (l.ret_type) |r|
+                    try self.resolveType(r)
+                else
+                    try self.primitive(.nil_);
+                // Swap current_ret_ty so `return expr` inside the
+                // lambda body checks against the lambda's own
+                // return type rather than the enclosing fn's.
+                const saved_ret = self.current_ret_ty;
+                self.current_ret_ty = ret_ty;
+                defer self.current_ret_ty = saved_ret;
                 for (l.body) |s| try self.walkStatement(s);
-                return null;
+                const sig = try self.arena.create(types.Type);
+                sig.* = .{ .function = .{
+                    .params = try param_types.toOwnedSlice(self.arena),
+                    .ret = ret_ty,
+                } };
+                return sig;
             },
             .list_lit => |ll| return try self.inferListLit(ll, hint),
             .list_repeat => |lr| return try self.inferListRepeat(lr, hint),

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1321,11 +1321,23 @@ pub const Checker = struct {
                 if (self.in_no_capture) self.lambda_locals = .{};
                 defer self.lambda_locals = saved_locals;
 
+                // Bidirectional hint: when the lambda flows into
+                // a function-typed slot (`let f: fn(...) -> R = ||
+                // ...`), use the hint's param + return types to
+                // refine any unannotated lambda slots. Lets a
+                // bare `|| 99` infer as `fn() -> i16` when the
+                // target binding declares that shape.
+                const hint_fn: ?types.Function = if (hint) |h|
+                    (if (h.* == .function) h.function else null)
+                else
+                    null;
                 var param_types: std.ArrayList(*const types.Type) = .empty;
                 errdefer param_types.deinit(self.arena);
-                for (l.params) |p| {
+                for (l.params, 0..) |p, i| {
                     const pt: *const types.Type = if (p.type_ann) |t|
                         try self.resolveType(t)
+                    else if (hint_fn) |hf|
+                        if (i < hf.params.len) hf.params[i] else try self.primitive(.nil_)
                     else
                         try self.primitive(.nil_);
                     try self.registerName(self.lexeme(p.name), .{
@@ -1337,6 +1349,8 @@ pub const Checker = struct {
                 }
                 const ret_ty: *const types.Type = if (l.ret_type) |r|
                     try self.resolveType(r)
+                else if (hint_fn) |hf|
+                    hf.ret
                 else
                     try self.primitive(.nil_);
                 // Swap current_ret_ty so `return expr` inside the

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -2333,6 +2333,83 @@ test "codegen/closure: AC4 — returned closure keeps env alive (escape analysis
     try std.testing.expectEqualStrings("1\n2\n", writer.written());
 }
 
+test "codegen/closure: nested lambda — inner closure pulls captures through outer env" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let n: i16 = 5
+        \\  let outer = lambda () -> i16
+        \\    let inner = lambda () -> i16
+        \\      return n + 1
+        \\    end
+        \\    return inner()
+        \\  end
+        \\  print outer()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("6\n", writer.written());
+}
+
+test "codegen/closure: nested mutation — inner mutates n through the outer's env (shared cell)" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let n: i16 = 0
+        \\  let outer = lambda () -> i16
+        \\    let inner = lambda () -> i16
+        \\      n = n + 10
+        \\      return n
+        \\    end
+        \\    inner()
+        \\    return inner()
+        \\  end
+        \\  print outer()
+        \\  print n
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // outer() runs inner() twice — n goes 0→10→20. outer returns
+    // 20. Then main prints n directly, also 20 (shared cell).
+    try std.testing.expectEqualStrings("20\n20\n", writer.written());
+}
+
+test "codegen/closure: short lambda body infers via fn-typed binding hint" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let f: fn() -> i16 = || 99
+        \\  print f()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("99\n", writer.written());
+}
+
 test "codegen/closure: multiple captures (mixed read-only and mutated)" {
     var compiled = try compileSource(
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -2186,3 +2186,176 @@ test "codegen/class: three-level inheritance — Grandparent ← Parent ← Chil
 
     try std.testing.expectEqualStrings("G\n", writer.written());
 }
+
+// ---------- M3b: closures (#259) ----------
+
+test "codegen/closure: lambda with no captures returns a constant" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let f = || 42
+        \\  print f()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("42\n", writer.written());
+}
+
+test "codegen/closure: AC1 — read-only capture reads parent local" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let n: i16 = 7
+        \\  let read = || n
+        \\  print read()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("7\n", writer.written());
+}
+
+test "codegen/closure: AC2 — mutated capture lives on the heap, closure shares state" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let n: i16 = 0
+        \\  let inc = lambda ()
+        \\    n = n + 1
+        \\  end
+        \\  inc()
+        \\  inc()
+        \\  print n
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("2\n", writer.written());
+}
+
+test "codegen/closure: AC3 — two closures over the same binding see consistent state" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let n: i16 = 0
+        \\  let inc = lambda ()
+        \\    n = n + 1
+        \\  end
+        \\  let read = || n
+        \\  inc()
+        \\  inc()
+        \\  inc()
+        \\  print read()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("3\n", writer.written());
+}
+
+test "codegen/closure: short lambda |x| with one user param" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let n: i16 = 10
+        \\  let add = |x: i16| n + x
+        \\  print add(5)
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("15\n", writer.written());
+}
+
+test "codegen/closure: AC4 — returned closure keeps env alive (escape analysis)" {
+    var compiled = try compileSource(
+        \\def make_counter() -> fn() -> i16
+        \\  let n: i16 = 0
+        \\  let inc = lambda () -> i16
+        \\    n = n + 1
+        \\    return n
+        \\  end
+        \\  return inc
+        \\end
+        \\
+        \\def main()
+        \\  let c = make_counter()
+        \\  print c()
+        \\  print c()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("1\n2\n", writer.written());
+}
+
+test "codegen/closure: multiple captures (mixed read-only and mutated)" {
+    var compiled = try compileSource(
+        \\def main()
+        \\  let counter: i16 = 0
+        \\  let base: i16 = 100
+        \\  let bump = lambda ()
+        \\    counter = counter + 1
+        \\  end
+        \\  let report = || counter + base
+        \\  bump()
+        \\  bump()
+        \\  print report()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("102\n", writer.written());
+}

--- a/tests/lang/codegen/lambda.test.zig
+++ b/tests/lang/codegen/lambda.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `lambda` codegen submodule is reachable
+/// through the public barrel. End-to-end coverage of closure
+/// creation, capture analysis, heap promotion, and dispatch
+/// lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/lambda: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.lambda;
+}


### PR DESCRIPTION
## Summary

Closures end-to-end. **Closes #259.**

- **Value model.** Closure = 2-byte pointer to heap tuple `(fn_ptr, capture_0, capture_1, ...)`. Lambda body emits as a plain def with mangled `__lambda_<fn>_<n>` label + hidden `env_ptr` first param; captures at `env_ptr + 2 + N*2`.
- **Capture analysis** (codegen-side `lambda.zig`). Per-fn pre-pass finds local bindings, lambdas + free vars, mutated names, escaping lambdas. A binding is promoted to a heap cell when captured AND (mutated OR captured by an escaping lambda).
- **Heap promotion.** Promoted bindings allocate a 2-byte cell via `sys alloc` at `let` time; the slot holds the cell pointer; reads/writes go through deref/store; closures capture the cell pointer (shared state).
- **Closure call.** `f(args)` dispatches via `call_reg` when `f` is a let-binding initialized from a lambda OR a local/param whose inferred type is `function` (covers closures returned from another fn).
- **Typecheck.** Lambda expressions now return a function type (was `null`); `return` inside a lambda body checks against the lambda's own return type.

8 codegen tests cover the 4 AC items + zero-capture + short-lambda + multi-capture + module-reachability smoke.

## Out of scope (known limits, follow-up if they materialize)

- Nested-lambda capture flow (an inner lambda's captures don't propagate through the outer lambda's env).
- Fn-typed globals (gero has none today; the closure-call dispatch only inspects locals + params for the function-type check).

## Also in this PR

- `docs(meta)` rolled into the commit: CLAUDE.md gets the no-PR-splitting clarification — one issue → one end-to-end PR, no LoC chunking, close the issue from the PR description with `Closes #N`. The prior chunked-M3b series violated this; ruling it out so it doesn't recur.

## Test plan

- [x] `zig build verify` green
- [x] `zig build ci` green (verify + test-modes Debug/ReleaseSafe/ReleaseFast/ReleaseSmall + test-all linux/macos/windows/wasi + examples + check-broken)
- [x] Lint EXIT=0
- [x] Self-review per CLAUDE.md 5-step walkthrough — AC verified, gates clean, public API surface (`src/gero.zig` + `src/lang.zig`) only adds the `internal.codegen.lambda` seam alongside the existing `class` one, no `std.debug.print` / `unreachable` / `anyerror` / `*anyopaque` added, no AI attribution in commit history, code-quality pass surfaced no blockers (two known limits explicitly noted as out-of-scope)