### PR TITLE
feat(cli): gero repl — interactive gero-lang prompt (closes #223)

### DIFF
--- a/.changeset/cli-repl.md
+++ b/.changeset/cli-repl.md
@@ -1,0 +1,35 @@
+---
+bump: minor
+---
+
+`gero repl` ships — an interactive gero-lang prompt that reads
+lines from stdin, classifies each input (top-level decl /
+prelude binding / per-iteration body), compiles the assembled
+session on every submit, and runs the result on a fresh VM.
+Closes #223.
+
+Input classification:
+
+- `def` / `class` / `struct` / `enum` / `use` / `bake def` /
+  `@ann` → module-scope declaration; persists across the
+  session.
+- `let` / `const` → re-run on every subsequent input so the
+  binding stays visible.
+- Everything else → one-shot body statement in the synthesized
+  `__repl_main`. Bare expressions auto-wrap in `print` so the
+  value lands on stdout; `name(args)` calls don't wrap (their
+  own `print`s surface the result).
+
+Multi-line continuation uses lex-only block-balance — `def` /
+`do` / `if` / `while` / `for` / `repeat` / `class` / `struct` /
+`enum` / `match` openers must match `end` / `until` closers
+before the input compiles. Strings + line comments are skipped
+in the count.
+
+Meta-commands: `.help`, `.quit` / `.exit`, `.reset`, `.dump
+<name>`. Parse / typecheck / codegen failures print diagnostics
+and leave the session source untouched so the prompt survives
+mistakes.
+
+Wired through `apps/gero-cli/{main,cli}.zig`; `docs/cli.md`
+§3.13 documents the surface.

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -21,6 +21,7 @@ pub const Command = enum {
     build,
     disasm,
     info,
+    repl,
 };
 
 /// `--optimize` values per `cli.md` §2.
@@ -138,6 +139,7 @@ fn commandFromStr(s: []const u8) ?Command {
     if (std.mem.eql(u8, s, "build")) return .build;
     if (std.mem.eql(u8, s, "disasm")) return .disasm;
     if (std.mem.eql(u8, s, "info")) return .info;
+    if (std.mem.eql(u8, s, "repl")) return .repl;
     return null;
 }
 
@@ -155,6 +157,7 @@ pub fn commandName(cmd: Command) []const u8 {
         .build => "build",
         .disasm => "disasm",
         .info => "info",
+        .repl => "repl",
     };
 }
 
@@ -172,6 +175,7 @@ fn commandSummary(cmd: Command) []const u8 {
         .build => "Resolve + asm + compile a project",
         .disasm => "Disassemble a .gx into asm",
         .info => "Print the .gx file header",
+        .repl => "Interactive gero-lang prompt",
     };
 }
 
@@ -180,7 +184,7 @@ fn commandSummary(cmd: Command) []const u8 {
 /// discoverable, but split into a separate "planned" section.
 fn commandIsImplemented(cmd: Command) bool {
     return switch (cmd) {
-        .asm_, .run, .info, .disasm, .test_, .check, .fmt, .new, .init, .build => true,
+        .asm_, .run, .info, .disasm, .test_, .check, .fmt, .new, .init, .build, .repl => true,
         .compile, .bench => false,
     };
 }
@@ -337,7 +341,16 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero build --target=vm{s}          {s}# explicit target override (default is the manifest's){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("\nResolves gero.toml via ancestor walk. Run `gero new <name>` to scaffold.\n", .{});
         },
-        else => unreachable, // allow-strict: commandIsImplemented() filtered above
+        .repl => {
+            try out.print("  {s}gero repl{s}\n\n", .{ a.cyan, a.reset });
+            try out.print("{s}META-COMMANDS{s}\n", .{ a.yellow, a.reset });
+            try out.print("  {s}.help{s}                            {s}# this list{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}.quit{s}                            {s}# leave the session{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}.reset{s}                           {s}# drop every binding, start fresh{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}.dump <name>{s}                     {s}# print the source of a previously-defined name{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+        },
+        // allow-strict: commandIsImplemented() filtered above
+        else => unreachable,
     }
 
     try out.print("\n{s}FLAGS{s}\n", .{ a.yellow, a.reset });
@@ -388,6 +401,7 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .new => &.{ .help, .quiet, .color, .no_color },
         .init => &.{ .help, .quiet, .color, .no_color },
         .build => &.{ .help, .target, .quiet, .verbose, .color, .no_color },
+        .repl => &.{ .help, .color, .no_color },
         .compile, .bench => &.{.help},
     };
 }

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -14,6 +14,7 @@ const fmt_cmd = @import("fmt.zig");
 const new_cmd = @import("new.zig");
 const init_cmd = @import("init.zig");
 const build_cmd = @import("build.zig");
+const repl_cmd = @import("repl.zig");
 
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
@@ -87,6 +88,7 @@ pub fn main(init: std.process.Init) !u8 {
         .new => new_cmd.execute(io, arena, parsed.options, stdout, &term),
         .init => init_cmd.execute(io, arena, parsed.options, stdout, &term),
         .build => build_cmd.execute(io, arena, parsed.options, stdout, &term),
+        .repl => repl_cmd.execute(io, arena, parsed.options, stdout, &term),
         else => blk: {
             try term.err("gero {s}: not yet implemented", .{cli.commandName(cmd)});
             break :blk 1;

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -96,19 +96,16 @@ pub fn execute(
 /// Errors during evaluation print diagnostics + leave both
 /// buffers untouched so the user's session survives mistakes.
 ///
-/// Known limitations (deferred follow-ups, not in the v0.3 AC):
+/// `evaluate` runs every parse / typecheck / codegen against a
+/// per-iteration scratch arena so the session arena stays
+/// bounded to the committed source buffers — long sessions
+/// won't accumulate stale allocator pages.
 ///
-/// - The session arena grows monotonically — every parse /
-///   typecheck / codegen accumulates and the REPL never resets.
-///   Fine for typical interactive sessions; long-running editor
-///   integrations may want a per-iteration scratch arena.
-/// - `const X = bake do …` at REPL routes to the prelude
-///   (local-const inside `__repl_main`). Bake codegen only
-///   handles `bake do` at module-scope const-init, so the
-///   compound surfaces `E_CODEGEN_UNSUPPORTED`. Workaround:
-///   define a `bake def` separately, then `const X = my_def()`
-///   at the prompt — the call dispatches through the bake-init
-///   path correctly.
+/// `const X = bake do …` and `const X = my_bake_def(…)` route
+/// to `decls_source` instead of `prelude_source` so the
+/// bake codegen handles them at module-scope. Other `const`
+/// initializers stay in the prelude where local-const init is
+/// the right model.
 const Session = struct {
     arena: std.mem.Allocator,
     stdout: *std.Io.Writer,
@@ -200,19 +197,31 @@ const Session = struct {
 
     /// One REPL submit: classify the leading token + route the
     /// input. Decls (def / class / struct / enum / use / bake def
-    /// / @ann) join `decls_source` at module scope; `let` /
-    /// `const` join `prelude_source` so they re-run on every
-    /// subsequent submit and stay visible; everything else runs
-    /// once in the current iteration's `__repl_main` body.
+    /// / @ann / `const X = bake …`) join `decls_source` at
+    /// module scope; non-bake `let` / `const` join
+    /// `prelude_source` so they re-run on every subsequent submit
+    /// and stay visible; everything else runs once in the current
+    /// iteration's `__repl_main` body.
+    ///
+    /// Per-iteration work allocates from a fresh scratch arena
+    /// that releases at the end of this call — the long-lived
+    /// session arena keeps only the committed source buffers.
     fn evaluate(self: *Session, new_input: []const u8) !void {
         const stripped = std.mem.trim(u8, new_input, " \t\n");
         if (stripped.len == 0) return;
 
-        const kind = classifyInput(stripped);
+        // Scratch arena — every parse / typecheck / codegen
+        // alloc lands here so the session arena doesn't grow
+        // unboundedly across submits. Released on every return.
+        var scratch = std.heap.ArenaAllocator.init(self.arena);
+        defer scratch.deinit();
+        const sa = scratch.allocator();
+
+        const kind = try self.classifyForRoute(sa, stripped);
 
         const decl_input: []const u8 = if (kind == .decl) new_input else "";
         const body_input: []const u8 = if (kind == .body)
-            try self.maybeWrapInPrint(new_input)
+            try self.maybeWrapInPrint(sa, new_input)
         else
             "";
         const prelude_extra: []const u8 = if (kind == .prelude) new_input else "";
@@ -222,7 +231,7 @@ const Session = struct {
         // Each piece is `\n`-terminated to keep the parser's
         // statement-boundary rules happy across joins.
         const source = try std.fmt.allocPrint(
-            self.arena,
+            sa,
             "{s}{s}\ndef __repl_main()\n{s}{s}{s}\nend\n",
             .{
                 self.decls_source.items,
@@ -233,13 +242,13 @@ const Session = struct {
             },
         );
 
-        var stream = gero.lang.tokenize(self.arena, source) catch {
+        var stream = gero.lang.tokenize(sa, source) catch {
             try self.term.err("repl: tokenizer failure", .{});
             return;
         };
         defer stream.deinit();
 
-        var tree = gero.lang.parse(self.arena, source, stream) catch {
+        var tree = gero.lang.parse(sa, source, stream) catch {
             try self.term.err("repl: parse failure", .{});
             return;
         };
@@ -251,7 +260,7 @@ const Session = struct {
             return;
         }
 
-        var checked = gero.lang.typecheck(self.arena, source, &tree.program) catch {
+        var checked = gero.lang.typecheck(sa, source, &tree.program) catch {
             try self.term.err("repl: typecheck failure", .{});
             return;
         };
@@ -261,7 +270,7 @@ const Session = struct {
             return;
         }
 
-        var compiled = gero.lang.compile(self.arena, source, &checked, .{ .entry_name = "__repl_main" }) catch {
+        var compiled = gero.lang.compile(sa, source, &checked, .{ .entry_name = "__repl_main" }) catch {
             try self.term.err("repl: codegen failure", .{});
             return;
         };
@@ -291,33 +300,61 @@ const Session = struct {
     /// already print or whose return is `nil` shouldn't get an
     /// extra `print` wrapping their return value. Pre-parses the
     /// input alone (sub-millisecond) to inspect the AST shape.
-    fn maybeWrapInPrint(self: *Session, input: []const u8) ![]const u8 {
-        const stripped = std.mem.trim(u8, input, " \t\n");
-        if (stripped.len == 0) return try self.arena.dupe(u8, input);
-        if (looksLikeMainBodyStatement(stripped)) return try self.arena.dupe(u8, input);
-
-        // Best-effort AST inspection: if the input parses as a
-        // single `expr_stmt` whose expression is a call or method
-        // call, leave it alone (it executes for effect; the
-        // user's own `print`s inside the callee surface the
-        // value). Anything else gets the `print` wrap.
-        if (try self.inputIsCallStatement(input)) return try self.arena.dupe(u8, input);
-        return try std.fmt.allocPrint(self.arena, "print {s}", .{input});
+    /// State-free; takes the scratch allocator directly.
+    fn maybeWrapInPrint(_: *Session, sa: std.mem.Allocator, input: []const u8) ![]const u8 {
+        return wrapInPrintIfBareExpr(sa, input);
     }
 
-    fn inputIsCallStatement(self: *Session, input: []const u8) !bool {
-        var stream = gero.lang.tokenize(self.arena, input) catch return false;
+    /// Route `const X = bake do …` / `const X = bake_def(…)` to
+    /// `.decl` even though the leading token is `const`. Module-
+    /// scope is where the bake codegen evaluates + serializes the
+    /// result into static data; routing these through the prelude
+    /// would land them inside `__repl_main` as locals where bake
+    /// init isn't supported.
+    fn classifyForRoute(self: *Session, sa: std.mem.Allocator, stripped: []const u8) !Session.InputKind {
+        const base = classifyInput(stripped);
+        if (base != .prelude) return base;
+        if (!startsWithToken(stripped, "const")) return base;
+        if (try constInitIsBake(self, sa, stripped)) return .decl;
+        return base;
+    }
+
+    /// `true` when `stripped` parses as a single `const X = …`
+    /// whose init is `bake do …` or a call to a known bake def.
+    fn constInitIsBake(self: *Session, sa: std.mem.Allocator, stripped: []const u8) !bool {
+        var stream = gero.lang.tokenize(sa, stripped) catch return false;
         defer stream.deinit();
-        var tree = gero.lang.parse(self.arena, input, stream) catch return false;
+        var tree = gero.lang.parse(sa, stripped, stream) catch return false;
         defer tree.deinit();
         if (tree.errors.len > 0) return false;
         if (tree.program.statements.len != 1) return false;
         const stmt = tree.program.statements[0];
-        if (stmt != .expr_stmt) return false;
-        return switch (stmt.expr_stmt.expr.*) {
-            .call, .method_call => true,
+        if (stmt != .const_decl) return false;
+        const init_expr = stmt.const_decl.init;
+        return switch (init_expr.*) {
+            .do_expr => |de| de.is_bake,
+            .call => |c| blk: {
+                if (c.callee.* != .ident) break :blk false;
+                const name = stripped[c.callee.ident.span.start..c.callee.ident.span.end];
+                break :blk self.committedHasBakeDef(name);
+            },
             else => false,
         };
+    }
+
+    /// Cheap textual scan for a `bake def <name>` in the
+    /// committed decls. Used by `constInitIsBake` to decide
+    /// whether a `const X = my_fn()` call hits a known bake def
+    /// and should route to module scope.
+    fn committedHasBakeDef(self: *Session, name: []const u8) bool {
+        var scan: usize = 0;
+        const src = self.decls_source.items;
+        while (std.mem.indexOfPos(u8, src, scan, "bake def ")) |hit| {
+            const after = hit + "bake def ".len;
+            if (after < src.len and matchesIdent(src[after..], name)) return true;
+            scan = hit + "bake def ".len;
+        }
+        return false;
     }
 
     /// Format every lang diagnostic onto the REPL's stderr. Bare
@@ -432,6 +469,37 @@ fn precededByIdent(source: []const u8, i: usize) bool {
 }
 
 // ---------- classify input ----------
+
+/// Wrap `input` in `print …` when it's a bare expression so the
+/// expression's value lands on stdout. Statement shapes (`print
+/// …`, control flow, etc.) and function-call expr_stmts pass
+/// through untouched — the latter would otherwise double-print.
+fn wrapInPrintIfBareExpr(sa: std.mem.Allocator, input: []const u8) ![]const u8 {
+    const stripped = std.mem.trim(u8, input, " \t\n");
+    if (stripped.len == 0) return try sa.dupe(u8, input);
+    if (looksLikeMainBodyStatement(stripped)) return try sa.dupe(u8, input);
+    if (try inputIsCallStatement(sa, input)) return try sa.dupe(u8, input);
+    return try std.fmt.allocPrint(sa, "print {s}", .{input});
+}
+
+/// `true` when `input` parses as a single `expr_stmt(.call |
+/// .method_call)`. Used by the print-wrap heuristic — calls
+/// already execute for effect; wrapping them would print their
+/// return value on top of any `print` inside the callee.
+fn inputIsCallStatement(sa: std.mem.Allocator, input: []const u8) !bool {
+    var stream = gero.lang.tokenize(sa, input) catch return false;
+    defer stream.deinit();
+    var tree = gero.lang.parse(sa, input, stream) catch return false;
+    defer tree.deinit();
+    if (tree.errors.len > 0) return false;
+    if (tree.program.statements.len != 1) return false;
+    const stmt = tree.program.statements[0];
+    if (stmt != .expr_stmt) return false;
+    return switch (stmt.expr_stmt.expr.*) {
+        .call, .method_call => true,
+        else => false,
+    };
+}
 
 /// Decide where one input lands in the session — see
 /// `Session.evaluate` for the routing rules.
@@ -592,6 +660,47 @@ test "repl/classifyInput: `bake do` is an expression, routes to .body" {
     // surfaces it via `print`. Only `bake def` is a decl.
     try testing.expectEqual(Session.InputKind.body, classifyInput("bake do 1 + 2 end"));
     try testing.expectEqual(Session.InputKind.body, classifyInput("bake do"));
+}
+
+test "repl/classifyForRoute: `const X = bake do …` re-routes to .decl" {
+    // Without the re-route a bake-do const would land inside
+    // __repl_main as a local; the bake codegen only handles
+    // module-scope const-init.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var session = Session.init(arena.allocator(), undefined, undefined);
+    const kind = try session.classifyForRoute(arena.allocator(), "const X = bake do 1 + 2 end");
+    try testing.expectEqual(Session.InputKind.decl, kind);
+}
+
+test "repl/classifyForRoute: plain `const X = 42` stays in the prelude" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var session = Session.init(arena.allocator(), undefined, undefined);
+    const kind = try session.classifyForRoute(arena.allocator(), "const X = 42");
+    try testing.expectEqual(Session.InputKind.prelude, kind);
+}
+
+test "repl/classifyForRoute: `const X = my_bake_def()` re-routes to .decl" {
+    // The session has to know `my_fn` is a bake def — seed the
+    // committed decls with the source text the textual scan
+    // looks for.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var session = Session.init(arena.allocator(), undefined, undefined);
+    try session.decls_source.appendSlice(arena.allocator(), "bake def my_fn() -> i16\n  return 7\nend\n");
+    const kind = try session.classifyForRoute(arena.allocator(), "const X = my_fn()");
+    try testing.expectEqual(Session.InputKind.decl, kind);
+}
+
+test "repl/classifyForRoute: `const X = unknown_fn()` stays in .prelude" {
+    // Unknown callee → not a bake def → keep prelude routing so
+    // the regular const-init path runs.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var session = Session.init(arena.allocator(), undefined, undefined);
+    const kind = try session.classifyForRoute(arena.allocator(), "const X = unknown_fn()");
+    try testing.expectEqual(Session.InputKind.prelude, kind);
 }
 
 test "repl/classifyInput: `let` / `const` route to .prelude" {

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -1,0 +1,588 @@
+/// `gero repl` — interactive gero-lang prompt. Reads lines from
+/// stdin into a session source buffer, recompiles on every
+/// submission, runs the result on a fresh VM. Each input
+/// classifies as either a top-level statement (let / const / def /
+/// class / struct / enum / use / print / control-flow) or a bare
+/// expression. Bare expressions get auto-wrapped in `print` so the
+/// value lands on stdout.
+///
+/// Multi-line input is detected by lexer-balance: while the running
+/// open-block count (def / do / if / while / for / repeat / class /
+/// struct / enum) exceeds the running close count (end / until),
+/// the prompt switches to `... ` and accumulates more lines.
+///
+/// Meta-commands:
+///
+///   `.help`       — usage summary
+///   `.quit`       — leave the session (also reached via EOF)
+///   `.reset`      — drop every binding
+///   `.dump <n>`   — print the source text of a previously-defined
+///                   name (`def`, `let`, `const`, etc.)
+const std = @import("std");
+const gero = @import("gero");
+const cli = @import("cli.zig");
+const term_mod = @import("term.zig");
+
+/// Drive `gero repl` end-to-end. Returns the exit code per the
+/// loop's terminating reason — `0` on clean `.quit` / EOF.
+pub fn execute(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+) !u8 {
+    _ = opts;
+    var session = Session.init(arena, stdout, term);
+
+    try session.banner();
+
+    var pending = std.ArrayList(u8).empty;
+    defer pending.deinit(arena);
+    var line_buf = std.ArrayList(u8).empty;
+    defer line_buf.deinit(arena);
+
+    // Stdin reader — same pattern as `gero fmt --stdin` (fmt.zig).
+    var stdin_buf: [256]u8 = undefined;
+    var stdin_reader = std.Io.File.stdin().reader(io, &stdin_buf);
+    const stdin = &stdin_reader.interface;
+
+    while (true) {
+        try session.prompt(pending.items.len > 0);
+        // Flush the prompt synchronously so users see it before
+        // their typing lands on the same line.
+        try stdout.flush();
+        line_buf.clearRetainingCapacity();
+        const eof = try readLine(stdin, arena, &line_buf);
+        if (eof) {
+            try stdout.writeAll("\n");
+            return 0;
+        }
+
+        const line = line_buf.items;
+
+        // Meta-commands fire only when we're not mid-block;
+        // otherwise the `.help` text would land inside the user's
+        // pending def body and confuse the parser later.
+        if (pending.items.len == 0 and isMetaCommand(line)) {
+            switch (try session.dispatchMeta(line)) {
+                .quit => return 0,
+                .continue_loop => continue,
+            }
+        }
+
+        try pending.appendSlice(arena, line);
+        try pending.append(arena, '\n');
+
+        if (!blockBalanced(pending.items)) continue;
+
+        try session.evaluate(pending.items);
+        pending.clearRetainingCapacity();
+    }
+}
+
+/// REPL session state. Two persistent buffers:
+///
+/// - `decls_source` — top-level `def` / `class` / `struct` / `enum`
+///   / `use` / `bake def` decls. Each iteration's compile sees the
+///   full set; commits append on success.
+/// - `prelude_source` — `let` / `const` bindings. The
+///   per-iteration `__repl_main` body re-runs the prelude so a
+///   `let x = 10` from a prior input is visible to a subsequent
+///   `x + 5`. This is the canonical REPL state model — bindings
+///   re-initialize from source each compile, costing one rerun
+///   per input.
+///
+/// Errors during evaluation print diagnostics + leave both
+/// buffers untouched so the user's session survives mistakes.
+const Session = struct {
+    arena: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+    decls_source: std.ArrayList(u8),
+    prelude_source: std.ArrayList(u8),
+
+    const MetaOutcome = enum { quit, continue_loop };
+
+    fn init(arena: std.mem.Allocator, stdout: *std.Io.Writer, term: *term_mod.Term) Session {
+        return .{
+            .arena = arena,
+            .stdout = stdout,
+            .term = term,
+            .decls_source = .empty,
+            .prelude_source = .empty,
+        };
+    }
+
+    fn banner(self: *Session) !void {
+        try self.stdout.print("gero repl — v{s} (type `.help`, `.quit` to leave)\n", .{cli.version_string});
+    }
+
+    fn prompt(self: *Session, continuation: bool) !void {
+        try self.stdout.writeAll(if (continuation) "... " else ">>> ");
+    }
+
+    /// Dispatch a `.` meta-command. Returns `.quit` on `.quit` /
+    /// `.exit`; otherwise the loop continues.
+    fn dispatchMeta(self: *Session, line: []const u8) !MetaOutcome {
+        const trimmed = std.mem.trim(u8, line, " \t");
+        if (std.mem.eql(u8, trimmed, ".quit") or std.mem.eql(u8, trimmed, ".exit")) {
+            return .quit;
+        }
+        if (std.mem.eql(u8, trimmed, ".help")) {
+            try self.stdout.writeAll(
+                "  .help          — this list\n" ++
+                    "  .quit          — leave the session\n" ++
+                    "  .reset         — drop every binding\n" ++
+                    "  .dump <name>   — print the source of a defined name\n",
+            );
+            return .continue_loop;
+        }
+        if (std.mem.eql(u8, trimmed, ".reset")) {
+            self.decls_source.clearRetainingCapacity();
+            self.prelude_source.clearRetainingCapacity();
+            try self.stdout.writeAll("session reset.\n");
+            return .continue_loop;
+        }
+        if (std.mem.startsWith(u8, trimmed, ".dump")) {
+            const rest = std.mem.trim(u8, trimmed[5..], " \t");
+            if (rest.len == 0) {
+                try self.stdout.writeAll("usage: .dump <name>\n");
+                return .continue_loop;
+            }
+            try self.dumpName(rest);
+            return .continue_loop;
+        }
+        try self.term.err("unknown meta-command `{s}` — try `.help`", .{trimmed});
+        return .continue_loop;
+    }
+
+    /// Find a `def name(…)` / `let name` / `const NAME` / `class
+    /// name` / `struct name` / `enum name` in the committed source
+    /// and print the line range covering it. Best-effort textual
+    /// match — sufficient for the REPL's introspection use case
+    /// without standing up a real symbol table.
+    fn dumpName(self: *Session, name: []const u8) !void {
+        const buffers = [_][]const u8{ self.decls_source.items, self.prelude_source.items };
+        const keywords = [_][]const u8{ "def ", "bake def ", "let ", "const ", "class ", "struct ", "enum " };
+        for (buffers) |src| {
+            for (keywords) |kw| {
+                var scan: usize = 0;
+                while (std.mem.indexOfPos(u8, src, scan, kw)) |hit| {
+                    const after = hit + kw.len;
+                    if (after < src.len and matchesIdent(src[after..], name)) {
+                        try printSourceBlock(self.stdout, src, hit);
+                        return;
+                    }
+                    scan = hit + kw.len;
+                }
+            }
+        }
+        try self.term.err("`{s}` not defined in this session", .{name});
+    }
+
+    /// Where one submit's input belongs in the session.
+    const InputKind = enum { decl, prelude, body };
+
+    /// One REPL submit: classify the leading token + route the
+    /// input. Decls (def / class / struct / enum / use / bake def
+    /// / @ann) join `decls_source` at module scope; `let` /
+    /// `const` join `prelude_source` so they re-run on every
+    /// subsequent submit and stay visible; everything else runs
+    /// once in the current iteration's `__repl_main` body.
+    fn evaluate(self: *Session, new_input: []const u8) !void {
+        const stripped = std.mem.trim(u8, new_input, " \t\n");
+        if (stripped.len == 0) return;
+
+        const kind = classifyInput(stripped);
+
+        const decl_input: []const u8 = if (kind == .decl) new_input else "";
+        const body_input: []const u8 = if (kind == .body)
+            try self.maybeWrapInPrint(new_input)
+        else
+            "";
+        const prelude_extra: []const u8 = if (kind == .prelude) new_input else "";
+
+        // Candidate source = committed decls + new decl +
+        // `__repl_main { prelude + new_prelude + body_input }`.
+        // Each piece is `\n`-terminated to keep the parser's
+        // statement-boundary rules happy across joins.
+        const source = try std.fmt.allocPrint(
+            self.arena,
+            "{s}{s}\ndef __repl_main()\n{s}{s}{s}\nend\n",
+            .{
+                self.decls_source.items,
+                decl_input,
+                self.prelude_source.items,
+                prelude_extra,
+                body_input,
+            },
+        );
+
+        var stream = gero.lang.tokenize(self.arena, source) catch {
+            try self.term.err("repl: tokenizer failure", .{});
+            return;
+        };
+        defer stream.deinit();
+
+        var tree = gero.lang.parse(self.arena, source, stream) catch {
+            try self.term.err("repl: parse failure", .{});
+            return;
+        };
+        defer tree.deinit();
+        if (tree.errors.len > 0) {
+            for (tree.errors) |e| {
+                try self.term.err("parse: {s}", .{e.message});
+            }
+            return;
+        }
+
+        var checked = gero.lang.typecheck(self.arena, source, &tree.program) catch {
+            try self.term.err("repl: typecheck failure", .{});
+            return;
+        };
+        defer checked.deinit();
+        if (checked.hasErrors()) {
+            try self.renderLangDiagnostics(source, checked.diagnostics);
+            return;
+        }
+
+        var compiled = gero.lang.compile(self.arena, source, &checked, .{ .entry_name = "__repl_main" }) catch {
+            try self.term.err("repl: codegen failure", .{});
+            return;
+        };
+        defer compiled.deinit();
+        if (compiled.hasErrors()) {
+            for (compiled.diagnostics) |d| try self.term.err("codegen: {s} [{s}]", .{ d.message, d.code });
+            return;
+        }
+
+        // All clean — boot a VM, run until halt / fault, capture
+        // print syscalls into our stdout.
+        try self.runImage(compiled.image);
+
+        // Commit on success. Decls join the module-scope buffer;
+        // `let` / `const` join the prelude. Body statements
+        // (`print`, control flow, bare exprs) don't persist by
+        // design — they're per-iteration.
+        switch (kind) {
+            .decl => try self.decls_source.appendSlice(self.arena, decl_input),
+            .prelude => try self.prelude_source.appendSlice(self.arena, prelude_extra),
+            .body => {},
+        }
+    }
+
+    /// Decide whether to wrap a body-shape input in `print`. The
+    /// auto-wrap is for displaying *values* — function calls that
+    /// already print or whose return is `nil` shouldn't get an
+    /// extra `print` wrapping their return value. Pre-parses the
+    /// input alone (sub-millisecond) to inspect the AST shape.
+    fn maybeWrapInPrint(self: *Session, input: []const u8) ![]const u8 {
+        const stripped = std.mem.trim(u8, input, " \t\n");
+        if (stripped.len == 0) return try self.arena.dupe(u8, input);
+        if (looksLikeMainBodyStatement(stripped)) return try self.arena.dupe(u8, input);
+
+        // Best-effort AST inspection: if the input parses as a
+        // single `expr_stmt` whose expression is a call or method
+        // call, leave it alone (it executes for effect; the
+        // user's own `print`s inside the callee surface the
+        // value). Anything else gets the `print` wrap.
+        if (try self.inputIsCallStatement(input)) return try self.arena.dupe(u8, input);
+        return try std.fmt.allocPrint(self.arena, "print {s}", .{input});
+    }
+
+    fn inputIsCallStatement(self: *Session, input: []const u8) !bool {
+        var stream = gero.lang.tokenize(self.arena, input) catch return false;
+        defer stream.deinit();
+        var tree = gero.lang.parse(self.arena, input, stream) catch return false;
+        defer tree.deinit();
+        if (tree.errors.len > 0) return false;
+        if (tree.program.statements.len != 1) return false;
+        const stmt = tree.program.statements[0];
+        if (stmt != .expr_stmt) return false;
+        return switch (stmt.expr_stmt.expr.*) {
+            .call, .method_call => true,
+            else => false,
+        };
+    }
+
+    /// Format every lang diagnostic onto the REPL's stderr. Bare
+    /// formatting — full caret rendering is overkill for an
+    /// interactive prompt where the source is right above.
+    fn renderLangDiagnostics(self: *Session, source: []const u8, diags: []const gero.lang.Diagnostic) !void {
+        for (diags) |d| {
+            const lc = gero.lang.render.lineColAt(source, d.span.start);
+            // `term.err` already writes the `error:` prefix; we
+            // append the rendered line / column + diagnostic
+            // body without re-prefixing.
+            switch (d.severity) {
+                .fatal => try self.term.err("{d}:{d}: {s} [{s}]", .{ lc.line, lc.col, d.message, d.code }),
+                .warning => try self.term.info("warning {d}:{d}: {s} [{s}]", .{ lc.line, lc.col, d.message, d.code }),
+                .note => try self.term.info("note {d}:{d}: {s} [{s}]", .{ lc.line, lc.col, d.message, d.code }),
+            }
+        }
+    }
+
+    /// Boot a fresh VM on the compiled image and run until halt
+    /// or fault. `int 0x10` (the canonical "print one byte" host
+    /// callback the runtime uses) routes to the REPL's stdout.
+    fn runImage(self: *Session, image: []const u8) !void {
+        const loaded = gero.vm.parseGx(image) catch {
+            try self.term.err("repl: invalid .gx produced by codegen", .{});
+            return;
+        };
+        var vm = gero.vm.VM.init(self.arena);
+        defer vm.deinit();
+        try vm.boot(self.arena, loaded);
+        vm.host = .{ .out = self.stdout };
+
+        while (true) {
+            const result = gero.vm.step(&vm);
+            switch (result) {
+                .cont, .branched => continue,
+                .halted => break,
+                .halted_on_fault => {
+                    try self.term.err("repl: VM faulted at ip=0x{X:0>4}", .{vm.regs.read(.ip)});
+                    break;
+                },
+                .breakpoint => break,
+            }
+        }
+        // Flush so each input's output lands before the next
+        // prompt prints. Print syscalls write through `vm.host.out`
+        // (== `self.stdout`) which buffers internally.
+        try self.stdout.flush();
+    }
+};
+
+// ---------- lex-only block balance ----------
+
+/// `true` when the open-block count in `source` equals the close
+/// count. Used by the multi-line continuation prompt — while
+/// imbalanced, we keep prompting the user for more input. Strings
+/// + line comments are skipped so a `--` line or a "do" literal
+/// inside `"…"` doesn't throw off the count.
+fn blockBalanced(source: []const u8) bool {
+    var depth: i32 = 0;
+    var i: usize = 0;
+    while (i < source.len) {
+        const c = source[i];
+        if (c == '-' and i + 1 < source.len and source[i + 1] == '-') {
+            // Skip line comment.
+            while (i < source.len and source[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '"') {
+            // Skip string literal (respects `\"` escapes).
+            i += 1;
+            while (i < source.len and source[i] != '"') {
+                if (source[i] == '\\' and i + 1 < source.len) i += 1;
+                i += 1;
+            }
+            if (i < source.len) i += 1;
+            continue;
+        }
+        if (isIdentStart(c) and !precededByIdent(source, i)) {
+            const start = i;
+            while (i < source.len and isIdentCont(source[i])) i += 1;
+            const tok = source[start..i];
+            depth += blockDelta(tok);
+            continue;
+        }
+        i += 1;
+    }
+    return depth <= 0;
+}
+
+fn blockDelta(tok: []const u8) i32 {
+    // `else` / `elif` are mid-block markers and the parser handles
+    // them as part of the surrounding if-chain; ignored here.
+    const opens = [_][]const u8{ "def", "do", "if", "while", "for", "repeat", "class", "struct", "enum", "match" };
+    const closes = [_][]const u8{ "end", "until" };
+    for (opens) |o| if (std.mem.eql(u8, tok, o)) return 1;
+    for (closes) |c| if (std.mem.eql(u8, tok, c)) return -1;
+    return 0;
+}
+
+fn isIdentStart(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or c == '_';
+}
+
+fn isIdentCont(c: u8) bool {
+    return isIdentStart(c) or (c >= '0' and c <= '9');
+}
+
+fn precededByIdent(source: []const u8, i: usize) bool {
+    if (i == 0) return false;
+    return isIdentCont(source[i - 1]);
+}
+
+// ---------- classify input ----------
+
+/// Decide where one input lands in the session — see
+/// `Session.evaluate` for the routing rules.
+fn classifyInput(stripped: []const u8) Session.InputKind {
+    if (stripped.len == 0) return .body;
+    if (stripped[0] == '@') return .decl;
+    if (startsWithToken(stripped, "let") or startsWithToken(stripped, "const")) {
+        return .prelude;
+    }
+    const decl_heads = [_][]const u8{ "def", "class", "struct", "enum", "use", "bake", "local" };
+    for (decl_heads) |h| {
+        if (startsWithToken(stripped, h)) return .decl;
+    }
+    return .body;
+}
+
+/// `true` when `stripped` is a statement-shape codegen handles
+/// inside a `def` body — `print`, control flow, assignments,
+/// etc. Anything else gets wrapped in `print` so the
+/// expression's value lands on stdout.
+fn looksLikeMainBodyStatement(stripped: []const u8) bool {
+    if (stripped.len == 0) return false;
+    if (stripped[0] == '_') return true;
+    const heads = [_][]const u8{ "print", "if", "while", "for", "repeat", "match", "return", "break", "continue", "defer", "do" };
+    for (heads) |h| {
+        if (startsWithToken(stripped, h)) return true;
+    }
+    return false;
+}
+
+fn startsWithToken(s: []const u8, kw: []const u8) bool {
+    if (!std.mem.startsWith(u8, s, kw)) return false;
+    if (s.len == kw.len) return true;
+    return !isIdentCont(s[kw.len]);
+}
+
+// ---------- meta-command + helpers ----------
+
+fn isMetaCommand(line: []const u8) bool {
+    const trimmed = std.mem.trim(u8, line, " \t");
+    return trimmed.len > 0 and trimmed[0] == '.';
+}
+
+fn matchesIdent(text: []const u8, name: []const u8) bool {
+    if (!std.mem.startsWith(u8, text, name)) return false;
+    if (text.len == name.len) return true;
+    return !isIdentCont(text[name.len]);
+}
+
+/// Print the source block starting at `hit` — typically a
+/// `def name(…) … end` or `let name = …` line. For multi-line
+/// blocks we walk forward until block-balance closes.
+fn printSourceBlock(stdout: *std.Io.Writer, source: []const u8, hit: usize) !void {
+    var i = hit;
+    var seen_open = false;
+    var depth: i32 = 0;
+    while (i < source.len) {
+        const c = source[i];
+        if (c == '\n' and (seen_open and depth <= 0)) {
+            try stdout.writeAll(source[hit..i]);
+            try stdout.writeByte('\n');
+            return;
+        }
+        if (isIdentStart(c) and !precededByIdent(source, i)) {
+            const start = i;
+            while (i < source.len and isIdentCont(source[i])) i += 1;
+            const tok = source[start..i];
+            const d = blockDelta(tok);
+            if (d > 0) seen_open = true;
+            depth += d;
+            continue;
+        }
+        if (c == '\n' and !seen_open) {
+            // Single-line let / const — print up to here.
+            try stdout.writeAll(source[hit..i]);
+            try stdout.writeByte('\n');
+            return;
+        }
+        i += 1;
+    }
+    try stdout.writeAll(source[hit..]);
+    try stdout.writeByte('\n');
+}
+
+// ---------- stdin reader ----------
+
+fn readLine(reader: *std.Io.Reader, arena: std.mem.Allocator, out: *std.ArrayList(u8)) !bool {
+    while (true) {
+        const byte = reader.takeByte() catch |err| switch (err) {
+            error.EndOfStream => return out.items.len == 0,
+            else => return err,
+        };
+        if (byte == '\n') return false;
+        if (byte == '\r') continue;
+        try out.append(arena, byte);
+    }
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "repl/blockBalanced: balanced single-line is true" {
+    try testing.expect(blockBalanced("let x = 10\n"));
+    try testing.expect(blockBalanced("def foo() end\n"));
+    try testing.expect(blockBalanced("if x do print x end\n"));
+}
+
+test "repl/blockBalanced: open `def` without `end` is false" {
+    try testing.expect(!blockBalanced("def foo()\n"));
+    try testing.expect(!blockBalanced("def foo()\n  print x\n"));
+}
+
+test "repl/blockBalanced: `do` / `end` count past nested blocks" {
+    try testing.expect(blockBalanced("def foo()\n  if x do print x end\nend\n"));
+    try testing.expect(!blockBalanced("def foo()\n  if x do print x\nend\n"));
+}
+
+test "repl/blockBalanced: `repeat` closes on `until`" {
+    try testing.expect(blockBalanced("repeat\n  print x\nuntil x > 0\n"));
+    try testing.expect(!blockBalanced("repeat\n  print x\n"));
+}
+
+test "repl/blockBalanced: string literals don't perturb the count" {
+    try testing.expect(blockBalanced("let s = \"def end do\"\n"));
+}
+
+test "repl/blockBalanced: line comments don't perturb the count" {
+    try testing.expect(blockBalanced("let x = 10 -- def end do\n"));
+}
+
+test "repl/classifyInput: top-level decls route to .decl" {
+    try testing.expectEqual(Session.InputKind.decl, classifyInput("def foo() end"));
+    try testing.expectEqual(Session.InputKind.decl, classifyInput("class Foo end"));
+    try testing.expectEqual(Session.InputKind.decl, classifyInput("struct Stats x: i16 end"));
+    try testing.expectEqual(Session.InputKind.decl, classifyInput("enum Color case Red"));
+    try testing.expectEqual(Session.InputKind.decl, classifyInput("use mem"));
+    try testing.expectEqual(Session.InputKind.decl, classifyInput("@cold"));
+    try testing.expectEqual(Session.InputKind.decl, classifyInput("bake def t() -> i16 return 0 end"));
+}
+
+test "repl/classifyInput: `let` / `const` route to .prelude" {
+    try testing.expectEqual(Session.InputKind.prelude, classifyInput("let x = 10"));
+    try testing.expectEqual(Session.InputKind.prelude, classifyInput("const N = 42"));
+}
+
+test "repl/classifyInput: bare expressions + statements route to .body" {
+    try testing.expectEqual(Session.InputKind.body, classifyInput("x + 5"));
+    try testing.expectEqual(Session.InputKind.body, classifyInput("print x"));
+    try testing.expectEqual(Session.InputKind.body, classifyInput("foo(42)"));
+    try testing.expectEqual(Session.InputKind.body, classifyInput("if x do end"));
+    try testing.expectEqual(Session.InputKind.body, classifyInput(""));
+}
+
+test "repl/startsWithToken: distinguishes prefix from identifier" {
+    try testing.expect(startsWithToken("let x = 10", "let"));
+    try testing.expect(!startsWithToken("letter", "let"));
+    try testing.expect(startsWithToken("let", "let"));
+}
+
+test "repl/looksLikeMainBodyStatement: recognizes the body shapes" {
+    try testing.expect(looksLikeMainBodyStatement("print x"));
+    try testing.expect(looksLikeMainBodyStatement("if x do end"));
+    try testing.expect(looksLikeMainBodyStatement("for i in 0..10 end"));
+    try testing.expect(looksLikeMainBodyStatement("_ = x"));
+    try testing.expect(!looksLikeMainBodyStatement("1 + 2"));
+    try testing.expect(!looksLikeMainBodyStatement("greet(42)"));
+}

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -95,6 +95,20 @@ pub fn execute(
 ///
 /// Errors during evaluation print diagnostics + leave both
 /// buffers untouched so the user's session survives mistakes.
+///
+/// Known limitations (deferred follow-ups, not in the v0.3 AC):
+///
+/// - The session arena grows monotonically — every parse /
+///   typecheck / codegen accumulates and the REPL never resets.
+///   Fine for typical interactive sessions; long-running editor
+///   integrations may want a per-iteration scratch arena.
+/// - `const X = bake do …` at REPL routes to the prelude
+///   (local-const inside `__repl_main`). Bake codegen only
+///   handles `bake do` at module-scope const-init, so the
+///   compound surfaces `E_CODEGEN_UNSUPPORTED`. Workaround:
+///   define a `bake def` separately, then `const X = my_def()`
+///   at the prompt — the call dispatches through the bake-init
+///   path correctly.
 const Session = struct {
     arena: std.mem.Allocator,
     stdout: *std.Io.Writer,
@@ -427,11 +441,25 @@ fn classifyInput(stripped: []const u8) Session.InputKind {
     if (startsWithToken(stripped, "let") or startsWithToken(stripped, "const")) {
         return .prelude;
     }
-    const decl_heads = [_][]const u8{ "def", "class", "struct", "enum", "use", "bake", "local" };
+    // `bake def …` is a top-level decl; `bake do … end` is an
+    // expression that should run in __repl_main body (the
+    // auto-wrap then surfaces its value via `print`). Peek the
+    // token after `bake` to pick.
+    if (startsWithToken(stripped, "bake")) {
+        const after = trimLeadingWhitespace(stripped["bake".len..]);
+        return if (startsWithToken(after, "def")) .decl else .body;
+    }
+    const decl_heads = [_][]const u8{ "def", "class", "struct", "enum", "use", "local" };
     for (decl_heads) |h| {
         if (startsWithToken(stripped, h)) return .decl;
     }
     return .body;
+}
+
+fn trimLeadingWhitespace(s: []const u8) []const u8 {
+    var i: usize = 0;
+    while (i < s.len and (s[i] == ' ' or s[i] == '\t' or s[i] == '\n' or s[i] == '\r')) i += 1;
+    return s[i..];
 }
 
 /// `true` when `stripped` is a statement-shape codegen handles
@@ -557,6 +585,13 @@ test "repl/classifyInput: top-level decls route to .decl" {
     try testing.expectEqual(Session.InputKind.decl, classifyInput("use mem"));
     try testing.expectEqual(Session.InputKind.decl, classifyInput("@cold"));
     try testing.expectEqual(Session.InputKind.decl, classifyInput("bake def t() -> i16 return 0 end"));
+}
+
+test "repl/classifyInput: `bake do` is an expression, routes to .body" {
+    // `bake do … end` produces a value; the REPL's auto-wrap
+    // surfaces it via `print`. Only `bake def` is a decl.
+    try testing.expectEqual(Session.InputKind.body, classifyInput("bake do 1 + 2 end"));
+    try testing.expectEqual(Session.InputKind.body, classifyInput("bake do"));
 }
 
 test "repl/classifyInput: `let` / `const` route to .prelude" {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,9 +19,9 @@ Discover the command list with `gero --help`. Discover per-command
 flags with `gero <cmd> --help`.
 
 A single `gero` binary covers asm, compile, run, test, bench, fmt,
-check, build, disasm, info. The bare-VM runtime is the only target
-this repo produces — fantasy-console hosts (e.g. gtx-16) live
-downstream and consume `.gx` files as library inputs.
+check, build, disasm, info, repl. The bare-VM runtime is the only
+target this repo produces — fantasy-console hosts (e.g. gtx-16)
+live downstream and consume `.gx` files as library inputs.
 
 ---
 
@@ -538,6 +538,49 @@ prints `not yet implemented` and exits non-zero.
 | `gero debug <file.gx>` | Interactive debugger — needs a real-mode UX design pass. |
 | `gero repl` | REPL on a 16-bit VM is awkward — no clear use case yet. |
 | `gero doc` | Docgen from `///` comments — waits for a substantial stdlib. |
+
+---
+
+### 3.13 `gero repl` — interactive gero-lang prompt
+
+Read-eval-print loop for gero-lang. Reads stdin lines into a
+session source buffer, recompiles + runs each input on a fresh
+VM. State persists across inputs.
+
+```bash
+gero repl                          # interactive prompt; .quit / EOF to leave
+```
+
+**Input classification**:
+
+- `def` / `class` / `struct` / `enum` / `use` / `bake def` / `@ann`
+  → module-scope declaration; persists across the session.
+- `let` / `const` → re-run on every subsequent input so the
+  binding stays visible.
+- Anything else → runs once in the current iteration's
+  `__repl_main` body. Bare expressions get auto-wrapped in
+  `print` so the value lands on stdout; `name(args)` calls don't
+  wrap (their own `print`s surface the result).
+
+**Multi-line input**: while open-block keywords (`def`, `do`, `if`,
+`while`, `for`, `repeat`, `class`, `struct`, `enum`, `match`)
+exceed close keywords (`end`, `until`), the prompt switches to
+`... ` and accumulates more lines.
+
+**Meta-commands** — all begin with a `.`:
+
+| Command | Effect |
+|---------|--------|
+| `.help` | Print the meta-command list. |
+| `.quit` / `.exit` | Leave the session (EOF also works). |
+| `.reset` | Drop every committed binding. |
+| `.dump <name>` | Print the source of a previously-defined name. |
+
+**Error handling**: parse / typecheck / codegen failures print
+diagnostics and leave the session source untouched, so the user
+keeps typing without restarting.
+
+**Exit**: `0` on clean `.quit` / EOF.
 
 ---
 


### PR DESCRIPTION
## Summary

`gero repl` ships an interactive gero-lang prompt — reads stdin
lines into a session, recompiles + runs each input on a fresh
VM. State persists across submits.

## Design

**Where stuff lives**:
- `apps/gero-cli/repl.zig` — driver, session state, lex-only
  helpers
- `apps/gero-cli/{main, cli}.zig` — `Command.repl` wiring +
  help text
- `docs/cli.md` §3.13 — user-facing surface

No new lang APIs — the REPL drives `gero.lang.{tokenize, parse,
typecheck, compile}` + `gero.vm` end-to-end.

## Per-input classification

The REPL inspects the first token (lex-only) of each submit:

| Shape | Routes to |
|-------|-----------|
| `def` / `class` / `struct` / `enum` / `use` / `bake def` / `@ann` | `decls_source` — module-scope, persists |
| `let` / `const` | `prelude_source` — re-runs in every subsequent `__repl_main` so the binding stays visible |
| Everything else | One-shot in the current iteration's `__repl_main` body |

For one-shot input the REPL pre-parses the line:
- single `expr_stmt(.call | .method_call)` → run as-is (callee owns the print)
- any other `expr_stmt` → wrap in `print` so the value lands on stdout
- statement shapes (`print`, control flow, etc.) → run as-is

## Multi-line continuation

Lex-only `blockBalanced` counts `def` / `do` / `if` / `while` /
`for` / `repeat` / `class` / `struct` / `enum` / `match` opens
vs `end` / `until` closes; the prompt switches to `... ` while
the count is positive. Strings + line comments are skipped so a
`"do … end"` literal or a `-- end` comment doesn't perturb the
count.

## Meta-commands

- `.help` — print the meta-command list
- `.quit` / `.exit` — leave the session (EOF works too)
- `.reset` — drop every committed binding
- `.dump <name>` — print the source of a previously-defined name

## Error handling

Parse / typecheck / codegen failures print diagnostics and
leave both `decls_source` and `prelude_source` untouched, so
the user keeps typing without restarting.

## Acceptance criteria

- [x] `gero repl` starts an interactive prompt
- [x] `let x = 10` followed by `x + 5` prints `15`
- [x] `def greet(n: i16) print n end` defines persistently; later `greet(42)` works
- [x] Multi-line block input handled (continuation prompt)
- [x] Type error doesn't kill the session
- [x] `.quit` exits cleanly
- [x] All four release modes pass

## Smoke transcript

\`\`\`
$ gero repl
gero repl — v0.3.0 (type \`.help\`, \`.quit\` to leave)
>>> let x = 10
>>> x + 5
15
>>> def greet(n: i16)
...   print n
... end
>>> greet(42)
42
>>> let y = bogus
error: 4:9: undefined symbol \`bogus\` [E_UNDEFINED_SYMBOL]
>>> x + 5
15
>>> .quit
\`\`\`

## Test plan

- [x] `zig build verify` green
- [x] `zig build test-modes` green
- [x] Changeset present (`cli-repl.md`)
- [x] No AI attribution in commits

Closes #223. Phase 11 fully shipped.