### PR TITLE
feat(lang): assert + debug_assert always-in-scope builtins (closes #219)

### DIFF
--- a/.changeset/lang-assert-builtins.md
+++ b/.changeset/lang-assert-builtins.md
@@ -1,0 +1,19 @@
+---
+bump: minor
+---
+
+`assert(cond, msg?)` and `debug_assert(cond, msg?)` are now
+always-in-scope builtins per spec §5.3. Both validate the cond
+against `bool` and the optional msg against `str` at the
+typechecker, and reject 0-arg / 3+arg shapes with
+`E_ASSERT_ARG_COUNT`. On `false` the emitted sequence prints the
+message via `sys print_str` (when provided) and halts the VM —
+the host sees the diagnostic before the clean halt. `assert`
+fires in every build mode; `debug_assert` is elided to zero
+bytecode (args not evaluated) under
+`--optimize=release` / `=size`, with a
+`W_DEBUG_ASSERT_SIDE_EFFECT` warning when a `debug_assert` arg
+contains a call, since the call disappears in release. Adds
+`CompileOptions.optimize` (`debug` / `release` / `size`) plumbed
+through to the codegen — same enum the CLI's `--optimize` parses.
+Closes #219.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -2207,14 +2207,17 @@ solves one concrete need:
 `assert` and `debug_assert` are **always in scope** without import —
 both are built-in pseudo-functions:
 
-- `assert(cond, msg?)` — always evaluated, in every build mode. On
-  `false`, traps via fault vector `$02` with the optional message
-  in the diagnostic. Use for invariants that **must never fail**
-  in production code.
+- `assert(cond, msg?)` — always evaluated, in every build mode.
+  On `false`, prints the optional message via the host print
+  channel and halts the VM. Use for invariants that **must never
+  fail** in production code.
 - `debug_assert(cond, msg?)` — evaluated in debug builds only.
-  Elided entirely (zero bytecode emitted) under `gero build
-  --release`. Use for pedagogical / development-time checks that
-  shouldn't carry shipping cost.
+  Elided entirely (zero bytecode emitted, args not evaluated)
+  under `gero compile --optimize=release` / `=size`. Use for
+  pedagogical / development-time checks that shouldn't carry
+  shipping cost. The typechecker emits
+  `W_DEBUG_ASSERT_SIDE_EFFECT` when an arg contains a call, since
+  observable effects in that arg disappear in release.
 
 ```
 assert(self.hp >= 0, "hp went negative")        -- always live

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -632,6 +632,15 @@ Per spec §4.10.
 | `E_DEFER_CONTROL_FLOW` | `defer return / break / continue` rejected. |
 | `E_DEFER_NESTED` | `defer defer ...` (pointless, doesn't compose). |
 
+### 5.12 Assert builtins (E_ASSERT_* / W_DEBUG_ASSERT_*)
+
+Per spec §5.3.
+
+| Code | Meaning |
+|------|---------|
+| `E_ASSERT_ARG_COUNT` | `assert` / `debug_assert` called with 0 or >2 args. |
+| `W_DEBUG_ASSERT_SIDE_EFFECT` | A `debug_assert` arg contains a function call; the call is elided in release. (Warning, not fatal.) |
+
 **Mockup — defer with return:**
 
 ```
@@ -715,6 +724,8 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_LOOP_OUTSIDE` | Loop labels | v0.3 |
 | `E_DEFER_CONTROL_FLOW` | Defer | v0.3 |
 | `E_DEFER_NESTED` | Defer | v0.3 |
+| `E_ASSERT_ARG_COUNT` | Assert builtins | v0.3 |
+| `W_DEBUG_ASSERT_SIDE_EFFECT` | Assert builtins | v0.3 |
 | `E_UNDEFINED_SYMBOL` | Name resolution | v0.3 |
 
 ---

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -81,8 +81,11 @@ pub const render = render_mod;
 
 /// Re-export: codegen output (`.gx` image + diagnostics).
 pub const Compiled = codegen_mod.Compiled;
-/// Re-export: codegen knobs (`entry_name`, `debug_symbols`).
+/// Re-export: codegen knobs (`entry_name`, `debug_symbols`,
+/// `optimize`).
 pub const CompileOptions = codegen_mod.Options;
+/// Re-export: build-mode selector consumed by `CompileOptions.optimize`.
+pub const Optimize = codegen_mod.Optimize;
 /// Re-export: errors `compile` can return (host-failure family —
 /// semantic errors land in `Compiled.diagnostics`).
 pub const CompileError = codegen_mod.CompileError;

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -112,6 +112,12 @@ pub const Compiled = struct {
     }
 };
 
+/// Build-mode selector. Mirrors the CLI's `--optimize=<m>` values
+/// per `docs/cli.md` §2. The lang doesn't itself depend on the CLI
+/// — the CLI plumbs its parsed value into `Options.optimize` when
+/// invoking `compile`.
+pub const Optimize = enum { debug, release, size };
+
 /// Knobs for `compile`. Mirrors `gero.asm_.Options` so callers
 /// can wrap both pipelines uniformly.
 pub const Options = struct {
@@ -121,6 +127,11 @@ pub const Options = struct {
     /// When `true` reserves a flag bit + section for debug
     /// symbols (per ISA §7.3). Slice M1 doesn't emit the body yet.
     debug_symbols: bool = true,
+    /// Build mode. Controls debug-only lowering decisions such as
+    /// `debug_assert` elision (§5.3) and overflow trap insertion
+    /// (§4.2.1). Defaults to `.debug` — release / size modes drop
+    /// debug-only checks.
+    optimize: Optimize = .debug,
 };
 
 /// Errors `compile` can return. Grammar / semantic errors land in
@@ -204,6 +215,7 @@ pub fn compile(
         .block_stack = .empty,
         .loop_stack = .empty,
         .diagnostics = &diagnostics,
+        .optimize = opts.optimize,
     };
     defer emitter.code.deinit(allocator);
     defer emitter.call_patches.deinit(allocator);
@@ -563,6 +575,10 @@ pub const Emitter = struct {
     loop_stack: std.ArrayList(LoopFrame),
     /// Sink for codegen-time diagnostics.
     diagnostics: *std.ArrayList(Diagnostic),
+    /// Active build mode — drives debug-only lowering decisions
+    /// (`debug_assert` elision per §5.3; overflow trap insertion
+    /// per §4.2.1 once it lands).
+    optimize: Optimize,
 
     /// Mutually recursive emit fns need an explicit error set to
     /// break Zig's inferred-set deadlock.

--- a/src/lang/codegen/assert.zig
+++ b/src/lang/codegen/assert.zig
@@ -1,0 +1,77 @@
+/// Builtin lowering for `assert(cond, msg?)` and
+/// `debug_assert(cond, msg?)` per spec §5.3. Both shapes parse as
+/// regular `CallExpr { callee: ident, args: ... }` — the
+/// typechecker validates the signature; the codegen dispatches on
+/// the callee name before the generic call path.
+///
+/// `assert` always emits the check (in every build mode).
+/// `debug_assert` is elided to zero bytecode when the active
+/// `Options.optimize` is anything other than `.debug` — argument
+/// expressions are not evaluated either, per spec.
+///
+/// On `false` the emitted sequence prints the optional message
+/// (via `sys print_str` when the arg is a string literal) and
+/// halts the VM. The host sees a clean halt with the assertion
+/// message in `Host.out` — matching the spec's "diagnostic"
+/// guarantee without reserving a new ISA fault vector.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const opcodes = @import("opcodes.zig");
+const codegen_mod = @import("../codegen.zig");
+const archive = @import("archive.zig");
+const strings = @import("strings.zig");
+
+const Emitter = codegen_mod.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Sys = opcodes.Sys;
+
+/// `true` when `name` is one of the always-in-scope assert
+/// builtins recognized at call sites.
+pub fn isAssertBuiltin(name: []const u8) bool {
+    return std.mem.eql(u8, name, "assert") or std.mem.eql(u8, name, "debug_assert");
+}
+
+/// Lower a call to `assert` or `debug_assert`. Caller must have
+/// confirmed `c.callee` is an ident with name matching
+/// `isAssertBuiltin`. Returns without emitting when the call is
+/// a `debug_assert` and the build mode elides debug checks.
+pub fn emitAssertCall(self: *Emitter, c: ast.CallExpr, name: []const u8) !void {
+    const is_debug = std.mem.eql(u8, name, "debug_assert");
+    if (is_debug and self.optimize != .debug) return;
+
+    // `cond` evaluated into `acu`; falsy ⇒ acu == 0 ⇒ Z flag set.
+    try self.emitExpr(c.args[0]);
+    try self.cmpRegImm(Reg.acu, 0);
+    // `jne skip` — when cond is truthy (Z = 0), jump past the
+    // trap. Patched after the trap body emits.
+    const skip_patch = try self.emitJumpPlaceholder(Op.jne_addr);
+
+    // Trap body. Message printed only when provided so the host
+    // gets a contextual diagnostic before the halt.
+    if (c.args.len >= 2) try emitMessage(self, c.args[1]);
+
+    try self.emitByte(Op.hlt);
+
+    const skip_target = try self.currentOffset();
+    try self.patchJumpTo(skip_patch, skip_target);
+}
+
+/// Emit the print syscall for the optional assert message. Plain
+/// string literals route to the pooled-address fast path
+/// (`mov str_addr, acu; sys print_str`); other str expressions
+/// evaluate normally and reuse the same syscall on the resulting
+/// pointer.
+fn emitMessage(self: *Emitter, msg: *const ast.Expr) !void {
+    if (msg.* == .str_lit and msg.str_lit.parts.len == 1 and msg.str_lit.parts[0] == .lit) {
+        const lit = msg.str_lit.parts[0].lit;
+        const raw = self.source[lit.span.start..lit.span.end];
+        const decoded = try archive.decodeStringEscapes(self.arena, raw);
+        const id = try strings.internString(self, decoded);
+        try strings.emitMovStringAddrToReg(self, id, Reg.acu);
+        try self.sys(Sys.print_str);
+        return;
+    }
+    try self.emitExpr(msg);
+    try self.sys(Sys.print_str);
+}

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -7,6 +7,7 @@ const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const archive = @import("archive.zig");
+const assert_builtin = @import("assert.zig");
 const class = @import("class.zig");
 const lambda = @import("lambda.zig");
 
@@ -459,6 +460,13 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     // declared. The instance address lands in `acu`.
     if (c.callee.* == .ident) {
         const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+        // `assert` / `debug_assert` always-in-scope builtins
+        // (§5.3) intercept before the free-fn path — they have no
+        // top-level def behind them.
+        if (assert_builtin.isAssertBuiltin(callee_name)) {
+            try assert_builtin.emitAssertCall(self, c, callee_name);
+            return;
+        }
         if (class.isClassName(self, callee_name)) {
             try class.emitConstructor(self, callee_name, c);
             return;

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -2225,6 +2225,15 @@ pub const Checker = struct {
 
     fn checkCall(self: *Checker, c: ast.CallExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
         _ = hint;
+        // `assert` / `debug_assert` always-in-scope builtins
+        // (§5.3) — no underlying `def`, so they skip the regular
+        // callee-resolution path.
+        if (c.callee.* == .ident) {
+            const callee_name = self.lexeme(c.callee.ident.span);
+            if (isAssertBuiltinName(callee_name)) {
+                return try self.checkAssertBuiltin(c, callee_name);
+            }
+        }
         // Abstract-class instantiation: `ClassName(args)` where
         // `ClassName` is abstract is rejected.
         if (c.callee.* == .ident) {
@@ -2291,6 +2300,58 @@ pub const Checker = struct {
             }
         }
         return f.ret;
+    }
+
+    // ---------- assert builtins (§5.3) ----------
+
+    /// Type-check `assert(cond, msg?)` / `debug_assert(cond, msg?)`.
+    /// Validates arity (1 or 2 args), bool cond, str msg, and
+    /// warns when a `debug_assert` arg looks side-effecting (any
+    /// nested `CallExpr` is the proxy). Returns `nil` — the
+    /// builtins are statement-shaped even when called in expression
+    /// position.
+    fn checkAssertBuiltin(
+        self: *Checker,
+        c: ast.CallExpr,
+        name: []const u8,
+    ) WalkError!?*const types.Type {
+        if (c.args.len == 0 or c.args.len > 2) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "`{s}` takes 1 or 2 arguments (cond, msg?), called with {d}",
+                .{ name, c.args.len },
+            );
+            try self.emitSpan("E_ASSERT_ARG_COUNT", c.span, msg);
+            for (c.args) |a| _ = try self.inferExpr(a, null);
+            return try self.primitive(.nil_);
+        }
+        const bool_ty = try self.primitive(.bool_);
+        const cond_ty = try self.inferExpr(c.args[0], bool_ty);
+        if (cond_ty != null and !relations.assignable(cond_ty.?.*, bool_ty.*)) {
+            try self.emitMismatch(c.args[0].span(), bool_ty, cond_ty.?);
+        }
+        if (c.args.len == 2) {
+            const str_ty = try self.primitive(.str);
+            const msg_ty = try self.inferExpr(c.args[1], str_ty);
+            if (msg_ty != null and !relations.assignable(msg_ty.?.*, str_ty.*)) {
+                try self.emitMismatch(c.args[1].span(), str_ty, msg_ty.?);
+            }
+        }
+        // `debug_assert` is elided in release — surface any
+        // observable side effect (a nested call) so the user
+        // doesn't rely on it firing in shipped builds.
+        if (std.mem.eql(u8, name, "debug_assert")) {
+            for (c.args) |a| if (exprContainsCall(a)) {
+                try self.diagnostics.append(self.diag_alloc, .{
+                    .severity = .warning,
+                    .code = "W_DEBUG_ASSERT_SIDE_EFFECT",
+                    .message = "`debug_assert` arguments are elided in release builds — any side effects here will not occur",
+                    .span = a.span(),
+                });
+                break;
+            };
+        }
+        return try self.primitive(.nil_);
     }
 
     // ---------- variadic (§4.6.2) ----------
@@ -2453,4 +2514,31 @@ fn isPlaceExpr(e: *const ast.Expr) bool {
 fn peelReference(t: ?*const types.Type) ?*const types.Type {
     const ty = t orelse return null;
     return if (ty.* == .reference) ty.reference else ty;
+}
+
+/// `true` when `name` is one of the always-in-scope assert
+/// builtins per spec §5.3. Recognized at call sites before any
+/// generic callee resolution.
+fn isAssertBuiltinName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "assert") or std.mem.eql(u8, name, "debug_assert");
+}
+
+/// `true` when `e` contains a `CallExpr` anywhere in its
+/// sub-tree. Used as a side-effect proxy for the
+/// `W_DEBUG_ASSERT_SIDE_EFFECT` warning — observable mutations
+/// happen through function calls in gero, so any call inside a
+/// `debug_assert` arg is worth flagging.
+fn exprContainsCall(e: *const ast.Expr) bool {
+    return switch (e.*) {
+        .call, .method_call => true,
+        .paren => |p| exprContainsCall(p.inner),
+        .unary => |u| exprContainsCall(u.operand),
+        .binary => |b| exprContainsCall(b.lhs) or exprContainsCall(b.rhs),
+        .field => |f| exprContainsCall(f.receiver),
+        .index => |ix| exprContainsCall(ix.receiver) or exprContainsCall(ix.index),
+        .cast => |c| exprContainsCall(c.inner),
+        .ref_of => |r| exprContainsCall(r.inner),
+        .is_test => |it| exprContainsCall(it.lhs),
+        else => false,
+    };
 }

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -2915,3 +2915,216 @@ test "codegen/debug-symbols: section omitted when opts.debug_symbols=false" {
     const flags = (@as(u16, compiled.image[7]) << 8) | @as(u16, compiled.image[6]);
     try std.testing.expect((flags & 0x0002) == 0);
 }
+
+// ---------- assert / debug_assert builtins (§5.3) ----------
+
+/// Compile `source` with the given optimize mode; helper for the
+/// assert tests that need to flip between debug and release.
+fn compileWithOptimize(source: []const u8, optimize: gero.lang.Optimize) !gero.lang.Compiled {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+    return gero.lang.compile(alloc, source, &checked, .{ .optimize = optimize });
+}
+
+test "codegen/assert: passing assert lets execution continue" {
+    try runAndExpect(
+        \\def main()
+        \\  assert(1 == 1)
+        \\  print "ok"
+        \\end
+    , "ok\n");
+}
+
+test "codegen/assert: failing assert halts after printing message" {
+    try runAndExpect(
+        \\def main()
+        \\  assert(1 == 2, "math broke")
+        \\  print "unreached"
+        \\end
+    , "math broke");
+}
+
+test "codegen/assert: failing assert without message halts silently" {
+    try runAndExpect(
+        \\def main()
+        \\  print "before"
+        \\  assert(false)
+        \\  print "after"
+        \\end
+    , "before\n");
+}
+
+test "codegen/debug_assert: fires in debug mode" {
+    try runAndExpect(
+        \\def main()
+        \\  debug_assert(false, "dev-time")
+        \\  print "unreached"
+        \\end
+    , "dev-time");
+}
+
+test "codegen/debug_assert: elided in release mode" {
+    var compiled = try compileWithOptimize(
+        \\def main()
+        \\  debug_assert(false, "should not print")
+        \\  print "ok"
+        \\end
+    , .release);
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("ok\n", writer.written());
+}
+
+test "codegen/debug_assert: identical bytecode to assert in debug mode" {
+    const assert_src =
+        \\def main()
+        \\  let x = 1
+        \\  assert(x == 1, "eq")
+        \\end
+    ;
+    const debug_assert_src =
+        \\def main()
+        \\  let x = 1
+        \\  debug_assert(x == 1, "eq")
+        \\end
+    ;
+    var a = try compileWithOptimize(assert_src, .debug);
+    defer a.deinit();
+    var b = try compileWithOptimize(debug_assert_src, .debug);
+    defer b.deinit();
+    try std.testing.expectEqualSlices(u8, a.image, b.image);
+}
+
+test "codegen/assert: identical bytecode in debug + release modes" {
+    const source =
+        \\def main()
+        \\  let x = 1
+        \\  assert(x == 1, "eq")
+        \\end
+    ;
+    var a = try compileWithOptimize(source, .debug);
+    defer a.deinit();
+    var b = try compileWithOptimize(source, .release);
+    defer b.deinit();
+    try std.testing.expectEqualSlices(u8, a.image, b.image);
+}
+
+test "codegen/debug_assert: release image matches debug_assert-stripped source" {
+    const with_da =
+        \\def main()
+        \\  let x = 1
+        \\  debug_assert(x == 1, "eq")
+        \\end
+    ;
+    const without =
+        \\def main()
+        \\  let x = 1
+        \\end
+    ;
+    var a = try compileWithOptimize(with_da, .release);
+    defer a.deinit();
+    var b = try compileWithOptimize(without, .release);
+    defer b.deinit();
+    try std.testing.expectEqualSlices(u8, a.image, b.image);
+}
+
+test "codegen/assert: 0 args rejected with E_ASSERT_ARG_COUNT" {
+    const source =
+        \\def main()
+        \\  assert()
+        \\end
+    ;
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    var found = false;
+    for (checked.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_ASSERT_ARG_COUNT")) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+test "codegen/assert: 3 args rejected with E_ASSERT_ARG_COUNT" {
+    const source =
+        \\def main()
+        \\  assert(true, "msg", 42)
+        \\end
+    ;
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    var found = false;
+    for (checked.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_ASSERT_ARG_COUNT")) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+test "codegen/debug_assert: warns when arg contains a call" {
+    const source =
+        \\def helper() -> bool
+        \\  return true
+        \\end
+        \\
+        \\def main()
+        \\  debug_assert(helper(), "calls have effects")
+        \\end
+    ;
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    var saw_warn = false;
+    for (checked.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "W_DEBUG_ASSERT_SIDE_EFFECT")) {
+            saw_warn = true;
+            try std.testing.expectEqual(gero.lang.Severity.warning, d.severity);
+        }
+    }
+    try std.testing.expect(saw_warn);
+}
+
+test "codegen/assert: plain `assert(call())` does NOT warn" {
+    const source =
+        \\def helper() -> bool
+        \\  return true
+        \\end
+        \\
+        \\def main()
+        \\  assert(helper())
+        \\end
+    ;
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    for (checked.diagnostics) |d| {
+        try std.testing.expect(!std.mem.eql(u8, d.code, "W_DEBUG_ASSERT_SIDE_EFFECT"));
+    }
+}

--- a/tests/lang/codegen/assert.test.zig
+++ b/tests/lang/codegen/assert.test.zig
@@ -1,0 +1,11 @@
+//! Mirror file for `src/lang/codegen/assert.zig`. The behavioral
+//! tests live in `tests/lang/codegen.test.zig` next to the rest of
+//! the codegen suite; this file exists to satisfy the mirror-layout
+//! lint rule.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/assert: module compiles through the barrel" {
+    _ = gero.lang.Optimize;
+}


### PR DESCRIPTION
## Summary

Per spec §5.3 `assert(cond, msg?)` and `debug_assert(cond,
msg?)` are always-in-scope builtins (no `import` needed, no
underlying `def`). `assert` always evaluates and traps on
`false`; `debug_assert` is elided entirely in release.

`assert` did not exist in the lang yet, so this PR ships both
builtins together (per scope discussion).

## What lands

**Typecheck** — new `checkAssertBuiltin` branch in `checkCall`
fires before generic callee resolution. Validates:
- 1 or 2 args (else `E_ASSERT_ARG_COUNT`)
- `cond` matches `bool`
- `msg` (when present) matches `str`
- `debug_assert` with a nested call warns
  `W_DEBUG_ASSERT_SIDE_EFFECT` (severity = warning) — the call
  disappears in release builds

**Codegen** — new `src/lang/codegen/assert.zig` lowers to
`eval cond; cmp acu, 0; jne skip; [print msg]; hlt; skip:`. On
`false` the host sees the message via `sys print_str` before
the clean halt — no new fault vector required. `debug_assert`
returns early (zero bytes, args not evaluated) when
`Options.optimize != .debug`.

**Build mode** — adds `CompileOptions.optimize` (`debug` /
`release` / `size`) and re-exports `gero.lang.Optimize`. The
CLI's `--optimize` flag plumbs into this when `gero compile`
lands (#198). The Emitter holds the active mode for any future
debug-only lowering (#218 will reuse it).

**Spec drift fix** — §5.3 previously claimed `assert` traps via
"fault vector \`\$02\`", but `\$02` is *invalid register fault*
per ISA §6. Reworded to describe the actual mechanism
(`sys print_str` of msg, then `hlt`) and the release-mode
elision rule.

## Acceptance criteria (issue #219)

- [x] `debug_assert(cond)` compiles
- [x] In debug builds, `debug_assert` and `assert` produce identical bytecode given the same args
- [x] In release builds, `debug_assert` produces zero bytecode (image-equality test against \`debug_assert\`-stripped source)
- [x] `assert` is unchanged in both modes (image-equality test debug vs release)
- [x] Typechecker warns on \`debug_assert(side_effecting_call())\` (`W_DEBUG_ASSERT_SIDE_EFFECT`)
- [x] All four release modes pass

## Test plan

- [x] `zig build verify` green
- [x] `zig build test-modes` green
- [x] Changeset present (`lang-assert-builtins.md`)
- [x] No AI attribution in commits

Closes #219.