### PR TITLE
feat(lang/codegen): match jump-table dispatch (closes #195)

### DIFF
--- a/.changeset/lang-match-jump-table.md
+++ b/.changeset/lang-match-jump-table.md
@@ -8,4 +8,7 @@ every arm is a bare `EnumName.Variant` and no guard is present.
 Trailing `_` / ident wildcards remain supported as the default
 target for unmapped tags. Mixed-shape matches (guards, payload
 binders, OR-patterns, literal arms) keep the existing sequential
-cmp-chain. Closes #195.
+cmp-chain. Exhaustiveness checking also extends to `bool` —
+`match` on a bool scrutinee must cover both `true` and `false`
+(or carry a wildcard), and redundant arms emit
+`E_MATCH_UNREACHABLE_ARM`. Closes #195.

--- a/.changeset/lang-match-jump-table.md
+++ b/.changeset/lang-match-jump-table.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+`match` on a nullary enum scrutinee now lowers to a jump table
+indexed by tag byte (spec §4.8.5 "single-arm tag dispatch") when
+every arm is a bare `EnumName.Variant` and no guard is present.
+Trailing `_` / ident wildcards remain supported as the default
+target for unmapped tags. Mixed-shape matches (guards, payload
+binders, OR-patterns, literal arms) keep the existing sequential
+cmp-chain. Closes #195.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -1918,10 +1918,20 @@ match item
 end
 ```
 
+`bool` is treated the same way: a `bool` scrutinee must cover both
+`true` and `false`, or fall back to a wildcard.
+
+```
+match flag
+  case true => ...
+  -- ERROR: missing case for `false`
+end
+```
+
 Add a `case _ => ...` to discharge the warning, OR list every
-variant explicitly. For non-enum scrutinees (integers, strings),
-exhaustiveness can't be checked — the compiler requires a wildcard
-arm or warns.
+variant / bool case explicitly. For other primitive scrutinees
+(integers, strings), exhaustiveness can't be checked — the
+compiler requires a wildcard arm or warns.
 
 #### 4.8.4 Worked example
 

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -878,6 +878,13 @@ pub const Emitter = struct {
         try self.emitU16Le(self.currentBufferBase() +% target_in_buffer);
     }
 
+    /// `jmp reg` (0x91) — indirect jump via the register's value.
+    /// `ip` becomes whatever the register holds.
+    pub fn jmpReg(self: *Emitter, reg: u8) !void {
+        try self.emitByte(Op.jmp_reg);
+        try self.emitByte(reg);
+    }
+
     /// Base address of the current code buffer in VM memory — used to
     /// turn a buffer-local offset into a `jmp` target.
     /// Base address of the current code buffer in VM memory.
@@ -1116,6 +1123,16 @@ pub const Emitter = struct {
     /// during print / match / store lowering.
     fn isEnumType(self: *const Emitter, ty: *const Type) bool {
         return ty.* == .named and self.enum_decls.contains(ty.named.name);
+    }
+
+    /// Resolve an expression's enum decl when its inferred type is
+    /// a `Named` variant pointing to a registered enum. Used by the
+    /// match-stmt lowerer to decide between jump-table and
+    /// sequential-arm dispatch.
+    pub fn enumDeclForExpr(self: *const Emitter, e: *const ast.Expr) ?*const ast.EnumDecl {
+        const ty = self.typeOf(e) orelse return null;
+        if (ty.* != .named) return null;
+        return self.enum_decls.get(ty.named.name);
     }
 
     /// Scan top-level `def`s, recording each name → its `@bank N`

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -390,11 +390,20 @@ pub fn emitLoopJump(self: *Emitter, j: ast.LoopJumpStmt, kind: LoopJumpKind) !vo
 
 // ---------- match ----------
 
-/// Lower `match scrutinee case … end` as a sequential cmp +
-/// branch decision tree. OR-patterns collapse onto one shared
-/// body label; range patterns emit a single low+high cmp pair;
-/// `when` guards run after the pattern bind.
+/// Lower `match scrutinee case … end`. The fast path is a jump-
+/// table indexed by tag byte, used when every arm is a bare
+/// variant pattern (with an optional trailing wildcard) on a
+/// nullary-payload enum scrutinee, with no guards (spec §4.8.5
+/// "Single-arm tag dispatch"). The fallback is a sequential
+/// `cmp + branch` decision tree: OR-patterns collapse onto one
+/// shared body label, range patterns emit a single low+high cmp
+/// pair, `when` guards run after the pattern bind.
 pub fn emitMatchStmt(self: *Emitter, ms: ast.MatchStmt) !void {
+    if (try tryEmitTagJumpTable(self, ms)) return;
+    try emitMatchSequential(self, ms);
+}
+
+fn emitMatchSequential(self: *Emitter, ms: ast.MatchStmt) !void {
     // Bind the scrutinee to a slot so subsequent arms can re-test
     // it without re-evaluating side effects. Skip the bind if the
     // source already wrote an ident — direct loads stay cheap.
@@ -440,4 +449,171 @@ pub fn emitMatchStmt(self: *Emitter, ms: ast.MatchStmt) !void {
 
     const end_offset = try self.currentOffset();
     for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
+}
+
+/// Detect the spec §4.8.5 "single-arm tag dispatch" shape and,
+/// when it matches, emit a jump table indexed by tag byte:
+///
+/// ```
+///   ; acu = tag
+///   cmp acu, max_tag                  ; bounds — fall back to default
+///   jgt <default_or_end>
+///   mov_reg_reg acu → r1
+///   shl r1, 1                         ; r1 = 2*tag
+///   add r1, acu                       ; acu = 3*tag (3-byte slots)
+///   mov_imm16 <table>, r1
+///   add r1, acu                       ; acu = table + 3*tag
+///   jmp [acu]
+/// table:
+///   jmp_addr <body_0>                 ; 3 bytes per entry
+///   jmp_addr <body_1>
+///   …
+///   jmp_addr <default_or_end>         ; for unmapped tags
+/// body_0:
+///   …
+/// body_1:
+///   …
+/// ```
+///
+/// Returns `true` when the table was emitted; `false` punts to
+/// the sequential lowerer. Eligibility (all must hold):
+///
+/// - Scrutinee's inferred type resolves to a registered enum
+/// - Every arm pattern is either a bare nullary `EnumName.Variant`
+///   or a `_` / ident wildcard (no payload binders, no OR,
+///   no range, no literal)
+/// - At most one wildcard arm (the implicit "default")
+/// - No arm carries a `when` guard
+/// - The enum has ≤ 32 variants (cap table size; matches the
+///   ISA's `mul reg, reg` semantics without overflow concerns)
+fn tryEmitTagJumpTable(self: *Emitter, ms: ast.MatchStmt) !bool {
+    const enum_decl = self.enumDeclForExpr(ms.scrutinee) orelse return false;
+    if (enum_decl.variants.len == 0) return false;
+    // Cap table size to keep the dispatch sequence trivial. 32
+    // variants × 3 bytes per entry = 96 bytes of table, well
+    // inside any sensible spec budget; larger enums fall back to
+    // the sequential cmp-chain (which is still O(N)) until the
+    // spec promises bigger tables.
+    if (enum_decl.variants.len > 32) return false;
+
+    // Variant tag → arm index in `ms.arms`. `null` = unmapped tag
+    // (will route to wildcard / end).
+    var tag_to_arm: [256]?usize = .{null} ** 256;
+    var wildcard_arm: ?usize = null;
+    var max_tag: u8 = 0;
+
+    for (ms.arms, 0..) |arm, idx| {
+        if (arm.guard != null) return false;
+        switch (arm.pattern.*) {
+            .variant_pattern => |vp| {
+                if (vp.args.len > 0) return false;
+                const path = self.source[vp.path.start..vp.path.end];
+                const dot = std.mem.indexOfScalar(u8, path, '.') orelse return false;
+                const enum_name = path[0..dot];
+                const variant_name = path[dot + 1 ..];
+                // Mixed-enum patterns can't share one tag table.
+                const decl_name = self.source[enum_decl.name.start..enum_decl.name.end];
+                if (!std.mem.eql(u8, enum_name, decl_name)) return false;
+                const tag = self.variantTag(enum_name, variant_name) orelse return false;
+                if (tag_to_arm[tag] != null) return false;
+                tag_to_arm[tag] = idx;
+                if (tag > max_tag) max_tag = tag;
+            },
+            .wildcard, .ident => {
+                // Repeated wildcards or non-trailing wildcards are
+                // dead — let the sequential lowerer handle the
+                // diagnostic / shape.
+                if (wildcard_arm != null) return false;
+                if (idx + 1 != ms.arms.len) return false;
+                wildcard_arm = idx;
+            },
+            else => return false,
+        }
+    }
+
+    // The exhaustiveness check has already gated absence of a
+    // wildcard. Walk every tag 0..max_tag for the table — entries
+    // with no matching arm route to the wildcard arm (if any) or
+    // to the post-match end (which is unreachable when the typecheck
+    // says the match is exhaustive).
+    // @as: widen max_tag (u8) to usize before +1 — the +1 can overflow a u8 (255 → 256).
+    const table_len: usize = @as(usize, max_tag) + 1;
+
+    // ---- emit dispatch prologue ----
+    try self.emitExpr(ms.scrutinee);
+    // Bounds: `tag > max_tag` → fall through to default. Even
+    // exhaustive matches keep this — a stray u8 value past the
+    // last declared variant can still reach here through a cast.
+    try self.cmpRegImm(Reg.acu, max_tag);
+    const bounds_patch = try self.emitJumpPlaceholder(Op.jgt_addr);
+
+    // acu = 3*tag (each table slot is `jmp_addr <body>`, 3 bytes).
+    try self.movRegToReg(Reg.acu, Reg.r1);
+    try self.shlRegImm(Reg.r1, 1); // r1 = 2*tag
+    try self.addRegToAcu(Reg.r1); // acu = 3*tag
+
+    // acu = table_base + 3*tag — patched once the table address is known.
+    try self.emitByte(Op.mov_imm16_reg);
+    const table_base_patch = try self.currentOffset();
+    try self.emitU16Le(0);
+    try self.emitByte(Reg.r1);
+    try self.addRegToAcu(Reg.r1);
+
+    // jmp [acu] — control transfers to the `jmp_addr <body>` at
+    // table_base + 3*tag, which then jumps to the actual body.
+    try self.jmpReg(Reg.acu);
+
+    // ---- emit table ----
+    const table_offset = try self.currentOffset();
+    // Patch the dispatch's `mov_imm16` so r1 = table_base. Same
+    // 2-byte LE address slot as a forward `jmp` patch.
+    try self.patchJumpTo(table_base_patch, table_offset);
+    // Slot per tag in 0..=max_tag. Each is a `jmp_addr <body>`
+    // placeholder; address slot resolves once the body emits.
+    var slot_patches: [256]usize = undefined;
+    var t: usize = 0;
+    while (t < table_len) : (t += 1) {
+        slot_patches[t] = try self.emitJumpPlaceholder(Op.jmp_addr);
+    }
+
+    // ---- emit arm bodies + collect end-of-match jumps ----
+    var arm_offsets: []usize = try self.arena.alloc(usize, ms.arms.len);
+    var end_patches: std.ArrayList(usize) = .empty;
+    defer end_patches.deinit(self.allocator);
+
+    for (ms.arms, 0..) |arm, idx| {
+        arm_offsets[idx] = try self.currentOffset();
+        // The wildcard arm shape `ident` binds the scrutinee to a
+        // local. The bare `_` form binds nothing. Both reach this
+        // body with `acu` still holding the scrutinee value.
+        if (arm.pattern.* == .ident) {
+            const name = self.source[arm.pattern.ident.name.start..arm.pattern.ident.name.end];
+            const dup = try self.arena.dupe(u8, name);
+            const ofs = try self.allocLocal(dup);
+            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+        }
+        try emitScopedBody(self, arm.body);
+        try end_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+    }
+
+    // The "default" target is the wildcard arm body when present,
+    // otherwise the post-match end. Unmapped table slots and the
+    // out-of-range bounds branch both land here.
+    const default_offset: usize = if (wildcard_arm) |w| arm_offsets[w] else try self.currentOffset();
+    try self.patchJumpTo(bounds_patch, default_offset);
+
+    // Patch each table slot to its arm's body (or default).
+    t = 0;
+    while (t < table_len) : (t += 1) {
+        // safety: tag_to_arm is indexed 0..=255; t ≤ max_tag ≤ 255.
+        const target = if (tag_to_arm[@intCast(t)]) |arm_idx| arm_offsets[arm_idx] else default_offset;
+        try self.patchJumpTo(slot_patches[t], target);
+    }
+
+    // Every arm body terminates with a `jmp end`. Resolve them all
+    // to the byte after the match statement.
+    const end_offset = try self.currentOffset();
+    for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
+
+    return true;
 }

--- a/src/lang/codegen/opcodes.zig
+++ b/src/lang/codegen/opcodes.zig
@@ -88,6 +88,9 @@ pub const Op = struct {
 
     /// `jmp addr` — unconditional jump.
     pub const jmp_addr: u8 = 0x90;
+    /// `jmp reg` — indirect jump via register (`ip ← reg`). Used by
+    /// the match-stmt jump-table dispatch.
+    pub const jmp_reg: u8 = 0x91;
     /// `jeq addr` — jump on Z = 1.
     pub const jeq_addr: u8 = 0x92;
     /// `jne addr` — jump on Z = 0.

--- a/src/lang/typecheck/match.zig
+++ b/src/lang/typecheck/match.zig
@@ -12,8 +12,8 @@ const Checker = typecheck.Checker;
 const WalkError = error{OutOfMemory};
 
 /// Type-check a `match` statement: infer the scrutinee type,
-/// walk every arm's pattern + guard + body, and (for enum
-/// scrutinees) check that every variant is covered.
+/// walk every arm's pattern + guard + body, and (for enum or
+/// `bool` scrutinees) check that every value is covered.
 pub fn checkMatch(self: *Checker, ms: ast.MatchStmt) WalkError!void {
     const scrut_ty = try self.inferExpr(ms.scrutinee, null);
 
@@ -22,15 +22,24 @@ pub fn checkMatch(self: *Checker, ms: ast.MatchStmt) WalkError!void {
         enumDeclForType(self, st.*)
     else
         null;
+    // `bool` is the only primitive with a closed value set the
+    // checker reasons about; track it the same way as enums.
+    const is_bool: bool = if (scrut_ty) |st|
+        st.* == .primitive and st.primitive == .bool_
+    else
+        false;
 
     // Track variant-name coverage when scrutinee is an enum.
     var covered: std.StringHashMapUnmanaged(void) = .{};
     defer covered.deinit(self.arena);
     var has_wildcard: bool = false;
+    var bool_true_covered: bool = false;
+    var bool_false_covered: bool = false;
 
     for (ms.arms) |arm| {
-        // Exhaustiveness + reachability checks (enum scrutinee only).
+        // Exhaustiveness + reachability checks (per scrutinee kind).
         if (enum_decl) |ed| try recordArmCoverage(self, arm, ed, &covered, &has_wildcard);
+        if (is_bool) try recordBoolArmCoverage(self, arm, &bool_true_covered, &bool_false_covered, &has_wildcard);
 
         const saved = self.current_scope;
         var child: Scope = .init(self.arena, saved);
@@ -41,10 +50,14 @@ pub fn checkMatch(self: *Checker, ms: ast.MatchStmt) WalkError!void {
         try self.walkStatementSequence(arm.body);
     }
 
-    // Exhaustiveness: every variant must be covered (or wildcard).
+    // Exhaustiveness: every variant / bool case must be covered
+    // unless a wildcard catches the rest.
     if (enum_decl) |ed| if (!has_wildcard) {
         try checkExhaustiveness(self, ms.span, ed, &covered);
     };
+    if (is_bool and !has_wildcard) {
+        try checkBoolExhaustiveness(self, ms.span, bool_true_covered, bool_false_covered);
+    }
 }
 
 /// Resolve `ty` to its underlying enum decl (when `ty` is a
@@ -120,6 +133,80 @@ fn walkArmPattern(
             // qualify as a catch-all.
         },
     }
+}
+
+/// Walk one bool-match arm and update coverage for the two
+/// reachable values + the wildcard flag. Mirrors
+/// `recordArmCoverage` but for the `bool` primitive — there are
+/// exactly two values (`true`, `false`) so the "covered set" is
+/// just two booleans.
+fn recordBoolArmCoverage(
+    self: *Checker,
+    arm: ast.MatchArm,
+    has_true: *bool,
+    has_false: *bool,
+    has_wildcard: *bool,
+) WalkError!void {
+    if (has_wildcard.*) {
+        try self.emitSpan("E_MATCH_UNREACHABLE_ARM", arm.span, "this arm cannot be reached — a wildcard `_` arm above already handles every remaining case");
+    } else if (has_true.* and has_false.*) {
+        try self.emitSpan("E_MATCH_UNREACHABLE_ARM", arm.span, "this arm cannot be reached — both `true` and `false` are already handled");
+    }
+    try walkBoolArmPattern(self, arm.pattern, has_true, has_false, has_wildcard);
+}
+
+fn walkBoolArmPattern(
+    self: *Checker,
+    pat: *const ast.Pattern,
+    has_true: *bool,
+    has_false: *bool,
+    has_wildcard: *bool,
+) WalkError!void {
+    switch (pat.*) {
+        .wildcard, .ident => {
+            // Bare ident in match-arm position binds the value —
+            // equivalent to `_` from the exhaustiveness POV.
+            has_wildcard.* = true;
+        },
+        .bool_lit => |bl| {
+            const slot = if (bl.value) has_true else has_false;
+            if (slot.*) {
+                const msg = if (bl.value) "`true` is already handled by an earlier arm" else "`false` is already handled by an earlier arm";
+                try self.emitSpan("E_MATCH_UNREACHABLE_ARM", pat.span(), msg);
+            } else {
+                slot.* = true;
+            }
+        },
+        .or_pattern => |op| {
+            for (op.alts) |alt| try walkBoolArmPattern(self, alt, has_true, has_false, has_wildcard);
+        },
+        else => {
+            // Non-bool patterns (literal int, range, variant, …)
+            // get caught elsewhere as a type mismatch — they don't
+            // contribute to bool-value coverage either way.
+        },
+    }
+}
+
+fn checkBoolExhaustiveness(
+    self: *Checker,
+    match_span: ast.Span,
+    has_true: bool,
+    has_false: bool,
+) WalkError!void {
+    if (has_true and has_false) return;
+    const missing: []const u8 = if (!has_true and !has_false)
+        "true, false"
+    else if (!has_true)
+        "true"
+    else
+        "false";
+    const msg = try std.fmt.allocPrint(
+        self.arena,
+        "non-exhaustive match on `bool` — missing: {s}",
+        .{missing},
+    );
+    try self.emitSpan("E_MATCH_NON_EXHAUSTIVE", match_span, msg);
 }
 
 fn checkExhaustiveness(

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1373,6 +1373,132 @@ test "codegen: match on nullary enum dispatches per variant tag" {
     , "3\n");
 }
 
+test "codegen/match: 4-variant nullary enum compiles to a jump table" {
+    // Per AC1 of #195 + spec §4.8.5: "Single-arm tag dispatch (no
+    // payloads) → jump table indexed by tag byte". Verify both
+    // the behavior (last variant routes to the right arm) AND the
+    // emit shape — the dispatch sequence ends with `jmp [reg]`
+    // (0x91), and the table has one `jmp_addr` (0x90) per tag.
+    var compiled = try compileSource(
+        \\enum Event
+        \\  case Quit
+        \\  case Pause
+        \\  case Resume
+        \\  case Tick
+        \\end
+        \\def main()
+        \\  let e: Event = Event.Tick
+        \\  match e
+        \\    case Event.Quit => print 1
+        \\    case Event.Pause => print 2
+        \\    case Event.Resume => print 3
+        \\    case Event.Tick => print 4
+        \\  end
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    // The dispatch sequence emits exactly one `jmp [reg]` (op 0x91)
+    // before the table. The bare `jmp_addr` opcode (0x90) shows up
+    // in many other places (every `end of arm → jmp end` edge), so
+    // we gate on the presence of 0x91 as the distinguishing mark.
+    var saw_jmp_reg = false;
+    for (compiled.image) |b| {
+        if (b == 0x91) {
+            saw_jmp_reg = true;
+            break;
+        }
+    }
+    try std.testing.expect(saw_jmp_reg);
+
+    // Functional gate: the scrutinee `Event.Tick` (tag 3) hits the
+    // 4th arm. The jump table must route it correctly.
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+    try std.testing.expectEqualStrings("4\n", writer.written());
+}
+
+test "codegen/match: enum match with a guard falls back to sequential dispatch" {
+    // Guards break the bare-tag-dispatch precondition (the body
+    // must run only if the post-bind guard evaluates truthy). The
+    // sequential cmp-chain handles this; the jump table cannot.
+    // No `jmp [reg]` (0x91) should appear in the emit.
+    var compiled = try compileSource(
+        \\enum Color
+        \\  case Red
+        \\  case Green
+        \\  case Blue
+        \\end
+        \\def main()
+        \\  let c: Color = Color.Green
+        \\  let flag: i16 = 1
+        \\  match c
+        \\    case Color.Red => print 1
+        \\    case Color.Green when flag == 1 => print 2
+        \\    case _ => print 9
+        \\  end
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    for (compiled.image) |b| {
+        try std.testing.expect(b != 0x91);
+    }
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+    try std.testing.expectEqualStrings("2\n", writer.written());
+}
+
+test "codegen/match: enum match with trailing wildcard still uses the jump table" {
+    // Wildcards are the spec's "default" — table slots for tags
+    // not in the explicit arms route to the wildcard body. The
+    // dispatch keeps its `jmp [reg]` shape.
+    var compiled = try compileSource(
+        \\enum Color
+        \\  case Red
+        \\  case Green
+        \\  case Blue
+        \\end
+        \\def main()
+        \\  let c: Color = Color.Blue
+        \\  match c
+        \\    case Color.Red => print 1
+        \\    case _ => print 9
+        \\  end
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var saw_jmp_reg = false;
+    for (compiled.image) |b| {
+        if (b == 0x91) {
+            saw_jmp_reg = true;
+            break;
+        }
+    }
+    try std.testing.expect(saw_jmp_reg);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+    try std.testing.expectEqualStrings("9\n", writer.written());
+}
+
 test "codegen: undefined enum variant in `is` rhs is rejected" {
     const source =
         \\enum Color

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -940,9 +940,10 @@ test "typecheck: or-pattern contributes each alternative to coverage" {
     );
 }
 
-test "typecheck: match on non-enum scrutinee skips exhaustiveness" {
-    // i16 has no variant list; the typechecker must not invent
-    // missing-variant diagnostics for primitive scrutinees.
+test "typecheck: match on non-enum, non-bool scrutinee skips exhaustiveness" {
+    // i16 has no closed value set; the typechecker must not invent
+    // missing-value diagnostics for arbitrary primitives. bool is
+    // the lone exception — its two-value coverage is tracked.
     try expectClean(
         \\let n: i16 = 0
         \\match n
@@ -950,6 +951,68 @@ test "typecheck: match on non-enum scrutinee skips exhaustiveness" {
         \\  case _ => let x = 1
         \\end
     );
+}
+
+test "typecheck: exhaustive bool match (true + false) accepts" {
+    try expectClean(
+        \\let flag: bool = true
+        \\match flag
+        \\  case true => let x = 0
+        \\  case false => let x = 1
+        \\end
+    );
+}
+
+test "typecheck: bool match missing `false` errors with E_MATCH_NON_EXHAUSTIVE" {
+    try expectCode(
+        \\let flag: bool = true
+        \\match flag
+        \\  case true => let x = 0
+        \\end
+    , "E_MATCH_NON_EXHAUSTIVE");
+}
+
+test "typecheck: bool match missing `true` errors with E_MATCH_NON_EXHAUSTIVE" {
+    try expectCode(
+        \\let flag: bool = true
+        \\match flag
+        \\  case false => let x = 0
+        \\end
+    , "E_MATCH_NON_EXHAUSTIVE");
+}
+
+test "typecheck: bool match with trailing wildcard accepts" {
+    try expectClean(
+        \\let flag: bool = true
+        \\match flag
+        \\  case true => let x = 0
+        \\  case _ => let x = 1
+        \\end
+    );
+}
+
+test "typecheck: redundant `true` bool arm errors with E_MATCH_UNREACHABLE_ARM" {
+    try expectCode(
+        \\let flag: bool = true
+        \\match flag
+        \\  case true => let x = 0
+        \\  case true => let x = 1
+        \\  case false => let x = 2
+        \\end
+    , "E_MATCH_UNREACHABLE_ARM");
+}
+
+test "typecheck: wildcard after exhaustive bool coverage errors with E_MATCH_UNREACHABLE_ARM" {
+    // Both `true` and `false` are already handled by the time the
+    // wildcard arm is reached — that arm cannot fire.
+    try expectCode(
+        \\let flag: bool = true
+        \\match flag
+        \\  case true => let x = 0
+        \\  case false => let x = 1
+        \\  case _ => let x = 2
+        \\end
+    , "E_MATCH_UNREACHABLE_ARM");
 }
 
 // ---------- slice 5: reference stack lifetime (§3.4.4) ----------


### PR DESCRIPTION
## Summary
- `match` on a nullary-enum scrutinee now compiles to a tag-indexed jump table when every arm is a bare `EnumName.Variant` (with an optional trailing `_` / ident wildcard) and no `when` guard is present — the spec §4.8.5 "single-arm tag dispatch" shape. Mixed-shape matches (guards, payload binders, OR-patterns, literal arms, range arms) keep the existing sequential cmp-chain.
- `match` exhaustiveness now also covers **bool** scrutinees: both `true` and `false` must be handled (or a wildcard catches the rest); redundant arms emit `E_MATCH_UNREACHABLE_ARM`. Spec §4.8.3 updated to list bool alongside enum as a finite-type scrutinee.
- Codegen-side bits already in place from prior PRs (and now exercised end-to-end through #195's AC): OR-pattern dedup collapses three alts onto one shared body label (codegen/pattern.zig `or_pattern`); range patterns emit one low+high cmp pair (`pattern.zig:58`); `when` guards run after the bind (`control_flow.zig:emitMatchSequential`); enum exhaustiveness + reachability emit `E_MATCH_NON_EXHAUSTIVE` / `E_MATCH_UNREACHABLE_ARM` (`typecheck/match.zig`).
- Added `jmp Reg` (opcode 0x91) to the codegen opcode mirror — the dispatch sequence's indirect tail jump.

Closes #195.

## Test plan
- [x] `zig build verify` green
- [x] `zig build test-modes` green (Debug/ReleaseSafe/ReleaseFast/ReleaseSmall)
- [ ] CI workflow on PR
- [ ] Spot-check a 4-variant exhaustive `match Event` to confirm the disasm shows a single `jmp [reg]` followed by the table-of-`jmp_addr` entries