### PR TITLE
feat(lang): `&T` auto-deref on field access + method dispatch (closes #216)

### DIFF
--- a/.changeset/lang-ref-autoderef.md
+++ b/.changeset/lang-ref-autoderef.md
@@ -1,0 +1,12 @@
+---
+bump: minor
+---
+
+`&T` references now auto-deref for field access and method
+dispatch per spec §3.4.4. Given `r: &Counter`, both `r.n` and
+`r.method()` resolve through the pointee's class layout / vtable
+— the typechecker peels one reference layer before field /
+method resolution, and the codegen emits an extra word-load
+through the reference slot to reach the heap-allocated instance.
+Mutation through a `&T` parameter (`r.n = r.n + 10`) writes
+back to the caller's binding. Closes #216.

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -1699,8 +1699,14 @@ pub const Emitter = struct {
     /// class-typed lowering and the existing free-fn / enum paths.
     pub fn classNameOf(self: *const Emitter, e: *const ast.Expr) ?[]const u8 {
         const ty = self.typeOf(e) orelse return null;
-        if (ty.* != .named) return null;
-        const name = ty.named.name;
+        // Per spec §3.4.4 `&T` auto-derefs for `.field` / `.method`;
+        // peeling one layer routes `r: &Class` into the same class
+        // dispatch path as a direct `Class` binding. The extra load
+        // through the reference is emitted in `class.emitInstancePtr`.
+        // `&&T` is rejected at typecheck so a single peel suffices.
+        const inner = if (ty.* == .reference) ty.reference else ty;
+        if (inner.* != .named) return null;
+        const name = inner.named.name;
         if (!self.class_decls.contains(name)) return null;
         return name;
     }

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -365,6 +365,20 @@ fn findInheritedField(
     }
 }
 
+/// Evaluate `recv` and land the class instance pointer in `acu`.
+/// Auto-derefs once when `recv`'s type is `&T` per spec §3.4.4 —
+/// `&c` produces the address of `c`'s slot, so reaching the heap-
+/// allocated instance needs one extra word load through that
+/// address.
+fn emitInstancePtr(self: *Emitter, recv: *const ast.Expr) !void {
+    try self.emitExpr(recv);
+    const ty = self.typeOf(recv) orelse return;
+    if (ty.* == .reference) {
+        try self.movRegToReg(Reg.acu, Reg.r1);
+        try emitWordLoadAtOffset(self, Reg.r1, 0, Reg.acu);
+    }
+}
+
 /// Lower `recv.field` (class-typed receiver) — evaluate the
 /// receiver into `acu` (instance pointer), then word- or byte-
 /// load at the field's offset.
@@ -384,7 +398,7 @@ pub fn emitFieldLoad(
         return;
     };
 
-    try self.emitExpr(recv);
+    try emitInstancePtr(self, recv);
     // acu = instance ptr; load at acu + field.offset.
     try self.movRegToReg(Reg.acu, Reg.r1);
     if (field.width == 1) {
@@ -415,7 +429,7 @@ pub fn emitFieldStore(
 
     try self.emitExpr(value);
     try self.pushReg(Reg.acu);
-    try self.emitExpr(recv);
+    try emitInstancePtr(self, recv);
     try self.movRegToReg(Reg.acu, Reg.r1);
     try self.popReg(Reg.r2);
     if (field.width == 1) {
@@ -446,8 +460,8 @@ pub fn emitMethodDispatch(
         return;
     };
 
-    // 1. Evaluate receiver, stash instance ptr in r1.
-    try self.emitExpr(recv);
+    // 1. Evaluate receiver (auto-deref if `&T`), stash instance ptr in r1.
+    try emitInstancePtr(self, recv);
     try self.movRegToReg(Reg.acu, Reg.r1);
 
     // 2. Load vtable pointer from [r1+0] into r2.

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1410,7 +1410,7 @@ pub const Checker = struct {
                 }
                 const recv_ty = try self.inferExpr(m.receiver, null);
                 try self.checkNotNullableDeref(m.receiver, recv_ty, m.span);
-                return try self.checkMethodCall(m, recv_ty);
+                return try self.checkMethodCall(m, peelReference(recv_ty));
             },
             .field => |f| {
                 // Special receivers (recognized before generic
@@ -1429,7 +1429,7 @@ pub const Checker = struct {
                 }
                 const recv_ty = try self.inferExpr(f.receiver, null);
                 try self.checkNotNullableDeref(f.receiver, recv_ty, f.span);
-                return try self.resolveFieldAccess(f, recv_ty);
+                return try self.resolveFieldAccess(f, peelReference(recv_ty));
             },
             .index => |ix| {
                 _ = try self.inferExpr(ix.receiver, null);
@@ -2444,4 +2444,13 @@ fn isPlaceExpr(e: *const ast.Expr) bool {
         .paren => |p| isPlaceExpr(p.inner),
         else => false,
     };
+}
+
+/// Peel one `&T` layer so field / method resolution sees the pointee
+/// type. Per spec §3.4.4, references auto-deref for `.field` and
+/// `.method()`. `&&T` is rejected at `checkRefOf`, so a single peel
+/// suffices. Pass-through for non-reference and `null` inputs.
+fn peelReference(t: ?*const types.Type) ?*const types.Type {
+    const ty = t orelse return null;
+    return if (ty.* == .reference) ty.reference else ty;
 }

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1687,6 +1687,69 @@ test "codegen: undefined mem.X is rejected by typecheck" {
     try std.testing.expect(found);
 }
 
+test "codegen: `&T` auto-derefs for class field read" {
+    try runAndExpect(
+        \\class Counter
+        \\  let n: i16
+        \\
+        \\  def init(self)
+        \\    self.n = 7
+        \\  end
+        \\end
+        \\
+        \\def read(r: &Counter)
+        \\  print r.n
+        \\end
+        \\
+        \\def main()
+        \\  let c = Counter()
+        \\  read(&c)
+        \\end
+    , "7\n");
+}
+
+test "codegen: `&T` mutation through param mutates caller's binding" {
+    try runAndExpect(
+        \\class Counter
+        \\  let n: i16
+        \\
+        \\  def init(self)
+        \\    self.n = 1
+        \\  end
+        \\end
+        \\
+        \\def bump(r: &Counter)
+        \\  r.n = r.n + 10
+        \\end
+        \\
+        \\def main()
+        \\  let c = Counter()
+        \\  bump(&c)
+        \\  bump(&c)
+        \\  print c.n
+        \\end
+    , "21\n");
+}
+
+test "codegen: `&T` auto-derefs for method dispatch" {
+    try runAndExpect(
+        \\class Echo
+        \\  def shout(self)
+        \\    print "hi"
+        \\  end
+        \\end
+        \\
+        \\def yell(r: &Echo)
+        \\  r.shout()
+        \\end
+        \\
+        \\def main()
+        \\  let e = Echo()
+        \\  yell(&e)
+        \\end
+    , "hi\n");
+}
+
 test "codegen: custom entry_name resolves" {
     const source = "def boot() end";
     var stream = try gero.lang.tokenize(alloc, source);


### PR DESCRIPTION
## Summary

Final AC for issue #216 — `&T` references now auto-deref for
`.field` and `.method` access per spec §3.4.4. Given `r: &Counter`,
both `r.n` and `r.method()` resolve through the pointee's class
layout / vtable, and mutation through a `&T` parameter writes
back to the caller's binding.

The earlier slices (PR #273 M3a) shipped the typed `&T` shape +
`&local` codegen + rejection paths (`&&T`, `&(a+b)`,
`return &local`). This PR closes out the remaining AC items.

## What lands

**Typecheck** — `.field` and `.method_call` arms peel one
reference layer (new `peelReference` helper) before calling
`resolveFieldAccess` / `checkMethodCall`. `&&T` is already
rejected at `checkRefOf` so a single peel suffices. Missing
fields / methods on the pointee are flagged with the existing
`E_TYPE_UNDEFINED_FIELD` / `E_TYPE_UNDEFINED_METHOD` codes.

**Codegen** — `classNameOf` peels `.reference` so `r: &Class`
routes into the class dispatch path. New `emitInstancePtr`
helper in `codegen/class.zig` emits an extra word-load through
the reference slot when the receiver type is a reference (since
`&c` yields the address of `c`'s slot rather than the heap
pointer it holds). Field load / field store / method dispatch
all funnel through this helper.

## Acceptance criteria (issue #216)

- [x] `def foo(s: &Stats)` accepts a `Stats` by reference; `foo(&my_stats)` passes the address
- [x] Mutation through a `&T` parameter mutates the caller's binding
- [x] `&&T` is rejected with a clear diagnostic (`E_REF_DOUBLE`)
- [x] `&(a + b)` is rejected (`E_REF_TEMPORARY`)
- [x] `return &local` rejected (`E_REF_STACK_LIFETIME`)
- [x] `&static_const` accepted
- [x] `mem.addr_of(x)` matches `&x` address (PR #273 test)
- [x] References auto-deref for field access and method dispatch
- [x] All four release modes pass

## Test plan

- [x] `zig build verify` green
- [x] `zig build test-modes` green
- [x] Changeset present (`lang-ref-autoderef.md`)
- [x] No AI attribution in commits

Closes #216.