### PR TITLE
feat(lang/typecheck): E_CAST_PRECISION_LOSS warning for implicit narrowing (closes #256)

### DIFF
--- a/.changeset/lang-cast-precision-loss.md
+++ b/.changeset/lang-cast-precision-loss.md
@@ -1,0 +1,22 @@
+---
+bump: minor
+---
+
+The typechecker now emits `E_CAST_PRECISION_LOSS` (warning) at
+every "store into a typed slot" site when the source's range
+doesn't fit in the destination's — let-init, assignment, call
+args, returns, struct + class literal fields, variadic args,
+and method-call args. Adding an explicit `as T` cast suppresses
+the warning. Closes #256.
+
+Widening conversions are now implicit per spec §3.5.1
+conversion table — `u8 → i16`, `i8 → i16`, `u8 → u16` no
+longer require `as`. Sign-flips at equal width (`i16 → u16`,
+`u8 → i8`, etc.) keep losing half the range, so they warn.
+`char` is treated as `u8`-equivalent for both rules (no-op
+per spec §2.5).
+
+`gero check` exits `0` on warning-only programs; `--werror`
+escalates per the previous PR. Drops the duplicate
+`E_TYPE_NARROWING` from §5.2 / the registry — `E_CAST_PRECISION_LOSS`
+is the canonical code.

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -225,7 +225,6 @@ Raised by the typechecker after parsing succeeds.
 | `E_TYPE_AMBIGUOUS_INFER` | Inference can't pin a single type. |
 | `E_TYPE_RECURSIVE_NO_RET` | Recursive fn missing return annotation. |
 | `E_TYPE_INVALID_CAST` | `as T` between incompatible types. |
-| `E_TYPE_NARROWING` | Implicit narrowing (warning by default). |
 
 **Mockup — type mismatch in let init:**
 
@@ -598,6 +597,29 @@ help: use a `match` with a `case Player { … } =>` arm to extract
       the player-specific shape
 ```
 
+**Mockup — implicit narrowing:**
+
+```
+warning: implicit narrowing from `i16` to `u8` may lose precision —
+        use an explicit `as u8` cast to silence this warning
+        [E_CAST_PRECISION_LOSS]
+  --> src/stats.gr:7:15
+   |
+7  |   let hp: u8 = damage
+   |               ^^^^^^
+   |
+help: add `as u8` if the narrowing is intentional, or change the
+      slot type to `i16` to keep the full range
+```
+
+`E_CAST_PRECISION_LOSS` fires at every "store into a typed
+slot" site: let-init, assignment, call args, returns, and
+struct / class literal fields. Widening conversions
+(`u8 → i16`, `i8 → i16`, `u8 → u16`) are implicit and never
+warn — only conversions whose source range doesn't fit in the
+destination range do (narrower widths, or same-width sign
+flips like `i16 → u16`).
+
 ### 5.10 Loop labels (E_LOOP_*)
 
 Per spec §4.5.5.
@@ -682,7 +704,6 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_TYPE_AMBIGUOUS_INFER` | Typechecker | v0.3 |
 | `E_TYPE_RECURSIVE_NO_RET` | Typechecker | v0.3 |
 | `E_TYPE_INVALID_CAST` | Typechecker | v0.3 |
-| `E_TYPE_NARROWING` | Typechecker | v0.3 |
 | `E_NULL_DEREF` | Nullable | v0.3 |
 | `E_NULL_NON_POINTER` | Nullable | v0.3 |
 | `E_NULL_NIL_TO_NONNULL` | Nullable | v0.3 |

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -342,6 +342,53 @@ pub const Checker = struct {
         try self.emitSpan("E_TYPE_MISMATCH", span, msg);
     }
 
+    /// Combined assignability + narrowing check for "store into a
+    /// typed slot" sites (let-init, assignment, call arg, return).
+    /// Routes the diagnostic per spec §3.5.1:
+    ///
+    /// - Assignable (`Type.eql`, `T → T?`, or integer widening) →
+    ///   no diagnostic.
+    /// - Integer / `char` narrowing without explicit `as` →
+    ///   `E_CAST_PRECISION_LOSS` (warning).
+    /// - Anything else → `E_TYPE_MISMATCH` (fatal).
+    ///
+    /// Keeps the four call sites uniform — none of them know about
+    /// the precision-loss case directly.
+    fn checkStoreCompat(
+        self: *Checker,
+        span: ast.Span,
+        expected: *const types.Type,
+        actual: *const types.Type,
+    ) WalkError!void {
+        if (relations.assignable(actual.*, expected.*)) return;
+        if (relations.isNarrowingInt(actual.*, expected.*)) {
+            try self.emitNarrowingWarning(span, expected, actual);
+            return;
+        }
+        try self.emitMismatch(span, expected, actual);
+    }
+
+    fn emitNarrowingWarning(
+        self: *Checker,
+        span: ast.Span,
+        expected_ty: *const types.Type,
+        actual_ty: *const types.Type,
+    ) WalkError!void {
+        const expected_s = try types.render(self.arena, expected_ty.*);
+        const actual_s = try types.render(self.arena, actual_ty.*);
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "implicit narrowing from `{s}` to `{s}` may lose precision — use an explicit `as {s}` cast to silence this warning",
+            .{ actual_s, expected_s, expected_s },
+        );
+        try self.diagnostics.append(self.diag_alloc, .{
+            .severity = .warning,
+            .code = "E_CAST_PRECISION_LOSS",
+            .message = msg,
+            .span = span,
+        });
+    }
+
     /// Return the source-text slice for `span`.
     pub fn lexeme(self: *const Checker, span: ast.Span) []const u8 {
         return self.source[span.start..span.end];
@@ -596,9 +643,7 @@ pub const Checker = struct {
         else
             null;
         if (ann_ty != null and init_ty != null) {
-            if (!relations.assignable(init_ty.?.*, ann_ty.?.*)) {
-                try self.emitMismatch(d.init.?.span(), ann_ty.?, init_ty.?);
-            }
+            try self.checkStoreCompat(d.init.?.span(), ann_ty.?, init_ty.?);
         }
         switch (d.pattern.*) {
             .ident => |i| {
@@ -690,8 +735,8 @@ pub const Checker = struct {
             null;
         const init_ty = try self.inferExpr(d.init, ann_ty);
         const final = ann_ty orelse init_ty;
-        if (ann_ty != null and init_ty != null and !relations.assignable(init_ty.?.*, ann_ty.?.*)) {
-            try self.emitMismatch(d.init.span(), ann_ty.?, init_ty.?);
+        if (ann_ty != null and init_ty != null) {
+            try self.checkStoreCompat(d.init.span(), ann_ty.?, init_ty.?);
         }
         if (final) |t| {
             self.current_scope.setType(self.lexeme(d.name), t) catch {
@@ -715,8 +760,8 @@ pub const Checker = struct {
         // Compound `op=` is sugar for `target = target op value`; the
         // target's type is the hint for the rhs in either form.
         const val_ty = try self.inferExpr(a.value, tgt_ty);
-        if (tgt_ty != null and val_ty != null and !relations.assignable(val_ty.?.*, tgt_ty.?.*)) {
-            try self.emitMismatch(a.value.span(), tgt_ty.?, val_ty.?);
+        if (tgt_ty != null and val_ty != null) {
+            try self.checkStoreCompat(a.value.span(), tgt_ty.?, val_ty.?);
         }
     }
 
@@ -865,8 +910,8 @@ pub const Checker = struct {
             try self.checkReturnStackLifetime(v);
             const v_ty = try self.inferExpr(v, self.current_ret_ty);
             if (self.current_ret_ty) |rt| if (v_ty) |vt| {
-                if (!relations.assignable(vt.*, rt.*) and !predicates.isNilType(rt.*)) {
-                    try self.emitMismatch(v.span(), rt, vt);
+                if (!predicates.isNilType(rt.*)) {
+                    try self.checkStoreCompat(v.span(), rt, vt);
                 }
             };
         }
@@ -1807,8 +1852,8 @@ pub const Checker = struct {
                     null;
                 const skip = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
                 const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-                if (!skip and param_ty != null and arg_ty != null and !relations.assignable(arg_ty.?.*, param_ty.?.*)) {
-                    try self.emitMismatch(arg.span(), param_ty.?, arg_ty.?);
+                if (!skip and param_ty != null and arg_ty != null) {
+                    try self.checkStoreCompat(arg.span(), param_ty.?, arg_ty.?);
                 }
             }
         }
@@ -1864,9 +1909,7 @@ pub const Checker = struct {
             };
             const expected_ty = try self.resolveType(decl_field.type_ann);
             const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
-            if (actual_ty) |at| if (!relations.assignable(at.*, expected_ty.*)) {
-                try self.emitMismatch(lit_field.value.span(), expected_ty, at);
-            };
+            if (actual_ty) |at| try self.checkStoreCompat(lit_field.value.span(), expected_ty, at);
             _ = try seen.put(self.arena, field_name, {});
         }
         // Missing fields.
@@ -1900,9 +1943,7 @@ pub const Checker = struct {
                 continue;
             }
             const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
-            if (expected_ty) |et| if (actual_ty) |at| if (!relations.assignable(at.*, et.*)) {
-                try self.emitMismatch(lit_field.value.span(), et, at);
-            };
+            if (expected_ty) |et| if (actual_ty) |at| try self.checkStoreCompat(lit_field.value.span(), et, at);
         }
         // Class literals don't require every field to be set
         // (constructors fill defaults). Slice 7 may tighten this
@@ -2295,8 +2336,8 @@ pub const Checker = struct {
             // those params accept any caller-supplied type.
             const skip = predicates.isNilType(param_ty.*);
             const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-            if (!skip and arg_ty != null and !relations.assignable(arg_ty.?.*, param_ty.*)) {
-                try self.emitMismatch(arg.span(), param_ty, arg_ty.?);
+            if (!skip and arg_ty != null) {
+                try self.checkStoreCompat(arg.span(), param_ty, arg_ty.?);
             }
         }
         return f.ret;
@@ -2394,8 +2435,8 @@ pub const Checker = struct {
             const param_ty = f.params[i];
             const skip = predicates.isNilType(param_ty.*);
             const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-            if (!skip and arg_ty != null and !relations.assignable(arg_ty.?.*, param_ty.*)) {
-                try self.emitMismatch(arg.span(), param_ty, arg_ty.?);
+            if (!skip and arg_ty != null) {
+                try self.checkStoreCompat(arg.span(), param_ty, arg_ty.?);
             }
         }
         // Variadic slot: all trailing args must share a type.

--- a/src/lang/typecheck/relations.zig
+++ b/src/lang/typecheck/relations.zig
@@ -7,9 +7,10 @@ const predicates = @import("predicates.zig");
 
 /// `true` when an `actual` typed value can be stored / returned /
 /// passed into an `expected` slot. Wider than `Type.eql` — allows
-/// `T → T?` (non-nil to nullable) and recurses into tuples for
-/// per-slot assignability. Used by return / let-init / assignment
-/// / call-arg checks; operator arms keep strict equality.
+/// `T → T?` (non-nil to nullable), integer widening conversions
+/// (e.g. `u8 → i16`) per spec §3.5.1, and recurses into tuples
+/// for per-slot assignability. Used by return / let-init /
+/// assignment / call-arg checks; operator arms keep strict equality.
 pub fn assignable(actual: types.Type, expected: types.Type) bool {
     if (actual.eql(expected)) return true;
     if (expected == .optional) {
@@ -22,7 +23,61 @@ pub fn assignable(actual: types.Type, expected: types.Type) bool {
         }
         return true;
     }
+    if (actual == .primitive and expected == .primitive and
+        isWideningInt(actual.primitive, expected.primitive))
+    {
+        return true;
+    }
     return false;
+}
+
+/// `true` when implicitly converting an integer / `char` of type
+/// `from` to type `to` is lossless — `from`'s value range is a
+/// subset of `to`'s. Per spec §3.5.1: signed widening sign-
+/// extends, unsigned widening zero-extends, and `u8 ↔ char` is a
+/// no-op. Same-type pairs return `false` because `eql` catches
+/// them earlier; callers should never see them here.
+pub fn isWideningInt(from: types.Primitive, to: types.Primitive) bool {
+    const f = normalizeCharToU8(from);
+    const t = normalizeCharToU8(to);
+    if (f == t) return true; // u8 ↔ char
+    const fr = primitiveIntRange(f) orelse return false;
+    const tr = primitiveIntRange(t) orelse return false;
+    return fr.min >= tr.min and fr.max <= tr.max;
+}
+
+/// `true` when assigning `actual` into `expected` loses precision
+/// — both are integer / `char` primitives and `actual`'s range
+/// doesn't fit in `expected`'s. Distinct from `assignable`'s
+/// widening rule: callers check `isNarrowingInt` only when
+/// `assignable` already returned `false`, so this picks up the
+/// integer-mismatch cases (`i16 → u8`, sign-flips at equal
+/// widths, etc.) without disturbing aggregate / reference shapes.
+pub fn isNarrowingInt(actual: types.Type, expected: types.Type) bool {
+    if (actual != .primitive or expected != .primitive) return false;
+    const a = normalizeCharToU8(actual.primitive);
+    const e = normalizeCharToU8(expected.primitive);
+    if (primitiveIntRange(a) == null or primitiveIntRange(e) == null) return false;
+    return !isWideningInt(a, e);
+}
+
+fn normalizeCharToU8(p: types.Primitive) types.Primitive {
+    return if (p == .char) .u8 else p;
+}
+
+const IntRange = struct { min: i32, max: i32 };
+
+/// Value range of the fixed-width integer primitives. `null` for
+/// non-integer primitives. Widened to `i32` so the four ranges
+/// share one comparison shape regardless of sign / width.
+fn primitiveIntRange(p: types.Primitive) ?IntRange {
+    return switch (p) {
+        .i8 => .{ .min = -128, .max = 127 },
+        .u8 => .{ .min = 0, .max = 255 },
+        .i16 => .{ .min = -32768, .max = 32767 },
+        .u16 => .{ .min = 0, .max = 65535 },
+        else => null,
+    };
 }
 
 /// Spec §3.5.1 conversion table. Allows integer ↔ integer (any

--- a/src/lang/typecheck/relations.zig
+++ b/src/lang/typecheck/relations.zig
@@ -35,12 +35,15 @@ pub fn assignable(actual: types.Type, expected: types.Type) bool {
 /// `from` to type `to` is lossless — `from`'s value range is a
 /// subset of `to`'s. Per spec §3.5.1: signed widening sign-
 /// extends, unsigned widening zero-extends, and `u8 ↔ char` is a
-/// no-op. Same-type pairs return `false` because `eql` catches
-/// them earlier; callers should never see them here.
+/// no-op. Same-primitive pairs are trivially lossless (returns
+/// `true`) — `assignable`'s `eql` short-circuit usually catches
+/// them, but `assignable` also reaches here for the `char ↔ u8`
+/// path where the source / dest primitive tags differ before
+/// normalization.
 pub fn isWideningInt(from: types.Primitive, to: types.Primitive) bool {
     const f = normalizeCharToU8(from);
     const t = normalizeCharToU8(to);
-    if (f == t) return true; // u8 ↔ char
+    if (f == t) return true; // u8 ↔ char, plus same-primitive identity
     const fr = primitiveIntRange(f) orelse return false;
     const tr = primitiveIntRange(t) orelse return false;
     return fr.min >= tr.min and fr.max <= tr.max;
@@ -53,6 +56,12 @@ pub fn isWideningInt(from: types.Primitive, to: types.Primitive) bool {
 /// `assignable` already returned `false`, so this picks up the
 /// integer-mismatch cases (`i16 → u8`, sign-flips at equal
 /// widths, etc.) without disturbing aggregate / reference shapes.
+///
+/// Does NOT peel optional layers — integer-optional types
+/// (`u8?`, `i16?`) are rejected separately by the nullable rule
+/// (§3.4.1: `T?` only applies to pointer-like types), so the
+/// narrowing-into-nullable case never arises in a well-typed
+/// program.
 pub fn isNarrowingInt(actual: types.Type, expected: types.Type) bool {
     if (actual != .primitive or expected != .primitive) return false;
     const a = normalizeCharToU8(actual.primitive);

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -1495,6 +1495,17 @@ test "typecheck: narrowing class-or-string mismatch stays a hard E_TYPE_MISMATCH
     , "E_TYPE_MISMATCH");
 }
 
+test "typecheck: narrowing through `char` slot (i16 → char) emits the warning" {
+    // `char` is u8-equivalent — narrowing i16 → char loses the
+    // upper byte just like narrowing i16 → u8 does.
+    try expectCodeAndSeverity(
+        \\def main()
+        \\  let a: i16 = 0
+        \\  let c: char = a
+        \\end
+    , "E_CAST_PRECISION_LOSS", .warning);
+}
+
 // ---------- slice 7: annotation validation (§3.7) ----------
 
 test "typecheck: unknown annotation errors with E_ANN_UNKNOWN" {

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -1382,10 +1382,10 @@ test "typecheck: char literal infers as `char` primitive" {
     );
 }
 
-test "typecheck: char literal does not match `u8` annotation (cast required)" {
-    try expectCode(
+test "typecheck: char literal accepts `u8` annotation (char ↔ u8 no-op per §2.5)" {
+    try expectClean(
         \\let c: u8 = 'A'
-    , "E_TYPE_MISMATCH");
+    );
 }
 
 test "typecheck: char ↔ u8 explicit cast accepts" {
@@ -1393,6 +1393,106 @@ test "typecheck: char ↔ u8 explicit cast accepts" {
         \\let c: char = 'A'
         \\let b: u8 = c as u8
     );
+}
+
+// ---------- E_CAST_PRECISION_LOSS (§3.5.1, narrowing warning) ----------
+
+/// Assert at least one diagnostic with `code` AND severity fires.
+fn expectCodeAndSeverity(
+    source: []const u8,
+    code: []const u8,
+    severity: gero.lang.Severity,
+) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    for (checked.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, code) and d.severity == severity) return;
+    }
+    std.debug.print("missing {s} `{s}` for `{s}`; got:\n", .{ @tagName(severity), code, source });
+    for (checked.diagnostics) |d| {
+        std.debug.print("  - [{s}] {s}: {s}\n", .{ @tagName(d.severity), d.code, d.message });
+    }
+    return error.MissingDiagnosticCode;
+}
+
+test "typecheck: let with narrowing init emits E_CAST_PRECISION_LOSS warning" {
+    try expectCodeAndSeverity(
+        \\def main()
+        \\  let a: i16 = 0
+        \\  let b: u8 = a
+        \\end
+    , "E_CAST_PRECISION_LOSS", .warning);
+}
+
+test "typecheck: explicit `as` cast suppresses the narrowing warning" {
+    try expectClean(
+        \\def main()
+        \\  let a: i16 = 0
+        \\  let b: u8 = a as u8
+        \\end
+    );
+}
+
+test "typecheck: widening init (u8 → i16) accepts without warning" {
+    try expectClean(
+        \\def main()
+        \\  let a: u8 = 0
+        \\  let b: i16 = a
+        \\end
+    );
+}
+
+test "typecheck: assignment with narrowing RHS emits the warning" {
+    try expectCodeAndSeverity(
+        \\def main()
+        \\  let a: i16 = 0
+        \\  let b: u8 = 0
+        \\  b = a
+        \\end
+    , "E_CAST_PRECISION_LOSS", .warning);
+}
+
+test "typecheck: call arg narrowing emits the warning" {
+    try expectCodeAndSeverity(
+        \\def take(b: u8) end
+        \\
+        \\def main()
+        \\  let a: i16 = 0
+        \\  take(a)
+        \\end
+    , "E_CAST_PRECISION_LOSS", .warning);
+}
+
+test "typecheck: return value narrowing emits the warning" {
+    try expectCodeAndSeverity(
+        \\def shrink(a: i16) -> u8
+        \\  return a
+        \\end
+    , "E_CAST_PRECISION_LOSS", .warning);
+}
+
+test "typecheck: sign-flip at same width (i16 → u16) emits the warning" {
+    try expectCodeAndSeverity(
+        \\def main()
+        \\  let a: i16 = 0
+        \\  let b: u16 = a
+        \\end
+    , "E_CAST_PRECISION_LOSS", .warning);
+}
+
+test "typecheck: narrowing class-or-string mismatch stays a hard E_TYPE_MISMATCH" {
+    // Non-integer mismatches don't get the friendlier narrowing
+    // treatment — they're outright type errors.
+    try expectCode(
+        \\def main()
+        \\  let b: u8 = "hi"
+        \\end
+    , "E_TYPE_MISMATCH");
 }
 
 // ---------- slice 7: annotation validation (§3.7) ----------

--- a/tests/lang/typecheck/relations.test.zig
+++ b/tests/lang/typecheck/relations.test.zig
@@ -32,16 +32,28 @@ test "typecheck/relations: assignable accepts identical primitives" {
     try std.testing.expect(relations.assignable(prim(.str), prim(.str)));
 }
 
-test "typecheck/relations: assignable rejects different-width integers" {
-    // §3.5: no implicit narrowing OR widening. Cast required.
-    try std.testing.expect(!relations.assignable(prim(.i8), prim(.i16)));
-    try std.testing.expect(!relations.assignable(prim(.i16), prim(.i8)));
-    try std.testing.expect(!relations.assignable(prim(.u8), prim(.u16)));
+test "typecheck/relations: assignable accepts integer widening per §3.5.1" {
+    // Lossless conversions — narrower → wider in the same domain,
+    // or unsigned-narrower → signed-wider (range fits).
+    try std.testing.expect(relations.assignable(prim(.i8), prim(.i16)));
+    try std.testing.expect(relations.assignable(prim(.u8), prim(.u16)));
+    try std.testing.expect(relations.assignable(prim(.u8), prim(.i16)));
 }
 
-test "typecheck/relations: assignable rejects signed/unsigned mix at same width" {
+test "typecheck/relations: assignable rejects integer narrowing (precision loss)" {
+    // Narrowing must be explicit via `as` — `checkStoreCompat` in
+    // the Checker upgrades these to `E_CAST_PRECISION_LOSS`
+    // warnings; the relation itself still says "not assignable".
+    try std.testing.expect(!relations.assignable(prim(.i16), prim(.i8)));
+    try std.testing.expect(!relations.assignable(prim(.i16), prim(.u8)));
+    try std.testing.expect(!relations.assignable(prim(.u16), prim(.u8)));
+}
+
+test "typecheck/relations: assignable rejects sign-flip at same width (loses half the range)" {
     try std.testing.expect(!relations.assignable(prim(.i16), prim(.u16)));
+    try std.testing.expect(!relations.assignable(prim(.u16), prim(.i16)));
     try std.testing.expect(!relations.assignable(prim(.u8), prim(.i8)));
+    try std.testing.expect(!relations.assignable(prim(.i8), prim(.u8)));
 }
 
 test "typecheck/relations: assignable rejects across primitive classes" {
@@ -49,7 +61,16 @@ test "typecheck/relations: assignable rejects across primitive classes" {
     try std.testing.expect(!relations.assignable(prim(.i16), prim(.bool_)));
     try std.testing.expect(!relations.assignable(prim(.str), prim(.i16)));
     try std.testing.expect(!relations.assignable(prim(.fixed), prim(.i16)));
-    try std.testing.expect(!relations.assignable(prim(.char), prim(.u8)));
+}
+
+test "typecheck/relations: assignable treats `char` as u8-equivalent (spec §2.5)" {
+    // `char` and `u8` are byte-equivalent per spec table — no-op
+    // conversion in either direction.
+    try std.testing.expect(relations.assignable(prim(.char), prim(.u8)));
+    try std.testing.expect(relations.assignable(prim(.u8), prim(.char)));
+    // `char` widens into the larger integer slots same as u8.
+    try std.testing.expect(relations.assignable(prim(.char), prim(.u16)));
+    try std.testing.expect(relations.assignable(prim(.char), prim(.i16)));
 }
 
 // ---------- assignable: nil → optional ----------


### PR DESCRIPTION
## Summary

The typechecker now distinguishes lossless widening from lossy
narrowing per spec §3.5.1 conversion table. Widening (\`u8 → i16\`,
\`i8 → i16\`, \`u8 → u16\`) flows implicitly. Narrowing (\`i16 → u8\`,
same-width sign-flips, etc.) emits **\`E_CAST_PRECISION_LOSS\`** at
warning severity — explicit \`as T\` cast suppresses it.

This is the first concrete consumer of the \`--werror\` flag
shipped in #285 — \`gero check\` exits \`0\` on warning-only
programs; \`gero check --werror\` exits \`4\`.

## What lands

**Relations** (\`src/lang/typecheck/relations.zig\`)
- \`assignable\` accepts integer widening (new arm).
- \`isWideningInt(from, to)\` — source range subset of destination.
- \`isNarrowingInt(actual, expected)\` — integer / \`char\` pair where widening fails.
- \`primitiveIntRange\` — shared min/max table (\`i32\` carrier so all four ranges share one comparison shape).
- \`char\` normalizes to \`u8\` per spec §2.5 (byte-equivalent no-op).

**Checker** (\`src/lang/typecheck.zig\`)
- \`checkStoreCompat(span, expected, actual)\` — three-way decision: assignable → narrowing → mismatch. Used at 8 emission sites:
  - let-init (\`checkLetDecl\`)
  - const-init
  - assignment (\`checkAssign\`)
  - return (\`checkReturn\`)
  - call args (\`checkCall\`)
  - variadic args (\`checkVariadicCall\`)
  - method-call args
  - struct + class literal fields
- \`emitNarrowingWarning\` parallels \`emitMismatch\`, emits \`.warning\` severity with an \"\`as T\` to silence\" hint.

**Spec drift fix** (\`docs/lang-diagnostics.md\`)
- Drops duplicate \`E_TYPE_NARROWING\` from §5.2 / the registry — \`E_CAST_PRECISION_LOSS\` is the canonical code (matches the issue title + existing checker naming).
- Adds the \`E_CAST_PRECISION_LOSS\` mockup to §5.9 with the new help text.

**Behavioral changes (visible)**
- \`let b: i16 = a\` where \`a: u8\` previously emitted \`E_TYPE_MISMATCH\`; now clean (lossless widening).
- \`let c: u8 = 'A'\` (char literal) previously emitted \`E_TYPE_MISMATCH\`; now clean (\`char ↔ u8\` no-op).
- Three existing relation tests updated to reflect the new semantics; one existing typecheck test that asserted the wrong behavior on \`char → u8\` was inverted (the test was always wrong per spec).

## Acceptance criteria

- [x] \`let a: i16 = 0; let b: u8 = a\` emits \`E_CAST_PRECISION_LOSS\` (warning)
- [x] \`let a: i16 = 0; let b: u8 = a as u8\` accepts
- [x] \`let a: u8 = 0; let b: i16 = a\` accepts (widening, no warning)
- [x] Same checks for assignment, call args, return values
- [x] All four release modes pass

## Smoke test

\`\`\`
$ gero check narrow.gr
✓ narrow.gr
1 warning in 1 file

narrow.gr
  warning: implicit narrowing from \`i16\` to \`u8\` may lose precision — use an explicit \`as u8\` cast to silence this warning [E_CAST_PRECISION_LOSS]
    --> narrow.gr:3:15
exit=0

$ gero check --werror narrow.gr
… (same diagnostic)
exit=4
\`\`\`

## Test plan

- [x] \`zig build verify\` green
- [x] \`zig build test-modes\` green
- [x] Changeset present (\`lang-cast-precision-loss.md\`)
- [x] No AI attribution in commits

Closes #256.