### PR TITLE
feat(lang/typecheck): "did you mean…?" suggestions on undefined-name errors (closes #257)

### DIFF
--- a/.changeset/lang-did-you-mean.md
+++ b/.changeset/lang-did-you-mean.md
@@ -1,0 +1,20 @@
+---
+bump: minor
+---
+
+The typechecker now attaches a `help: did you mean \`X\`?` line
+to `E_UNDEFINED_SYMBOL`, `E_TYPE_UNDEFINED`,
+`E_TYPE_UNDEFINED_FIELD`, and `E_TYPE_UNDEFINED_METHOD` when a
+known name is within Levenshtein distance 2 of the user's
+spelling. No help line fires when no candidate qualifies — a
+missing suggestion beats a misleading one.
+
+The candidate pool varies per emission site: full scope chain
+for symbols, registry-plus-primitives for type names, the
+type's own field list (inheritance-walked for classes) for
+fields, the class's method list (inheritance-walked) for
+methods.
+
+`tc_suggestions` (Levenshtein + bestMatch helpers) lives under
+`gero.lang.internal.typechecker.suggestions` — same `internal.*`
+seam pattern as the other typecheck sub-modules. Closes #257.

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -145,8 +145,8 @@ trace lives behind `gero check --verbose`.
 ### 4.3 "Did you mean…?" suggestions
 
 For undefined-identifier errors, the typechecker computes
-Levenshtein distance against all in-scope names and offers
-suggestions when distance ≤ 2:
+Levenshtein distance against the visible candidate pool and
+attaches a `help:` line with the closest match within distance 2:
 
 ```
 error: undefined symbol `lenght` [E_UNDEFINED_SYMBOL]
@@ -158,8 +158,21 @@ error: undefined symbol `lenght` [E_UNDEFINED_SYMBOL]
 help: did you mean `length`?
 ```
 
-Multiple candidates: list up to 3, ordered by distance then
-alphabetically.
+The pool varies by emission site:
+
+- `E_UNDEFINED_SYMBOL` — every binding visible in the scope
+  chain (locals, params, globals, defs, classes, structs, enums).
+- `E_TYPE_UNDEFINED` — the primitive type names plus every
+  registered struct / class / enum.
+- `E_TYPE_UNDEFINED_FIELD` — the resolved type's field list,
+  walking the inheritance chain for class receivers.
+- `E_TYPE_UNDEFINED_METHOD` — the resolved class's method list,
+  walking the inheritance chain.
+
+Single-candidate ranking — the first-iterated match at the
+minimum distance wins. Multi-candidate listing (top-3,
+alphabetical) is a future extension; today's renderer surfaces
+exactly one suggestion or none.
 
 ---
 

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -22,6 +22,7 @@ const tc_predicates = @import("lang/typecheck/predicates.zig");
 const tc_annotations = @import("lang/typecheck/annotations.zig");
 const tc_relations = @import("lang/typecheck/relations.zig");
 const tc_flow = @import("lang/typecheck/flow.zig");
+const tc_suggestions = @import("lang/typecheck/suggestions.zig");
 const cg_opcodes = @import("lang/codegen/opcodes.zig");
 const cg_archive = @import("lang/codegen/archive.zig");
 const cg_mem_builtin = @import("lang/codegen/mem_builtin.zig");
@@ -127,6 +128,9 @@ pub const internal = struct {
         pub const match = tc_match;
         /// Internal — `mem.*` stdlib typecheck dispatch.
         pub const mem_builtin = tc_mem_builtin;
+        /// Internal — "did you mean…?" Levenshtein-based suggestion
+        /// pool helpers (#257).
+        pub const suggestions = tc_suggestions;
     };
 
     /// Internal — codegen submodule seams.

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -473,8 +473,9 @@ pub const Checker = struct {
     /// attaching a `help: did you mean \`X\`?` line when
     /// `candidate` is non-null. Centralizes the "look up a
     /// suggestion → branch on hit/miss" dispatch used by every
-    /// `E_*_UNDEFINED*` / `E_UNDEFINED_SYMBOL` site.
-    fn emitSpanWithSuggestion(
+    /// `E_*_UNDEFINED*` / `E_UNDEFINED_SYMBOL` site (including
+    /// the `mem.X` resolvers in `typecheck/mem_builtin.zig`).
+    pub fn emitSpanWithSuggestion(
         self: *Checker,
         code: []const u8,
         span: ast.Span,

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -163,6 +163,7 @@ const predicates = @import("typecheck/predicates.zig");
 const annotations = @import("typecheck/annotations.zig");
 const relations = @import("typecheck/relations.zig");
 const flow = @import("typecheck/flow.zig");
+const suggestions = @import("typecheck/suggestions.zig");
 
 const T = annotations.T;
 
@@ -392,6 +393,97 @@ pub const Checker = struct {
     /// Return the source-text slice for `span`.
     pub fn lexeme(self: *const Checker, span: ast.Span) []const u8 {
         return self.source[span.start..span.end];
+    }
+
+    // ---------- "did you mean…?" suggestions (#257) ----------
+
+    /// Walk the scope chain and every type registry collecting
+    /// candidate names visible at `name`'s use site, then return
+    /// the closest Levenshtein match within `suggestions.max_distance`.
+    /// Used for `E_UNDEFINED_SYMBOL` — covers locals, params,
+    /// globals, defs, classes, structs, enums.
+    fn suggestSymbol(self: *Checker, name: []const u8) WalkError!?[]const u8 {
+        var pool: std.ArrayList([]const u8) = .empty;
+        defer pool.deinit(self.arena);
+        var scope: ?*const Scope = self.current_scope;
+        while (scope) |s| : (scope = s.parent) {
+            var it = s.entries.keyIterator();
+            while (it.next()) |k| try pool.append(self.arena, k.*);
+        }
+        return suggestions.bestMatch(name, pool.items);
+    }
+
+    /// Same pool as `suggestSymbol` plus the primitive type names —
+    /// used by `E_TYPE_UNDEFINED` when an unknown type name shows
+    /// up in an annotation / struct-lit position.
+    fn suggestTypeName(self: *Checker, name: []const u8) WalkError!?[]const u8 {
+        var pool: std.ArrayList([]const u8) = .empty;
+        defer pool.deinit(self.arena);
+        // Primitive types — must be matched first so `let x: i8`
+        // wins over a stray `i9` local. Mirrors `types.primitiveFromName`.
+        const primitives = [_][]const u8{ "i8", "u8", "i16", "u16", "int", "uint", "bool", "nil", "str", "fixed", "char" };
+        for (primitives) |p| try pool.append(self.arena, p);
+        var struct_it = self.struct_registry.keyIterator();
+        while (struct_it.next()) |k| try pool.append(self.arena, k.*);
+        var class_it = self.class_registry.keyIterator();
+        while (class_it.next()) |k| try pool.append(self.arena, k.*);
+        var enum_it = self.enum_registry.keyIterator();
+        while (enum_it.next()) |k| try pool.append(self.arena, k.*);
+        return suggestions.bestMatch(name, pool.items);
+    }
+
+    /// Collect the field names of a struct decl into the candidate
+    /// pool for an `E_TYPE_UNDEFINED_FIELD` suggestion.
+    fn suggestStructField(self: *Checker, sd: *const ast.StructDecl, name: []const u8) WalkError!?[]const u8 {
+        var pool: std.ArrayList([]const u8) = .empty;
+        defer pool.deinit(self.arena);
+        for (sd.fields) |f| try pool.append(self.arena, self.lexeme(f.name));
+        return suggestions.bestMatch(name, pool.items);
+    }
+
+    /// Collect every field reachable from a class via its
+    /// inheritance chain — for `E_TYPE_UNDEFINED_FIELD` on a class
+    /// receiver. Walks parents so suggestions can land on inherited
+    /// fields.
+    fn suggestClassField(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
+        var pool: std.ArrayList([]const u8) = .empty;
+        defer pool.deinit(self.arena);
+        var cur: ?*const ast.ClassDecl = cd;
+        while (cur) |c| {
+            for (c.fields) |f| try pool.append(self.arena, self.lexeme(f.name));
+            cur = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
+        }
+        return suggestions.bestMatch(name, pool.items);
+    }
+
+    /// Collect every method reachable from a class via its
+    /// inheritance chain — for `E_TYPE_UNDEFINED_METHOD`.
+    fn suggestClassMethod(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
+        var pool: std.ArrayList([]const u8) = .empty;
+        defer pool.deinit(self.arena);
+        var cur: ?*const ast.ClassDecl = cd;
+        while (cur) |c| {
+            for (c.methods) |m| try pool.append(self.arena, self.lexeme(m.name));
+            cur = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
+        }
+        return suggestions.bestMatch(name, pool.items);
+    }
+
+    /// Emit a fatal `Diagnostic` for an undefined-name code,
+    /// attaching a `help: did you mean \`X\`?` line when
+    /// `candidate` is non-null. Centralizes the "look up a
+    /// suggestion → branch on hit/miss" dispatch used by every
+    /// `E_*_UNDEFINED*` / `E_UNDEFINED_SYMBOL` site.
+    fn emitSpanWithSuggestion(
+        self: *Checker,
+        code: []const u8,
+        span: ast.Span,
+        message: []const u8,
+        candidate: ?[]const u8,
+    ) WalkError!void {
+        const name = candidate orelse return self.emitSpan(code, span, message);
+        const help = try std.fmt.allocPrint(self.arena, "did you mean `{s}`?", .{name});
+        try self.emitSpanHelp(code, span, message, help);
     }
 
     // ---------- Pass 1: top-level decl registration ----------
@@ -1272,7 +1364,7 @@ pub const Checker = struct {
                     "undefined type `{s}`",
                     .{name},
                 );
-                try self.emitSpan("E_TYPE_UNDEFINED", n.name, msg);
+                try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", n.name, msg, try self.suggestTypeName(name));
                 return try types.mkNamed(self.arena, name, n.span);
             },
             .nullable => |n| {
@@ -1417,7 +1509,7 @@ pub const Checker = struct {
                     "undefined symbol `{s}`",
                     .{name},
                 );
-                try self.emitSpan("E_UNDEFINED_SYMBOL", i.span, msg);
+                try self.emitSpanWithSuggestion("E_UNDEFINED_SYMBOL", i.span, msg, try self.suggestSymbol(name));
                 return null;
             },
             .self_expr => |se| {
@@ -1779,7 +1871,17 @@ pub const Checker = struct {
             "type `{s}` has no field `{s}`",
             .{ type_name, field_name },
         );
-        try self.emitSpan("E_TYPE_UNDEFINED_FIELD", span, msg);
+        // Suggestion across struct + class registries — whichever
+        // resolves the type name supplies the field pool. Misses
+        // (no candidate within distance 2, or unknown type) fall
+        // through to the bare diagnostic.
+        const candidate: ?[]const u8 = if (self.struct_registry.get(type_name)) |sd|
+            try self.suggestStructField(sd, field_name)
+        else if (self.class_registry.get(type_name)) |cd|
+            try self.suggestClassField(cd, field_name)
+        else
+            null;
+        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_FIELD", span, msg, candidate);
     }
 
     /// Type-check a method call against the class registry.
@@ -1812,7 +1914,7 @@ pub const Checker = struct {
                 "class `{s}` has no method `{s}`",
                 .{ named_name, method_name },
             );
-            try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
+            try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", m.method, msg, try self.suggestClassMethod(cd, method_name));
             for (m.args) |a| _ = try self.inferExpr(a, null);
             return null;
         };
@@ -1887,7 +1989,7 @@ pub const Checker = struct {
             "undefined type `{s}`",
             .{type_name},
         );
-        try self.emitSpan("E_TYPE_UNDEFINED", sl.type_name, msg);
+        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", sl.type_name, msg, try self.suggestTypeName(type_name));
         for (sl.fields) |f| _ = try self.inferExpr(f.value, null);
         return named_ty;
     }

--- a/src/lang/typecheck/mem_builtin.zig
+++ b/src/lang/typecheck/mem_builtin.zig
@@ -7,6 +7,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const types = @import("../types.zig");
 const typecheck = @import("../typecheck.zig");
+const suggestions = @import("suggestions.zig");
 
 const Checker = typecheck.Checker;
 const WalkError = error{OutOfMemory};
@@ -48,6 +49,16 @@ pub fn lookupMemBuiltin(name: []const u8) ?MemBuiltinSig {
     return null;
 }
 
+/// Closest-spelling `mem.X` builtin name within Levenshtein
+/// distance 2, or `null` when nothing qualifies. Backs the
+/// "did you mean…?" help line on `E_TYPE_UNDEFINED_METHOD`
+/// emitted by `checkMemMethodCall` / `resolveMemBuiltin`.
+fn suggestMemBuiltin(name: []const u8) ?[]const u8 {
+    var pool: [mem_builtins.len][]const u8 = undefined;
+    inline for (mem_builtins, 0..) |b, i| pool[i] = b.name;
+    return suggestions.bestMatch(name, &pool);
+}
+
 /// Type-check `mem.X(args)` as a method-call expression. The
 /// stdlib `mem` module is compiler-recognized; the call's
 /// arity + per-arg types are validated against the builtin's
@@ -63,7 +74,7 @@ pub fn checkMemMethodCall(self: *Checker, m: ast.MethodCallExpr) WalkError!?*con
             "stdlib module `mem` has no member `{s}`",
             .{fn_name},
         );
-        try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
+        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", m.method, msg, suggestMemBuiltin(fn_name));
         for (m.args) |a| _ = try self.inferExpr(a, null);
         return null;
     }
@@ -114,7 +125,7 @@ pub fn resolveMemBuiltin(self: *Checker, f: ast.FieldExpr) WalkError!?*const typ
             "stdlib module `mem` has no member `{s}`",
             .{fn_name},
         );
-        try self.emitSpan("E_TYPE_UNDEFINED_METHOD", f.field, msg);
+        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", f.field, msg, suggestMemBuiltin(fn_name));
         return null;
     }
     if (sig.?.is_addr_of) {

--- a/src/lang/typecheck/suggestions.zig
+++ b/src/lang/typecheck/suggestions.zig
@@ -1,0 +1,85 @@
+/// "Did you mean…?" suggestion helpers for typecheck diagnostics
+/// (`E_UNDEFINED_SYMBOL`, `E_TYPE_UNDEFINED`, `E_TYPE_UNDEFINED_FIELD`,
+/// `E_TYPE_UNDEFINED_METHOD`). Pure functions over byte slices — the
+/// caller assembles the candidate list and feeds it in.
+///
+/// The cap is intentionally tight: distance ≤ 2 captures typical typos
+/// (single transposition, single missing / extra char, simple
+/// substitution) without spamming irrelevant suggestions for genuinely
+/// unrelated names. Beyond two edits the user is more likely to have
+/// the wrong concept than a misspelling.
+const std = @import("std");
+
+/// Maximum edit distance for a suggestion to count. Per spec
+/// (issue #257). Values above this cap return `null` from
+/// `bestMatch` so the diagnostic stays clean — no suggestion is
+/// better than a misleading one.
+pub const max_distance: usize = 2;
+
+/// Bounded Levenshtein distance — returns the actual distance when
+/// it's `≤ cap`, or `cap + 1` when it's known to exceed (the
+/// caller only needs the cap test, so the exact distance past the
+/// cap doesn't matter). The bound makes the inner loop O(|b| × cap)
+/// rather than O(|a| × |b|) once the running minimum exceeds cap.
+pub fn levenshtein(a: []const u8, b: []const u8, cap: usize) usize {
+    // Early outs based on length difference — distance is at least
+    // the length-delta, so a delta past `cap` is a definite reject.
+    const la = a.len;
+    const lb = b.len;
+    const delta = if (la > lb) la - lb else lb - la;
+    if (delta > cap) return cap + 1;
+
+    // Two-row dynamic-programming table — only the previous row
+    // matters at any step, so we ping-pong between two buffers.
+    // Bounded by 32 chars per name (identifiers in gero are short)
+    // to keep the table on the stack.
+    const max_name_len: usize = 64;
+    if (la > max_name_len or lb > max_name_len) return cap + 1;
+
+    var prev_buf: [max_name_len + 1]usize = undefined;
+    var curr_buf: [max_name_len + 1]usize = undefined;
+    var prev = prev_buf[0 .. lb + 1];
+    var curr = curr_buf[0 .. lb + 1];
+
+    for (prev, 0..) |*p, j| p.* = j;
+
+    for (a, 0..) |ca, i| {
+        curr[0] = i + 1;
+        var row_min: usize = curr[0];
+        for (b, 0..) |cb, j| {
+            const ins = curr[j] + 1;
+            const del = prev[j + 1] + 1;
+            // @as: widen the 0/1 substitution cost from comptime_int to usize.
+            const sub = prev[j] + @as(usize, if (ca == cb) 0 else 1);
+            curr[j + 1] = @min(@min(ins, del), sub);
+            if (curr[j + 1] < row_min) row_min = curr[j + 1];
+        }
+        if (row_min > cap) return cap + 1;
+        std.mem.swap([]usize, &prev, &curr);
+    }
+
+    return prev[lb];
+}
+
+/// Pick the closest-spelling candidate to `target` within
+/// `max_distance` edits. Returns the FIRST match at the minimum
+/// distance — for the case where two candidates tie, the caller
+/// gets a deterministic answer that depends on iteration order
+/// (so callers wanting stability sort the candidate slice first).
+pub fn bestMatch(target: []const u8, candidates: []const []const u8) ?[]const u8 {
+    var best: ?[]const u8 = null;
+    var best_dist: usize = max_distance + 1;
+    for (candidates) |c| {
+        const d = levenshtein(target, c, max_distance);
+        if (d < best_dist) {
+            best = c;
+            best_dist = d;
+            // Distance-0 match is the user's exact name — the
+            // caller would have hit `lookup` instead of falling
+            // through here. Short-circuit anyway in case some
+            // future call site bypasses that step.
+            if (best_dist == 0) return best;
+        }
+    }
+    return best;
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2064,3 +2064,12 @@ test "typecheck/suggest: primitive type typo (i17 → i16) surfaces the primitiv
         \\end
     , "E_TYPE_UNDEFINED", "i16");
 }
+
+test "typecheck/suggest: unknown mem.X member surfaces the closest stdlib name" {
+    try expectSuggestion(
+        \\use mem
+        \\def main()
+        \\  let v: u8 = mem.read_u17($2100)
+        \\end
+    , "E_TYPE_UNDEFINED_METHOD", "read_u16");
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -1925,3 +1925,142 @@ test "typecheck: @static method with `self` param is rejected" {
         \\end
     , "E_STATIC_HAS_SELF");
 }
+
+// ---------- "did you mean…?" suggestions (#257) ----------
+
+/// Assert the named diagnostic fires with a `help:` block
+/// containing the suggestion. Verifies both that the code matches
+/// AND that the rendered help string mentions the candidate name.
+fn expectSuggestion(source: []const u8, code: []const u8, candidate: []const u8) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    for (checked.diagnostics) |d| {
+        if (!std.mem.eql(u8, d.code, code)) continue;
+        const help = d.help orelse continue;
+        if (std.mem.indexOf(u8, help, candidate) != null) return;
+    }
+    std.debug.print("missing {s} with help mentioning `{s}` for `{s}`; got:\n", .{ code, candidate, source });
+    for (checked.diagnostics) |d| {
+        const help_str = d.help orelse "<none>";
+        std.debug.print("  - {s}: {s}  help=`{s}`\n", .{ d.code, d.message, help_str });
+    }
+    return error.MissingSuggestion;
+}
+
+/// Assert that NO diagnostic of the given code carries a `help:`
+/// block — used to verify "no candidate within distance 2 → no
+/// suggestion" path.
+fn expectNoSuggestion(source: []const u8, code: []const u8) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source, &tree.program);
+    defer checked.deinit();
+
+    var saw_code = false;
+    for (checked.diagnostics) |d| {
+        if (!std.mem.eql(u8, d.code, code)) continue;
+        saw_code = true;
+        if (d.help != null) {
+            std.debug.print("unexpected help on {s} for `{s}`: `{s}`\n", .{ code, source, d.help.? });
+            return error.UnexpectedSuggestion;
+        }
+    }
+    try std.testing.expect(saw_code);
+}
+
+test "typecheck/suggest: undefined ident with a close-spelling local" {
+    try expectSuggestion(
+        \\def main()
+        \\  let helo: i16 = 0
+        \\  let x: i16 = helllo
+        \\end
+    , "E_UNDEFINED_SYMBOL", "helo");
+}
+
+test "typecheck/suggest: no candidate within distance 2 → no help" {
+    try expectNoSuggestion(
+        \\def main()
+        \\  let aaaa: i16 = 0
+        \\  let x: i16 = zzzzzz
+        \\end
+    , "E_UNDEFINED_SYMBOL");
+}
+
+test "typecheck/suggest: undefined struct field surfaces sibling name" {
+    try expectSuggestion(
+        \\struct Stats
+        \\  hp: i16
+        \\  mp: i16
+        \\end
+        \\
+        \\def main()
+        \\  let s: Stats = Stats { hp: 10, mp: 5 }
+        \\  let n: i16 = s.hpp
+        \\end
+    , "E_TYPE_UNDEFINED_FIELD", "hp");
+}
+
+test "typecheck/suggest: undefined class field — walks the inheritance chain" {
+    try expectSuggestion(
+        \\class Entity
+        \\  let health: i16
+        \\end
+        \\
+        \\class Player extends Entity end
+        \\
+        \\def main()
+        \\  let p = Player()
+        \\  let n: i16 = p.helath
+        \\end
+    , "E_TYPE_UNDEFINED_FIELD", "health");
+}
+
+test "typecheck/suggest: undefined class method surfaces sibling name" {
+    try expectSuggestion(
+        \\class Player
+        \\  def attack(self) end
+        \\end
+        \\
+        \\def main()
+        \\  let p = Player()
+        \\  p.attaack()
+        \\end
+    , "E_TYPE_UNDEFINED_METHOD", "attack");
+}
+
+test "typecheck/suggest: undefined type in annotation suggests a registered type" {
+    try expectSuggestion(
+        \\class Player end
+        \\
+        \\def main()
+        \\  let p: Playr = Player()
+        \\end
+    , "E_TYPE_UNDEFINED", "Player");
+}
+
+test "typecheck/suggest: undefined type in struct literal suggests a registered type" {
+    try expectSuggestion(
+        \\struct Stats
+        \\  hp: i16
+        \\end
+        \\
+        \\def main()
+        \\  let s = Stahts { hp: 1 }
+        \\end
+    , "E_TYPE_UNDEFINED", "Stats");
+}
+
+test "typecheck/suggest: primitive type typo (i17 → i16) surfaces the primitive" {
+    try expectSuggestion(
+        \\def main()
+        \\  let x: i17 = 0
+        \\end
+    , "E_TYPE_UNDEFINED", "i16");
+}

--- a/tests/lang/typecheck/suggestions.test.zig
+++ b/tests/lang/typecheck/suggestions.test.zig
@@ -1,0 +1,54 @@
+/// Unit tests for the Levenshtein / bestMatch helpers backing
+/// the "did you mean…?" suggestion family. The end-to-end wiring
+/// (per-emission-site help blocks) is exercised in
+/// `tests/lang/typecheck.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+const suggestions = gero.lang.internal.typechecker.suggestions;
+
+test "levenshtein: identical strings → 0" {
+    try std.testing.expectEqual(@as(usize, 0), suggestions.levenshtein("foo", "foo", 2));
+}
+
+test "levenshtein: single insert / delete / substitute → 1" {
+    try std.testing.expectEqual(@as(usize, 1), suggestions.levenshtein("foo", "foob", 2));
+    try std.testing.expectEqual(@as(usize, 1), suggestions.levenshtein("foob", "foo", 2));
+    try std.testing.expectEqual(@as(usize, 1), suggestions.levenshtein("foo", "foa", 2));
+}
+
+test "levenshtein: transposition → 2" {
+    // No native transposition primitive — counts as one delete + one insert.
+    try std.testing.expectEqual(@as(usize, 2), suggestions.levenshtein("ab", "ba", 2));
+}
+
+test "levenshtein: distance > cap returns cap + 1" {
+    try std.testing.expectEqual(@as(usize, 3), suggestions.levenshtein("hello", "world", 2));
+    try std.testing.expectEqual(@as(usize, 3), suggestions.levenshtein("", "abcde", 2));
+}
+
+test "levenshtein: length-delta past cap short-circuits" {
+    // No DP work happens — the length-delta check catches it.
+    try std.testing.expectEqual(@as(usize, 3), suggestions.levenshtein("a", "abcd", 2));
+}
+
+test "bestMatch: returns nearest candidate within cap" {
+    const candidates = [_][]const u8{ "foo", "bar", "fooz", "qux" };
+    try std.testing.expectEqualStrings("foo", suggestions.bestMatch("fo", &candidates).?);
+}
+
+test "bestMatch: returns null when no candidate is within cap" {
+    const candidates = [_][]const u8{ "hello", "world", "totally_unrelated" };
+    try std.testing.expectEqual(@as(?[]const u8, null), suggestions.bestMatch("xyz", &candidates));
+}
+
+test "bestMatch: empty candidate list returns null" {
+    const candidates = [_][]const u8{};
+    try std.testing.expectEqual(@as(?[]const u8, null), suggestions.bestMatch("anything", &candidates));
+}
+
+test "bestMatch: ties resolve to the first-iterated candidate" {
+    // "ab" and "ba" both have distance 2 from "aa" — first wins.
+    const candidates = [_][]const u8{ "ab", "ba" };
+    try std.testing.expectEqualStrings("ab", suggestions.bestMatch("aa", &candidates).?);
+}


### PR DESCRIPTION
## Summary

`E_UNDEFINED_SYMBOL`, `E_TYPE_UNDEFINED`, `E_TYPE_UNDEFINED_FIELD`,
and `E_TYPE_UNDEFINED_METHOD` now carry a `help: did you mean
\`X\`?` line when a known name is within Levenshtein distance 2
of the user's spelling. No help fires when no candidate qualifies
— a missing suggestion beats a misleading one (the cap is
intentionally tight per spec §4.3).

## What lands

**`src/lang/typecheck/suggestions.zig`** — pure helpers:
- `levenshtein(a, b, cap)` runs a bounded two-row DP with early
  exit when the running row-minimum exceeds `cap`. Names past 64
  bytes early-exit with `cap + 1` so the DP table stays on the
  stack.
- `bestMatch(target, candidates)` picks the first-iterated
  candidate at the minimum distance; returns `null` when no
  candidate is within `max_distance`.

**Per-emission-site candidate pools** in `Checker`:

| Site | Pool |
|------|------|
| `E_UNDEFINED_SYMBOL` | every binding visible in the scope chain (locals, params, globals, defs, classes, structs, enums) |
| `E_TYPE_UNDEFINED` | primitive type names + struct / class / enum registries |
| `E_TYPE_UNDEFINED_FIELD` | the type's field list — walks the inheritance chain for class receivers |
| `E_TYPE_UNDEFINED_METHOD` | the class's method list — walks the inheritance chain |

The five call sites (the type-undefined code fires from both
type-annotation resolution and struct-literal heads) collapse
through one shared `emitSpanWithSuggestion(code, span, msg,
candidate)` helper — no per-site `if candidate then with-help
else bare` branching.

**Docs** — §4.3 in `docs/lang-diagnostics.md` updated to match
the shipped single-candidate behavior; the prior aspirational
"top-3 alphabetical" text is now an explicit future-extension
note (the issue's "Out of scope").

## Acceptance criteria

- [x] `let helo = 0; let x = helllo` emits `E_UNDEFINED_SYMBOL` with `help: did you mean \`helo\`?`
- [x] No suggestion when no candidate is within distance 2
- [x] Same for `s.foo` on a struct that has `s.bar` field
- [x] Tests cover suggestion-found, no-candidate, and the four emission sites
- [x] All four release modes pass

## Smoke tests

\`\`\`
$ gero check typo.gr
1 error in 1 file

typo.gr
  error: undefined symbol \`helllo\` [E_UNDEFINED_SYMBOL]
    --> typo.gr:3:16
help: did you mean \`helo\`?
\`\`\`

Also wired for fields (\`p.helath\` → suggests \`health\`), methods
(\`p.attaack()\` → \`attack\`), and types (\`let p: Playr\` →
\`Player\`).

## Test plan

- [x] \`zig build verify\` green
- [x] \`zig build test-modes\` green
- [x] Changeset present (\`lang-did-you-mean.md\`)
- [x] No AI attribution in commits

Closes #257.