### PR TITLE
feat(cli): --werror escalates warning diagnostics to exit 4 (closes #255)

### DIFF
--- a/.changeset/cli-werror-flag.md
+++ b/.changeset/cli-werror-flag.md
@@ -1,0 +1,18 @@
+---
+bump: minor
+---
+
+`gero check --werror` escalates warning-severity diagnostics to
+a fatal exit code (4). Without the flag, warning-only files now
+print their diagnostics but exit `0` — previously every
+diagnostic, regardless of severity, escalated to exit 4 because
+the check loop didn't distinguish severities for `.gr` files.
+
+The lang-side summary header now names severities honestly:
+`N warnings in M files` for warning-only reports,
+`N errors + M warnings in K files` for mixed reports, and the
+existing `N errors in M files` for fatal-only reports.
+
+Asm-side diagnostics have no warning severity today, so
+`--werror` is a no-op for `.gas` inputs (documented in cli.md
+§3.9). Closes #255.

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -88,21 +88,34 @@ pub fn execute(
     var read_errors: std.ArrayList(diagnostics.ReadErrorEntry) = .empty;
     var pass: usize = 0;
     var failures: std.ArrayList(FileEntry) = .empty;
-    var gr_failures: std.ArrayList(GrFailure) = .empty;
+    var gr_files: std.ArrayList(GrFile) = .empty;
     for (files.items) |path| {
-        // `.gr` files route through the gero-lang pipeline. Failures
-        // collect into `gr_failures` and render via
-        // `gero.lang.render.pretty` after the loop.
+        // `.gr` files route through the gero-lang pipeline. Files
+        // with diagnostics collect into `gr_files`, are rendered
+        // via `gero.lang.render.pretty` after the loop, and the
+        // `is_failure` flag drives the exit-code computation
+        // (warnings don't fail the build unless `--werror`).
         if (std.mem.endsWith(u8, path, ".gr")) {
             const res = try checkOneGr(io, arena, path);
-            if (res.diagnostics.len == 0 and res.parse_errors.len == 0 and !res.read_error) {
-                pass += 1;
-                if (!opts.quiet and !json_mode) try printPassGr(stdout, style, path, single);
-            } else if (res.read_error) {
+            if (res.read_error) {
                 if (!json_mode) try term.err("gero check: cannot read {s}", .{path});
                 try failures.append(arena, .{ .path = path, .info = .read_error });
-            } else {
-                try gr_failures.append(arena, .{ .path = path, .source = res.source, .parse_errors = res.parse_errors, .diagnostics = res.diagnostics });
+                continue;
+            }
+            if (res.diagnostics.len == 0 and res.parse_errors.len == 0) {
+                pass += 1;
+                if (!opts.quiet and !json_mode) try printPassGr(stdout, style, path, single);
+                continue;
+            }
+            // Classify the diagnostics — a file with only warnings
+            // passes the build (exit 0) unless `--werror` escalates
+            // it. Always render the diagnostics so the user sees
+            // the warnings either way.
+            const is_failure = isFailure(res.diagnostics, opts.werror);
+            try gr_files.append(arena, .{ .path = path, .source = res.source, .diagnostics = res.diagnostics, .is_failure = is_failure });
+            if (!is_failure) {
+                pass += 1;
+                if (!opts.quiet and !json_mode) try printPassGr(stdout, style, path, single);
             }
             continue;
         }
@@ -162,7 +175,11 @@ pub fn execute(
         }
     }
 
-    const fail = failures.items.len + gr_failures.items.len;
+    var gr_fail_count: usize = 0;
+    for (gr_files.items) |gf| if (gf.is_failure) {
+        gr_fail_count += 1;
+    };
+    const fail = failures.items.len + gr_fail_count;
 
     // JSON mode emits one object covering every diagnostic + read
     // error, then exits. No human-readable header / summary / footer.
@@ -174,17 +191,18 @@ pub fn execute(
         };
         try diagnostics.printJsonReport(stdout, pipeline_failures.items, read_errors.items, files.items.len, fail);
         // Append lang diagnostics as ndjson lines on the same
-        // stdout — consumers parse line-by-line.
-        if (gr_failures.items.len > 0) {
+        // stdout — consumers parse line-by-line. Includes warning-
+        // only files so editors render the squiggles regardless.
+        if (gr_files.items.len > 0) {
             var lang_files: std.ArrayList(gero.lang.render.FileDiagnostics) = .empty;
-            for (gr_failures.items) |gf| try lang_files.append(arena, .{
+            for (gr_files.items) |gf| try lang_files.append(arena, .{
                 .path = gf.path,
                 .source = gf.source,
                 .diagnostics = gf.diagnostics,
             });
             try gero.lang.render.json(stdout, lang_files.items);
         }
-        return if (fail > 0 or gr_failures.items.len > 0) 4 else 0;
+        return if (fail > 0) 4 else 0;
     }
 
     // Pass 2: render the merged diagnostic report (if any failure).
@@ -204,11 +222,12 @@ pub fn execute(
         }
     }
 
-    // Pass 2b: render lang-side diagnostics.
-    if (gr_failures.items.len > 0) {
+    // Pass 2b: render lang-side diagnostics — both warning-only
+    // files (so the user sees them) and failures.
+    if (gr_files.items.len > 0) {
         if (!single and !opts.quiet and (pass > 0 or failures.items.len > 0)) try stdout.writeByte('\n');
         var lang_files: std.ArrayList(gero.lang.render.FileDiagnostics) = .empty;
-        for (gr_failures.items) |gf| try lang_files.append(arena, .{
+        for (gr_files.items) |gf| try lang_files.append(arena, .{
             .path = gf.path,
             .source = gf.source,
             .diagnostics = gf.diagnostics,
@@ -244,13 +263,70 @@ const FileEntry = struct {
 
 /// One `.gr` file's diagnostic context — source bytes + combined
 /// parser + typechecker diagnostics, ready for
-/// `gero.lang.render.pretty` / `.json`.
-const GrFailure = struct {
+/// `gero.lang.render.pretty` / `.json`. `is_failure` is `true` when
+/// the file has a fatal diagnostic OR a warning under `--werror`;
+/// warning-only files without `--werror` still collect here so the
+/// renderer surfaces the diagnostics, but they count as a `pass`.
+const GrFile = struct {
     path: []const u8,
     source: []const u8,
-    parse_errors: []const u8 = "", // placeholder field — kept for symmetry
     diagnostics: []gero.lang.Diagnostic,
+    is_failure: bool,
 };
+
+/// Classify a `.gr` file's diagnostics against the `--werror`
+/// policy. A file is a failure when it has at least one fatal
+/// diagnostic, or when `werror` is set and it has any warning.
+/// Pulled out as its own fn so it can be unit-tested without
+/// running the full pipeline.
+pub fn isFailure(diags: []const gero.lang.Diagnostic, werror: bool) bool {
+    var has_fatal = false;
+    var has_warning = false;
+    for (diags) |d| switch (d.severity) {
+        .fatal => has_fatal = true,
+        .warning => has_warning = true,
+        .note => {},
+    };
+    return has_fatal or (werror and has_warning);
+}
+
+test "isFailure: empty diagnostics → not a failure" {
+    try std.testing.expect(!isFailure(&.{}, false));
+    try std.testing.expect(!isFailure(&.{}, true));
+}
+
+test "isFailure: only fatals → always a failure" {
+    const diags = [_]gero.lang.Diagnostic{
+        .{ .severity = .fatal, .code = "E_X", .message = "", .span = .{ .start = 0, .end = 0 } },
+    };
+    try std.testing.expect(isFailure(&diags, false));
+    try std.testing.expect(isFailure(&diags, true));
+}
+
+test "isFailure: only warnings → pass without --werror, fail with --werror" {
+    const diags = [_]gero.lang.Diagnostic{
+        .{ .severity = .warning, .code = "W_X", .message = "", .span = .{ .start = 0, .end = 0 } },
+    };
+    try std.testing.expect(!isFailure(&diags, false));
+    try std.testing.expect(isFailure(&diags, true));
+}
+
+test "isFailure: fatal + warning → always a failure" {
+    const diags = [_]gero.lang.Diagnostic{
+        .{ .severity = .warning, .code = "W_X", .message = "", .span = .{ .start = 0, .end = 0 } },
+        .{ .severity = .fatal, .code = "E_X", .message = "", .span = .{ .start = 0, .end = 0 } },
+    };
+    try std.testing.expect(isFailure(&diags, false));
+    try std.testing.expect(isFailure(&diags, true));
+}
+
+test "isFailure: only notes → not a failure (notes are informational)" {
+    const diags = [_]gero.lang.Diagnostic{
+        .{ .severity = .note, .code = "N_X", .message = "", .span = .{ .start = 0, .end = 0 } },
+    };
+    try std.testing.expect(!isFailure(&diags, false));
+    try std.testing.expect(!isFailure(&diags, true));
+}
 
 /// Result of running parse + typecheck on one `.gr` source.
 const GrCheckResult = struct {

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -77,6 +77,11 @@ pub const Options = struct {
     /// `human` (default) is the caret-style report; `json` is a
     /// machine-parseable shape for editor integration.
     format: Format = .human,
+    /// `--werror` for `gero check` — escalate warning-severity
+    /// diagnostics to a fatal exit code. Off by default so editor
+    /// integrations can surface warnings without blocking the
+    /// build; CI gates set this for zero-warning policies.
+    werror: bool = false,
     /// `--target=<vm|gtx-16>` for `gero build` — overrides the
     /// manifest's `package.target`. `null` = inherit from manifest;
     /// `gtx-16` is reserved (errors with "not yet implemented").
@@ -364,6 +369,7 @@ fn flagHelpLine(kind: FlagKind) FlagHelpLine {
         .stdin => .{ .sig = "--stdin", .desc = "Read source from stdin, write formatted bytes to stdout." },
         .format => .{ .sig = "--format=<m>", .desc = "human (default) / json. JSON output suppresses human messages." },
         .target => .{ .sig = "--target=<m>", .desc = "vm (default) / gtx-16. Overrides manifest's [package].target." },
+        .werror => .{ .sig = "--werror", .desc = "Treat warnings as errors (escalates exit code to 4)." },
     };
 }
 
@@ -377,7 +383,7 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .info => &.{ .help, .color, .no_color },
         .disasm => &.{ .help, .bank, .no_show_bytes, .check_roundtrip, .quiet, .color, .no_color },
         .test_ => &.{ .help, .verbose, .color, .no_color },
-        .check => &.{ .help, .format, .quiet, .verbose, .color, .no_color },
+        .check => &.{ .help, .format, .werror, .quiet, .verbose, .color, .no_color },
         .fmt => &.{ .help, .check, .stdin, .quiet, .color, .no_color },
         .new => &.{ .help, .quiet, .color, .no_color },
         .init => &.{ .help, .quiet, .color, .no_color },
@@ -411,7 +417,7 @@ fn parseFormat(s: []const u8) ParseError!Format {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check, stdin, format, target };
+const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check, stdin, format, target, werror };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
@@ -430,6 +436,7 @@ fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "stdin")) return .stdin;
     if (std.mem.eql(u8, s, "format")) return .format;
     if (std.mem.eql(u8, s, "target")) return .target;
+    if (std.mem.eql(u8, s, "werror")) return .werror;
     return null;
 }
 
@@ -462,6 +469,7 @@ fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void
         .stdin => opts.stdin = true,
         .format => opts.format = try parseFormat(value orelse return error.MissingFlagValue),
         .target => opts.target = value orelse return error.MissingFlagValue,
+        .werror => opts.werror = true,
     }
 }
 
@@ -735,6 +743,14 @@ test "parse: --check-roundtrip defaults off, opts in when set" {
 
     const on_p = try parse(&[_][]const u8{ "disasm", "--check-roundtrip", "x.gx" });
     try testing.expect(on_p.options.check_roundtrip);
+}
+
+test "parse: --werror defaults off, opts in on `gero check --werror`" {
+    const default_p = try parse(&[_][]const u8{ "check", "main.gr" });
+    try testing.expect(!default_p.options.werror);
+
+    const on_p = try parse(&[_][]const u8{ "check", "--werror", "main.gr" });
+    try testing.expect(on_p.options.werror);
 }
 
 test "run: no command prints top help, exit 0" {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -345,10 +345,11 @@ gero check main.gas               # one .gas file
 gero check src/                   # walk recursively for *.gas
 gero check a.gas b.gas src/       # any mix of files + dirs
 gero check                        # project-aware: [build].entry + [test].include
-gero check main.gr                # → "not yet implemented" while gero-lang is not yet implemented
+gero check main.gr                # type-check a gero-lang source
 gero check main.gas --quiet       # suppress per-file lines + summary
 gero check main.gas --verbose     # per-phase timings (single-file only)
 gero check --format=json src/     # editor-friendly JSON diagnostics
+gero check --werror src/          # warnings escalate to exit 4 (CI gate)
 ```
 
 **Project-aware fallback**: invoked with no positional args
@@ -404,8 +405,12 @@ summary, no footer). Stderr stays reserved for host I/O failures
 - The `version` field lets the schema evolve while keeping the
   contract stable.
 
-**Exit:** `0` if clean; `4` on any diagnostic; `1` on host IO
-problem; `2` on usage error.
+**Exit:** `0` if clean; `4` on any fatal diagnostic; `1` on host
+IO problem; `2` on usage error. Warning-severity diagnostics
+print but exit `0` by default — `--werror` escalates any warning
+to a fatal exit code for CI gates that want zero-warning builds.
+(Asm-side diagnostics have no warning severity today; `--werror`
+is a no-op for `.gas` inputs.)
 
 ### 3.10 `gero new <name>` — scaffold a fresh project
 

--- a/src/lang/render.zig
+++ b/src/lang/render.zig
@@ -75,16 +75,20 @@ pub fn pretty(
     files: []const FileDiagnostics,
     style: Style,
 ) !void {
-    var total: usize = 0;
-    var files_with_errors: usize = 0;
+    var errors: usize = 0;
+    var warnings: usize = 0;
+    var files_with_diags: usize = 0;
     for (files) |f| {
-        if (f.diagnostics.len > 0) {
-            total += f.diagnostics.len;
-            files_with_errors += 1;
-        }
+        if (f.diagnostics.len == 0) continue;
+        files_with_diags += 1;
+        for (f.diagnostics) |d| switch (d.severity) {
+            .fatal => errors += 1,
+            .warning => warnings += 1,
+            .note => {},
+        };
     }
-    if (total == 0) return;
-    try writeSummaryHeader(writer, style, total, files_with_errors);
+    if (errors + warnings == 0) return;
+    try writeSummaryHeader(writer, style, errors, warnings, files_with_diags);
 
     for (files) |f| {
         if (f.diagnostics.len == 0) continue;
@@ -247,12 +251,31 @@ fn writeRightPadInt(writer: *std.Io.Writer, n: usize, width: usize) !void {
     try writer.print("{d}", .{n});
 }
 
-fn writeSummaryHeader(writer: *std.Io.Writer, style: Style, total: usize, files: usize) !void {
-    const err_noun: []const u8 = if (total == 1) "error" else "errors";
+fn writeSummaryHeader(
+    writer: *std.Io.Writer,
+    style: Style,
+    errors: usize,
+    warnings: usize,
+    files: usize,
+) !void {
     const file_noun: []const u8 = if (files == 1) "file" else "files";
-    try writer.print("{s}{d} {s}{s} in {d} {s}\n", .{
-        style.code, total, err_noun, style.reset, files, file_noun,
-    });
+    // Format mirrors rustc: lead with errors when present, append
+    // "+ N warnings" when warnings tag along; warning-only header
+    // says "warnings" honestly so users aren't told their warning
+    // is an error.
+    try writer.writeAll(style.code);
+    if (errors > 0) {
+        const noun: []const u8 = if (errors == 1) "error" else "errors";
+        try writer.print("{d} {s}", .{ errors, noun });
+        if (warnings > 0) {
+            const w_noun: []const u8 = if (warnings == 1) "warning" else "warnings";
+            try writer.print(" + {d} {s}", .{ warnings, w_noun });
+        }
+    } else {
+        const noun: []const u8 = if (warnings == 1) "warning" else "warnings";
+        try writer.print("{d} {s}", .{ warnings, noun });
+    }
+    try writer.print("{s} in {d} {s}\n", .{ style.reset, files, file_noun });
 }
 
 // ---------- (line, col) + line slice + caret math ----------

--- a/tests/lang/render.test.zig
+++ b/tests/lang/render.test.zig
@@ -190,3 +190,57 @@ test "render: pretty skips files with zero diagnostics in multi-file mode" {
     // Clean file must not appear in the report.
     try std.testing.expect(std.mem.indexOf(u8, out, "clean.gr") == null);
 }
+
+test "render: pretty summary names warnings honestly when no errors" {
+    const w = Diagnostic{
+        .severity = .warning,
+        .code = "W_DEBUG_ASSERT_SIDE_EFFECT",
+        .message = "calls in debug_assert are elided in release",
+        .span = .{ .start = 0, .end = 1 },
+    };
+    const file: FileDiagnostics = .{ .path = "x.gr", .source = "x = 1", .diagnostics = &.{w} };
+
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    try gero.lang.render.pretty(&writer.writer, &.{file}, gero.lang.render.Style.none);
+    const out = try writer.toOwnedSlice();
+    defer alloc.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "1 warning in 1 file") != null);
+    // Must NOT call a warning an error.
+    try std.testing.expect(std.mem.indexOf(u8, out, "error in") == null);
+}
+
+test "render: pretty summary mixes `N errors + M warnings` when both present" {
+    const err = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "boom",
+        .span = .{ .start = 0, .end = 1 },
+    };
+    const w1 = Diagnostic{
+        .severity = .warning,
+        .code = "W_X",
+        .message = "a",
+        .span = .{ .start = 0, .end = 1 },
+    };
+    const w2 = Diagnostic{
+        .severity = .warning,
+        .code = "W_Y",
+        .message = "b",
+        .span = .{ .start = 0, .end = 1 },
+    };
+    const file: FileDiagnostics = .{ .path = "x.gr", .source = "x = 1", .diagnostics = &.{ err, w1, w2 } };
+
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    try gero.lang.render.pretty(&writer.writer, &.{file}, gero.lang.render.Style.none);
+    const out = try writer.toOwnedSlice();
+    defer alloc.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "1 error + 2 warnings in 1 file") != null);
+}


### PR DESCRIPTION
## Summary

`gero check --werror` makes any warning-severity lang diagnostic
fail the build (exit 4), mirroring rustc / clang's `-Werror`.
Without the flag, warning-only files now print their diagnostics
but exit `0` — previously the check loop didn't distinguish
severities for `.gr` files, so every warning escalated to exit
4 (a latent bug now visible since `W_DEBUG_ASSERT_SIDE_EFFECT`
shipped in #219).

## What lands

**CLI plumbing** (`apps/gero-cli/cli.zig`)
- `Options.werror: bool = false`
- `--werror` long-flag recognized; help text + per-command list
  for `check` updated; parse test for default-off / opt-in.

**Check policy** (`apps/gero-cli/check.zig`)
- `isFailure(diags, werror)` encapsulates the rule: at least one
  fatal, or any warning under `--werror`. Five unit tests cover
  the corners (empty, only fatals, only warnings ± werror, mixed,
  notes-only).
- `GrFailure` renamed `GrFile` — files with diagnostics collect
  here, the `is_failure` flag drives the exit-code computation
  separately from the rendering decision. Warning-only files
  still print their diagnostics but count as a `pass` and get a
  `✓` line.
- Exit code: `4` when any failure (fatal OR `werror`-escalated
  warning); `0` otherwise.

**Render** (`src/lang/render.zig`)
- Summary header now names severities honestly:
  - `N warnings in M files` (no errors)
  - `N errors + M warnings in K files` (both)
  - `N errors in M files` (fatal-only, unchanged)
- Three new render tests cover the warning-only and mixed paths.

**Docs** (`docs/cli.md`)
- `gero check --werror` example added.
- Exit-code paragraph in §3.9 expanded — fatal vs warning
  semantics + the `--werror` escalation rule. Notes that asm-side
  has no warning severity today (no-op for `.gas` inputs).

## Acceptance criteria

- [x] At least one warning-severity diagnostic exists in the typechecker (`W_DEBUG_ASSERT_SIDE_EFFECT` from #219)
- [x] `gero check` (no flag): warnings print but exit `0`
- [x] `gero check --werror`: warnings exit `4`
- [x] Tests cover both paths (parse-side, policy unit tests, render-side header tests)
- [x] All four release modes pass

## Smoke test transcripts

```
$ gero check warn.gr           # warning-only file
✓ warn.gr
1 warning in 1 file
… (warning body)
    Finished in < 1 ms
exit=0

$ gero check --werror warn.gr  # same file, escalated
1 warning in 1 file
… (warning body)
    Failed in < 1 ms
exit=4
```

## Test plan

- [x] `zig build verify` green
- [x] `zig build test-modes` green
- [x] Changeset present (`cli-werror-flag.md`)
- [x] No AI attribution in commits

Closes #255.