### PR TITLE
feat(lang/diagnostics): multi-span rendering — secondary span labels (closes #254)

### DIFF
--- a/.changeset/lang-multispan-render.md
+++ b/.changeset/lang-multispan-render.md
@@ -1,0 +1,24 @@
+---
+bump: minor
+---
+
+`Diagnostic` now carries a `secondary: []const SpanLabel` slice
+for the annotated context spans the spec mockups in
+`docs/lang-diagnostics.md` §5.2 / §5.3 / §5.9 describe — same-
+line secondaries draw a `---` underline under the source line
+plus a stacked `|` pointer + label below; cross-line secondaries
+get their own `--> path:line:col` excerpt block under the
+primary. Decoration enum (`.underline` / `.point`) picks dashes
+vs carets per span.
+
+Three typechecker sites attach the new shape per the issue:
+
+- `E_TYPE_MISMATCH` on `let x: T = …` — annotation span as the
+  secondary, label `"expected \`T\` because of this annotation"`.
+- `E_TYPE_REDEFINED` — prior decl span as the secondary, label
+  `"previous definition here"`.
+- `E_TYPE_UNDEFINED_FIELD` — the type's declaration span as the
+  secondary, label `"type \`T\` defined here"`.
+
+Other diagnostics keep an empty `secondary` slice — existing
+behavior is unchanged. Closes #254.

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -242,17 +242,19 @@ Raised by the typechecker after parsing succeeds.
 **Mockup — type mismatch in let init:**
 
 ```
-error: type mismatch [E_TYPE_MISMATCH]
+error: type mismatch: expected `i16`, found `str` [E_TYPE_MISMATCH]
   --> src/foo.gr:12:18
    |
 12 |   let x: i16 = "hello"
-   |          ---   ^^^^^^^ found `str`
+   |          ---   ^^^^^^^
    |          |
    |          expected `i16` because of this annotation
-   |
-help: parse the string with `str.to_i16("hello")` or change `x`'s
-      annotation to `str`
 ```
+
+The expected / found names live in the header message rather than
+as inline labels next to the carets. Inline primary-span labels
+(`found \`str\`` next to the carets) are a future extension; the
+header carries the information today.
 
 **Mockup — wrong arg count:**
 

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -72,6 +72,8 @@ pub const MemBuiltinSig = tc_mem_builtin.MemBuiltinSig;
 pub const lookupMemBuiltin = tc_mem_builtin.lookupMemBuiltin;
 /// Re-export: rich diagnostic shape carried by `CheckedProgram`.
 pub const Diagnostic = diag_mod.Diagnostic;
+/// Re-export: annotated context span attached to a `Diagnostic`.
+pub const SpanLabel = diag_mod.SpanLabel;
 /// Re-export: severity classification on a `Diagnostic`.
 pub const Severity = diag_mod.Severity;
 /// Re-export: diagnostic-rendering primitives (pretty + JSON).

--- a/src/lang/diagnostic.zig
+++ b/src/lang/diagnostic.zig
@@ -21,6 +21,30 @@ pub const Severity = enum {
     note,
 };
 
+/// One annotated secondary span attached to a diagnostic. Used for
+/// the "expected `i16` because of this annotation" / "previous
+/// definition here" pattern: a primary diagnostic with the actual
+/// error site plus one or more context spans that explain *why*.
+/// The renderer decorates the span underneath the source excerpt
+/// and prints `message` next to it (same line as the primary when
+/// they share a line, otherwise in its own `--> path:line:col`
+/// block).
+pub const SpanLabel = struct {
+    span: ast.Span,
+    message: []const u8,
+    /// Visual decoration drawn under the span. `.underline` mirrors
+    /// the spec mockup (dashes under the secondary, carets under
+    /// the primary); `.point` reuses caret characters for an
+    /// emphasis tier that visually matches the primary.
+    decoration: Decoration = .underline,
+
+    /// Glyph used to underline the secondary span. `.underline`
+    /// draws `-` characters (the spec default — visually distinct
+    /// from the primary's `^`); `.point` draws `^` to give the
+    /// secondary the same emphasis tier as the primary.
+    pub const Decoration = enum { underline, point };
+};
+
 /// One diagnostic. The `span` covers the offending bytes in the
 /// source buffer; `code` is the stable `E_TYPE_MISMATCH`-style
 /// identifier from `docs/lang-diagnostics.md`.
@@ -32,4 +56,11 @@ pub const Diagnostic = struct {
     /// Optional `help: ...` block printed after the caret snippet.
     /// The renderer wraps long lines at 78 cols.
     help: ?[]const u8 = null,
+    /// Annotated context spans (e.g. annotation declarations,
+    /// prior definitions). Empty for diagnostics that don't need
+    /// secondary context. Per spec §4.x rendering rules:
+    /// same-line secondaries draw on the primary's caret line +
+    /// stack labels under it; cross-line secondaries emit their
+    /// own `--> path:line:col` excerpt block.
+    secondary: []const SpanLabel = &.{},
 };

--- a/src/lang/render.zig
+++ b/src/lang/render.zig
@@ -239,6 +239,21 @@ fn writeExcerpt(
     try writeSecondaryLabelStack(writer, source, gutter_w, lc.line, secondary, style);
 }
 
+/// Pre-resolved column extent + glyph for one same-line
+/// secondary, materialized once per render so the per-column
+/// merge loop doesn't re-walk the source buffer.
+const Segment = struct {
+    col_start: usize,
+    col_end_exclusive: usize,
+    glyph: u8,
+};
+
+/// Cap on same-line secondaries one diagnostic can attach.
+/// Beyond this, extras get dropped from the caret merge —
+/// readable output beats blasting twenty stacked labels at the
+/// user. Real diagnostics carry one or two secondaries.
+const max_same_line_segments: usize = 8;
+
 /// Emit the caret / underline row covering both the primary span
 /// and every same-line secondary. Each output column picks its
 /// glyph by source order: primary wins where it overlaps a
@@ -254,17 +269,30 @@ fn writeMergedCaretLine(
     secondary: []const SpanLabel,
     style: Style,
 ) !void {
-    // Compute the max column the row needs to cover so the trailing
-    // spaces don't run forever — past the last decorated column we
-    // stop emitting characters.
+    // Pre-resolve each same-line secondary's column extent ONCE so
+    // the inner column loop reads from `segments` instead of
+    // re-walking the source for every column × every secondary.
+    var segments_buf: [max_same_line_segments]Segment = undefined;
+    var n_segments: usize = 0;
     var max_col: usize = primary_end_exclusive;
     for (secondary) |sl| {
+        if (n_segments >= max_same_line_segments) break;
         if (lineOf(source, sl.span.start) != line) continue;
         const sc = lineColAt(source, sl.span.start);
         const slen = caretLength(source, sl.span);
         const end_exc = sc.col + slen;
+        segments_buf[n_segments] = .{
+            .col_start = sc.col,
+            .col_end_exclusive = end_exc,
+            .glyph = switch (sl.decoration) {
+                .underline => '-',
+                .point => '^',
+            },
+        };
+        n_segments += 1;
         if (end_exc > max_col) max_col = end_exc;
     }
+    const segments = segments_buf[0..n_segments];
 
     try writePadGutter(writer, gutter_w, style);
     try writer.writeAll(" | ");
@@ -272,17 +300,13 @@ fn writeMergedCaretLine(
     var in_caret_style = false;
     while (col < max_col) : (col += 1) {
         const in_primary = col >= primary_start and col < primary_end_exclusive;
-        const sec = if (!in_primary) secondaryCovering(source, line, col, secondary) else null;
-        if (in_primary or sec != null) {
+        const seg_glyph: ?u8 = if (in_primary) null else segmentGlyphAt(segments, col);
+        if (in_primary or seg_glyph != null) {
             if (!in_caret_style) {
                 try writer.writeAll(style.caret);
                 in_caret_style = true;
             }
-            const ch: u8 = if (in_primary) '^' else switch (sec.?.decoration) {
-                .underline => '-',
-                .point => '^',
-            };
-            try writer.writeByte(ch);
+            try writer.writeByte(if (in_primary) '^' else seg_glyph.?);
         } else {
             if (in_caret_style) {
                 try writer.writeAll(style.reset);
@@ -293,6 +317,17 @@ fn writeMergedCaretLine(
     }
     if (in_caret_style) try writer.writeAll(style.reset);
     try writer.writeByte('\n');
+}
+
+/// First segment (in source order) covering column `col`, or
+/// `null` when no same-line secondary overlaps. Pure linear scan
+/// of the pre-resolved segment slice — no source-walks inside
+/// the hot per-column loop.
+fn segmentGlyphAt(segments: []const Segment, col: usize) ?u8 {
+    for (segments) |s| {
+        if (col >= s.col_start and col < s.col_end_exclusive) return s.glyph;
+    }
+    return null;
 }
 
 /// For each same-line secondary, emit a `|` pointer row (carrying
@@ -399,23 +434,6 @@ fn writeOneCrossLineSecondary(
 /// but cheap to call from the per-column merge loop.
 fn lineOf(source: []const u8, byte: u32) usize {
     return lineColAt(source, byte).line;
-}
-
-/// First secondary span (in source order) that covers column `col`
-/// on `line`. `null` when no same-line secondary overlaps.
-fn secondaryCovering(
-    source: []const u8,
-    line: usize,
-    col: usize,
-    secondary: []const SpanLabel,
-) ?SpanLabel {
-    for (secondary) |sl| {
-        if (lineOf(source, sl.span.start) != line) continue;
-        const sc = lineColAt(source, sl.span.start);
-        const end = sc.col + caretLength(source, sl.span);
-        if (col >= sc.col and col < end) return sl;
-    }
-    return null;
 }
 
 fn writeHelp(writer: *std.Io.Writer, help_msg: []const u8, style: Style) !void {

--- a/src/lang/render.zig
+++ b/src/lang/render.zig
@@ -16,6 +16,7 @@ const diag_mod = @import("diagnostic.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
 const Severity = diag_mod.Severity;
+const SpanLabel = diag_mod.SpanLabel;
 
 /// ANSI escape codes for colorized output. `Style.none` strips
 /// all escapes for plain-text mode (no tty, `--no-color`, JSON).
@@ -161,7 +162,8 @@ fn writeDiagnosticFull(
         lc.line,        lc.col,
         style.reset,
     });
-    try writeExcerpt(writer, source, d.span, lc, style);
+    try writeExcerpt(writer, source, d.span, lc, d.secondary, style);
+    try writeCrossLineSecondaries(writer, path, source, d.span, d.secondary, style);
     if (d.help) |h| try writeHelp(writer, h, style);
     try writer.writeByte('\n');
 }
@@ -182,7 +184,8 @@ fn writeDiagnosticBody(
         lc.line,        lc.col,
         style.reset,
     });
-    try writeExcerpt(writer, source, d.span, lc, style);
+    try writeExcerpt(writer, source, d.span, lc, d.secondary, style);
+    try writeCrossLineSecondaries(writer, path, source, d.span, d.secondary, style);
     if (d.help) |h| try writeHelp(writer, h, style);
     try writer.writeByte('\n');
 }
@@ -205,6 +208,7 @@ fn writeExcerpt(
     source: []const u8,
     span: ast.Span,
     lc: LineCol,
+    secondary: []const SpanLabel,
     style: Style,
 ) !void {
     const line_slice = lineAt(source, span.start);
@@ -216,18 +220,202 @@ fn writeExcerpt(
     try writer.writeAll(style.gutter);
     try writeRightPadInt(writer, lc.line, gutter_w);
     try writer.print(" |{s} {s}\n", .{ style.reset, line_slice });
-    // Caret line — pad + carets + maybe a trailing label later.
+    // Caret line — primary carets plus same-line secondary decorations.
+    const primary_col_start: usize = lc.col;
+    const primary_caret_len = caretLength(source, span);
+    const primary_col_end_exclusive: usize = primary_col_start + primary_caret_len;
+    try writeMergedCaretLine(
+        writer,
+        source,
+        gutter_w,
+        primary_col_start,
+        primary_col_end_exclusive,
+        lc.line,
+        secondary,
+        style,
+    );
+    // Stack `|` pointer + label rows under each same-line secondary,
+    // in source order so the first-declared appears closest.
+    try writeSecondaryLabelStack(writer, source, gutter_w, lc.line, secondary, style);
+}
+
+/// Emit the caret / underline row covering both the primary span
+/// and every same-line secondary. Each output column picks its
+/// glyph by source order: primary wins where it overlaps a
+/// secondary; otherwise the first secondary covering the column
+/// supplies the dash / caret.
+fn writeMergedCaretLine(
+    writer: *std.Io.Writer,
+    source: []const u8,
+    gutter_w: usize,
+    primary_start: usize,
+    primary_end_exclusive: usize,
+    line: usize,
+    secondary: []const SpanLabel,
+    style: Style,
+) !void {
+    // Compute the max column the row needs to cover so the trailing
+    // spaces don't run forever — past the last decorated column we
+    // stop emitting characters.
+    var max_col: usize = primary_end_exclusive;
+    for (secondary) |sl| {
+        if (lineOf(source, sl.span.start) != line) continue;
+        const sc = lineColAt(source, sl.span.start);
+        const slen = caretLength(source, sl.span);
+        const end_exc = sc.col + slen;
+        if (end_exc > max_col) max_col = end_exc;
+    }
+
     try writePadGutter(writer, gutter_w, style);
     try writer.writeAll(" | ");
-    // Pad with spaces up to the caret column.
+    var col: usize = 1;
+    var in_caret_style = false;
+    while (col < max_col) : (col += 1) {
+        const in_primary = col >= primary_start and col < primary_end_exclusive;
+        const sec = if (!in_primary) secondaryCovering(source, line, col, secondary) else null;
+        if (in_primary or sec != null) {
+            if (!in_caret_style) {
+                try writer.writeAll(style.caret);
+                in_caret_style = true;
+            }
+            const ch: u8 = if (in_primary) '^' else switch (sec.?.decoration) {
+                .underline => '-',
+                .point => '^',
+            };
+            try writer.writeByte(ch);
+        } else {
+            if (in_caret_style) {
+                try writer.writeAll(style.reset);
+                in_caret_style = false;
+            }
+            try writer.writeByte(' ');
+        }
+    }
+    if (in_caret_style) try writer.writeAll(style.reset);
+    try writer.writeByte('\n');
+}
+
+/// For each same-line secondary, emit a `|` pointer row (carrying
+/// the vertical from the underline upward to its label) and the
+/// label row itself. Pointer rows stack so multiple secondaries
+/// can coexist without their labels colliding.
+fn writeSecondaryLabelStack(
+    writer: *std.Io.Writer,
+    source: []const u8,
+    gutter_w: usize,
+    line: usize,
+    secondary: []const SpanLabel,
+    style: Style,
+) !void {
+    for (secondary) |sl| {
+        if (lineOf(source, sl.span.start) != line) continue;
+        const sc = lineColAt(source, sl.span.start);
+
+        // Pointer row: spaces up to col-1, then `|`.
+        try writePadGutter(writer, gutter_w, style);
+        try writer.writeAll(" | ");
+        var i: usize = 1;
+        while (i < sc.col) : (i += 1) try writer.writeByte(' ');
+        try writer.writeAll(style.caret);
+        try writer.writeByte('|');
+        try writer.writeAll(style.reset);
+        try writer.writeByte('\n');
+
+        // Label row: spaces up to col-1, then the message body.
+        try writePadGutter(writer, gutter_w, style);
+        try writer.writeAll(" | ");
+        i = 1;
+        while (i < sc.col) : (i += 1) try writer.writeByte(' ');
+        try writer.writeAll(style.caret);
+        try writer.writeAll(sl.message);
+        try writer.writeAll(style.reset);
+        try writer.writeByte('\n');
+    }
+}
+
+/// Cross-line secondaries (`note: …` blocks the spec mockup
+/// shows) get their own `--> path:line:col` excerpt below the
+/// primary block. Each carries a `--> path:line:col`, source line,
+/// underline + the label, mirroring the primary block's shape so
+/// the eye can track which span is which.
+fn writeCrossLineSecondaries(
+    writer: *std.Io.Writer,
+    path: []const u8,
+    source: []const u8,
+    primary: ast.Span,
+    secondary: []const SpanLabel,
+    style: Style,
+) !void {
+    const primary_line = lineOf(source, primary.start);
+    for (secondary) |sl| {
+        const sl_line = lineOf(source, sl.span.start);
+        if (sl_line == primary_line) continue;
+        try writeOneCrossLineSecondary(writer, path, source, sl, style);
+    }
+}
+
+fn writeOneCrossLineSecondary(
+    writer: *std.Io.Writer,
+    path: []const u8,
+    source: []const u8,
+    sl: SpanLabel,
+    style: Style,
+) !void {
+    const lc = lineColAt(source, sl.span.start);
+    const line_slice = lineAt(source, sl.span.start);
+    const gutter_w: usize = digitsOf(lc.line);
+
+    try writer.print("  {s}-->{s} {s}{s}:{d}:{d}{s}\n", .{
+        style.location, style.reset,
+        style.location, path,
+        lc.line,        lc.col,
+        style.reset,
+    });
+    try writePadGutter(writer, gutter_w, style);
+    try writer.writeAll(" |\n");
+    try writer.writeAll(style.gutter);
+    try writeRightPadInt(writer, lc.line, gutter_w);
+    try writer.print(" |{s} {s}\n", .{ style.reset, line_slice });
+
+    try writePadGutter(writer, gutter_w, style);
+    try writer.writeAll(" | ");
     var i: usize = 1;
     while (i < lc.col) : (i += 1) try writer.writeByte(' ');
     try writer.writeAll(style.caret);
-    const caret_len = caretLength(source, span);
+    const dec_char: u8 = switch (sl.decoration) {
+        .underline => '-',
+        .point => '^',
+    };
+    const caret_len = caretLength(source, sl.span);
     var c: usize = 0;
-    while (c < caret_len) : (c += 1) try writer.writeByte('^');
+    while (c < caret_len) : (c += 1) try writer.writeByte(dec_char);
+    try writer.writeByte(' ');
+    try writer.writeAll(sl.message);
     try writer.writeAll(style.reset);
     try writer.writeByte('\n');
+}
+
+/// Source line containing `byte` — same accounting as `lineColAt`
+/// but cheap to call from the per-column merge loop.
+fn lineOf(source: []const u8, byte: u32) usize {
+    return lineColAt(source, byte).line;
+}
+
+/// First secondary span (in source order) that covers column `col`
+/// on `line`. `null` when no same-line secondary overlaps.
+fn secondaryCovering(
+    source: []const u8,
+    line: usize,
+    col: usize,
+    secondary: []const SpanLabel,
+) ?SpanLabel {
+    for (secondary) |sl| {
+        if (lineOf(source, sl.span.start) != line) continue;
+        const sc = lineColAt(source, sl.span.start);
+        const end = sc.col + caretLength(source, sl.span);
+        if (col >= sc.col and col < end) return sl;
+    }
+    return null;
 }
 
 fn writeHelp(writer: *std.Io.Writer, help_msg: []const u8, style: Style) !void {

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -343,6 +343,54 @@ pub const Checker = struct {
         try self.emitSpan("E_TYPE_MISMATCH", span, msg);
     }
 
+    /// Same as `emitMismatch` plus a secondary span pinned to the
+    /// `: T` annotation that drove the expected type. Renderer
+    /// surfaces it as the "expected `T` because of this annotation"
+    /// label under the source line.
+    fn emitMismatchAnnotated(
+        self: *Checker,
+        span: ast.Span,
+        expected_ty: *const types.Type,
+        actual_ty: *const types.Type,
+        annotation_span: ast.Span,
+    ) WalkError!void {
+        const expected_s = try types.render(self.arena, expected_ty.*);
+        const actual_s = try types.render(self.arena, actual_ty.*);
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "type mismatch: expected `{s}`, found `{s}`",
+            .{ expected_s, actual_s },
+        );
+        const label_msg = try std.fmt.allocPrint(
+            self.arena,
+            "expected `{s}` because of this annotation",
+            .{expected_s},
+        );
+        const sec = try self.singleSecondary(annotation_span, label_msg, .underline);
+        try self.diagnostics.append(self.diag_alloc, .{
+            .severity = .fatal,
+            .code = "E_TYPE_MISMATCH",
+            .message = msg,
+            .span = span,
+            .secondary = sec,
+        });
+    }
+
+    /// Allocate a single-element `SpanLabel` slice on `self.arena`
+    /// — the typical shape for diagnostics with one context span.
+    /// Lives long enough to back the `Diagnostic.secondary` field
+    /// (arena released by `CheckedProgram.deinit`).
+    fn singleSecondary(
+        self: *Checker,
+        span: ast.Span,
+        message: []const u8,
+        decoration: diag_mod.SpanLabel.Decoration,
+    ) WalkError![]const diag_mod.SpanLabel {
+        const sec = try self.arena.alloc(diag_mod.SpanLabel, 1);
+        sec[0] = .{ .span = span, .message = message, .decoration = decoration };
+        return sec;
+    }
+
     /// Combined assignability + narrowing check for "store into a
     /// typed slot" sites (let-init, assignment, call arg, return).
     /// Routes the diagnostic per spec §3.5.1:
@@ -589,8 +637,14 @@ pub const Checker = struct {
                     "`{s}` is already defined in this scope",
                     .{name},
                 );
-                try self.emitSpan("E_TYPE_REDEFINED", info.decl_span, msg);
-                _ = existing;
+                const sec = try self.singleSecondary(existing.decl_span, "previous definition here", .underline);
+                try self.diagnostics.append(self.diag_alloc, .{
+                    .severity = .fatal,
+                    .code = "E_TYPE_REDEFINED",
+                    .message = msg,
+                    .span = info.decl_span,
+                    .secondary = sec,
+                });
                 return;
             },
             error.OutOfMemory => return error.OutOfMemory,
@@ -736,7 +790,19 @@ pub const Checker = struct {
         else
             null;
         if (ann_ty != null and init_ty != null) {
-            try self.checkStoreCompat(d.init.?.span(), ann_ty.?, init_ty.?);
+            // Hard mismatches on an annotated `let` attach the
+            // annotation as a secondary span so the renderer
+            // surfaces "expected `T` because of this annotation"
+            // — sole call site that overrides the plain
+            // `checkStoreCompat` path (#254 AC).
+            if (!relations.assignable(init_ty.?.*, ann_ty.?.*) and
+                !relations.isNarrowingInt(init_ty.?.*, ann_ty.?.*) and
+                d.type_ann != null)
+            {
+                try self.emitMismatchAnnotated(d.init.?.span(), ann_ty.?, init_ty.?, d.type_ann.?.span());
+            } else {
+                try self.checkStoreCompat(d.init.?.span(), ann_ty.?, init_ty.?);
+            }
         }
         switch (d.pattern.*) {
             .ident => |i| {
@@ -1875,14 +1941,34 @@ pub const Checker = struct {
         // Suggestion across struct + class registries — whichever
         // resolves the type name supplies the field pool. Misses
         // (no candidate within distance 2, or unknown type) fall
-        // through to the bare diagnostic.
-        const candidate: ?[]const u8 = if (self.struct_registry.get(type_name)) |sd|
-            try self.suggestStructField(sd, field_name)
-        else if (self.class_registry.get(type_name)) |cd|
-            try self.suggestClassField(cd, field_name)
+        // through to the bare diagnostic. The same lookup yields
+        // the type's declaration span, which doubles as the
+        // secondary "type defined here" anchor.
+        var candidate: ?[]const u8 = null;
+        var type_decl_span: ?ast.Span = null;
+        if (self.struct_registry.get(type_name)) |sd| {
+            candidate = try self.suggestStructField(sd, field_name);
+            type_decl_span = sd.name;
+        } else if (self.class_registry.get(type_name)) |cd| {
+            candidate = try self.suggestClassField(cd, field_name);
+            type_decl_span = cd.name;
+        }
+        const help: ?[]const u8 = if (candidate) |c|
+            try std.fmt.allocPrint(self.arena, "did you mean `{s}`?", .{c})
         else
             null;
-        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_FIELD", span, msg, candidate);
+        const secondary: []const diag_mod.SpanLabel = if (type_decl_span) |ts|
+            try self.singleSecondary(ts, try std.fmt.allocPrint(self.arena, "type `{s}` defined here", .{type_name}), .underline)
+        else
+            &.{};
+        try self.diagnostics.append(self.diag_alloc, .{
+            .severity = .fatal,
+            .code = "E_TYPE_UNDEFINED_FIELD",
+            .message = msg,
+            .span = span,
+            .help = help,
+            .secondary = secondary,
+        });
     }
 
     /// Type-check a method call against the class registry.

--- a/tests/lang/render.test.zig
+++ b/tests/lang/render.test.zig
@@ -268,6 +268,56 @@ test "render: cross-line secondary emits its own `-->` excerpt block" {
     try std.testing.expect(std.mem.indexOf(u8, out, "previous definition here") != null);
 }
 
+test "render: two same-line secondaries each get their own pointer + label stack" {
+    // `let x: i16 = "hi"`
+    //  0    5  8   13  17
+    // Two non-overlapping secondaries on the same line. Both
+    // should draw their underline + their own `|` / label rows.
+    const source = "let x: i16 = \"hi\"";
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "type mismatch",
+        .span = .{ .start = 13, .end = 17 },
+        .secondary = &[_]gero.lang.SpanLabel{
+            .{ .span = .{ .start = 4, .end = 5 }, .message = "binding declared here" },
+            .{ .span = .{ .start = 7, .end = 10 }, .message = "annotation pins the type" },
+        },
+    };
+    const file: FileDiagnostics = .{ .path = "x.gr", .source = source, .diagnostics = &.{d} };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "binding declared here") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "annotation pins the type") != null);
+}
+
+test "render: secondary `Decoration.point` uses caret glyphs instead of dashes" {
+    const source = "let x: i16 = \"hi\"";
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "type mismatch",
+        .span = .{ .start = 13, .end = 17 },
+        .secondary = &[_]gero.lang.SpanLabel{
+            .{
+                .span = .{ .start = 7, .end = 10 },
+                .message = "carets, not dashes",
+                .decoration = .point,
+            },
+        },
+    };
+    const file: FileDiagnostics = .{ .path = "x.gr", .source = source, .diagnostics = &.{d} };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+
+    // With `.point`, the secondary draws `^` — so there is NO `-`
+    // anywhere in the output (the primary uses `^` too, and the
+    // header / location lines don't contain dashes).
+    try std.testing.expect(std.mem.indexOf(u8, out, "---") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "carets, not dashes") != null);
+}
+
 test "render: empty `secondary` keeps the existing single-span layout" {
     const source = "let x: i16 = \"hi\"";
     const d = Diagnostic{

--- a/tests/lang/render.test.zig
+++ b/tests/lang/render.test.zig
@@ -213,6 +213,84 @@ test "render: pretty summary names warnings honestly when no errors" {
     try std.testing.expect(std.mem.indexOf(u8, out, "error in") == null);
 }
 
+// ---------- multi-span rendering (#254) ----------
+
+test "render: same-line secondary draws `---` underline + stacked label" {
+    // `let x: i16 = "hi"`
+    //  0    5  8   13  17
+    const source = "let x: i16 = \"hi\"";
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "type mismatch: expected `i16`, found `str`",
+        .span = .{ .start = 13, .end = 17 },
+        .secondary = &[_]gero.lang.SpanLabel{
+            .{
+                .span = .{ .start = 7, .end = 10 },
+                .message = "expected `i16` because of this annotation",
+            },
+        },
+    };
+    const file: FileDiagnostics = .{ .path = "x.gr", .source = source, .diagnostics = &.{d} };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+
+    // Primary carets + secondary dashes on the same line.
+    try std.testing.expect(std.mem.indexOf(u8, out, "---") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "^^^^") != null);
+    // Pointer (`|`) line then the label line stacked under it.
+    // Order matters: pointer first, label second.
+    const ptr_idx = std.mem.indexOf(u8, out, "|\n").?;
+    const label_idx = std.mem.indexOf(u8, out, "expected `i16` because of this annotation").?;
+    try std.testing.expect(label_idx > ptr_idx);
+}
+
+test "render: cross-line secondary emits its own `-->` excerpt block" {
+    const source = "let foo: i16 = 1\nlet foo: i16 = 2";
+    // Primary at the SECOND `foo` (offset 21..24), secondary at the FIRST (offset 4..7).
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_REDEFINED",
+        .message = "`foo` is already defined in this scope",
+        .span = .{ .start = 21, .end = 24 },
+        .secondary = &[_]gero.lang.SpanLabel{
+            .{ .span = .{ .start = 4, .end = 7 }, .message = "previous definition here" },
+        },
+    };
+    const file: FileDiagnostics = .{ .path = "x.gr", .source = source, .diagnostics = &.{d} };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+
+    // Two `-->` blocks — one for the primary, one for the secondary.
+    const first_arrow = std.mem.indexOf(u8, out, "-->").?;
+    try std.testing.expect(std.mem.indexOf(u8, out[first_arrow + 1 ..], "-->") != null);
+    // Inline label after the secondary's dashes.
+    try std.testing.expect(std.mem.indexOf(u8, out, "previous definition here") != null);
+}
+
+test "render: empty `secondary` keeps the existing single-span layout" {
+    const source = "let x: i16 = \"hi\"";
+    const d = Diagnostic{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = "type mismatch",
+        .span = .{ .start = 13, .end = 17 },
+    };
+    const file: FileDiagnostics = .{ .path = "x.gr", .source = source, .diagnostics = &.{d} };
+    const out = try renderPretty(file);
+    defer alloc.free(out);
+
+    // No secondary → no underline, no second `-->`.
+    try std.testing.expect(std.mem.indexOf(u8, out, "---") == null);
+    var arrow_count: usize = 0;
+    var search_from: usize = 0;
+    while (std.mem.indexOf(u8, out[search_from..], "-->")) |idx| {
+        arrow_count += 1;
+        search_from += idx + 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), arrow_count);
+}
+
 test "render: pretty summary mixes `N errors + M warnings` when both present" {
     const err = Diagnostic{
         .severity = .fatal,


### PR DESCRIPTION
## Summary

\`Diagnostic\` now carries a \`secondary: []const SpanLabel\`
slice for the annotated context spans the spec mockups in §5.2 /
§5.3 / §5.9 describe. Same-line secondaries weave into the
primary's caret row + stack pointer / label rows beneath;
cross-line secondaries emit their own \`-->\` excerpt block below
the primary.

## What lands

**Data shape** (\`src/lang/diagnostic.zig\`)
- New \`SpanLabel { span, message, decoration }\` struct.
- \`Decoration\` enum: \`.underline\` (\`-\` glyph, the spec default)
  / \`.point\` (\`^\` to match primary emphasis).
- \`Diagnostic.secondary: []const SpanLabel = &.{}\` —
  backwards-compatible default; existing call sites pass through
  unchanged.

**Renderer** (\`src/lang/render.zig\`)
- \`writeMergedCaretLine\` produces one caret row covering both
  the primary and every same-line secondary; primary wins on
  overlap, otherwise the first secondary covering a column
  supplies the glyph.
- \`writeSecondaryLabelStack\` emits per-secondary \`|\` pointer
  row + label row beneath the caret row, in source order so
  earlier-declared secondaries appear closer to their underline.
- \`writeCrossLineSecondaries\` + \`writeOneCrossLineSecondary\`
  handle the cross-line case — a full \`--> path:line:col\` block
  per secondary, mirroring the primary block's shape.

**Typechecker** (\`src/lang/typecheck.zig\`) — three emission
sites carry secondaries per the issue's AC:

| Code | Secondary span | Label |
|------|---------------|-------|
| \`E_TYPE_MISMATCH\` (let-init) | the \`: T\` annotation | \`expected \`T\` because of this annotation\` |
| \`E_TYPE_REDEFINED\` | prior decl's name | \`previous definition here\` |
| \`E_TYPE_UNDEFINED_FIELD\` | the type's \`decl.name\` | \`type \`T\` defined here\` |

Other emission sites keep an empty \`secondary\` slice — no
visual change.

**Spec drift fix** (\`docs/lang-diagnostics.md\` §5.2) — the
mockup's inline \`found \`str\`\` next to the primary carets is
explicitly future-work; the shipped layout puts the names in
the header (\`expected \`T\`, found \`U\`\`) and uses the secondary
labels for context.

## Acceptance criteria (#254)

- [x] \`Diagnostic\` accepts \`secondary: []SpanLabel\`; existing call sites unchanged
- [x] At least three typechecker sites attach a secondary span
- [x] Same-line secondary renders with \`---\` underline + label
- [x] Cross-line secondary renders with its own \`-->\` block
- [x] All existing render tests pass; new tests cover both same-line + cross-line
- [x] All four release modes pass

## Smoke transcripts

**Same-line** (\`E_TYPE_MISMATCH\`):
\`\`\`
error: type mismatch: expected \`i16\`, found \`str\` [E_TYPE_MISMATCH]
  --> file.gr:2:16
  |
2 |   let x: i16 = \"hello\"
  |          ---   ^^^^^^^
  |          |
  |          expected \`i16\` because of this annotation
\`\`\`

**Cross-line** (\`E_TYPE_REDEFINED\`):
\`\`\`
error: \`foo\` is already defined in this scope [E_TYPE_REDEFINED]
  --> file.gr:2:5
  |
2 | let foo: i16 = 2
  |     ^^^
  --> file.gr:1:5
  |
1 | let foo: i16 = 1
  |     --- previous definition here
\`\`\`

## Test plan

- [x] \`zig build verify\` green
- [x] \`zig build test-modes\` green
- [x] Changeset present (\`lang-multispan-render.md\`)
- [x] No AI attribution in commits

Closes #254.