### PR TITLE
chore(meta): split CLAUDE.md — move reference content to docs/development.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,11 @@ parser-combinator layer (asm + lang).
 The fantasy-console (gtx-16) and web playground live elsewhere and
 consume gero as a library — out of scope for this repo.
 
+For source layout, full lint rule list, branch / commit /
+changeset conventions, release flow, and tech-stack reference,
+read [`docs/development.md`](docs/development.md). Read it on demand,
+not every prompt — the rules below are what you need every PR.
+
 ---
 
 ## When in doubt, read the specs
@@ -53,8 +58,8 @@ merge signal → next issue. Never batch multiple issues into a
 single PR. **Do not** split a single issue across multiple PRs
 either — one issue maps to exactly one end-to-end PR, no matter
 the diff size. Multi-concern changes within that PR split into
-multiple commits (see [Branches + commits + changesets](#branches--commits--changesets)),
-but the PR boundary matches the issue boundary.
+multiple commits (see `docs/development.md` — Branches + commits
++ changesets), but the PR boundary matches the issue boundary.
 
 **Close the issue from the PR.** Every `feat` / `fix` / `perf` PR
 description ends with `Closes #N` (or `Advances #N` when a partial
@@ -238,52 +243,6 @@ Never a third "LGTM with footnotes" shape.
 
 ---
 
-## Source layout
-
-```
-src/
-├── gero.zig               # Public barrel
-├── vm/                    # Bytecode interpreter
-├── asm/                   # Assembler (consumes knit)
-├── disasm/                # Disassembler
-├── lang/                  # Gero language compiler (consumes knit)
-└── common/                # Shared types: Value, Bytecode, Span
-
-tests/
-├── util.zig               # Shared test helpers
-├── gero.test.zig          # Public-surface smoke tests
-└── <mod>/<file>.test.zig  # Mirrors src/<mod>/<file>.zig
-
-apps/         # CLIs
-docs/         # ISA spec + lang spec
-editors/      # Tree-sitter grammar + VS Code ext (submodules)
-tools/        # Single-binary dev utilities (lint, etc.)
-scripts/      # Bash helpers for build.zig + lefthook
-.changeset/   # *.md changeset files
-.github/      # Workflows + templates
-```
-
-**Mirror rule:** every `src/<mod>/<file>.zig` requires a matching
-`tests/<mod>/<file>.test.zig` — lint-enforced. Exempt:
-`src/gero.zig` and any top-level module barrel (e.g. `src/lang.zig`).
-
-`internal.zig` colocated with a module dir is the convention for
-private helpers — exempt from the mirror rule, must not be
-re-exported through `src/gero.zig`, exercised through its
-consuming modules' tests.
-
-**Imports:** single-level relative only. `../foo.zig` or `./foo.zig`
-— anything deeper (`../../...`) is rejected by the lint binary.
-Public consumers (and tests) import only `gero`:
-
-```zig
-const gero = @import("gero");
-```
-
-Tests can also import `../util.zig` (one level) for shared helpers.
-
----
-
 ## Code rules
 
 ### Structure
@@ -328,7 +287,8 @@ Tests can also import `../util.zig` (one level) for shared helpers.
 
 ### Tests
 
-- One spec per source file (mirror layout, lint-enforced).
+- One spec per source file (mirror layout — full rule in
+  `docs/development.md` — lint-enforced).
 - Naming: `<file>.test.zig`, `test "<symbol>: <behavior>" { ... }`.
 - Shared helpers in `tests/util.zig` — don't reinvent per-spec.
 - No snapshot tests.
@@ -350,39 +310,8 @@ Tests can also import `../util.zig` (one level) for shared helpers.
   all before writing the consolidated test suite (rather than
   pipelining test-on-slice-1 with refactor-of-slice-2).
 
----
-
-## Strict-mode lint (`gero-lint`)
-
-Single Zig binary at `tools/lint/main.zig`, built as
-`zig-out/bin/gero-lint`, runs in ~2–3s. Fails on any of these in
-`src/`:
-
-- `anyerror`, `*anyopaque` / `*const anyopaque`
-- `@as(` / `@ptrCast(` / `@alignCast(` / `@bitCast(` without
-  `// @as:` / `// safety:` justification directly above
-- `unreachable` / `@compileError("TODO")` without a justifying
-  comment
-- `std.debug.print` outside test code
-- `catch unreachable` without `// allow-strict: <invariant>`
-- `catch |x| return x` — use `try` instead
-- `std.heap.page_allocator` direct use — accept allocators from
-  callers
-- `usingnamespace`
-- `//!` file-level doc anywhere except the top barrel
-- Issue numbers / version markers in any comment
-- Mirror-layout violations
-- Multi-level relative imports (`../../`)
-- Naming: `pub fn Foo(...) type` must be PascalCase;
-  `pub fn foo(...) <other>` must be camelCase
-- Public declarations without `///` doc comments
-
-Allowlist a violation with `// allow-strict: <reason>` directly
-above the line. Reviewer-gated — bring a real reason.
-
-`pub const` naming is convention-only (not enforced): PascalCase
-for types (`pub const Foo = struct {...}`), snake_case for values
-(`pub const max_count = 42`).
+The full `gero-lint` rule list (every violation it catches +
+how to allowlist) lives in `docs/development.md`.
 
 ---
 
@@ -408,88 +337,3 @@ zig build ci      # full matrix (~4s warm / ~2m cold) — verify
 
 GitHub Actions runs `ci` on every push — don't gate every commit
 on it locally, but `verify` green is required before pushing.
-
----
-
-## Branches + commits + changesets
-
-**Branches:**
-
-- `feat/<short>` — new module, new public API
-- `fix/<short>` — bug fix
-- `perf/<short>` — measurable performance improvement
-- `chore/<short>` — tooling, deps, CI, build
-- `docs/<short>` — docs-only change
-- `refactor/<short>` — internal restructure, no behavior change
-
-Branch from `main`. One issue → one branch → one PR end-to-end
-(no chunking; see [The contract](#the-contract)).
-
-**Commits:** Conventional Commits enforced by **convco** with a
-strict scope-enum from `.versionrc`.
-
-- No scope-less commits (`feat: add x` → rejected)
-- Multi-concern changes split into multiple commits in the PR
-- `fixup!` for review feedback, then `--autosquash`
-- Tooling-only `perf` → use `chore(tooling)` (changeset gate
-  auto-skips). Library API perf wins stay `perf(<scope>)`.
-
-**Allowed scopes:**
-
-```
-vm                  → src/vm/*
-asm                 → src/asm/*
-disasm              → src/disasm/*
-lang                → src/lang/*
-common              → src/common/*
-tooling             → build.zig, lefthook, convco, tools/*, scripts/*
-ci                  → .github/workflows/*
-docs                → in-source doc comments, README, doc files
-meta                → top-level repo files (CLAUDE.md, LICENSE, root configs)
-<area>/<sub>        → e.g. lang/codegen, vm/handlers, asm/parser
-apps/<name>         → apps/<name>/
-editors/<name>      → editors/<name>/
-```
-
-**Changesets** — every PR with a user-visible change drops
-`.changeset/<short>.md`. CHANGELOG + version bump derive from
-accumulated changesets at release time.
-
-- **Add one** for `feat`, `fix`, library-level `perf`, breaking
-  refactor.
-- **Skip** for `chore`, `docs`, `test`, internal-only `refactor`,
-  `ci`, `build`, `style`. The `changeset-check` workflow
-  auto-skips these PR titles.
-
-`zig build changeset` scaffolds one interactively.
-
----
-
-## Releases (manual)
-
-Releases are cut manually. Multiple merged PRs accumulate
-changesets on `main`; the maintainer cuts a release when several
-are worth a coherent semver bump. Pushing to `main` runs CI but
-**never** publishes — only pushing a `vX.Y.Z` tag triggers
-`release.yml`.
-
-```bash
-git checkout main && git pull
-zig build version           # consume changesets, bump version, prepend CHANGELOG
-git diff                    # review the generated CHANGELOG, edit by hand if needed
-git add . && git commit -m "chore(meta): release vX.Y.Z"
-git tag vX.Y.Z
-git push origin main --tags
-```
-
----
-
-## Tech stack (one-liner reference)
-
-Zig 0.16.0 minimum (pinned in `build.zig.zon`), zero runtime deps,
-`build.zig` is the task runner (no Makefile, no shell wrapper —
-`zig build --help` lists every step), `zig fmt` via
-`zig build fmt`/`fmt-check`, lint via `zig build lint`, git hooks
-via [lefthook](https://github.com/evilmartians/lefthook),
-commits via [convco](https://github.com/convco/convco), changesets
-as manual `.changeset/*.md` files.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,174 @@
+# Development reference
+
+Long-form companion to [`CLAUDE.md`](../CLAUDE.md). CLAUDE.md
+holds the rules that govern every PR (specs-first reading,
+workflow contract, self-review loop, code rules, build gates).
+This file holds the structural references Claude reads only when
+needed — source layout, the full lint rule list, the
+branch/commit/changeset conventions, the release flow, and the
+tech-stack one-liner.
+
+---
+
+## Source layout
+
+```
+src/
+├── gero.zig               # Public barrel
+├── vm/                    # Bytecode interpreter
+├── asm/                   # Assembler (consumes knit)
+├── disasm/                # Disassembler
+├── lang/                  # Gero language compiler (consumes knit)
+└── common/                # Shared types: Value, Bytecode, Span
+
+tests/
+├── util.zig               # Shared test helpers
+├── gero.test.zig          # Public-surface smoke tests
+└── <mod>/<file>.test.zig  # Mirrors src/<mod>/<file>.zig
+
+apps/         # CLIs
+docs/         # ISA spec + lang spec
+editors/      # Tree-sitter grammar + VS Code ext (submodules)
+tools/        # Single-binary dev utilities (lint, etc.)
+scripts/      # Bash helpers for build.zig + lefthook
+.changeset/   # *.md changeset files
+.github/      # Workflows + templates
+```
+
+**Mirror rule:** every `src/<mod>/<file>.zig` requires a matching
+`tests/<mod>/<file>.test.zig` — lint-enforced. Exempt:
+`src/gero.zig` and any top-level module barrel (e.g. `src/lang.zig`).
+
+`internal.zig` colocated with a module dir is the convention for
+private helpers — exempt from the mirror rule, must not be
+re-exported through `src/gero.zig`, exercised through its
+consuming modules' tests.
+
+**Imports:** single-level relative only. `../foo.zig` or `./foo.zig`
+— anything deeper (`../../...`) is rejected by the lint binary.
+Public consumers (and tests) import only `gero`:
+
+```zig
+const gero = @import("gero");
+```
+
+Tests can also import `../util.zig` (one level) for shared helpers.
+
+---
+
+## Strict-mode lint (`gero-lint`)
+
+Single Zig binary at `tools/lint/main.zig`, built as
+`zig-out/bin/gero-lint`, runs in ~2–3s. Fails on any of these in
+`src/`:
+
+- `anyerror`, `*anyopaque` / `*const anyopaque`
+- `@as(` / `@ptrCast(` / `@alignCast(` / `@bitCast(` without
+  `// @as:` / `// safety:` justification directly above
+- `unreachable` / `@compileError("TODO")` without a justifying
+  comment
+- `std.debug.print` outside test code
+- `catch unreachable` without `// allow-strict: <invariant>`
+- `catch |x| return x` — use `try` instead
+- `std.heap.page_allocator` direct use — accept allocators from
+  callers
+- `usingnamespace`
+- `//!` file-level doc anywhere except the top barrel
+- Issue numbers / version markers in any comment
+- Mirror-layout violations
+- Multi-level relative imports (`../../`)
+- Naming: `pub fn Foo(...) type` must be PascalCase;
+  `pub fn foo(...) <other>` must be camelCase
+- Public declarations without `///` doc comments
+
+Allowlist a violation with `// allow-strict: <reason>` directly
+above the line. Reviewer-gated — bring a real reason.
+
+`pub const` naming is convention-only (not enforced): PascalCase
+for types (`pub const Foo = struct {...}`), snake_case for values
+(`pub const max_count = 42`).
+
+---
+
+## Branches + commits + changesets
+
+**Branches:**
+
+- `feat/<short>` — new module, new public API
+- `fix/<short>` — bug fix
+- `perf/<short>` — measurable performance improvement
+- `chore/<short>` — tooling, deps, CI, build
+- `docs/<short>` — docs-only change
+- `refactor/<short>` — internal restructure, no behavior change
+
+Branch from `main`. One issue → one branch → one PR end-to-end
+(no chunking — see CLAUDE.md "The contract").
+
+**Commits:** Conventional Commits enforced by **convco** with a
+strict scope-enum from `.versionrc`.
+
+- No scope-less commits (`feat: add x` → rejected)
+- Multi-concern changes split into multiple commits in the PR
+- `fixup!` for review feedback, then `--autosquash`
+- Tooling-only `perf` → use `chore(tooling)` (changeset gate
+  auto-skips). Library API perf wins stay `perf(<scope>)`.
+
+**Allowed scopes:**
+
+```
+vm                  → src/vm/*
+asm                 → src/asm/*
+disasm              → src/disasm/*
+lang                → src/lang/*
+common              → src/common/*
+tooling             → build.zig, lefthook, convco, tools/*, scripts/*
+ci                  → .github/workflows/*
+docs                → in-source doc comments, README, doc files
+meta                → top-level repo files (CLAUDE.md, LICENSE, root configs)
+<area>/<sub>        → e.g. lang/codegen, vm/handlers, asm/parser
+apps/<name>         → apps/<name>/
+editors/<name>      → editors/<name>/
+```
+
+**Changesets** — every PR with a user-visible change drops
+`.changeset/<short>.md`. CHANGELOG + version bump derive from
+accumulated changesets at release time.
+
+- **Add one** for `feat`, `fix`, library-level `perf`, breaking
+  refactor.
+- **Skip** for `chore`, `docs`, `test`, internal-only `refactor`,
+  `ci`, `build`, `style`. The `changeset-check` workflow
+  auto-skips these PR titles.
+
+`zig build changeset` scaffolds one interactively.
+
+---
+
+## Releases (manual)
+
+Releases are cut manually. Multiple merged PRs accumulate
+changesets on `main`; the maintainer cuts a release when several
+are worth a coherent semver bump. Pushing to `main` runs CI but
+**never** publishes — only pushing a `vX.Y.Z` tag triggers
+`release.yml`.
+
+```bash
+git checkout main && git pull
+zig build version           # consume changesets, bump version, prepend CHANGELOG
+git diff                    # review the generated CHANGELOG, edit by hand if needed
+git add . && git commit -m "chore(meta): release vX.Y.Z"
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+---
+
+## Tech stack (one-liner reference)
+
+Zig 0.16.0 minimum (pinned in `build.zig.zon`), zero runtime deps,
+`build.zig` is the task runner (no Makefile, no shell wrapper —
+`zig build --help` lists every step), `zig fmt` via
+`zig build fmt`/`fmt-check`, lint via `zig build lint`, git hooks
+via [lefthook](https://github.com/evilmartians/lefthook),
+commits via [convco](https://github.com/convco/convco), changesets
+as manual `.changeset/*.md` files.


### PR DESCRIPTION
## Summary
- CLAUDE.md is auto-loaded into every Claude session. Today it's 495 lines (~6k tokens), and a chunk of that is reference material (source layout, full lint rule list, branch/commit/changeset conventions, release flow, tech stack) that's rarely needed in-line during a PR.
- Move those five sections to a new `docs/development.md`. Keep in CLAUDE.md only what governs every PR: spec discipline, the contract, before-every-push checklist, self-review loop, code rules, build commands.
- 339 lines stays in CLAUDE.md; 174 lines moves to `docs/development.md`. Cross-references updated.

## Token impact
- ~1.9k tokens off every prompt-cache miss (Opus 4.7 has a 5-min TTL — every long-idle resumption re-pays the prefix).
- Combined with claude-mem `PreToolUse:Read` + `Stop` hooks disabled (local config, not in this PR), savings are roughly 10-15k tokens per session in this project.

## No content lost
Every paragraph moved verbatim. The split is structural — no rule rewrites, no policy changes. Internal links updated to point at the new location.

## Test plan
- [x] `zig build verify` green (the lint binary doesn't read CLAUDE.md / docs/development.md, so no behavior change)
- [ ] Skim that Claude on next session still reaches for `docs/development.md` when it needs the lint rule list or scope enum

## Out of scope
- claude-mem hook trim (~/.claude/plugins/...) — that's a user-config change, not a repo change.