### PR TITLE
feat(lang): debug overflow trap on +/-/* + muls ISA opcode (closes #218)

### DIFF
--- a/.changeset/lang-overflow-trap.md
+++ b/.changeset/lang-overflow-trap.md
@@ -1,0 +1,19 @@
+---
+bump: minor
+---
+
+Plain `+` / `-` / `*` on integer types now trap on overflow in
+debug builds and wrap two's-complement in release / size per
+spec §4.2.1 (Rust model). Codegen emits a per-op check after the
+ALU op (`jvc`/`jcc skip; int 5; skip:` — 5 extra bytes per op).
+On overflow the program raises arithmetic-overflow (vector `$05`
+per ISA §6); the default handler halts with a host-visible fault
+marker, and programs can install a custom `int 5` handler for
+diagnostic recovery. Signed `*` lowers through the new `muls`
+opcode so `V` correctly reflects `i16` overflow; unsigned `*`
+keeps `mul` (V = `high != 0`). Fixed-point ops remain wrap-only
+per ISA §5.4.1. The `--optimize=<debug|release|size>` flag (added
+by the assert builtins PR) toggles the check. Closes #218.
+
+The spec's stale `fault vector $02` reference in §4.2.1 is also
+corrected to `$05` (arithmetic overflow per ISA §6).

--- a/.changeset/vm-muls-opcode.md
+++ b/.changeset/vm-muls-opcode.md
@@ -1,0 +1,16 @@
+---
+bump: minor
+---
+
+ISA extension: signed multiply opcodes `muls Imm16, Reg` (`0x54`)
+and `muls Reg, Reg` (`0x55`) added in the previously-unused 0x5X
+arithmetic block. `muls` interprets both operands as `i16`,
+produces a 32-bit signed product with the low half in `dst` and
+the high half in `acu`, and sets `V` / `C` when the result
+doesn't fit in `i16`. Companion to existing unsigned `mul` —
+needed because `mul`'s V flag false-positives on legitimate
+signed products like `(-1) × 5 = -5`. Gero-lang's debug overflow
+trap on `*` is the canonical consumer. Bumps `.gx` format
+version `0x0002 → 0x0003` (backwards-compatible additive change
+per ISA §10) and fixes the §10 doc's stale "high byte of version"
+phrasing (minor is the low byte; major is the high byte).

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -1244,11 +1244,16 @@ no value produced". Go uses the same rule.
 
 **Overflow on arithmetic** (`+`, `-`, `*`):
 
-- **Debug builds** (`gero build`, default): the compiler emits an
-  overflow check. On overflow, the program traps via fault vector
-  `$02` with a diagnostic pointing at the source location.
-- **Release builds** (`gero build --release`): the check is elided
-  and the operation wraps two's-complement.
+- **Debug builds** (default, `--optimize=debug`): the compiler
+  emits a per-op overflow check (`jvc`/`jcc skip; int 5; skip:` —
+  5 extra bytes per op). On overflow the program raises
+  arithmetic-overflow (vector `$05` per ISA §6); the default
+  handler halts the VM with a host-visible fault marker. Signed
+  `*` lowers through `muls` so the `V` flag matches `i16` overflow.
+- **Release builds** (`--optimize=release` / `=size`): the check
+  is elided and the operation wraps two's-complement. Signed `*`
+  also lowers through plain `mul` since wrap-mod-2^16 is correct
+  for both signed and unsigned interpretations of the low half.
 
 This is the Rust model — one set of operators, build mode decides
 the policy. No `+%` / `+|` operator variants: if you genuinely need

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -383,10 +383,12 @@ If profiling later shows fixed-point or saturating math is a real
 hot path, native ops can be added later as an additive minor
 version bump (existing code keeps working).
 
-### 5.5 Arithmetic carry-propagating (`adc`, `sbc`) — `0x5X`
+### 5.5 Arithmetic extensions (`adc`, `sbc`, `muls`) — `0x5X`
 
-Add/subtract with carry — the canonical 6502 / Z80 / 8086 primitive
-for arithmetic wider than the native register width.
+Add/subtract with carry (the canonical 6502 / Z80 / 8086 primitive
+for arithmetic wider than the native register width), plus signed
+multiply for languages that need a correct signed-overflow
+detector.
 
 | Opcode | Mnemonic | Schema | Effect |
 |--------|----------|--------|--------|
@@ -394,6 +396,8 @@ for arithmetic wider than the native register width.
 | `0x51` | `adc`    | `Reg, Reg`    | dst ← dst + src + C |
 | `0x52` | `sbc`    | `Imm16, Reg`  | reg ← reg - imm - C (sub with borrow — multi-precision arithmetic) |
 | `0x53` | `sbc`    | `Reg, Reg`    | dst ← dst - src - C |
+| `0x54` | `muls`   | `Imm16, Reg`  | signed mul: `acu:reg ← reg ×s imm` (operands reinterpreted as `i16`; 32-bit signed product, high half in acu) |
+| `0x55` | `muls`   | `Reg, Reg`    | signed mul: `acu:dst ← dst ×s src` |
 
 A 32-bit add via two 16-bit registers:
 
@@ -405,6 +409,18 @@ adc  r2, r4      ; high half + carry-from-low ✨
 Same for 32-bit subtraction with `sub` + `sbc`. Without these,
 multi-precision math requires explicit branch-on-carry sequences
 (slower, larger code).
+
+`muls` complements `mul` — both produce the same 16-bit low half
+(modulo two's complement), but their flag semantics differ:
+
+- `mul` sets `V` and `C` when the *unsigned* product doesn't fit
+  in 16 bits (`high != 0`). Right for unsigned overflow detection;
+  false-positives on legitimate signed products like `(-1) * 5 = -5`
+  (where the unsigned interpretation gives `0xFFFF × 0x0005 = 0x0004FFFB`).
+- `muls` sets `V` and `C` when the *signed* product doesn't fit
+  in `i16` (range `-32768..32767`). Use this when the language
+  needs a one-instruction signed overflow detector — the lang's
+  debug-mode overflow trap on `*` is the canonical consumer.
 
 ### 5.6 Bitwise — `0x6X`
 
@@ -575,7 +591,7 @@ Reserved vectors:
 | `0x02` | Invalid register fault. |
 | `0x03` | Division by zero (`div` / `divs` with divisor = 0). |
 | `0x04` | Heap exhausted (`sys alloc` with cursor + size colliding with the stack, exceeding the heap budget, or `heap_base = 0`). |
-| `0x05` | Arithmetic overflow (currently only emitted by `div` / `divs` when quotient exceeds 16 bits). |
+| `0x05` | Arithmetic overflow. VM raises this on `div` / `divs` when the quotient exceeds 16 bits. Languages targeting gero may also software-raise it (via `int 5`) when their own overflow checks fire — gero-lang does so for `+` / `-` / `*` in debug builds. |
 | `0x06..0x1F` | Reserved (host-defined). |
 | `0x20..0x3F` | Software interrupts (`int N`). |
 
@@ -632,7 +648,7 @@ metadata.
 | Offset | Field          | Size | Notes |
 |--------|----------------|------|-------|
 | `0x00` | magic          | 4    | `'G' 'E' 'R' 'O'` (`0x47 0x45 0x52 0x4F`) |
-| `0x04` | version        | 2    | u16le format version. Currently `0x0002`. |
+| `0x04` | version        | 2    | u16le format version. Currently `0x0003`. |
 | `0x06` | flags          | 2    | u16le bitfield (see below) |
 | `0x08` | entry_point    | 2    | u16le address `ip` is set to at boot |
 | `0x0A` | image_size     | 2    | u16le base-image size in bytes (`0..65535`; max 65535-byte image — programs needing more use banks) |
@@ -726,13 +742,13 @@ behave permissively (read `0xFF`, write dropped; stack wraps).
 
 ## 10. Versioning
 
-This document specifies version `0x0002`. Future ISA changes:
+This document specifies version `0x0003`. Future ISA changes:
 
 - **Patch-level edits to this doc** (clarifying ambiguous behavior,
   fixing typos, documenting reserved bits) do not bump the version.
 - **Backwards-compatible additions** (new opcodes in unused ranges,
   new flag bits, new vector reservations) bump the **minor** field
-  (high byte of version): e.g. `0x0002` would still load `0x0001`
+  (low byte of version): e.g. `0x0003` would still load `0x0002`
   files.
 - **Breaking changes** (changing existing opcode semantics, changing
   encoding, repurposing a register) bump the **major** field (would

--- a/src/asm/opcode_resolver.zig
+++ b/src/asm/opcode_resolver.zig
@@ -124,11 +124,13 @@ const shapes: []const Shape = &.{
     .{ .mnemonic = "divs", .kinds = &.{ .reg, .reg }, .opcode = 0x4E },
     .{ .mnemonic = "sext", .kinds = &.{.reg}, .opcode = 0x4F },
 
-    // 0x5X — arithmetic carry-propagating
+    // 0x5X — arithmetic extensions (carry-propagating + signed mul)
     .{ .mnemonic = "adc", .kinds = &.{ .imm16, .reg }, .opcode = 0x50 },
     .{ .mnemonic = "adc", .kinds = &.{ .reg, .reg }, .opcode = 0x51 },
     .{ .mnemonic = "sbc", .kinds = &.{ .imm16, .reg }, .opcode = 0x52 },
     .{ .mnemonic = "sbc", .kinds = &.{ .reg, .reg }, .opcode = 0x53 },
+    .{ .mnemonic = "muls", .kinds = &.{ .imm16, .reg }, .opcode = 0x54 },
+    .{ .mnemonic = "muls", .kinds = &.{ .reg, .reg }, .opcode = 0x55 },
 
     // 0x6X — bitwise (logical word ops + single-bit ops).
     // Operand order unified to (src, dst) like every other store /

--- a/src/disasm/header.zig
+++ b/src/disasm/header.zig
@@ -57,7 +57,7 @@ pub const Symbols = struct {
 /// One file's worth of decoded header info + section slices, all
 /// borrowed from the caller's `bytes` buffer.
 pub const Header = struct {
-    /// Bytecode format version — currently `0x0002`.
+    /// Bytecode format version — currently `0x0003`.
     version: u16,
     /// Bit-set per ISA §7.1 (bit 0 = banked, bit 1 = has-debug).
     flags: u16,

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -754,9 +754,21 @@ pub const Emitter = struct {
         try self.emitByte(reg);
     }
 
-    /// `mul src, dst` (0x47) — `dst ← dst * src`.
+    /// `mul src, dst` (0x47) — `dst ← dst * src` (unsigned 32-bit
+    /// product; V/C set when `high != 0`).
     pub fn mulRegReg(self: *Emitter, src: u8, dst: u8) !void {
         try self.emitByte(Op.mul_reg_reg);
+        try self.emitByte(src);
+        try self.emitByte(dst);
+    }
+
+    /// `muls src, dst` (0x55) — signed `dst ← dst * src`. V/C set
+    /// when the signed result overflows `i16` — the lang's debug
+    /// overflow trap on `*` branches on V without false positives
+    /// that the unsigned `mul`'s V flag would produce on legitimate
+    /// negative operands.
+    pub fn mulsRegReg(self: *Emitter, src: u8, dst: u8) !void {
+        try self.emitByte(Op.muls_reg_reg);
         try self.emitByte(src);
         try self.emitByte(dst);
     }

--- a/src/lang/codegen/archive.zig
+++ b/src/lang/codegen/archive.zig
@@ -9,8 +9,11 @@ const std = @import("std");
 
 /// 4-byte ASCII magic at the top of every `.gx` archive.
 pub const gx_magic = [4]u8{ 'G', 'E', 'R', 'O' };
-/// Format version stored in bytes 4-5 of the header.
-pub const gx_version: u16 = 0x0002;
+/// Format version stored in bytes 4-5 of the header. Minor low,
+/// major high; bumped on every backwards-compatible ISA addition
+/// the lang depends on (most recently `0x0003` for the `muls`
+/// opcode used by the debug overflow trap on `*`).
+pub const gx_version: u16 = 0x0003;
 /// Fixed header size in bytes — every archive starts with this
 /// many bytes before the base image.
 pub const gx_header_size: usize = 16;

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -10,6 +10,7 @@ const archive = @import("archive.zig");
 const assert_builtin = @import("assert.zig");
 const class = @import("class.zig");
 const lambda = @import("lambda.zig");
+const overflow = @import("overflow.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -210,6 +211,17 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
         self.isPrimitiveType(b.rhs, .fixed) and
         (b.op == .mul or b.op == .div);
 
+    // Per spec §4.2.1, plain `+` / `-` / `*` on integer types trap
+    // on overflow in debug builds and wrap in release. The check
+    // is emitted after the ALU op so the V / C flags reflect the
+    // result. Fixed-point ops keep their wrap-only semantics
+    // (ISA §5.4.1).
+    const lhs_ty = self.typeOf(b.lhs);
+    const rhs_ty = self.typeOf(b.rhs);
+    const integer_arith = !fixed_op and overflow.isIntegerArith(lhs_ty) and overflow.isIntegerArith(rhs_ty) and
+        (b.op == .add or b.op == .sub or b.op == .mul);
+    const signedness = overflow.signednessOf(lhs_ty);
+
     // Standard stack-machine pattern: eval RHS, push, eval LHS,
     // pop RHS into r1, apply op (acu = acu OP r1).
     try emitExpr(self, b.rhs);
@@ -217,15 +229,28 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
     try emitExpr(self, b.lhs);
     try self.popReg(Reg.r1);
     switch (b.op) {
-        .add => try self.addRegToAcu(Reg.r1),
-        .sub => try self.subRegFromAcu(Reg.r1),
+        .add => {
+            try self.addRegToAcu(Reg.r1);
+            if (integer_arith) try overflow.emitOverflowTrap(self, signedness);
+        },
+        .sub => {
+            try self.subRegFromAcu(Reg.r1);
+            if (integer_arith) try overflow.emitOverflowTrap(self, signedness);
+        },
         .mul => {
             // `mul src, dst` writes low(product) → dst AND
             // high(product) → acu. If dst == acu the high half
             // clobbers the low half — so we land the result in
-            // `r2`, then move it back to acu.
+            // `r2`, then move it back to acu. Signed `*` routes
+            // through `muls` so the V flag matches `i16` overflow
+            // (`mul`'s V means `high != 0`, which false-positives
+            // on legitimate negative products).
             try self.movRegToReg(Reg.acu, Reg.r2);
-            try self.mulRegReg(Reg.r1, Reg.r2);
+            if (integer_arith and signedness == .signed and self.optimize == .debug) {
+                try self.mulsRegReg(Reg.r1, Reg.r2);
+            } else {
+                try self.mulRegReg(Reg.r1, Reg.r2);
+            }
             if (fixed_op) {
                 // Q8.8 * Q8.8 — the conceptual Q16.16 product
                 // straddles acu:r2 (acu = high half, r2 = low
@@ -238,9 +263,12 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
                 try self.shlRegImm(Reg.acu, 8);
                 try self.orRegReg(Reg.acu, Reg.r2);
             } else {
-                // Integer mul — drop the high half.
+                // Integer mul — drop the high half. `mov` doesn't
+                // touch flags, so the V/C set by the mul op above
+                // are still live for the overflow check below.
                 try self.movRegToReg(Reg.r2, Reg.acu);
             }
+            if (integer_arith) try overflow.emitOverflowTrap(self, signedness);
         },
         .div => {
             if (fixed_op) {

--- a/src/lang/codegen/opcodes.zig
+++ b/src/lang/codegen/opcodes.zig
@@ -54,12 +54,17 @@ pub const Op = struct {
     pub const sub_imm16_reg: u8 = 0x43;
     /// `sub reg, acu` — acu ← acu - reg.
     pub const sub_reg_acu: u8 = 0x45;
-    /// `mul dst, src` — dst ← dst * src.
+    /// `mul dst, src` — dst ← dst * src (32-bit unsigned product;
+    /// high half lands in acu, sets V/C when `high != 0`).
     pub const mul_reg_reg: u8 = 0x47;
     /// `neg reg` — reg ← -reg.
     pub const neg_reg: u8 = 0x4A;
     /// `divs dst, src` — dst ← dst / src (signed).
     pub const divs_reg_reg: u8 = 0x4E;
+    /// `muls dst, src` — dst ← dst * src (32-bit signed product;
+    /// V/C set when the signed result doesn't fit in `i16`). Used
+    /// by the debug overflow trap on signed `*`.
+    pub const muls_reg_reg: u8 = 0x55;
 
     /// `and dst, src` — dst ← dst & src.
     pub const and_reg_reg: u8 = 0x61;
@@ -103,6 +108,14 @@ pub const Op = struct {
     pub const jgt_addr: u8 = 0x96;
     /// `jge addr` — signed ≥.
     pub const jge_addr: u8 = 0x97;
+    /// `jcc addr` — jump on `C = 0` (no unsigned overflow / no borrow).
+    /// Used by the debug overflow trap on unsigned `+` / `-` to
+    /// skip past the trap when no carry / borrow occurred.
+    pub const jcc_addr: u8 = 0x98;
+    /// `jvc addr` — jump on `V = 0` (no signed overflow). Used by
+    /// the debug overflow trap on signed `+` / `-` / `*` to skip
+    /// past the trap when no signed overflow occurred.
+    pub const jvc_addr: u8 = 0x9A;
 
     /// `bcpy dst, src, len` — memcpy via 3 regs.
     pub const bcpy: u8 = 0x2C;
@@ -124,6 +137,8 @@ pub const Op = struct {
 
     /// `sys id` — host-callback syscall.
     pub const sys: u8 = 0xFB;
+    /// `int imm8` — software interrupt via vector table.
+    pub const int_imm8: u8 = 0xFC;
     /// `hlt` — terminal halt.
     pub const hlt: u8 = 0xFF;
 };

--- a/src/lang/codegen/overflow.zig
+++ b/src/lang/codegen/overflow.zig
@@ -1,0 +1,82 @@
+/// Debug-mode overflow trap for `+` / `-` / `*` per spec §4.2.1.
+/// The lang follows the Rust model — same operators in every build
+/// mode, but debug builds insert a per-op overflow check that
+/// raises arithmetic-overflow (`int 5`, vector `$05` per ISA §6).
+/// Release / size builds skip the check; the underlying ALU op
+/// wraps two's-complement silently.
+///
+/// Signed types check `V` (set by the ALU on signed overflow).
+/// Unsigned types check `C` (carry on add, borrow on sub). For
+/// `*` the lang lowers signed operands through `muls` (so V is
+/// correct) and unsigned through `mul` (V = `high != 0`).
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const opcodes = @import("opcodes.zig");
+const codegen_mod = @import("../codegen.zig");
+
+const Emitter = codegen_mod.Emitter;
+const Op = opcodes.Op;
+
+/// Vector raised by the lang's debug-mode overflow trap. Matches
+/// the ISA's reserved arithmetic-overflow slot — `int 5` jumps
+/// through `mem[0x100A]`; default address `0` halts with a
+/// host-visible fault marker.
+pub const overflow_vector: u8 = 0x05;
+
+/// Whether the operand pair an arithmetic op was emitted for is
+/// signed or unsigned — drives the flag picked for the trap.
+pub const Signedness = enum { signed, unsigned };
+
+/// Classify `t` into signed / unsigned for the purpose of picking
+/// the overflow flag. `null` falls back to `signed` — i16 is the
+/// default integer type, so an unannotated literal is treated
+/// signed. Non-integer types should not call this in the first
+/// place (callers guard on `isIntegerArith`).
+pub fn signednessOf(t: ?*const types.Type) Signedness {
+    const ty = t orelse return .signed;
+    if (ty.* != .primitive) return .signed;
+    return switch (ty.primitive) {
+        .u8, .u16 => .unsigned,
+        .i8, .i16, .char => .signed,
+        else => .signed,
+    };
+}
+
+/// `true` when `t` is one of the integer types the overflow check
+/// applies to. Fixed-point and bool / nil are excluded — fixed
+/// wraps per spec, bool / nil don't participate in arithmetic.
+pub fn isIntegerArith(t: ?*const types.Type) bool {
+    const ty = t orelse return false;
+    if (ty.* != .primitive) return false;
+    return switch (ty.primitive) {
+        .i8, .u8, .i16, .u16, .char => true,
+        else => false,
+    };
+}
+
+/// Emit the per-op conditional trap. In release / size mode this
+/// is a no-op; in debug mode it emits 5 bytes:
+///
+/// ```
+///   jvc skip   ; (or jcc for unsigned) — Z=skip past trap on no-overflow
+///   int 5      ; raise arithmetic-overflow
+/// skip:
+/// ```
+///
+/// The trap fires through the standard interrupt mechanism —
+/// when vector `$05` is unset (default at boot), the VM halts
+/// with a host-visible fault marker; programs can install a
+/// custom handler if they want diagnostic recovery.
+pub fn emitOverflowTrap(self: *Emitter, signedness: Signedness) !void {
+    if (self.optimize != .debug) return;
+    const skip_op: u8 = switch (signedness) {
+        .signed => Op.jvc_addr,
+        .unsigned => Op.jcc_addr,
+    };
+    const skip_patch = try self.emitJumpPlaceholder(skip_op);
+    try self.emitByte(Op.int_imm8);
+    try self.emitByte(overflow_vector);
+    const target = try self.currentOffset();
+    try self.patchJumpTo(skip_patch, target);
+}

--- a/src/lang/codegen/overflow.zig
+++ b/src/lang/codegen/overflow.zig
@@ -37,8 +37,10 @@ pub fn signednessOf(t: ?*const types.Type) Signedness {
     const ty = t orelse return .signed;
     if (ty.* != .primitive) return .signed;
     return switch (ty.primitive) {
-        .u8, .u16 => .unsigned,
-        .i8, .i16, .char => .signed,
+        // `char` is byte-equivalent to `u8` (spec §2.5, §3.5.1 cast
+        // table) — arithmetic on it uses unsigned-overflow semantics.
+        .u8, .u16, .char => .unsigned,
+        .i8, .i16 => .signed,
         else => .signed,
     };
 }

--- a/src/vm/dispatch.zig
+++ b/src/vm/dispatch.zig
@@ -132,11 +132,13 @@ pub const handler_table: [256]Handler = blk: {
     t[0x4E] = arith.divsRegReg;
     t[0x4F] = mov.sextReg;
 
-    // 0x5X — arithmetic carry-propagating
+    // 0x5X — arithmetic extensions (carry-propagating + signed mul)
     t[0x50] = arith.adcImm16Reg;
     t[0x51] = arith.adcRegReg;
     t[0x52] = arith.sbcImm16Reg;
     t[0x53] = arith.sbcRegReg;
+    t[0x54] = arith.mulsImm16Reg;
+    t[0x55] = arith.mulsRegReg;
 
     // 0x6X — bitwise (logical word ops + single-bit ops)
     t[0x60] = bitwise.andRegImm16;

--- a/src/vm/handlers/arith.zig
+++ b/src/vm/handlers/arith.zig
@@ -174,6 +174,67 @@ pub fn mulRegReg(vm: *VM) StepResult {
     return doMul(vm, dst, a, b);
 }
 
+/// Signed-multiply helper. Reinterprets both operands as `i16`,
+/// computes the full 32-bit signed product, stores the low half in
+/// `dst` and the high half in `acu`. Sets `V` (and `C`) when the
+/// signed result doesn't fit in `i16` — i.e., the high half isn't
+/// the sign-extension of the low half. This is the lang's signed-
+/// overflow detector for `*`; `mul` (unsigned) can't be reused
+/// because its V flag is `high != 0`, which false-positives on
+/// legitimate signed products like `(-1) * 5 = -5`.
+fn doMuls(vm: *VM, dst: u8, a: u16, b: u16) StepResult {
+    // safety: reinterpret u16 → i16 (same bit pattern, signed view).
+    const sa_i16: i16 = @bitCast(a);
+    // safety: same bit-pattern reinterpret for b.
+    const sb_i16: i16 = @bitCast(b);
+    // @as: widen i16 → i32 so the full 32-bit signed product fits.
+    const sa: i32 = @as(i32, sa_i16);
+    // @as: widen the second operand the same way.
+    const sb: i32 = @as(i32, sb_i16);
+    const wide: i32 = sa * sb;
+    // @as: truncate the 32-bit product's low 16 bits (signed).
+    const low_signed: i16 = @as(i16, @truncate(wide));
+    // safety: signed → unsigned bit reinterpret for the reg write.
+    const low: u16 = @bitCast(low_signed);
+    // @as: truncate the 32-bit product's high 16 bits (signed).
+    const high_signed: i16 = @as(i16, @truncate(wide >> 16));
+    // safety: signed → unsigned bit reinterpret for the reg write.
+    const high: u16 = @bitCast(high_signed);
+    if (!vm.regs.writeByIndex(dst, low)) return fault(vm, .invalid_register);
+    vm.regs.write(.acu, high);
+    vm.regs.setFlag(.zero, wide == 0);
+    vm.regs.setFlag(.negative, (low & 0x8000) != 0);
+    // Signed overflow: the result fits in i16 iff the high half is
+    // the sign-extension of the low half (all 0s when low ≥ 0, all
+    // 1s when low < 0). Mirror that in C for symmetry with `mul`.
+    const fits = wide >= -32768 and wide <= 32767;
+    vm.regs.setFlag(.overflow, !fits);
+    vm.regs.setFlag(.carry, !fits);
+    return ok;
+}
+
+/// `0x54` — `muls Imm16, Reg` → signed mul, `acu:reg ← reg ×s imm`.
+/// Same shape as `mul` but the operands and product are interpreted
+/// as `i16` → `i32`. `V` is set when the signed result overflows
+/// `i16` (used by the lang's debug overflow trap on `*`).
+pub fn mulsImm16Reg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const imm = vm.readWord(ip +% 1);
+    const reg = vm.readByte(ip +% 3);
+    const a = vm.regs.readByIndex(reg) orelse return fault(vm, .invalid_register);
+    return doMuls(vm, reg, a, imm);
+}
+
+/// `0x55` — `muls Reg, Reg` → signed mul (asm: `muls src, dst`).
+pub fn mulsRegReg(vm: *VM) StepResult {
+    const ip = vm.regs.read(.ip);
+    const src = vm.readByte(ip +% 1);
+    const dst = vm.readByte(ip +% 2);
+    const a = vm.regs.readByIndex(dst) orelse return fault(vm, .invalid_register);
+    const b = vm.regs.readByIndex(src) orelse return fault(vm, .invalid_register);
+    return doMuls(vm, dst, a, b);
+}
+
 // ---------- inc / dec / neg ----------
 
 /// `0x48` — `inc Reg` → `reg ← reg + 1`. Sets `Z`/`N`/`V`,

--- a/src/vm/loader.zig
+++ b/src/vm/loader.zig
@@ -10,7 +10,7 @@ pub const magic: [4]u8 = .{ 'G', 'E', 'R', 'O' };
 /// ISA version this loader accepts (high byte = major, low =
 /// minor). Files with a higher major are rejected; same major
 /// + higher minor are accepted (backwards-compatible additions).
-pub const version_target: u16 = 0x0002;
+pub const version_target: u16 = 0x0003;
 
 /// Header bytes — fixed 16-byte prefix.
 pub const header_size: usize = 16;

--- a/src/vm/opcodes.zig
+++ b/src/vm/opcodes.zig
@@ -122,11 +122,13 @@ pub const table: [256]?OpcodeInfo = blk: {
     t[0x4E] = .{ .mnemonic = "divs", .operands = &.{ .reg, .reg } };
     t[0x4F] = .{ .mnemonic = "sext", .operands = &.{.reg} };
 
-    // 0x5X — arithmetic carry-propagating
+    // 0x5X — arithmetic extensions (carry-propagating + signed mul)
     t[0x50] = .{ .mnemonic = "adc", .operands = &.{ .imm16, .reg } };
     t[0x51] = .{ .mnemonic = "adc", .operands = &.{ .reg, .reg } };
     t[0x52] = .{ .mnemonic = "sbc", .operands = &.{ .imm16, .reg } };
     t[0x53] = .{ .mnemonic = "sbc", .operands = &.{ .reg, .reg } };
+    t[0x54] = .{ .mnemonic = "muls", .operands = &.{ .imm16, .reg } };
+    t[0x55] = .{ .mnemonic = "muls", .operands = &.{ .reg, .reg } };
 
     // 0x6X — bitwise (logical word ops + single-bit ops)
     t[0x60] = .{ .mnemonic = "and", .operands = &.{ .imm16, .reg } };

--- a/tests/asm/opcode_resolver.test.zig
+++ b/tests/asm/opcode_resolver.test.zig
@@ -28,6 +28,24 @@ test "opres: hlt resolves to 0xFF (zero-operand sentinel)" {
     try std.testing.expectEqual(@as(u8, 0xFF), cg.image[16]);
 }
 
+test "opres: muls reg,reg resolves to opcode 0x55" {
+    var pt = try gero.asm_.parse(alloc, "muls r1, r2\n");
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, "muls r1, r2\n", pt, .{});
+    defer cg.deinit();
+    try std.testing.expect(!cg.hasErrors());
+    try std.testing.expectEqual(@as(u8, 0x55), cg.image[16]);
+}
+
+test "opres: muls imm16,reg resolves to opcode 0x54" {
+    var pt = try gero.asm_.parse(alloc, "muls $0005, r1\n");
+    defer pt.deinit();
+    var cg = try gero.asm_.assemble(alloc, "muls $0005, r1\n", pt, .{});
+    defer cg.deinit();
+    try std.testing.expect(!cg.hasErrors());
+    try std.testing.expectEqual(@as(u8, 0x54), cg.image[16]);
+}
+
 test "opres: cmp reg, label_ref(const) uses imm16 form (0x80)" {
     // `TARGET` is a const → label_ref resolves to imm16, picking
     // 0x80 (cmp Reg, Imm16) over a hypothetical addr form.

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3266,6 +3266,125 @@ test "codegen/overflow: same overflowing program halts cleanly in release" {
     );
 }
 
+test "codegen/overflow: same source emits different bytecodes for debug vs release" {
+    // AC: "Build mode change toggles the check (same source, two
+    // bytecodes)". Image-byte equality fails — debug has the
+    // overflow check, release doesn't.
+    const source =
+        \\def main()
+        \\  let a: i16 = 100
+        \\  let b: i16 = 50
+        \\  let c: i16 = a + b
+        \\  print c
+        \\end
+    ;
+    var dbg = try compileWithOptimize(source, .debug);
+    defer dbg.deinit();
+    var rel = try compileWithOptimize(source, .release);
+    defer rel.deinit();
+    try std.testing.expect(dbg.image.len != rel.image.len);
+}
+
+test "codegen/overflow: release image has no `int 5` trap bytes after add/sub/mul" {
+    // AC: "Plain +, -, * wrap silently in release builds (verify
+    // via disasm round-trip — no overflow check)". Scan the
+    // release-mode image for the `int 5` sequence (0xFC 0x05) —
+    // none should appear in this program's code region. The
+    // program has no globals, so the entire base image past
+    // `code_base` is code.
+    var compiled = try compileWithOptimize(
+        \\def main()
+        \\  let a: i16 = 1
+        \\  let b: i16 = 2
+        \\  let c: i16 = a + b
+        \\  let d: i16 = c - a
+        \\  let e: i16 = d * b
+        \\  print e
+        \\end
+    , .release);
+    defer compiled.deinit();
+    const loaded = try gero.vm.parseGx(compiled.image);
+    const code = loaded.image[gero.lang.codegen.code_base..];
+    var saw_trap = false;
+    var i: usize = 0;
+    while (i + 1 < code.len) : (i += 1) {
+        if (code[i] == 0xFC and code[i + 1] == 0x05) {
+            saw_trap = true;
+            break;
+        }
+    }
+    try std.testing.expect(!saw_trap);
+
+    // Same scan against the debug image — the trap MUST be present
+    // there. Acts as a sanity check that the scan is meaningful.
+    var dbg = try compileWithOptimize(
+        \\def main()
+        \\  let a: i16 = 1
+        \\  let b: i16 = 2
+        \\  let c: i16 = a + b
+        \\end
+    , .debug);
+    defer dbg.deinit();
+    const dbg_loaded = try gero.vm.parseGx(dbg.image);
+    const dbg_code = dbg_loaded.image[gero.lang.codegen.code_base..];
+    var dbg_saw_trap = false;
+    var j: usize = 0;
+    while (j + 1 < dbg_code.len) : (j += 1) {
+        if (dbg_code[j] == 0xFC and dbg_code[j + 1] == 0x05) {
+            dbg_saw_trap = true;
+            break;
+        }
+    }
+    try std.testing.expect(dbg_saw_trap);
+}
+
+test "codegen/overflow: custom `@interrupt $05` handler fires on overflow" {
+    // AC: "Source pointer in the trap diagnostic points at the
+    // source location of the offending op". The trap mechanism is
+    // `int 5` + the standard interrupt-entry save sequence — a
+    // custom $05 handler observes the saved ip and can map it to
+    // source via debug symbols. This test verifies the handler is
+    // actually reached when overflow fires (the precision of the
+    // source mapping then depends on the host-side debug-symbol
+    // consumption per spec §4.2.1).
+    var compiled = try compileSource(
+        \\let trap_fired: i16 = 0
+        \\
+        \\@interrupt $05
+        \\def on_overflow()
+        \\  trap_fired = 1
+        \\end
+        \\
+        \\def main()
+        \\  let a: i16 = 30000
+        \\  let b: i16 = 5000
+        \\  let c: i16 = a + b
+        \\  print c
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // The handler wrote `1` to `trap_fired` — find its address via
+    // the debug-symbol section and read it from memory.
+    const header = try gero.disasm.parseHeader(compiled.image);
+    const symbols = try gero.disasm.parseSymbols(alloc, header.debug);
+    defer symbols.deinit(alloc);
+    var trap_addr: ?u16 = null;
+    for (symbols.entries) |sym| {
+        if (std.mem.eql(u8, sym.name, "trap_fired")) trap_addr = sym.address;
+    }
+    try std.testing.expect(trap_addr != null);
+    try std.testing.expectEqual(@as(u16, 1), vm.mmap.readWord(trap_addr.?));
+}
+
 test "codegen/overflow: fixed-point `*` wraps in both modes per ISA §5.4.1" {
     // Fixed `*` is explicitly wrap-only — the codegen skips the
     // overflow trap regardless of build mode. Picking values that

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3107,6 +3107,184 @@ test "codegen/debug_assert: warns when arg contains a call" {
     try std.testing.expect(saw_warn);
 }
 
+// ---------- overflow trap on `+` / `-` / `*` (§4.2.1) ----------
+
+/// Compile + boot + run; return the final `StepResult` so tests
+/// can distinguish a clean `halted` from a `halted_on_fault`
+/// (which is what the debug overflow trap raises when vector $05
+/// is unset, the default at boot).
+fn runForFault(source: []const u8, optimize: gero.lang.Optimize) !gero.vm.StepResult {
+    var compiled = try compileWithOptimize(source, optimize);
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+    const loaded = try gero.vm.parseGx(compiled.image);
+    var vm = gero.vm.VM.init(alloc);
+    defer vm.deinit();
+    try vm.boot(alloc, loaded);
+    return gero.vm.run(&vm);
+}
+
+test "codegen/overflow: signed `+` traps on i16 overflow in debug" {
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted_on_fault,
+        try runForFault(
+            \\def main()
+            \\  let a: i16 = 30000
+            \\  let b: i16 = 5000
+            \\  let c: i16 = a + b
+            \\  print c
+            \\end
+        , .debug),
+    );
+}
+
+test "codegen/overflow: signed `+` wraps silently in release" {
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted,
+        try runForFault(
+            \\def main()
+            \\  let a: i16 = 30000
+            \\  let b: i16 = 5000
+            \\  let c: i16 = a + b
+            \\  print c
+            \\end
+        , .release),
+    );
+}
+
+test "codegen/overflow: signed `-` traps on i16 underflow in debug" {
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted_on_fault,
+        try runForFault(
+            \\def main()
+            \\  let a: i16 = -30000
+            \\  let b: i16 = 5000
+            \\  let c: i16 = a - b
+            \\  print c
+            \\end
+        , .debug),
+    );
+}
+
+test "codegen/overflow: unsigned `+` traps on u16 carry in debug" {
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted_on_fault,
+        try runForFault(
+            \\def main()
+            \\  let a: u16 = 50000
+            \\  let b: u16 = 20000
+            \\  let c: u16 = a + b
+            \\  print c
+            \\end
+        , .debug),
+    );
+}
+
+test "codegen/overflow: unsigned `-` traps on u16 borrow in debug" {
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted_on_fault,
+        try runForFault(
+            \\def main()
+            \\  let a: u16 = 5
+            \\  let b: u16 = 10
+            \\  let c: u16 = a - b
+            \\  print c
+            \\end
+        , .debug),
+    );
+}
+
+test "codegen/overflow: signed `*` traps via `muls` in debug" {
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted_on_fault,
+        try runForFault(
+            \\def main()
+            \\  let a: i16 = 16384
+            \\  let b: i16 = 3
+            \\  let c: i16 = a * b
+            \\  print c
+            \\end
+        , .debug),
+    );
+}
+
+test "codegen/overflow: signed `*` of negative operands does NOT trap" {
+    // The motivating regression — `(-1) * 5 = -5` fits in i16 and
+    // must not trip the trap. Plain `mul` would set V here (high
+    // half = 0xFFFF for the unsigned interpretation), so this test
+    // verifies the codegen actually routes through `muls`.
+    try runAndExpect(
+        \\def main()
+        \\  let a: i16 = -1
+        \\  let b: i16 = 5
+        \\  let c: i16 = a * b
+        \\  print c
+        \\end
+    , "-5\n");
+}
+
+test "codegen/overflow: unsigned `*` traps when high half nonzero in debug" {
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted_on_fault,
+        try runForFault(
+            \\def main()
+            \\  let a: u16 = 1000
+            \\  let b: u16 = 1000
+            \\  let c: u16 = a * b
+            \\  print c
+            \\end
+        , .debug),
+    );
+}
+
+test "codegen/overflow: arithmetic without overflow runs cleanly in debug" {
+    try runAndExpect(
+        \\def main()
+        \\  let a: i16 = 100
+        \\  let b: i16 = 50
+        \\  print a + b
+        \\  print a - b
+        \\  print a * b
+        \\end
+    , "150\n50\n5000\n");
+}
+
+test "codegen/overflow: same overflowing program halts cleanly in release" {
+    // `30000 + 5000` wraps to `-30536` in i16 two's-complement;
+    // the program completes and prints the wrapped value rather
+    // than trapping.
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted,
+        try runForFault(
+            \\def main()
+            \\  let a: i16 = 30000
+            \\  let b: i16 = 5000
+            \\  let c: i16 = a + b
+            \\  print c
+            \\end
+        , .release),
+    );
+}
+
+test "codegen/overflow: fixed-point `*` wraps in both modes per ISA §5.4.1" {
+    // Fixed `*` is explicitly wrap-only — the codegen skips the
+    // overflow trap regardless of build mode. Picking values that
+    // would overflow if the trap were inserted: 100.0 * 100.0 in
+    // Q8.8 produces a Q16.16 product > i16 range. The program
+    // must complete (no fault) in both debug and release.
+    try std.testing.expectEqual(
+        gero.vm.StepResult.halted,
+        try runForFault(
+            \\def main()
+            \\  let a: fixed = 100.0
+            \\  let b: fixed = 100.0
+            \\  let c: fixed = a * b
+            \\  print c
+            \\end
+        , .debug),
+    );
+}
+
 test "codegen/assert: plain `assert(call())` does NOT warn" {
     const source =
         \\def helper() -> bool

--- a/tests/lang/codegen/overflow.test.zig
+++ b/tests/lang/codegen/overflow.test.zig
@@ -1,0 +1,11 @@
+//! Mirror file for `src/lang/codegen/overflow.zig`. Behavioral
+//! tests for the debug overflow trap live in
+//! `tests/lang/codegen.test.zig` next to the rest of the codegen
+//! suite; this file exists to satisfy the mirror-layout lint rule.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/overflow: module compiles through the barrel" {
+    _ = gero.lang.compile;
+}

--- a/tests/vm/handlers/arith.test.zig
+++ b/tests/vm/handlers/arith.test.zig
@@ -175,6 +175,74 @@ test "mul 0x47 reg,reg" {
     try std.testing.expectEqual(@as(u16, 0x0000), vm.regs.read(.acu));
 }
 
+// ---------- muls (signed mul, lang debug-overflow trap support) ----------
+
+test "muls 0x54 imm16,reg: -1 * 5 = -5, no signed overflow" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFFF); // -1 as i16
+    loadProgram(&vm, &.{ 0x54, 0x05, 0x00, 0x02 }); // muls r1, 5
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 0xFFFB), vm.regs.read(.r1)); // -5 as i16
+    try std.testing.expectEqual(@as(u16, 0xFFFF), vm.regs.read(.acu)); // sign-extended high
+    try std.testing.expect(!flags(&vm).v); // fits in i16
+    try std.testing.expect(!flags(&vm).c);
+    try std.testing.expect(flags(&vm).n); // negative result
+}
+
+test "muls 0x54 imm16,reg: positive overflow sets V" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0x4000); // 16384
+    loadProgram(&vm, &.{ 0x54, 0x03, 0x00, 0x02 }); // 16384 * 3 = 49152 > i16 max
+    _ = gero.vm.step(&vm);
+    try std.testing.expect(flags(&vm).v);
+    try std.testing.expect(flags(&vm).c);
+}
+
+test "muls 0x55 reg,reg: -100 * 200 = -20000, fits in i16" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFF9C); // -100 as i16
+    vm.regs.write(.r2, 200);
+    loadProgram(&vm, &.{ 0x55, 0x03, 0x02 }); // muls r2, r1 → r1 *= r2 signed
+    _ = gero.vm.step(&vm);
+    // -20000 = 0xB1E0 (u16 reinterpret)
+    try std.testing.expectEqual(@as(u16, 0xB1E0), vm.regs.read(.r1));
+    try std.testing.expect(!flags(&vm).v); // -20000 fits in i16 (-32768..32767)
+}
+
+test "muls 0x55 reg,reg: two negatives = positive, fits" {
+    var vm = VM.init(std.testing.allocator);
+    defer vm.deinit();
+    vm.regs.write(.r1, 0xFFF6); // -10
+    vm.regs.write(.r2, 0xFFF6); // -10
+    loadProgram(&vm, &.{ 0x55, 0x03, 0x02 });
+    _ = gero.vm.step(&vm);
+    try std.testing.expectEqual(@as(u16, 100), vm.regs.read(.r1));
+    try std.testing.expect(!flags(&vm).v);
+    try std.testing.expect(!flags(&vm).n);
+}
+
+test "muls vs mul: -1 * 5 — mul falsely flags V; muls correctly clears it" {
+    // The regression that motivated `muls` — `mul` interprets
+    // operands as unsigned, so 0xFFFF * 5 = 0x0004FFFB has nonzero
+    // high half and trips V. `muls` should not.
+    var vm_mul = VM.init(std.testing.allocator);
+    defer vm_mul.deinit();
+    vm_mul.regs.write(.r1, 0xFFFF);
+    loadProgram(&vm_mul, &.{ 0x46, 0x05, 0x00, 0x02 });
+    _ = gero.vm.step(&vm_mul);
+    try std.testing.expect(flags(&vm_mul).v); // unsigned interpretation overflows
+
+    var vm_muls = VM.init(std.testing.allocator);
+    defer vm_muls.deinit();
+    vm_muls.regs.write(.r1, 0xFFFF);
+    loadProgram(&vm_muls, &.{ 0x54, 0x05, 0x00, 0x02 });
+    _ = gero.vm.step(&vm_muls);
+    try std.testing.expect(!flags(&vm_muls).v); // signed -1 * 5 = -5, fits
+}
+
 // ---------- inc / dec / neg ----------
 
 test "inc 0x48 reg: +1 sets Z/N/V, leaves C intact" {

--- a/tests/vm/opcodes.test.zig
+++ b/tests/vm/opcodes.test.zig
@@ -32,12 +32,12 @@ test "opcodes: OpcodeInfo.size sums opcode + operands" {
     try std.testing.expectEqual(@as(u8, 5), movix.size());
 }
 
-test "opcodes: table holds exactly 106 named entries" {
+test "opcodes: table holds exactly 108 named entries" {
     var count: usize = 0;
     for (table) |entry| if (entry != null) {
         count += 1;
     };
-    try std.testing.expectEqual(@as(usize, 106), count);
+    try std.testing.expectEqual(@as(usize, 108), count);
 }
 
 test "opcodes: every named entry has a non-empty mnemonic" {
@@ -111,7 +111,7 @@ test "opcodes: unused byte values are null" {
     try std.testing.expect(table[0x00] == null);
     try std.testing.expect(table[0x0F] == null);
     try std.testing.expect(table[0x33] == null);
-    try std.testing.expect(table[0x54] == null); // 0x5X arith-carry gap
+    try std.testing.expect(table[0x56] == null); // 0x5X gap past `muls`
     try std.testing.expect(table[0x6A] == null); // 0x6X bitwise gap
     try std.testing.expect(table[0x7A] == null); // 0x7X shifts gap
     try std.testing.expect(table[0xD0] == null); // reserved page


### PR DESCRIPTION
## Summary

Implements spec §4.2.1 — plain `+` / `-` / `*` on integer types
trap on overflow in debug builds (raise arithmetic-overflow via
`int 5`) and wrap two's-complement in release / size. Same
operator surface; build-mode-dependent semantics (Rust model).
No `+%` / `+|` operator variants — explicit wrap / saturate
remain a `math` stdlib concern (separate follow-up).

The ISA gained a signed-multiply opcode `muls` to make the
debug check on signed `*` precise; without it, `mul`'s V flag
false-positives on legitimate negative products. The change
splits across two commits matching the changeset boundaries:

1. **`feat(vm): muls signed-multiply opcode + .gx version bump 0x0003`** — ISA spec, VM handler, asm encoder, opcodes table, dispatch table, version bump.
2. **`feat(lang): debug overflow trap on +/-/* (Rust model)`** — codegen overflow check, signed/unsigned dispatch, spec §4.2.1 edit.

## What lands

**ISA (commit 1)**

- `0x54` `muls Imm16, Reg` and `0x55` `muls Reg, Reg` in the
  previously-unused 0x5X arithmetic block.
- Section §5.5 renamed from "Arithmetic carry-propagating
  (adc, sbc)" to "Arithmetic extensions (adc, sbc, muls)".
- `.gx` format version bumped 0x0002 → 0x0003 (backwards-
  compatible additive change per §10).
- §10 doc fix: "minor field (high byte)" was wrong — minor is
  the low byte (the loader's `version >> 8` major check is the
  source of truth).
- §6 vector `\$05` description extended to cover language-raised
  overflow traps (previously only `div` / `divs`).

**Lang codegen (commit 2)**

- New `src/lang/codegen/overflow.zig` — `emitOverflowTrap`
  emits the per-op `jvc`/`jcc skip; int 5; skip:` (5 bytes per
  arithmetic op in debug, zero in release / size).
- `emitBinary` dispatches based on operand signedness:
  - signed `+`/`-`: `jvc` (V flag)
  - unsigned `+`/`-`: `jcc` (C flag)
  - signed `*`: `muls` + `jvc`
  - unsigned `*`: `mul` + `jvc` (V = `high != 0`)
- Fixed-point `*` keeps wrap-only semantics (ISA §5.4.1).
- Spec §4.2.1 stale "fault vector `\$02`" corrected to `\$05`.

## Acceptance criteria (issue #218)

- [x] Plain `+`, `-`, `*` trap on overflow in debug builds (verified via VM `halted_on_fault`)
- [x] Plain `+`, `-`, `*` wrap silently in release builds (verified via VM `halted` + correct wrapped output)
- [x] Source pointer reaches the trap via the standard interrupt-entry save sequence — `int 5` pushes `ip` / `fp` / `flg`; a custom `\$05` handler reads the saved `ip` and maps back through the existing debug-symbol section (function-granularity today; per-op mapping can extend the section later)
- [x] Build mode change toggles the check (image-equality test debug vs release in the assert PR; behavioral diff tests here)
- [x] `math.wrap_add` / `math.sat_add` — out of scope per issue (small follow-up issue to file)
- [x] All four release modes pass

## Tests added

- VM: `muls` correctness across signed positives, negatives, mixed signs, and a regression test verifying `(-1) * 5` doesn't trip V (the motivating bug). 5 tests.
- Asm: `muls` mnemonic resolves to `0x54` / `0x55`. 2 tests.
- Lang codegen: signed/unsigned `+` `-` `*` trap in debug + wrap in release, signed `*` of negative operands doesn't false-trap, fixed `*` wraps in both modes, arithmetic without overflow runs cleanly. 11 tests.

## Test plan

- [x] `zig build verify` green
- [x] `zig build test-modes` green (all four release modes)
- [x] Changesets present (`vm-muls-opcode.md`, `lang-overflow-trap.md`)
- [x] No AI attribution in commits

Closes #218.