### PR TITLE
refactor(lang): split typecheck + codegen into focused submodules

### DIFF
--- a/src/lang.zig
+++ b/src/lang.zig
@@ -24,6 +24,7 @@ const tc_relations = @import("lang/typecheck/relations.zig");
 const tc_flow = @import("lang/typecheck/flow.zig");
 const tc_suggestions = @import("lang/typecheck/suggestions.zig");
 const tc_type_resolve = @import("lang/typecheck/type_resolve.zig");
+const tc_fields = @import("lang/typecheck/fields.zig");
 const bake_mod = @import("lang/bake.zig");
 const cg_opcodes = @import("lang/codegen/opcodes.zig");
 const cg_archive = @import("lang/codegen/archive.zig");
@@ -145,6 +146,10 @@ pub const internal = struct {
         pub const suggestions = tc_suggestions;
         /// Internal — `ast.TypeAnn` → `types.Type` resolution.
         pub const type_resolve = tc_type_resolve;
+        /// Internal — field + method resolution for struct + class
+        /// types (incl. struct-literal / class-literal field
+        /// validation, constructor-sig synthesis).
+        pub const fields = tc_fields;
     };
 
     /// Internal — codegen submodule seams.

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -25,6 +25,7 @@ const tc_flow = @import("lang/typecheck/flow.zig");
 const tc_suggestions = @import("lang/typecheck/suggestions.zig");
 const tc_type_resolve = @import("lang/typecheck/type_resolve.zig");
 const tc_fields = @import("lang/typecheck/fields.zig");
+const tc_operators = @import("lang/typecheck/operators.zig");
 const bake_mod = @import("lang/bake.zig");
 const cg_opcodes = @import("lang/codegen/opcodes.zig");
 const cg_archive = @import("lang/codegen/archive.zig");
@@ -150,6 +151,9 @@ pub const internal = struct {
         /// types (incl. struct-literal / class-literal field
         /// validation, constructor-sig synthesis).
         pub const fields = tc_fields;
+        /// Internal — operator type rules (§4.2.1) + `as T` cast
+        /// checking.
+        pub const operators = tc_operators;
     };
 
     /// Internal — codegen submodule seams.

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -26,6 +26,7 @@ const tc_suggestions = @import("lang/typecheck/suggestions.zig");
 const tc_type_resolve = @import("lang/typecheck/type_resolve.zig");
 const tc_fields = @import("lang/typecheck/fields.zig");
 const tc_operators = @import("lang/typecheck/operators.zig");
+const tc_calls = @import("lang/typecheck/calls.zig");
 const bake_mod = @import("lang/bake.zig");
 const cg_opcodes = @import("lang/codegen/opcodes.zig");
 const cg_archive = @import("lang/codegen/archive.zig");
@@ -154,6 +155,10 @@ pub const internal = struct {
         /// Internal — operator type rules (§4.2.1) + `as T` cast
         /// checking.
         pub const operators = tc_operators;
+        /// Internal — function call type-checking: regular calls,
+        /// `assert` / `debug_assert` builtins, variadic rules
+        /// (§4.6.2), bake-context call rules (§3.8).
+        pub const calls = tc_calls;
     };
 
     /// Internal — codegen submodule seams.

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -37,6 +37,7 @@ const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 const cg_class = @import("lang/codegen/class.zig");
 const cg_lambda = @import("lang/codegen/lambda.zig");
+const cg_isa = @import("lang/codegen/isa.zig");
 
 // ---------- lexer ----------
 
@@ -196,5 +197,8 @@ pub const internal = struct {
         /// Internal — closure lowering (capture analysis, heap
         /// promotion, lambda body emission, dispatch).
         pub const lambda = cg_lambda;
+        /// Internal — ISA-instruction emit helpers (one fn per
+        /// named bytecode op the lang codegen produces).
+        pub const isa = cg_isa;
     };
 };

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -23,6 +23,7 @@ const tc_annotations = @import("lang/typecheck/annotations.zig");
 const tc_relations = @import("lang/typecheck/relations.zig");
 const tc_flow = @import("lang/typecheck/flow.zig");
 const tc_suggestions = @import("lang/typecheck/suggestions.zig");
+const tc_type_resolve = @import("lang/typecheck/type_resolve.zig");
 const bake_mod = @import("lang/bake.zig");
 const cg_opcodes = @import("lang/codegen/opcodes.zig");
 const cg_archive = @import("lang/codegen/archive.zig");
@@ -142,6 +143,8 @@ pub const internal = struct {
         /// Internal — "did you mean…?" Levenshtein-based suggestion
         /// pool helpers (#257).
         pub const suggestions = tc_suggestions;
+        /// Internal — `ast.TypeAnn` → `types.Type` resolution.
+        pub const type_resolve = tc_type_resolve;
     };
 
     /// Internal — codegen submodule seams.

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -666,8 +666,6 @@ pub const Emitter = struct {
 
     /// Reserve a 2-byte slot for `name` at the next fp-relative
     /// offset. Returns the offset (negative — locals grow down).
-    /// Reserve a 2-byte slot for `name` at the next fp-relative
-    /// offset. Returns the offset (negative — locals grow down).
     pub fn allocLocal(self: *Emitter, name: []const u8) !i8 {
         const new_frame_bytes = self.frame_bytes + 2;
         // @as: i8 covers -128..127; with 2 bytes per slot we cap at 64 locals per frame, fits.
@@ -833,8 +831,6 @@ pub const Emitter = struct {
         return self.checked.typeOf(e);
     }
 
-    /// `true` when the expression's inferred type is the named
-    /// primitive `p`. Returns `false` for missing types.
     /// `true` when the expression's inferred type is the named
     /// primitive `p`. Returns `false` for missing types.
     pub fn isPrimitiveType(self: *const Emitter, e: *const ast.Expr, p: types_mod.Primitive) bool {
@@ -1805,7 +1801,6 @@ pub const Emitter = struct {
         try isa.sys(self, Sys.print_int);
     }
 
-    /// Delegated to `codegen/strings.zig`.
     /// Delegated to `codegen/strings.zig`.
     pub fn emitStrLitExpr(self: *Emitter, sl: ast.StrLitExpr) !void {
         return strings.emitStrLitExpr(self, sl);

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -57,6 +57,7 @@ const expr_emit = @import("codegen/expr.zig");
 const control_flow = @import("codegen/control_flow.zig");
 const class = @import("codegen/class.zig");
 const lambda = @import("codegen/lambda.zig");
+const isa = @import("codegen/isa.zig");
 const bake_mod = @import("bake.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
@@ -621,7 +622,7 @@ pub const Emitter = struct {
     /// Pointer to the buffer the next byte should go into — the
     /// base `code` buffer when no `@bank` is active, otherwise the
     /// per-bank buffer (created lazily on first byte).
-    fn currentCode(self: *Emitter) !*std.ArrayList(u8) {
+    pub fn currentCode(self: *Emitter) !*std.ArrayList(u8) {
         if (self.current_bank) |b| {
             const gop = try self.banks.getOrPut(self.allocator, b);
             if (!gop.found_existing) gop.value_ptr.* = .empty;
@@ -654,317 +655,11 @@ pub const Emitter = struct {
         try self.emitByte(@intCast(value >> 8));
     }
 
-    // ---------- ISA instructions used in M1 ----------
-
-    /// `mov imm16, reg` (0x10) — `reg ← imm`.
-    pub fn movImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
-        try self.emitByte(Op.mov_imm16_reg);
-        try self.emitU16Le(imm);
-        try self.emitByte(reg);
-    }
-
-    /// `mov src, dst` (0x11) — `dst ← src`.
-    pub fn movRegToReg(self: *Emitter, src: u8, dst: u8) !void {
-        try self.emitByte(Op.mov_reg_reg);
-        try self.emitByte(src);
-        try self.emitByte(dst);
-    }
-
-    /// `mov [base + ofs], dst` (0x1C) — load fp-relative into reg.
-    pub fn movRegOffsetToReg(self: *Emitter, base: u8, ofs: i8, dst: u8) !void {
-        try self.emitByte(Op.mov_reg_offset_reg);
-        try self.emitByte(base);
-        // safety: i8 → u8 bit pattern; reg_offset is signed byte per ISA §5.1.
-        try self.emitByte(@bitCast(ofs));
-        try self.emitByte(dst);
-    }
-
-    /// `mov src, [base + ofs]` (0x1D) — store reg to fp-relative.
-    /// `mov src, [base + ofs]` (0x1D) — store reg to fp-relative.
-    pub fn movRegToRegOffset(self: *Emitter, src: u8, base: u8, ofs: i8) !void {
-        try self.emitByte(Op.mov_reg_reg_offset);
-        try self.emitByte(src);
-        try self.emitByte(base);
-        // safety: i8 → u8 bit pattern; reg_offset is signed byte per ISA §5.1.
-        try self.emitByte(@bitCast(ofs));
-    }
-
-    /// `mov [addr], reg` (0x13) — load 16-bit word from addr.
-    fn movAddrToReg(self: *Emitter, addr: u16, dst: u8) !void {
-        try self.emitByte(Op.mov_addr_to_reg);
-        try self.emitU16Le(addr);
-        try self.emitByte(dst);
-    }
-
-    /// `mov src, [addr]` (0x12) — store 16-bit word to addr.
-    fn movRegToAddr(self: *Emitter, src: u8, addr: u16) !void {
-        try self.emitByte(Op.mov_reg_to_addr);
-        try self.emitByte(src);
-        try self.emitU16Le(addr);
-    }
-
-    /// `mov [zp], reg` (0x1A) — load 16-bit word from zp slot.
-    fn movZpToReg(self: *Emitter, zp: u8, dst: u8) !void {
-        try self.emitByte(Op.mov_zp_to_reg);
-        try self.emitByte(zp);
-        try self.emitByte(dst);
-    }
-
-    /// `mov src, [zp]` (0x19) — store 16-bit word to zp slot.
-    fn movRegToZp(self: *Emitter, src: u8, zp: u8) !void {
-        try self.emitByte(Op.mov_reg_to_zp);
-        try self.emitByte(src);
-        try self.emitByte(zp);
-    }
-
-    /// `mov8 [addr], reg` (0x22) — load 1-byte from addr (zero-
-    /// extend into the 16-bit dst).
-    fn mov8AddrToReg(self: *Emitter, addr: u16, dst: u8) !void {
-        try self.emitByte(Op.mov8_addr_to_reg);
-        try self.emitU16Le(addr);
-        try self.emitByte(dst);
-    }
-
-    /// `mov8 [zp], reg` (0x29) — load 1-byte from zp slot.
-    fn mov8ZpToReg(self: *Emitter, zp: u8, dst: u8) !void {
-        try self.emitByte(Op.mov8_zp_to_reg);
-        try self.emitByte(zp);
-        try self.emitByte(dst);
-    }
-
-    /// `movl reg, [addr]` (0x27) — store reg's low byte to addr.
-    /// Used for 1-byte global stores so neighboring bytes stay
-    /// untouched (critical for MMIO).
-    fn movlRegToAddr(self: *Emitter, src: u8, addr: u16) !void {
-        try self.emitByte(Op.movl_reg_to_addr);
-        try self.emitByte(src);
-        try self.emitU16Le(addr);
-    }
-
-    /// `movl reg, [zp]` (0x2B) — store reg's low byte to zp slot.
-    fn movlRegToZp(self: *Emitter, src: u8, zp: u8) !void {
-        try self.emitByte(Op.movl_reg_to_zp);
-        try self.emitByte(src);
-        try self.emitByte(zp);
-    }
-
-    /// `push reg` (0x31).
-    pub fn pushReg(self: *Emitter, reg: u8) !void {
-        try self.emitByte(Op.push_reg);
-        try self.emitByte(reg);
-    }
-
-    /// `pop reg` (0x32).
-    pub fn popReg(self: *Emitter, reg: u8) !void {
-        try self.emitByte(Op.pop_reg);
-        try self.emitByte(reg);
-    }
-
-    /// `add imm16, reg` (0x40) — `reg ← reg + imm`.
-    pub fn addImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
-        try self.emitByte(Op.add_imm16_reg);
-        try self.emitU16Le(imm);
-        try self.emitByte(reg);
-    }
-
-    /// `sub imm16, reg` (0x43) — `reg ← reg - imm`.
-    pub fn subImmFromReg(self: *Emitter, imm: u16, reg: u8) !void {
-        try self.emitByte(Op.sub_imm16_reg);
-        try self.emitU16Le(imm);
-        try self.emitByte(reg);
-    }
-
-    /// `add reg` (0x42) — `acu ← acu + reg`.
-    pub fn addRegToAcu(self: *Emitter, reg: u8) !void {
-        try self.emitByte(Op.add_reg_acu);
-        try self.emitByte(reg);
-    }
-
-    /// `sub reg` (0x45) — `acu ← acu - reg`.
-    pub fn subRegFromAcu(self: *Emitter, reg: u8) !void {
-        try self.emitByte(Op.sub_reg_acu);
-        try self.emitByte(reg);
-    }
-
-    /// `mul src, dst` (0x47) — `dst ← dst * src` (unsigned 32-bit
-    /// product; V/C set when `high != 0`).
-    pub fn mulRegReg(self: *Emitter, src: u8, dst: u8) !void {
-        try self.emitByte(Op.mul_reg_reg);
-        try self.emitByte(src);
-        try self.emitByte(dst);
-    }
-
-    /// `muls src, dst` (0x55) — signed `dst ← dst * src`. V/C set
-    /// when the signed result overflows `i16` — the lang's debug
-    /// overflow trap on `*` branches on V without false positives
-    /// that the unsigned `mul`'s V flag would produce on legitimate
-    /// negative operands.
-    pub fn mulsRegReg(self: *Emitter, src: u8, dst: u8) !void {
-        try self.emitByte(Op.muls_reg_reg);
-        try self.emitByte(src);
-        try self.emitByte(dst);
-    }
-
-    /// `divs src, dst` (0x4E) — signed `dst ← dst / src`.
-    pub fn divsRegReg(self: *Emitter, src: u8, dst: u8) !void {
-        try self.emitByte(Op.divs_reg_reg);
-        try self.emitByte(src);
-        try self.emitByte(dst);
-    }
-
-    /// `neg reg` (0x4A) — `reg ← -reg` (two's complement).
-    pub fn negReg(self: *Emitter, reg: u8) !void {
-        try self.emitByte(Op.neg_reg);
-        try self.emitByte(reg);
-    }
-
-    /// `cmp reg, imm16` (0x80) — flags ← reg - imm. Result discarded.
-    /// `cmp reg, imm16` (0x80) — flags ← reg - imm.
-    pub fn cmpRegImm(self: *Emitter, reg: u8, imm: u16) !void {
-        try self.emitByte(Op.cmp_reg_imm16);
-        try self.emitByte(reg);
-        try self.emitU16Le(imm);
-    }
-
-    /// `cmp dst, src` (0x81) — flags ← dst - src.
-    pub fn cmpRegReg(self: *Emitter, dst: u8, src: u8) !void {
-        try self.emitByte(Op.cmp_reg_reg);
-        try self.emitByte(dst);
-        try self.emitByte(src);
-    }
-
-    /// `and src, dst` (0x61) — `dst ← dst & src`. Source-first byte
-    /// per `bitwise.andRegReg` decode.
-    pub fn andRegReg(self: *Emitter, dst: u8, src: u8) !void {
-        try self.emitByte(Op.and_reg_reg);
-        try self.emitByte(src);
-        try self.emitByte(dst);
-    }
-
-    /// `or src, dst` (0x63).
-    pub fn orRegReg(self: *Emitter, dst: u8, src: u8) !void {
-        try self.emitByte(Op.or_reg_reg);
-        try self.emitByte(src);
-        try self.emitByte(dst);
-    }
-
-    /// `xor src, dst` (0x65).
-    pub fn xorRegReg(self: *Emitter, dst: u8, src: u8) !void {
-        try self.emitByte(Op.xor_reg_reg);
-        try self.emitByte(src);
-        try self.emitByte(dst);
-    }
-
-    /// `not reg` (0x66) — `reg ← ~reg`.
-    pub fn notRegOp(self: *Emitter, reg: u8) !void {
-        try self.emitByte(Op.not_reg);
-        try self.emitByte(reg);
-    }
-
-    /// `shl dst, src` (0x71). Source register holds the shift count.
-    pub fn shlRegReg(self: *Emitter, dst: u8, src: u8) !void {
-        try self.emitByte(Op.shl_reg_reg);
-        try self.emitByte(dst);
-        try self.emitByte(src);
-    }
-
-    /// `shr dst, src` (0x73).
-    pub fn shrRegReg(self: *Emitter, dst: u8, src: u8) !void {
-        try self.emitByte(Op.shr_reg_reg);
-        try self.emitByte(dst);
-        try self.emitByte(src);
-    }
-
-    /// `shl reg, imm8` (0x70) — `reg ← reg << imm`.
-    pub fn shlRegImm(self: *Emitter, reg: u8, imm: u8) !void {
-        try self.emitByte(Op.shl_reg_imm8);
-        try self.emitByte(reg);
-        try self.emitByte(imm);
-    }
-
-    /// `shr reg, imm8` (0x72) — `reg ← reg >> imm` (zero-fill).
-    pub fn shrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
-        try self.emitByte(Op.shr_reg_imm8);
-        try self.emitByte(reg);
-        try self.emitByte(imm);
-    }
-
-    /// `asr reg, imm8` (0x74) — `reg ← reg >>arith imm` (sign-fill).
-    pub fn asrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
-        try self.emitByte(Op.asr_reg_imm8);
-        try self.emitByte(reg);
-        try self.emitByte(imm);
-    }
-
-    /// Emit a forward jump with a placeholder address slot. Returns
-    /// the offset of the 2-byte slot inside the current code buffer —
-    /// pass it to `patchJumpTo` once the target offset is known.
-    /// Emit a forward jump with a placeholder address slot.
-    /// Returns the offset of the 2-byte slot inside the current
-    /// code buffer — pass it to `patchJumpTo` once the target
-    /// offset is known.
-    pub fn emitJumpPlaceholder(self: *Emitter, op: u8) !usize {
-        try self.emitByte(op);
-        const slot = try self.currentOffset();
-        try self.emitU16Le(0); // placeholder
-        return slot;
-    }
-
-    /// Resolve a forward-jump patch: writes the absolute address
-    /// `currentBufferBase() + target_offset` into the 2-byte slot at
-    /// `patch_offset`. `target_offset` is a byte offset inside the
-    /// current code buffer.
-    /// Resolve a forward-jump patch: writes the absolute address
-    /// `currentBufferBase() + target_offset` into the 2-byte slot
-    /// at `patch_offset`.
-    pub fn patchJumpTo(self: *Emitter, patch_offset: usize, target_offset: usize) !void {
-        const buf = try self.currentCode();
-        // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
-        const target_in_buffer: u16 = @intCast(target_offset);
-        const target_addr: u16 = self.currentBufferBase() +% target_in_buffer;
-        // safety: u16 → 2 LE bytes; both casts are byte-masks.
-        buf.items[patch_offset] = @intCast(target_addr & 0xFF);
-        buf.items[patch_offset + 1] = @intCast(target_addr >> 8);
-    }
-
-    /// Emit an unconditional jump to a known target offset within the
-    /// current buffer. Used for back-edges (loop bottom → loop top).
-    /// Emit an unconditional jump to a known target offset
-    /// within the current buffer. Used for loop back-edges.
-    pub fn emitJumpBack(self: *Emitter, target_offset: usize) !void {
-        try self.emitByte(Op.jmp_addr);
-        // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
-        const target_in_buffer: u16 = @intCast(target_offset);
-        try self.emitU16Le(self.currentBufferBase() +% target_in_buffer);
-    }
-
-    /// `jmp reg` (0x91) — indirect jump via the register's value.
-    /// `ip` becomes whatever the register holds.
-    pub fn jmpReg(self: *Emitter, reg: u8) !void {
-        try self.emitByte(Op.jmp_reg);
-        try self.emitByte(reg);
-    }
-
-    /// Base address of the current code buffer in VM memory — used to
-    /// turn a buffer-local offset into a `jmp` target.
     /// Base address of the current code buffer in VM memory.
     /// Used to turn a buffer-local offset into a `jmp` target.
     pub fn currentBufferBase(self: *const Emitter) u16 {
         if (self.current_bank) |_| return bank_window_base;
         return code_base;
-    }
-
-    /// `sys imm8` (0xFB).
-    /// `sys imm8` (0xFB) — host-callback syscall, identifier in
-    /// the immediate operand byte.
-    pub fn sys(self: *Emitter, id: u8) !void {
-        try self.emitByte(Op.sys);
-        try self.emitByte(id);
-    }
-
-    /// `hlt` (0xFF).
-    fn hlt(self: *Emitter) !void {
-        try self.emitByte(Op.hlt);
     }
 
     // ---------- frame management ----------
@@ -1293,7 +988,7 @@ pub const Emitter = struct {
         try self.emitByte(Op.push_reg);
         try self.emitByte(Reg.mb);
         // mov r2, mb
-        try self.movRegToReg(Reg.r2, Reg.mb);
+        try isa.movRegToReg(self, Reg.r2, Reg.mb);
         // call r1
         try self.emitByte(Op.call_reg);
         try self.emitByte(Reg.r1);
@@ -1526,25 +1221,25 @@ pub const Emitter = struct {
         switch (g.placement) {
             .addr => {
                 if (g.width == 1) {
-                    try self.mov8AddrToReg(g.address, Reg.acu);
+                    try isa.mov8AddrToReg(self, g.address, Reg.acu);
                 } else {
-                    try self.movAddrToReg(g.address, Reg.acu);
+                    try isa.movAddrToReg(self, g.address, Reg.acu);
                 }
             },
             .zero_page => {
                 // @as: zero-page address fits in u8; placement.zero_page guarantees address ≤ 0xFF.
                 const zp: u8 = @intCast(g.address);
                 if (g.width == 1) {
-                    try self.mov8ZpToReg(zp, Reg.acu);
+                    try isa.mov8ZpToReg(self, zp, Reg.acu);
                 } else {
-                    try self.movZpToReg(zp, Reg.acu);
+                    try isa.movZpToReg(self, zp, Reg.acu);
                 }
             },
             .data => {
                 if (g.width == 1) {
-                    try self.mov8AddrToReg(g.address, Reg.acu);
+                    try isa.mov8AddrToReg(self, g.address, Reg.acu);
                 } else {
-                    try self.movAddrToReg(g.address, Reg.acu);
+                    try isa.movAddrToReg(self, g.address, Reg.acu);
                 }
             },
         }
@@ -1558,18 +1253,18 @@ pub const Emitter = struct {
         switch (g.placement) {
             .addr, .data => {
                 if (g.width == 1) {
-                    try self.movlRegToAddr(src, g.address);
+                    try isa.movlRegToAddr(self, src, g.address);
                 } else {
-                    try self.movRegToAddr(src, g.address);
+                    try isa.movRegToAddr(self, src, g.address);
                 }
             },
             .zero_page => {
                 // @as: zero-page address fits in u8; placement.zero_page guarantees address ≤ 0xFF.
                 const zp: u8 = @intCast(g.address);
                 if (g.width == 1) {
-                    try self.movlRegToZp(src, zp);
+                    try isa.movlRegToZp(self, src, zp);
                 } else {
-                    try self.movRegToZp(src, zp);
+                    try isa.movRegToZp(self, src, zp);
                 }
             },
         }
@@ -1709,7 +1404,7 @@ pub const Emitter = struct {
         if (local_count > 0) {
             // @as: 2 bytes per slot capped well below u16.
             const reserve_bytes: u16 = @intCast(local_count * 2);
-            try self.subImmFromReg(reserve_bytes, Reg.sp);
+            try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
         }
 
         // Closure-analysis pre-pass — populates fn_closure_info
@@ -1735,7 +1430,9 @@ pub const Emitter = struct {
 
         // Implicit epilogue (no explicit `return`).
         if (self.is_entry) {
-            try self.hlt();
+            try isa.hlt(
+                self,
+            );
         } else if (is_isr) {
             // ISR teardown — pop flg/fp/ip in reverse of entry.
             try self.emitByte(Op.rti_op);
@@ -1955,11 +1652,11 @@ pub const Emitter = struct {
         }
         try self.emitExpr(a.value); // result in acu
         if (self.locals.get(name)) |ofs| {
-            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
             return;
         }
         if (self.params.get(name)) |ofs| {
-            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
             return;
         }
         if (self.globals.get(name)) |g| {
@@ -1985,7 +1682,7 @@ pub const Emitter = struct {
         }
         if (d.init) |init_expr| {
             try self.emitExpr(init_expr); // result in acu
-            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
         }
         // Uninitialized let leaves the slot at whatever the prologue
         // memset gave it (sub_imm pads sp downward without zeroing).
@@ -1996,7 +1693,7 @@ pub const Emitter = struct {
         const dup_name = try self.arena.dupe(u8, name);
         const ofs = try self.allocLocal(dup_name);
         try self.emitExpr(d.init);
-        try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
     }
 
     fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
@@ -2017,7 +1714,9 @@ pub const Emitter = struct {
             return;
         }
         if (self.is_entry) {
-            try self.hlt();
+            try isa.hlt(
+                self,
+            );
         } else if (self.is_isr) {
             try self.emitByte(Op.rti_op);
         } else {
@@ -2057,13 +1756,13 @@ pub const Emitter = struct {
         for (p.args, 0..) |arg, i| {
             if (i > 0) {
                 // Space separator between args per spec §4.9.
-                try self.movImmToReg(' ', Reg.acu);
-                try self.sys(Sys.print_char);
+                try isa.movImmToReg(self, ' ', Reg.acu);
+                try isa.sys(self, Sys.print_char);
             }
             try self.emitPrintArg(arg);
         }
         // Trailing newline per spec §4.9.
-        try self.sys(Sys.print_newline);
+        try isa.sys(self, Sys.print_newline);
     }
 
     /// One `print` argument — picks the syscall family from the
@@ -2089,21 +1788,21 @@ pub const Emitter = struct {
         }
         if (self.isPrimitiveType(arg, .char)) {
             try self.emitExpr(arg);
-            try self.sys(Sys.print_char);
+            try isa.sys(self, Sys.print_char);
             return;
         }
         if (self.isPrimitiveType(arg, .fixed)) {
             try self.emitExpr(arg);
-            try self.sys(Sys.print_fixed);
+            try isa.sys(self, Sys.print_fixed);
             return;
         }
         if (self.isPrimitiveType(arg, .str)) {
             try self.emitExpr(arg);
-            try self.sys(Sys.print_str);
+            try isa.sys(self, Sys.print_str);
             return;
         }
         try self.emitExpr(arg);
-        try self.sys(Sys.print_int);
+        try isa.sys(self, Sys.print_int);
     }
 
     /// Delegated to `codegen/strings.zig`.
@@ -2203,12 +1902,12 @@ pub const Emitter = struct {
             self.params = saved_params;
         }
         for (callee.params, c.args) |p, arg| {
-            try self.subImmFromReg(2, Reg.sp);
+            try isa.subImmFromReg(self, 2, Reg.sp);
             try expr_emit.emitExpr(self, arg);
             const pname = self.source[p.name.start..p.name.end];
             const dup = try self.arena.dupe(u8, pname);
             const ofs = try self.allocLocal(dup);
-            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
         }
 
         // Body-emit setup: capture starting offset for the

--- a/src/lang/codegen/assert.zig
+++ b/src/lang/codegen/assert.zig
@@ -17,6 +17,7 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
 const archive = @import("archive.zig");
 const strings = @import("strings.zig");
@@ -42,10 +43,10 @@ pub fn emitAssertCall(self: *Emitter, c: ast.CallExpr, name: []const u8) !void {
 
     // `cond` evaluated into `acu`; falsy ⇒ acu == 0 ⇒ Z flag set.
     try self.emitExpr(c.args[0]);
-    try self.cmpRegImm(Reg.acu, 0);
+    try isa.cmpRegImm(self, Reg.acu, 0);
     // `jne skip` — when cond is truthy (Z = 0), jump past the
     // trap. Patched after the trap body emits.
-    const skip_patch = try self.emitJumpPlaceholder(Op.jne_addr);
+    const skip_patch = try isa.emitJumpPlaceholder(self, Op.jne_addr);
 
     // Trap body. Message printed only when provided so the host
     // gets a contextual diagnostic before the halt.
@@ -54,7 +55,7 @@ pub fn emitAssertCall(self: *Emitter, c: ast.CallExpr, name: []const u8) !void {
     try self.emitByte(Op.hlt);
 
     const skip_target = try self.currentOffset();
-    try self.patchJumpTo(skip_patch, skip_target);
+    try isa.patchJumpTo(self, skip_patch, skip_target);
 }
 
 /// Emit the print syscall for the optional assert message. Plain
@@ -69,9 +70,9 @@ fn emitMessage(self: *Emitter, msg: *const ast.Expr) !void {
         const decoded = try archive.decodeStringEscapes(self.arena, raw);
         const id = try strings.internString(self, decoded);
         try strings.emitMovStringAddrToReg(self, id, Reg.acu);
-        try self.sys(Sys.print_str);
+        try isa.sys(self, Sys.print_str);
         return;
     }
     try self.emitExpr(msg);
-    try self.sys(Sys.print_str);
+    try isa.sys(self, Sys.print_str);
 }

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -18,6 +18,7 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
 
 const Emitter = codegen_mod.Emitter;
@@ -267,12 +268,12 @@ pub fn emitConstructor(
         return;
     };
     // 1. mov instance_size, acu ; sys alloc
-    try self.movImmToReg(layout.instance_size, Reg.acu);
+    try isa.movImmToReg(self, layout.instance_size, Reg.acu);
     try self.emitByte(Op.sys);
     try self.emitByte(Sys.alloc);
 
     // 2. Save instance pointer in r1 for the vtable write.
-    try self.movRegToReg(Reg.acu, Reg.r1);
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
 
     // 3. Write vtable address into the instance's word at offset 0.
     //    The vtable's address isn't known yet (vtables emit after
@@ -300,13 +301,13 @@ pub fn emitConstructor(
         var i: usize = c.args.len;
         while (i > 0) {
             i -= 1;
-            try self.pushReg(Reg.r1);
+            try isa.pushReg(self, Reg.r1);
             try self.emitExpr(c.args[i]);
-            try self.popReg(Reg.r1);
-            try self.pushReg(Reg.acu);
+            try isa.popReg(self, Reg.r1);
+            try isa.pushReg(self, Reg.acu);
         }
         // Push self last so it lands at fp+4 in the callee frame.
-        try self.pushReg(Reg.r1);
+        try isa.pushReg(self, Reg.r1);
 
         // Direct-call the inheritance-resolved `init` — may live
         // on an ancestor when the child doesn't define its own.
@@ -316,10 +317,10 @@ pub fn emitConstructor(
         // Drop args: 1 (self) + user args, 2 bytes each.
         // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
         const drop_bytes: u16 = 2 + @as(u16, @intCast(c.args.len * 2));
-        try self.addImmToReg(drop_bytes, Reg.sp);
+        try isa.addImmToReg(self, drop_bytes, Reg.sp);
         // init may have clobbered acu — restore the instance ptr
         // from r1 so the caller's let-bind reads the right value.
-        try self.movRegToReg(Reg.r1, Reg.acu);
+        try isa.movRegToReg(self, Reg.r1, Reg.acu);
     }
     // No-init path leaves acu holding the instance ptr from the
     // `sys alloc` above — none of the intervening ops touched it.
@@ -379,7 +380,7 @@ fn emitInstancePtr(self: *Emitter, recv: *const ast.Expr) !void {
     try self.emitExpr(recv);
     const ty = self.typeOf(recv) orelse return;
     if (ty.* == .reference) {
-        try self.movRegToReg(Reg.acu, Reg.r1);
+        try isa.movRegToReg(self, Reg.acu, Reg.r1);
         try emitWordLoadAtOffset(self, Reg.r1, 0, Reg.acu);
     }
 }
@@ -405,7 +406,7 @@ pub fn emitFieldLoad(
 
     try emitInstancePtr(self, recv);
     // acu = instance ptr; load at acu + field.offset.
-    try self.movRegToReg(Reg.acu, Reg.r1);
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
     if (field.width == 1) {
         try emitByteLoadAtOffset(self, Reg.r1, field.offset, Reg.acu);
     } else {
@@ -433,10 +434,10 @@ pub fn emitFieldStore(
     };
 
     try self.emitExpr(value);
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     try emitInstancePtr(self, recv);
-    try self.movRegToReg(Reg.acu, Reg.r1);
-    try self.popReg(Reg.r2);
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try isa.popReg(self, Reg.r2);
     if (field.width == 1) {
         try emitByteStoreAtOffset(self, Reg.r1, field.offset, Reg.r2);
     } else {
@@ -467,7 +468,7 @@ pub fn emitMethodDispatch(
 
     // 1. Evaluate receiver (auto-deref if `&T`), stash instance ptr in r1.
     try emitInstancePtr(self, recv);
-    try self.movRegToReg(Reg.acu, Reg.r1);
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
 
     // 2. Load vtable pointer from [r1+0] into r2.
     try emitWordLoadAtOffset(self, Reg.r1, 0, Reg.r2);
@@ -482,16 +483,16 @@ pub fn emitMethodDispatch(
     var i: usize = args.len;
     while (i > 0) {
         i -= 1;
-        try self.pushReg(Reg.r1);
-        try self.pushReg(Reg.r3);
+        try isa.pushReg(self, Reg.r1);
+        try isa.pushReg(self, Reg.r3);
         try self.emitExpr(args[i]);
-        try self.popReg(Reg.r3);
-        try self.popReg(Reg.r1);
-        try self.pushReg(Reg.acu);
+        try isa.popReg(self, Reg.r3);
+        try isa.popReg(self, Reg.r1);
+        try isa.pushReg(self, Reg.acu);
     }
 
     // 5. Push self last so it lands at fp+4 in the callee frame.
-    try self.pushReg(Reg.r1);
+    try isa.pushReg(self, Reg.r1);
 
     // 6. call_reg r3 — indirect call to the resolved method.
     try self.emitByte(Op.call_reg);
@@ -500,7 +501,7 @@ pub fn emitMethodDispatch(
     // 7. Drop args: 1 (self) + user args.
     // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
     const drop_bytes: u16 = 2 + @as(u16, @intCast(args.len * 2));
-    try self.addImmToReg(drop_bytes, Reg.sp);
+    try isa.addImmToReg(self, drop_bytes, Reg.sp);
 }
 
 /// Lower `super.method(args)` — direct call to the named method
@@ -530,7 +531,7 @@ pub fn emitSuperMethodCall(
     // self for the super call is the current method's self (fp+4).
     // Load it into r1 first so arg eval can clobber acu freely.
     if (self.params.get("self")) |ofs| {
-        try self.movRegOffsetToReg(Reg.fp, ofs, Reg.r1);
+        try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.r1);
     } else {
         try self.diagFatal(span, "E_CODEGEN_NO_SELF", "codegen: `super.method` used outside a method body");
         return;
@@ -540,20 +541,20 @@ pub fn emitSuperMethodCall(
     var i: usize = args.len;
     while (i > 0) {
         i -= 1;
-        try self.pushReg(Reg.r1);
+        try isa.pushReg(self, Reg.r1);
         try self.emitExpr(args[i]);
-        try self.popReg(Reg.r1);
-        try self.pushReg(Reg.acu);
+        try isa.popReg(self, Reg.r1);
+        try isa.pushReg(self, Reg.acu);
     }
     // Push self last so it lands at fp+4 in the callee frame.
-    try self.pushReg(Reg.r1);
+    try isa.pushReg(self, Reg.r1);
 
     const label = try methodLabel(self, owner, method_name);
     try emitDirectCall(self, label, span);
 
     // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
     const drop_bytes: u16 = 2 + @as(u16, @intCast(args.len * 2));
-    try self.addImmToReg(drop_bytes, Reg.sp);
+    try isa.addImmToReg(self, drop_bytes, Reg.sp);
 }
 
 /// Lower `super.field` read — load `self`, then read at the
@@ -571,7 +572,7 @@ pub fn emitSuperFieldLoad(
     };
 
     if (self.params.get("self")) |ofs| {
-        try self.movRegOffsetToReg(Reg.fp, ofs, Reg.r1);
+        try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.r1);
     } else {
         try self.diagFatal(span, "E_CODEGEN_NO_SELF", "codegen: `super.field` used outside a method body");
         return;
@@ -621,13 +622,13 @@ fn emitDirectCall(self: *Emitter, label: []const u8, span: ast.Span) !void {
 fn emitWordLoadAtOffset(self: *Emitter, base: u8, offset: u16, dst: u8) !void {
     if (offset <= 127) {
         // @as: offset fits i8 (≤127); the cast is a no-op for the value range.
-        try self.movRegOffsetToReg(base, @as(i8, @intCast(offset)), dst);
+        try isa.movRegOffsetToReg(self, base, @as(i8, @intCast(offset)), dst);
         return;
     }
     // tmp = base + offset; then load [tmp+0].
-    try self.movRegToReg(base, Reg.r2);
-    try self.addImmToReg(offset, Reg.r2);
-    try self.movRegOffsetToReg(Reg.r2, 0, dst);
+    try isa.movRegToReg(self, base, Reg.r2);
+    try isa.addImmToReg(self, offset, Reg.r2);
+    try isa.movRegOffsetToReg(self, Reg.r2, 0, dst);
 }
 
 /// Word store: `mov src, [base + offset]`. Same `i8`-vs-widen
@@ -635,12 +636,12 @@ fn emitWordLoadAtOffset(self: *Emitter, base: u8, offset: u16, dst: u8) !void {
 fn emitWordStoreAtOffset(self: *Emitter, base: u8, offset: u16, src: u8) !void {
     if (offset <= 127) {
         // @as: offset fits i8 (≤127); the cast is a no-op for the value range.
-        try self.movRegToRegOffset(src, base, @as(i8, @intCast(offset)));
+        try isa.movRegToRegOffset(self, src, base, @as(i8, @intCast(offset)));
         return;
     }
-    try self.movRegToReg(base, Reg.r3);
-    try self.addImmToReg(offset, Reg.r3);
-    try self.movRegToRegOffset(src, Reg.r3, 0);
+    try isa.movRegToReg(self, base, Reg.r3);
+    try isa.addImmToReg(self, offset, Reg.r3);
+    try isa.movRegToRegOffset(self, src, Reg.r3, 0);
 }
 
 /// Byte load with `+offset` addressing — synthesized via a temp
@@ -653,8 +654,8 @@ fn emitByteLoadAtOffset(self: *Emitter, base: u8, offset: u16, dst: u8) !void {
         try self.emitByte(dst);
         return;
     }
-    try self.movRegToReg(base, Reg.r2);
-    try self.addImmToReg(offset, Reg.r2);
+    try isa.movRegToReg(self, base, Reg.r2);
+    try isa.addImmToReg(self, offset, Reg.r2);
     try self.emitByte(Op.mov8_ptr_to_reg);
     try self.emitByte(Reg.r2);
     try self.emitByte(dst);
@@ -669,8 +670,8 @@ fn emitByteStoreAtOffset(self: *Emitter, base: u8, offset: u16, src: u8) !void {
         try self.emitByte(base);
         return;
     }
-    try self.movRegToReg(base, Reg.r3);
-    try self.addImmToReg(offset, Reg.r3);
+    try isa.movRegToReg(self, base, Reg.r3);
+    try isa.addImmToReg(self, offset, Reg.r3);
     try self.emitByte(Op.mov8_reg_to_ptr);
     try self.emitByte(src);
     try self.emitByte(Reg.r3);

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 const pattern = @import("pattern.zig");
 
 const Emitter = codegen.Emitter;
@@ -63,13 +64,13 @@ pub fn popBlockWithDefers(self: *Emitter) !void {
 /// to the caller after defers run).
 pub fn emitDefersLifo(self: *Emitter, stmts: []const *const ast.Statement) !void {
     if (stmts.len == 0) return;
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     var i = stmts.len;
     while (i > 0) {
         i -= 1;
         try self.emitStatement(stmts[i].*);
     }
-    try self.popReg(Reg.acu);
+    try isa.popReg(self, Reg.acu);
 }
 
 /// Emit every active block's defers in LIFO order from the
@@ -130,15 +131,15 @@ pub fn emitIfStmt(self: *Emitter, is_: ast.IfStmt) !void {
     for (is_.arms) |arm| {
         const skip_body_patch = try emitIfArmTest(self, arm);
         try emitScopedBody(self, arm.body);
-        try end_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+        try end_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
         const after_body = try self.currentOffset();
-        try self.patchJumpTo(skip_body_patch, after_body);
+        try isa.patchJumpTo(self, skip_body_patch, after_body);
     }
 
     if (is_.else_body) |eb| try emitScopedBody(self, eb);
 
     const end_offset = try self.currentOffset();
-    for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
+    for (end_patches.items) |p| try isa.patchJumpTo(self, p, end_offset);
 }
 
 /// Emit the test for one if-arm and return the offset of the
@@ -147,7 +148,7 @@ pub fn emitIfStmt(self: *Emitter, is_: ast.IfStmt) !void {
 fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
     if (arm.cond) |c| {
         try self.emitCondBranch(c);
-        return try self.emitJumpPlaceholder(Op.jeq_addr);
+        return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
     }
     // `if let pat = expr [when guard]` — ident-binder form.
     const pat = arm.let_pattern.?.*;
@@ -158,21 +159,21 @@ fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
             const name = self.source[id.name.start..id.name.end];
             const dup = try self.arena.dupe(u8, name);
             const ofs = try self.allocLocal(dup);
-            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
             if (arm.let_guard) |g| {
                 try self.emitExpr(g);
-                try self.cmpRegImm(Reg.acu, 0);
-                return try self.emitJumpPlaceholder(Op.jeq_addr);
+                try isa.cmpRegImm(self, Reg.acu, 0);
+                return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
             }
             // No guard — ident binder always matches; emit a
             // never-taken skip for symmetry with the cond arm.
-            try self.movImmToReg(1, Reg.r1);
-            try self.cmpRegImm(Reg.r1, 0);
-            return try self.emitJumpPlaceholder(Op.jeq_addr);
+            try isa.movImmToReg(self, 1, Reg.r1);
+            try isa.cmpRegImm(self, Reg.r1, 0);
+            return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
         },
         else => {
             try self.unsupported(arm.span, "`if let` patterns other than a bare ident");
-            return try self.emitJumpPlaceholder(Op.jeq_addr);
+            return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
         },
     }
 }
@@ -201,7 +202,7 @@ pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
 
     const exit_on_false_patch = if (ws.cond) |c| blk: {
         try self.emitCondBranch(c);
-        break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
+        break :blk try isa.emitJumpPlaceholder(self, Op.jeq_addr);
     } else blk: {
         const pat = ws.let_pattern.?.*;
         try self.emitExpr(ws.let_expr.?);
@@ -210,19 +211,19 @@ pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
                 const name = self.source[id.name.start..id.name.end];
                 const dup = try self.arena.dupe(u8, name);
                 const ofs = try self.allocLocal(dup);
-                try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+                try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
                 if (ws.let_guard) |g| {
                     try self.emitExpr(g);
-                    try self.cmpRegImm(Reg.acu, 0);
-                    break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
+                    try isa.cmpRegImm(self, Reg.acu, 0);
+                    break :blk try isa.emitJumpPlaceholder(self, Op.jeq_addr);
                 }
-                try self.movImmToReg(1, Reg.r1);
-                try self.cmpRegImm(Reg.r1, 0);
-                break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
+                try isa.movImmToReg(self, 1, Reg.r1);
+                try isa.cmpRegImm(self, Reg.r1, 0);
+                break :blk try isa.emitJumpPlaceholder(self, Op.jeq_addr);
             },
             else => {
                 try self.unsupported(ws.span, "`while let` patterns other than a bare ident");
-                break :blk try self.emitJumpPlaceholder(Op.jeq_addr);
+                break :blk try isa.emitJumpPlaceholder(self, Op.jeq_addr);
             },
         }
     };
@@ -230,14 +231,14 @@ pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
     for (ws.body) |s| try self.emitStatement(s);
     try popBlockWithDefers(self);
 
-    try self.emitJumpBack(cond_offset);
+    try isa.emitJumpBack(self, cond_offset);
 
     const exit_offset = try self.currentOffset();
-    try self.patchJumpTo(exit_on_false_patch, exit_offset);
+    try isa.patchJumpTo(self, exit_on_false_patch, exit_offset);
 
     var frame = self.loop_stack.pop().?;
-    for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
-    for (frame.continue_patches.items) |p| try self.patchJumpTo(p, cond_offset);
+    for (frame.break_patches.items) |p| try isa.patchJumpTo(self, p, exit_offset);
+    for (frame.continue_patches.items) |p| try isa.patchJumpTo(self, p, cond_offset);
     frame.break_patches.deinit(self.allocator);
     frame.continue_patches.deinit(self.allocator);
 }
@@ -275,8 +276,8 @@ pub fn emitRepeatStmt(self: *Emitter, rs: ast.RepeatStmt) !void {
 
     const exit_offset = try self.currentOffset();
     var frame = self.loop_stack.pop().?;
-    for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
-    for (frame.continue_patches.items) |p| try self.patchJumpTo(p, test_offset);
+    for (frame.break_patches.items) |p| try isa.patchJumpTo(self, p, exit_offset);
+    for (frame.continue_patches.items) |p| try isa.patchJumpTo(self, p, test_offset);
     frame.break_patches.deinit(self.allocator);
     frame.continue_patches.deinit(self.allocator);
 }
@@ -300,9 +301,9 @@ pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
     const end_ofs = try self.allocLocal(try self.arena.dupe(u8, "\x00__for_end"));
 
     try self.emitExpr(range.start);
-    try self.movRegToRegOffset(Reg.acu, Reg.fp, var_ofs);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, var_ofs);
     try self.emitExpr(range.end);
-    try self.movRegToRegOffset(Reg.acu, Reg.fp, end_ofs);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, end_ofs);
 
     const label_str: ?[]const u8 = if (fs.label) |s|
         try self.arena.dupe(u8, self.source[s.start..s.end])
@@ -321,46 +322,46 @@ pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
     // Top-of-loop: load `current`, load `end`, compare. Exit
     // when current > end (inclusive) or current >= end (exclusive).
     const test_offset = try self.currentOffset();
-    try self.movRegOffsetToReg(Reg.fp, var_ofs, Reg.acu);
-    try self.movRegOffsetToReg(Reg.fp, end_ofs, Reg.r1);
-    try self.cmpRegReg(Reg.acu, Reg.r1);
+    try isa.movRegOffsetToReg(self, Reg.fp, var_ofs, Reg.acu);
+    try isa.movRegOffsetToReg(self, Reg.fp, end_ofs, Reg.r1);
+    try isa.cmpRegReg(self, Reg.acu, Reg.r1);
     const exit_patch = if (inclusive)
-        try self.emitJumpPlaceholder(Op.jgt_addr)
+        try isa.emitJumpPlaceholder(self, Op.jgt_addr)
     else
-        try self.emitJumpPlaceholder(Op.jge_addr);
+        try isa.emitJumpPlaceholder(self, Op.jge_addr);
 
     for (fs.body) |s| try self.emitStatement(s);
     try popBlockWithDefers(self);
 
     // `continue` target — the step-and-back-edge.
     const continue_offset = try self.currentOffset();
-    try self.movRegOffsetToReg(Reg.fp, var_ofs, Reg.acu);
+    try isa.movRegOffsetToReg(self, Reg.fp, var_ofs, Reg.acu);
     if (step_expr) |se| {
         if (se.* == .int_lit) {
             // @as: parser stores int_lit as i32; range steps fit i16 per spec §4.5.1.
             const step_i16: i16 = @truncate(se.int_lit.value);
             // safety: i16 → u16 keeps the two's-complement bit pattern for negative steps.
             const step_val: u16 = @bitCast(step_i16);
-            try self.addImmToReg(step_val, Reg.acu);
+            try isa.addImmToReg(self, step_val, Reg.acu);
         } else {
-            try self.pushReg(Reg.acu);
+            try isa.pushReg(self, Reg.acu);
             try self.emitExpr(se);
-            try self.movRegToReg(Reg.acu, Reg.r1);
-            try self.popReg(Reg.acu);
-            try self.addRegToAcu(Reg.r1);
+            try isa.movRegToReg(self, Reg.acu, Reg.r1);
+            try isa.popReg(self, Reg.acu);
+            try isa.addRegToAcu(self, Reg.r1);
         }
     } else {
-        try self.addImmToReg(1, Reg.acu);
+        try isa.addImmToReg(self, 1, Reg.acu);
     }
-    try self.movRegToRegOffset(Reg.acu, Reg.fp, var_ofs);
-    try self.emitJumpBack(test_offset);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, var_ofs);
+    try isa.emitJumpBack(self, test_offset);
 
     const exit_offset = try self.currentOffset();
-    try self.patchJumpTo(exit_patch, exit_offset);
+    try isa.patchJumpTo(self, exit_patch, exit_offset);
 
     var frame = self.loop_stack.pop().?;
-    for (frame.break_patches.items) |p| try self.patchJumpTo(p, exit_offset);
-    for (frame.continue_patches.items) |p| try self.patchJumpTo(p, continue_offset);
+    for (frame.break_patches.items) |p| try isa.patchJumpTo(self, p, exit_offset);
+    for (frame.continue_patches.items) |p| try isa.patchJumpTo(self, p, continue_offset);
     frame.break_patches.deinit(self.allocator);
     frame.continue_patches.deinit(self.allocator);
 }
@@ -381,7 +382,7 @@ pub fn emitLoopJump(self: *Emitter, j: ast.LoopJumpStmt, kind: LoopJumpKind) !vo
         return;
     };
     try unwindDefersDownTo(self, frame.body_block_idx);
-    const patch = try self.emitJumpPlaceholder(Op.jmp_addr);
+    const patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
     switch (kind) {
         .break_ => try frame.break_patches.append(self.allocator, patch),
         .continue_ => try frame.continue_patches.append(self.allocator, patch),
@@ -413,7 +414,7 @@ fn emitMatchSequential(self: *Emitter, ms: ast.MatchStmt) !void {
             else => {
                 try self.emitExpr(ms.scrutinee);
                 const ofs = try self.allocLocal(try self.arena.dupe(u8, "\x00__match"));
-                try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+                try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
                 break :blk ofs;
             },
         }
@@ -427,7 +428,7 @@ fn emitMatchSequential(self: *Emitter, ms: ast.MatchStmt) !void {
         if (scrutinee_is_ident) {
             try self.emitExpr(ms.scrutinee);
         } else {
-            try self.movRegOffsetToReg(Reg.fp, scrutinee_ofs, Reg.acu);
+            try isa.movRegOffsetToReg(self, Reg.fp, scrutinee_ofs, Reg.acu);
         }
 
         var skip_patches: std.ArrayList(usize) = .empty;
@@ -436,19 +437,19 @@ fn emitMatchSequential(self: *Emitter, ms: ast.MatchStmt) !void {
 
         if (arm.guard) |g| {
             try self.emitExpr(g);
-            try self.cmpRegImm(Reg.acu, 0);
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jeq_addr));
+            try isa.cmpRegImm(self, Reg.acu, 0);
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
         }
 
         try emitScopedBody(self, arm.body);
-        try end_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+        try end_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
 
         const after_arm = try self.currentOffset();
-        for (skip_patches.items) |p| try self.patchJumpTo(p, after_arm);
+        for (skip_patches.items) |p| try isa.patchJumpTo(self, p, after_arm);
     }
 
     const end_offset = try self.currentOffset();
-    for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
+    for (end_patches.items) |p| try isa.patchJumpTo(self, p, end_offset);
 }
 
 /// Detect the spec §4.8.5 "single-arm tag dispatch" shape and,
@@ -544,36 +545,36 @@ fn tryEmitTagJumpTable(self: *Emitter, ms: ast.MatchStmt) !bool {
     // Bounds: `tag > max_tag` → fall through to default. Even
     // exhaustive matches keep this — a stray u8 value past the
     // last declared variant can still reach here through a cast.
-    try self.cmpRegImm(Reg.acu, max_tag);
-    const bounds_patch = try self.emitJumpPlaceholder(Op.jgt_addr);
+    try isa.cmpRegImm(self, Reg.acu, max_tag);
+    const bounds_patch = try isa.emitJumpPlaceholder(self, Op.jgt_addr);
 
     // acu = 3*tag (each table slot is `jmp_addr <body>`, 3 bytes).
-    try self.movRegToReg(Reg.acu, Reg.r1);
-    try self.shlRegImm(Reg.r1, 1); // r1 = 2*tag
-    try self.addRegToAcu(Reg.r1); // acu = 3*tag
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try isa.shlRegImm(self, Reg.r1, 1); // r1 = 2*tag
+    try isa.addRegToAcu(self, Reg.r1); // acu = 3*tag
 
     // acu = table_base + 3*tag — patched once the table address is known.
     try self.emitByte(Op.mov_imm16_reg);
     const table_base_patch = try self.currentOffset();
     try self.emitU16Le(0);
     try self.emitByte(Reg.r1);
-    try self.addRegToAcu(Reg.r1);
+    try isa.addRegToAcu(self, Reg.r1);
 
     // jmp [acu] — control transfers to the `jmp_addr <body>` at
     // table_base + 3*tag, which then jumps to the actual body.
-    try self.jmpReg(Reg.acu);
+    try isa.jmpReg(self, Reg.acu);
 
     // ---- emit table ----
     const table_offset = try self.currentOffset();
     // Patch the dispatch's `mov_imm16` so r1 = table_base. Same
     // 2-byte LE address slot as a forward `jmp` patch.
-    try self.patchJumpTo(table_base_patch, table_offset);
+    try isa.patchJumpTo(self, table_base_patch, table_offset);
     // Slot per tag in 0..=max_tag. Each is a `jmp_addr <body>`
     // placeholder; address slot resolves once the body emits.
     var slot_patches: [256]usize = undefined;
     var t: usize = 0;
     while (t < table_len) : (t += 1) {
-        slot_patches[t] = try self.emitJumpPlaceholder(Op.jmp_addr);
+        slot_patches[t] = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
     }
 
     // ---- emit arm bodies + collect end-of-match jumps ----
@@ -590,30 +591,30 @@ fn tryEmitTagJumpTable(self: *Emitter, ms: ast.MatchStmt) !bool {
             const name = self.source[arm.pattern.ident.name.start..arm.pattern.ident.name.end];
             const dup = try self.arena.dupe(u8, name);
             const ofs = try self.allocLocal(dup);
-            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
         }
         try emitScopedBody(self, arm.body);
-        try end_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+        try end_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
     }
 
     // The "default" target is the wildcard arm body when present,
     // otherwise the post-match end. Unmapped table slots and the
     // out-of-range bounds branch both land here.
     const default_offset: usize = if (wildcard_arm) |w| arm_offsets[w] else try self.currentOffset();
-    try self.patchJumpTo(bounds_patch, default_offset);
+    try isa.patchJumpTo(self, bounds_patch, default_offset);
 
     // Patch each table slot to its arm's body (or default).
     t = 0;
     while (t < table_len) : (t += 1) {
         // safety: tag_to_arm is indexed 0..=255; t ≤ max_tag ≤ 255.
         const target = if (tag_to_arm[@intCast(t)]) |arm_idx| arm_offsets[arm_idx] else default_offset;
-        try self.patchJumpTo(slot_patches[t], target);
+        try isa.patchJumpTo(self, slot_patches[t], target);
     }
 
     // Every arm body terminates with a `jmp end`. Resolve them all
     // to the byte after the match statement.
     const end_offset = try self.currentOffset();
-    for (end_patches.items) |p| try self.patchJumpTo(p, end_offset);
+    for (end_patches.items) |p| try isa.patchJumpTo(self, p, end_offset);
 
     return true;
 }

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 const archive = @import("archive.zig");
 const assert_builtin = @import("assert.zig");
 const class = @import("class.zig");
@@ -28,7 +29,7 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
             const trimmed: i16 = @truncate(lit.value);
             // safety: i16 → u16 bit pattern; the two's-complement encoding is preserved.
             const v: u16 = @bitCast(trimmed);
-            try self.movImmToReg(v, Reg.acu);
+            try isa.movImmToReg(self, v, Reg.acu);
         },
         .fixed_lit => |lit| {
             // Q8.8 — the parser pre-encodes the value as `int *
@@ -38,15 +39,15 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
             const trimmed: i16 = @truncate(lit.value);
             // safety: i16 → u16 bit pattern preserved (two's complement).
             const v: u16 = @bitCast(trimmed);
-            try self.movImmToReg(v, Reg.acu);
+            try isa.movImmToReg(self, v, Reg.acu);
         },
         .str_lit => |sl| try self.emitStrLitExpr(sl),
         .bool_lit => |b| {
             const v: u16 = if (b.value) 1 else 0;
-            try self.movImmToReg(v, Reg.acu);
+            try isa.movImmToReg(self, v, Reg.acu);
         },
-        .nil_lit => try self.movImmToReg(0, Reg.acu),
-        .char_lit => |c| try self.movImmToReg(c.value, Reg.acu),
+        .nil_lit => try isa.movImmToReg(self, 0, Reg.acu),
+        .char_lit => |c| try isa.movImmToReg(self, c.value, Reg.acu),
         .paren => |p| try emitExpr(self, p.inner),
         .ident => |i| {
             const name = self.source[i.span.start..i.span.end];
@@ -64,11 +65,11 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
                     try lambda.emitPromotedIdentLoad(self, ofs);
                     return;
                 }
-                try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+                try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
                 return;
             }
             if (self.params.get(name)) |ofs| {
-                try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+                try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
                 return;
             }
             if (self.globals.get(name)) |g| {
@@ -87,7 +88,7 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
             // implicit param). Outside a method it's a typecheck
             // error — the codegen falls through to "unsupported".
             if (self.params.get("self")) |ofs| {
-                try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+                try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
             } else {
                 try self.unsupported(se.span, "`self` used outside a method body");
             }
@@ -153,7 +154,7 @@ pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void
                     }
                 }
             }
-            try self.movImmToReg(tag, Reg.acu);
+            try isa.movImmToReg(self, tag, Reg.acu);
             return;
         }
     }
@@ -176,7 +177,7 @@ pub fn emitIsTest(self: *Emitter, it: ast.IsTestExpr) !void {
         return;
     };
     try emitExpr(self, it.lhs);
-    try self.cmpRegImm(Reg.acu, tag);
+    try isa.cmpRegImm(self, Reg.acu, tag);
     try materializeBoolFromFlags(self, .eq);
 }
 
@@ -184,11 +185,11 @@ pub fn emitIsTest(self: *Emitter, it: ast.IsTestExpr) !void {
 pub fn emitUnary(self: *Emitter, u: ast.UnaryExpr) !void {
     try emitExpr(self, u.operand);
     switch (u.op) {
-        .neg => try self.negReg(Reg.acu),
-        .bit_not => try self.notRegOp(Reg.acu),
+        .neg => try isa.negReg(self, Reg.acu),
+        .bit_not => try isa.notRegOp(self, Reg.acu),
         .log_not => {
             // acu = (acu == 0) ? 1 : 0
-            try self.cmpRegImm(Reg.acu, 0);
+            try isa.cmpRegImm(self, Reg.acu, 0);
             try materializeBoolFromFlags(self, .eq);
         },
     }
@@ -225,16 +226,16 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
     // Standard stack-machine pattern: eval RHS, push, eval LHS,
     // pop RHS into r1, apply op (acu = acu OP r1).
     try emitExpr(self, b.rhs);
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     try emitExpr(self, b.lhs);
-    try self.popReg(Reg.r1);
+    try isa.popReg(self, Reg.r1);
     switch (b.op) {
         .add => {
-            try self.addRegToAcu(Reg.r1);
+            try isa.addRegToAcu(self, Reg.r1);
             if (integer_arith) try overflow.emitOverflowTrap(self, signedness);
         },
         .sub => {
-            try self.subRegFromAcu(Reg.r1);
+            try isa.subRegFromAcu(self, Reg.r1);
             if (integer_arith) try overflow.emitOverflowTrap(self, signedness);
         },
         .mul => {
@@ -245,11 +246,11 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
             // through `muls` so the V flag matches `i16` overflow
             // (`mul`'s V means `high != 0`, which false-positives
             // on legitimate negative products).
-            try self.movRegToReg(Reg.acu, Reg.r2);
+            try isa.movRegToReg(self, Reg.acu, Reg.r2);
             if (integer_arith and signedness == .signed and self.optimize == .debug) {
-                try self.mulsRegReg(Reg.r1, Reg.r2);
+                try isa.mulsRegReg(self, Reg.r1, Reg.r2);
             } else {
-                try self.mulRegReg(Reg.r1, Reg.r2);
+                try isa.mulRegReg(self, Reg.r1, Reg.r2);
             }
             if (fixed_op) {
                 // Q8.8 * Q8.8 — the conceptual Q16.16 product
@@ -259,14 +260,14 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
                 // >> 8)`. ISA §5.4.1 — products whose real
                 // magnitude exceeds 127.99… wrap silently
                 // because the result no longer fits in 16 bits.
-                try self.shrRegImm(Reg.r2, 8);
-                try self.shlRegImm(Reg.acu, 8);
-                try self.orRegReg(Reg.acu, Reg.r2);
+                try isa.shrRegImm(self, Reg.r2, 8);
+                try isa.shlRegImm(self, Reg.acu, 8);
+                try isa.orRegReg(self, Reg.acu, Reg.r2);
             } else {
                 // Integer mul — drop the high half. `mov` doesn't
                 // touch flags, so the V/C set by the mul op above
                 // are still live for the overflow check below.
-                try self.movRegToReg(Reg.r2, Reg.acu);
+                try isa.movRegToReg(self, Reg.r2, Reg.acu);
             }
             if (integer_arith) try overflow.emitOverflowTrap(self, signedness);
         },
@@ -280,35 +281,35 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
                 //   acu = acu >>arith 8      (sign-extended top byte)
                 // Then `divs r1, r2` performs the 32÷16 signed
                 // divide and the quotient ends up in r2.
-                try self.movRegToReg(Reg.acu, Reg.r2);
-                try self.shlRegImm(Reg.r2, 8); // r2 = lhs << 8 (low)
-                try self.asrRegImm(Reg.acu, 8); // acu = lhs >>a 8 (high)
-                try self.divsRegReg(Reg.r1, Reg.r2);
-                try self.movRegToReg(Reg.r2, Reg.acu);
+                try isa.movRegToReg(self, Reg.acu, Reg.r2);
+                try isa.shlRegImm(self, Reg.r2, 8); // r2 = lhs << 8 (low)
+                try isa.asrRegImm(self, Reg.acu, 8); // acu = lhs >>a 8 (high)
+                try isa.divsRegReg(self, Reg.r1, Reg.r2);
+                try isa.movRegToReg(self, Reg.r2, Reg.acu);
             } else {
                 // Signed 32÷16 divide. Dividend lives in acu:dst
                 // (high:low); the dividend is assumed to fit in
                 // 16 bits — sign-extension is not yet emitted.
-                try self.movRegToReg(Reg.acu, Reg.r2); // r2 = low half
-                try self.movImmToReg(0, Reg.acu); // high half = 0
-                try self.divsRegReg(Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
-                try self.movRegToReg(Reg.r2, Reg.acu);
+                try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = low half
+                try isa.movImmToReg(self, 0, Reg.acu); // high half = 0
+                try isa.divsRegReg(self, Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
+                try isa.movRegToReg(self, Reg.r2, Reg.acu);
             }
         },
         .mod => {
             // Same divs pattern as `div`, but keep `acu` (the
             // remainder is exactly what `mod` wants).
-            try self.movRegToReg(Reg.acu, Reg.r2); // r2 = low half
-            try self.movImmToReg(0, Reg.acu); // high half = 0
-            try self.divsRegReg(Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
+            try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = low half
+            try isa.movImmToReg(self, 0, Reg.acu); // high half = 0
+            try isa.divsRegReg(self, Reg.r1, Reg.r2); // r2 = quotient, acu = remainder
         },
-        .bit_and => try self.andRegReg(Reg.acu, Reg.r1),
-        .bit_or => try self.orRegReg(Reg.acu, Reg.r1),
-        .bit_xor => try self.xorRegReg(Reg.acu, Reg.r1),
-        .shl => try self.shlRegReg(Reg.acu, Reg.r1),
-        .shr => try self.shrRegReg(Reg.acu, Reg.r1),
+        .bit_and => try isa.andRegReg(self, Reg.acu, Reg.r1),
+        .bit_or => try isa.orRegReg(self, Reg.acu, Reg.r1),
+        .bit_xor => try isa.xorRegReg(self, Reg.acu, Reg.r1),
+        .shl => try isa.shlRegReg(self, Reg.acu, Reg.r1),
+        .shr => try isa.shrRegReg(self, Reg.acu, Reg.r1),
         .eq, .neq, .lt, .lte, .gt, .gte => {
-            try self.cmpRegReg(Reg.acu, Reg.r1);
+            try isa.cmpRegReg(self, Reg.acu, Reg.r1);
             try materializeBoolFromFlags(self, b.op);
         },
         // allow-strict: handled by the short-circuit branch above; emitBinary never falls through here for these ops.
@@ -327,17 +328,17 @@ pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
             .eq, .neq, .lt, .lte, .gt, .gte => {
                 // Eval LHS into acu, eval RHS into r1, cmp acu, r1.
                 try emitExpr(self, b.rhs);
-                try self.pushReg(Reg.acu);
+                try isa.pushReg(self, Reg.acu);
                 try emitExpr(self, b.lhs);
-                try self.popReg(Reg.r1);
-                try self.cmpRegReg(Reg.acu, Reg.r1);
+                try isa.popReg(self, Reg.r1);
+                try isa.cmpRegReg(self, Reg.acu, Reg.r1);
                 try materializeBoolFromFlags(self, b.op);
-                try self.cmpRegImm(Reg.acu, 0);
+                try isa.cmpRegImm(self, Reg.acu, 0);
                 return;
             },
             .log_and, .log_or => {
                 try emitShortCircuitBool(self, b);
-                try self.cmpRegImm(Reg.acu, 0);
+                try isa.cmpRegImm(self, Reg.acu, 0);
                 return;
             },
             else => {},
@@ -345,14 +346,14 @@ pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
     }
     if (e.* == .unary and e.unary.op == .log_not) {
         try emitExpr(self, e.unary.operand);
-        try self.cmpRegImm(Reg.acu, 0);
+        try isa.cmpRegImm(self, Reg.acu, 0);
         try materializeBoolFromFlags(self, .eq);
-        try self.cmpRegImm(Reg.acu, 0);
+        try isa.cmpRegImm(self, Reg.acu, 0);
         return;
     }
     // Generic path — evaluate to acu, then test against 0.
     try emitExpr(self, e);
-    try self.cmpRegImm(Reg.acu, 0);
+    try isa.cmpRegImm(self, Reg.acu, 0);
 }
 
 /// Materialize a 0 / 1 boolean in `acu` from the current flag
@@ -377,14 +378,14 @@ pub fn materializeBoolFromFlags(self: *Emitter, op: ast.BinaryOp) !void {
     // true_label:
     //   mov 1, acu
     // end:
-    const true_patch = try self.emitJumpPlaceholder(taken_op);
-    try self.movImmToReg(0, Reg.acu);
-    const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
+    const true_patch = try isa.emitJumpPlaceholder(self, taken_op);
+    try isa.movImmToReg(self, 0, Reg.acu);
+    const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
     const true_offset = try self.currentOffset();
-    try self.movImmToReg(1, Reg.acu);
+    try isa.movImmToReg(self, 1, Reg.acu);
     const end_offset = try self.currentOffset();
-    try self.patchJumpTo(true_patch, true_offset);
-    try self.patchJumpTo(end_patch, end_offset);
+    try isa.patchJumpTo(self, true_patch, true_offset);
+    try isa.patchJumpTo(self, end_patch, end_offset);
 }
 
 /// Lower a short-circuiting `and` / `or` into a chain of
@@ -394,31 +395,31 @@ pub fn emitShortCircuitBool(self: *Emitter, b: ast.BinaryExpr) !void {
         .log_and => {
             // acu = lhs; if acu == 0 -> short-circuit false.
             try emitExpr(self, b.lhs);
-            try self.cmpRegImm(Reg.acu, 0);
-            const short_patch = try self.emitJumpPlaceholder(Op.jeq_addr);
+            try isa.cmpRegImm(self, Reg.acu, 0);
+            const short_patch = try isa.emitJumpPlaceholder(self, Op.jeq_addr);
             try emitExpr(self, b.rhs);
-            try self.cmpRegImm(Reg.acu, 0);
+            try isa.cmpRegImm(self, Reg.acu, 0);
             try materializeBoolFromFlags(self, .neq);
-            const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
+            const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
             const short_offset = try self.currentOffset();
-            try self.movImmToReg(0, Reg.acu);
+            try isa.movImmToReg(self, 0, Reg.acu);
             const end_offset = try self.currentOffset();
-            try self.patchJumpTo(short_patch, short_offset);
-            try self.patchJumpTo(end_patch, end_offset);
+            try isa.patchJumpTo(self, short_patch, short_offset);
+            try isa.patchJumpTo(self, end_patch, end_offset);
         },
         .log_or => {
             try emitExpr(self, b.lhs);
-            try self.cmpRegImm(Reg.acu, 0);
-            const short_patch = try self.emitJumpPlaceholder(Op.jne_addr);
+            try isa.cmpRegImm(self, Reg.acu, 0);
+            const short_patch = try isa.emitJumpPlaceholder(self, Op.jne_addr);
             try emitExpr(self, b.rhs);
-            try self.cmpRegImm(Reg.acu, 0);
+            try isa.cmpRegImm(self, Reg.acu, 0);
             try materializeBoolFromFlags(self, .neq);
-            const end_patch = try self.emitJumpPlaceholder(Op.jmp_addr);
+            const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
             const short_offset = try self.currentOffset();
-            try self.movImmToReg(1, Reg.acu);
+            try isa.movImmToReg(self, 1, Reg.acu);
             const end_offset = try self.currentOffset();
-            try self.patchJumpTo(short_patch, short_offset);
-            try self.patchJumpTo(end_patch, end_offset);
+            try isa.patchJumpTo(self, short_patch, short_offset);
+            try isa.patchJumpTo(self, end_patch, end_offset);
         },
         // allow-strict: caller filters to log_and / log_or before invoking this helper.
         else => unreachable,
@@ -544,7 +545,7 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     while (i > 0) {
         i -= 1;
         try emitExpr(self, c.args[i]);
-        try self.pushReg(Reg.acu);
+        try isa.pushReg(self, Reg.acu);
     }
 
     if (cross_bank) {
@@ -557,7 +558,7 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
         try self.emitU16Le(0); // placeholder
         try self.emitByte(Reg.r1);
         const target_bank_byte: u8 = target_bank orelse 0;
-        try self.movImmToReg(target_bank_byte, Reg.r2);
+        try isa.movImmToReg(self, target_bank_byte, Reg.r2);
         try self.emitByte(Op.call_addr);
         const tramp_patch_offset = try self.currentOffset();
         try self.emitU16Le(0);
@@ -595,6 +596,6 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     if (c.args.len > 0 and !skip_cleanup) {
         // @as: each arg is one 16-bit word; arg count capped by parser.
         const drop_bytes: u16 = @intCast(c.args.len * 2);
-        try self.addImmToReg(drop_bytes, Reg.sp);
+        try isa.addImmToReg(self, drop_bytes, Reg.sp);
     }
 }

--- a/src/lang/codegen/isa.zig
+++ b/src/lang/codegen/isa.zig
@@ -1,0 +1,303 @@
+/// Codegen ISA primitives — one helper per named bytecode
+/// instruction the Emitter relies on. Splits out of `codegen.zig`
+/// so the walker file stays scannable. Every entry takes a
+/// `*Emitter` and writes through its raw-emit primitives
+/// (`emitByte` / `emitU16Le` / `currentOffset` /
+/// `currentBufferBase`). Pure byte emission, no codegen state
+/// mutation beyond the code buffer cursor.
+const std = @import("std");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+
+/// `mov imm16, reg` (0x10) — `reg ← imm`.
+pub fn movImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
+    try self.emitByte(Op.mov_imm16_reg);
+    try self.emitU16Le(imm);
+    try self.emitByte(reg);
+}
+
+/// `mov src, dst` (0x11) — `dst ← src`.
+pub fn movRegToReg(self: *Emitter, src: u8, dst: u8) !void {
+    try self.emitByte(Op.mov_reg_reg);
+    try self.emitByte(src);
+    try self.emitByte(dst);
+}
+
+/// `mov [base + ofs], dst` (0x1C) — load fp-relative into reg.
+pub fn movRegOffsetToReg(self: *Emitter, base: u8, ofs: i8, dst: u8) !void {
+    try self.emitByte(Op.mov_reg_offset_reg);
+    try self.emitByte(base);
+    // safety: i8 → u8 bit pattern; reg_offset is signed byte per ISA §5.1.
+    try self.emitByte(@bitCast(ofs));
+    try self.emitByte(dst);
+}
+
+/// `mov src, [base + ofs]` (0x1D) — store reg to fp-relative.
+pub fn movRegToRegOffset(self: *Emitter, src: u8, base: u8, ofs: i8) !void {
+    try self.emitByte(Op.mov_reg_reg_offset);
+    try self.emitByte(src);
+    try self.emitByte(base);
+    // safety: i8 → u8 bit pattern; reg_offset is signed byte per ISA §5.1.
+    try self.emitByte(@bitCast(ofs));
+}
+
+/// `mov [addr], reg` (0x13) — load 16-bit word from addr.
+pub fn movAddrToReg(self: *Emitter, addr: u16, dst: u8) !void {
+    try self.emitByte(Op.mov_addr_to_reg);
+    try self.emitU16Le(addr);
+    try self.emitByte(dst);
+}
+
+/// `mov src, [addr]` (0x12) — store 16-bit word to addr.
+pub fn movRegToAddr(self: *Emitter, src: u8, addr: u16) !void {
+    try self.emitByte(Op.mov_reg_to_addr);
+    try self.emitByte(src);
+    try self.emitU16Le(addr);
+}
+
+/// `mov [zp], reg` (0x1A) — load 16-bit word from zp slot.
+pub fn movZpToReg(self: *Emitter, zp: u8, dst: u8) !void {
+    try self.emitByte(Op.mov_zp_to_reg);
+    try self.emitByte(zp);
+    try self.emitByte(dst);
+}
+
+/// `mov src, [zp]` (0x19) — store 16-bit word to zp slot.
+pub fn movRegToZp(self: *Emitter, src: u8, zp: u8) !void {
+    try self.emitByte(Op.mov_reg_to_zp);
+    try self.emitByte(src);
+    try self.emitByte(zp);
+}
+
+/// `mov8 [addr], reg` (0x22) — load 1-byte from addr (zero-
+/// extend into the 16-bit dst).
+pub fn mov8AddrToReg(self: *Emitter, addr: u16, dst: u8) !void {
+    try self.emitByte(Op.mov8_addr_to_reg);
+    try self.emitU16Le(addr);
+    try self.emitByte(dst);
+}
+
+/// `mov8 [zp], reg` (0x29) — load 1-byte from zp slot.
+pub fn mov8ZpToReg(self: *Emitter, zp: u8, dst: u8) !void {
+    try self.emitByte(Op.mov8_zp_to_reg);
+    try self.emitByte(zp);
+    try self.emitByte(dst);
+}
+
+/// `movl reg, [addr]` (0x27) — store reg's low byte to addr.
+/// Used for 1-byte global stores so neighboring bytes stay
+/// untouched (critical for MMIO).
+pub fn movlRegToAddr(self: *Emitter, src: u8, addr: u16) !void {
+    try self.emitByte(Op.movl_reg_to_addr);
+    try self.emitByte(src);
+    try self.emitU16Le(addr);
+}
+
+/// `movl reg, [zp]` (0x2B) — store reg's low byte to zp slot.
+pub fn movlRegToZp(self: *Emitter, src: u8, zp: u8) !void {
+    try self.emitByte(Op.movl_reg_to_zp);
+    try self.emitByte(src);
+    try self.emitByte(zp);
+}
+
+/// `push reg` (0x31).
+pub fn pushReg(self: *Emitter, reg: u8) !void {
+    try self.emitByte(Op.push_reg);
+    try self.emitByte(reg);
+}
+
+/// `pop reg` (0x32).
+pub fn popReg(self: *Emitter, reg: u8) !void {
+    try self.emitByte(Op.pop_reg);
+    try self.emitByte(reg);
+}
+
+/// `add imm16, reg` (0x40) — `reg ← reg + imm`.
+pub fn addImmToReg(self: *Emitter, imm: u16, reg: u8) !void {
+    try self.emitByte(Op.add_imm16_reg);
+    try self.emitU16Le(imm);
+    try self.emitByte(reg);
+}
+
+/// `sub imm16, reg` (0x43) — `reg ← reg - imm`.
+pub fn subImmFromReg(self: *Emitter, imm: u16, reg: u8) !void {
+    try self.emitByte(Op.sub_imm16_reg);
+    try self.emitU16Le(imm);
+    try self.emitByte(reg);
+}
+
+/// `add reg` (0x42) — `acu ← acu + reg`.
+pub fn addRegToAcu(self: *Emitter, reg: u8) !void {
+    try self.emitByte(Op.add_reg_acu);
+    try self.emitByte(reg);
+}
+
+/// `sub reg` (0x45) — `acu ← acu - reg`.
+pub fn subRegFromAcu(self: *Emitter, reg: u8) !void {
+    try self.emitByte(Op.sub_reg_acu);
+    try self.emitByte(reg);
+}
+
+/// `mul src, dst` (0x47) — `dst ← dst * src` (unsigned 32-bit
+/// product; V/C set when `high != 0`).
+pub fn mulRegReg(self: *Emitter, src: u8, dst: u8) !void {
+    try self.emitByte(Op.mul_reg_reg);
+    try self.emitByte(src);
+    try self.emitByte(dst);
+}
+
+/// `muls src, dst` (0x55) — signed `dst ← dst * src`. V/C set
+/// when the signed result overflows `i16` — the lang's debug
+/// overflow trap on `*` branches on V without false positives
+/// that the unsigned `mul`'s V flag would produce on legitimate
+/// negative operands.
+pub fn mulsRegReg(self: *Emitter, src: u8, dst: u8) !void {
+    try self.emitByte(Op.muls_reg_reg);
+    try self.emitByte(src);
+    try self.emitByte(dst);
+}
+
+/// `divs src, dst` (0x4E) — signed `dst ← dst / src`.
+pub fn divsRegReg(self: *Emitter, src: u8, dst: u8) !void {
+    try self.emitByte(Op.divs_reg_reg);
+    try self.emitByte(src);
+    try self.emitByte(dst);
+}
+
+/// `neg reg` (0x4A) — `reg ← -reg` (two's complement).
+pub fn negReg(self: *Emitter, reg: u8) !void {
+    try self.emitByte(Op.neg_reg);
+    try self.emitByte(reg);
+}
+
+/// `cmp reg, imm16` (0x80) — flags ← reg - imm. Result discarded.
+pub fn cmpRegImm(self: *Emitter, reg: u8, imm: u16) !void {
+    try self.emitByte(Op.cmp_reg_imm16);
+    try self.emitByte(reg);
+    try self.emitU16Le(imm);
+}
+
+/// `cmp dst, src` (0x81) — flags ← dst - src.
+pub fn cmpRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    try self.emitByte(Op.cmp_reg_reg);
+    try self.emitByte(dst);
+    try self.emitByte(src);
+}
+
+/// `and src, dst` (0x61) — `dst ← dst & src`. Source-first byte
+/// per `bitwise.andRegReg` decode.
+pub fn andRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    try self.emitByte(Op.and_reg_reg);
+    try self.emitByte(src);
+    try self.emitByte(dst);
+}
+
+/// `or src, dst` (0x63).
+pub fn orRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    try self.emitByte(Op.or_reg_reg);
+    try self.emitByte(src);
+    try self.emitByte(dst);
+}
+
+/// `xor src, dst` (0x65).
+pub fn xorRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    try self.emitByte(Op.xor_reg_reg);
+    try self.emitByte(src);
+    try self.emitByte(dst);
+}
+
+/// `not reg` (0x66) — `reg ← ~reg`.
+pub fn notRegOp(self: *Emitter, reg: u8) !void {
+    try self.emitByte(Op.not_reg);
+    try self.emitByte(reg);
+}
+
+/// `shl dst, src` (0x71). Source register holds the shift count.
+pub fn shlRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    try self.emitByte(Op.shl_reg_reg);
+    try self.emitByte(dst);
+    try self.emitByte(src);
+}
+
+/// `shr dst, src` (0x73).
+pub fn shrRegReg(self: *Emitter, dst: u8, src: u8) !void {
+    try self.emitByte(Op.shr_reg_reg);
+    try self.emitByte(dst);
+    try self.emitByte(src);
+}
+
+/// `shl reg, imm8` (0x70) — `reg ← reg << imm`.
+pub fn shlRegImm(self: *Emitter, reg: u8, imm: u8) !void {
+    try self.emitByte(Op.shl_reg_imm8);
+    try self.emitByte(reg);
+    try self.emitByte(imm);
+}
+
+/// `shr reg, imm8` (0x72) — `reg ← reg >> imm` (zero-fill).
+pub fn shrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
+    try self.emitByte(Op.shr_reg_imm8);
+    try self.emitByte(reg);
+    try self.emitByte(imm);
+}
+
+/// `asr reg, imm8` (0x74) — `reg ← reg >>arith imm` (sign-fill).
+pub fn asrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
+    try self.emitByte(Op.asr_reg_imm8);
+    try self.emitByte(reg);
+    try self.emitByte(imm);
+}
+
+/// Emit a forward jump with a placeholder address slot. Returns
+/// the offset of the 2-byte slot inside the current code buffer —
+/// pass it to `patchJumpTo` once the target offset is known.
+pub fn emitJumpPlaceholder(self: *Emitter, op: u8) !usize {
+    try self.emitByte(op);
+    const slot = try self.currentOffset();
+    try self.emitU16Le(0); // placeholder
+    return slot;
+}
+
+/// Resolve a forward-jump patch: writes the absolute address
+/// `currentBufferBase() + target_offset` into the 2-byte slot at
+/// `patch_offset`. `target_offset` is a byte offset inside the
+/// current code buffer.
+pub fn patchJumpTo(self: *Emitter, patch_offset: usize, target_offset: usize) !void {
+    const buf = try self.currentCode();
+    // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
+    const target_in_buffer: u16 = @intCast(target_offset);
+    const target_addr: u16 = self.currentBufferBase() +% target_in_buffer;
+    // safety: u16 → 2 LE bytes; both casts are byte-masks.
+    buf.items[patch_offset] = @intCast(target_addr & 0xFF);
+    buf.items[patch_offset + 1] = @intCast(target_addr >> 8);
+}
+
+/// Emit an unconditional jump to a known target offset within
+/// the current buffer. Used for loop back-edges.
+pub fn emitJumpBack(self: *Emitter, target_offset: usize) !void {
+    try self.emitByte(Op.jmp_addr);
+    // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
+    const target_in_buffer: u16 = @intCast(target_offset);
+    try self.emitU16Le(self.currentBufferBase() +% target_in_buffer);
+}
+
+/// `jmp reg` (0x91) — indirect jump via the register's value.
+/// `ip` becomes whatever the register holds.
+pub fn jmpReg(self: *Emitter, reg: u8) !void {
+    try self.emitByte(Op.jmp_reg);
+    try self.emitByte(reg);
+}
+
+/// `sys imm8` (0xFB) — host-callback syscall, identifier in the
+/// immediate operand byte.
+pub fn sys(self: *Emitter, id: u8) !void {
+    try self.emitByte(Op.sys);
+    try self.emitByte(id);
+}
+
+/// `hlt` (0xFF).
+pub fn hlt(self: *Emitter) !void {
+    try self.emitByte(Op.hlt);
+}

--- a/src/lang/codegen/lambda.zig
+++ b/src/lang/codegen/lambda.zig
@@ -49,6 +49,7 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
 
 const Emitter = codegen_mod.Emitter;
@@ -220,24 +221,24 @@ pub fn emitPromotedLetInit(
     slot_ofs: i8,
 ) !void {
     // Allocate a 2-byte cell on the heap.
-    try self.movImmToReg(2, Reg.acu);
+    try isa.movImmToReg(self, 2, Reg.acu);
     try self.emitByte(Op.sys);
     try self.emitByte(Sys.alloc);
     // acu = cell pointer; store it in the local slot.
-    try self.movRegToRegOffset(Reg.acu, Reg.fp, slot_ofs);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, slot_ofs);
     // Seed the cell with the init value when present.
     if (init) |init_expr| {
-        try self.movRegToReg(Reg.acu, Reg.r1); // r1 = cell ptr
-        try self.pushReg(Reg.r1);
+        try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = cell ptr
+        try isa.pushReg(self, Reg.r1);
         try self.emitExpr(init_expr); // acu = init value
-        try self.popReg(Reg.r1);
+        try isa.popReg(self, Reg.r1);
         try cellStore(self, Reg.r1, Reg.acu);
     }
 }
 
 /// Read a promoted local: load cell pointer from slot, then deref.
 pub fn emitPromotedIdentLoad(self: *Emitter, slot_ofs: i8) !void {
-    try self.movRegOffsetToReg(Reg.fp, slot_ofs, Reg.r1);
+    try isa.movRegOffsetToReg(self, Reg.fp, slot_ofs, Reg.r1);
     try cellLoad(self, Reg.r1, Reg.acu);
 }
 
@@ -245,9 +246,9 @@ pub fn emitPromotedIdentLoad(self: *Emitter, slot_ofs: i8) !void {
 /// the cell pointer, deref-write.
 pub fn emitPromotedAssign(self: *Emitter, slot_ofs: i8, value: *const ast.Expr) !void {
     try self.emitExpr(value);
-    try self.pushReg(Reg.acu);
-    try self.movRegOffsetToReg(Reg.fp, slot_ofs, Reg.r1);
-    try self.popReg(Reg.r2);
+    try isa.pushReg(self, Reg.acu);
+    try isa.movRegOffsetToReg(self, Reg.fp, slot_ofs, Reg.r1);
+    try isa.popReg(self, Reg.r2);
     try cellStore(self, Reg.r1, Reg.r2);
 }
 
@@ -277,11 +278,11 @@ pub fn emitLambdaExpr(self: *Emitter, lambda: ast.LambdaExpr, expr: *const ast.E
 
     // @as: tuple size = 2 (fn_ptr) + 2*N (capture slots). N caps well below 32k by parser limits.
     const tuple_size: u16 = 2 + @as(u16, @intCast(li.captures.items.len * 2));
-    try self.movImmToReg(tuple_size, Reg.acu);
+    try isa.movImmToReg(self, tuple_size, Reg.acu);
     try self.emitByte(Op.sys);
     try self.emitByte(Sys.alloc);
     // acu = tuple ptr; stash in r1 for the populate phase.
-    try self.movRegToReg(Reg.acu, Reg.r1);
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
 
     // Write fn_ptr at offset 0 — placeholder, patched when the
     // lambda body emits at the end of the fn pass.
@@ -304,15 +305,15 @@ pub fn emitLambdaExpr(self: *Emitter, lambda: ast.LambdaExpr, expr: *const ast.E
     for (li.captures.items, 0..) |cap, idx| {
         // @as: idx fits u16 — capture count caps below 32k.
         const slot_offset: u16 = 2 + @as(u16, @intCast(idx)) * 2;
-        try self.pushReg(Reg.r1); // preserve tuple ptr
+        try isa.pushReg(self, Reg.r1); // preserve tuple ptr
         try emitCaptureSource(self, cap);
-        try self.popReg(Reg.r1);
+        try isa.popReg(self, Reg.r1);
         // acu = capture value (cell ptr if promoted, value otherwise)
         try emitWordStoreAtOffset(self, Reg.r1, slot_offset, Reg.acu);
     }
 
     // Result: tuple ptr in acu.
-    try self.movRegToReg(Reg.r1, Reg.acu);
+    try isa.movRegToReg(self, Reg.r1, Reg.acu);
 }
 
 /// Load a capture's source value into `acu` at closure-creation
@@ -336,11 +337,11 @@ fn emitCaptureSource(self: *Emitter, name: []const u8) !void {
         return;
     }
     if (self.locals.get(name)) |ofs| {
-        try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+        try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
         return;
     }
     if (self.params.get(name)) |ofs| {
-        try self.movRegOffsetToReg(Reg.fp, ofs, Reg.acu);
+        try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
         return;
     }
     if (self.globals.get(name)) |g| {
@@ -457,7 +458,7 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
     if (local_count > 0) {
         // @as: 2 bytes per slot, caps well below u16.
         const reserve_bytes: u16 = @intCast(local_count * 2);
-        try self.subImmFromReg(reserve_bytes, Reg.sp);
+        try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
     }
 
     try self.pushBlock();
@@ -484,7 +485,7 @@ pub const CaptureSlot = struct {
 /// Load env_ptr from `[fp + 4]` into `dst` — used by capture
 /// loads / stores inside the lambda body.
 fn loadEnvPtr(self: *Emitter, dst: u8) !void {
-    try self.movRegOffsetToReg(Reg.fp, 4, dst);
+    try isa.movRegOffsetToReg(self, Reg.fp, 4, dst);
 }
 
 /// Read a captured binding from inside the lambda body.
@@ -493,7 +494,7 @@ pub fn emitCaptureLoad(self: *Emitter, slot: CaptureSlot) !void {
     try loadEnvPtr(self, Reg.r1);
     try emitWordLoadAtOffset(self, Reg.r1, slot.env_offset, Reg.acu);
     if (slot.is_cell) {
-        try self.movRegToReg(Reg.acu, Reg.r1);
+        try isa.movRegToReg(self, Reg.acu, Reg.r1);
         try cellLoad(self, Reg.r1, Reg.acu);
     }
 }
@@ -509,10 +510,10 @@ pub fn emitCaptureStore(self: *Emitter, slot: CaptureSlot, value: *const ast.Exp
         return;
     }
     try self.emitExpr(value);
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     try loadEnvPtr(self, Reg.r1);
     try emitWordLoadAtOffset(self, Reg.r1, slot.env_offset, Reg.r1);
-    try self.popReg(Reg.r2);
+    try isa.popReg(self, Reg.r2);
     try cellStore(self, Reg.r1, Reg.r2);
 }
 
@@ -528,7 +529,7 @@ pub fn emitClosureCall(
 ) !void {
     // Evaluate closure value into r1 (the tuple pointer).
     try self.emitExpr(callee);
-    try self.movRegToReg(Reg.acu, Reg.r1);
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
 
     // Load fn_ptr from [r1 + 0] into r3.
     try emitWordLoadAtOffset(self, Reg.r1, 0, Reg.r3);
@@ -537,23 +538,23 @@ pub fn emitClosureCall(
     var i: usize = c.args.len;
     while (i > 0) {
         i -= 1;
-        try self.pushReg(Reg.r1);
-        try self.pushReg(Reg.r3);
+        try isa.pushReg(self, Reg.r1);
+        try isa.pushReg(self, Reg.r3);
         try self.emitExpr(c.args[i]);
-        try self.popReg(Reg.r3);
-        try self.popReg(Reg.r1);
-        try self.pushReg(Reg.acu);
+        try isa.popReg(self, Reg.r3);
+        try isa.popReg(self, Reg.r1);
+        try isa.pushReg(self, Reg.acu);
     }
 
     // Push env_ptr (the closure itself) as the hidden first arg.
-    try self.pushReg(Reg.r1);
+    try isa.pushReg(self, Reg.r1);
 
     try self.emitByte(Op.call_reg);
     try self.emitByte(Reg.r3);
 
     // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
     const drop_bytes: u16 = 2 + @as(u16, @intCast(c.args.len * 2));
-    try self.addImmToReg(drop_bytes, Reg.sp);
+    try isa.addImmToReg(self, drop_bytes, Reg.sp);
 }
 
 /// Patch every recorded lambda-fn-ptr placeholder with the
@@ -1057,21 +1058,21 @@ fn findLambdaInfo(self: *Emitter, expr: *const ast.Expr) ?*const LambdaInfo {
 fn emitWordLoadAtOffset(self: *Emitter, base: u8, offset: u16, dst: u8) !void {
     if (offset <= 127) {
         // @as: offset fits i8 (≤127); the cast is a no-op for the value range.
-        try self.movRegOffsetToReg(base, @as(i8, @intCast(offset)), dst);
+        try isa.movRegOffsetToReg(self, base, @as(i8, @intCast(offset)), dst);
         return;
     }
-    try self.movRegToReg(base, Reg.r2);
-    try self.addImmToReg(offset, Reg.r2);
-    try self.movRegOffsetToReg(Reg.r2, 0, dst);
+    try isa.movRegToReg(self, base, Reg.r2);
+    try isa.addImmToReg(self, offset, Reg.r2);
+    try isa.movRegOffsetToReg(self, Reg.r2, 0, dst);
 }
 
 fn emitWordStoreAtOffset(self: *Emitter, base: u8, offset: u16, src: u8) !void {
     if (offset <= 127) {
         // @as: offset fits i8 (≤127); the cast is a no-op for the value range.
-        try self.movRegToRegOffset(src, base, @as(i8, @intCast(offset)));
+        try isa.movRegToRegOffset(self, src, base, @as(i8, @intCast(offset)));
         return;
     }
-    try self.movRegToReg(base, Reg.r3);
-    try self.addImmToReg(offset, Reg.r3);
-    try self.movRegToRegOffset(src, Reg.r3, 0);
+    try isa.movRegToReg(self, base, Reg.r3);
+    try isa.addImmToReg(self, offset, Reg.r3);
+    try isa.movRegToRegOffset(self, src, Reg.r3, 0);
 }

--- a/src/lang/codegen/mem_builtin.zig
+++ b/src/lang/codegen/mem_builtin.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -54,7 +55,7 @@ fn emitMemRead1Arg(self: *Emitter, c: ast.CallExpr, kind: MemReadKind) !void {
         return;
     }
     try self.emitExpr(c.args[0]); // acu = addr
-    try self.movRegToReg(Reg.acu, Reg.r1); // r1 = addr
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = addr
     switch (kind) {
         .word => {
             try self.emitByte(Op.mov_ptr_to_reg);
@@ -74,8 +75,8 @@ fn emitMemRead1Arg(self: *Emitter, c: ast.CallExpr, kind: MemReadKind) !void {
             // in `acu.lo`; shifting it into the top byte and back
             // arithmetic-shift-right preserves the sign bit
             // through the high half.
-            try self.shlRegImm(Reg.acu, 8);
-            try self.asrRegImm(Reg.acu, 8);
+            try isa.shlRegImm(self, Reg.acu, 8);
+            try isa.asrRegImm(self, Reg.acu, 8);
         },
     }
 }
@@ -89,9 +90,9 @@ fn emitMemWrite2Args(self: *Emitter, c: ast.CallExpr, kind: MemWriteKind) !void 
         return;
     }
     try self.emitExpr(c.args[0]); // acu = addr
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     try self.emitExpr(c.args[1]); // acu = value
-    try self.popReg(Reg.r1); // r1 = addr
+    try isa.popReg(self, Reg.r1); // r1 = addr
     switch (kind) {
         .word => {
             try self.emitByte(Op.mov_reg_to_ptr);
@@ -114,13 +115,13 @@ fn emitMemCopy(self: *Emitter, c: ast.CallExpr) !void {
         return;
     }
     try self.emitExpr(c.args[0]); // dst
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     try self.emitExpr(c.args[1]); // src
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     try self.emitExpr(c.args[2]); // n → acu
-    try self.movRegToReg(Reg.acu, Reg.r3); // r3 = len
-    try self.popReg(Reg.r2); // r2 = src
-    try self.popReg(Reg.r1); // r1 = dst
+    try isa.movRegToReg(self, Reg.acu, Reg.r3); // r3 = len
+    try isa.popReg(self, Reg.r2); // r2 = src
+    try isa.popReg(self, Reg.r1); // r1 = dst
     try self.emitByte(Op.bcpy);
     try self.emitByte(Reg.r1); // dst
     try self.emitByte(Reg.r2); // src
@@ -136,13 +137,13 @@ fn emitMemFill(self: *Emitter, c: ast.CallExpr) !void {
         return;
     }
     try self.emitExpr(c.args[0]); // dst
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     try self.emitExpr(c.args[1]); // v
-    try self.pushReg(Reg.acu);
+    try isa.pushReg(self, Reg.acu);
     try self.emitExpr(c.args[2]); // n → acu
-    try self.movRegToReg(Reg.acu, Reg.r3); // r3 = len
-    try self.popReg(Reg.r2); // r2 = val
-    try self.popReg(Reg.r1); // r1 = dst
+    try isa.movRegToReg(self, Reg.acu, Reg.r3); // r3 = len
+    try isa.popReg(self, Reg.r2); // r2 = val
+    try isa.popReg(self, Reg.r1); // r1 = dst
     try self.emitByte(Op.bfill);
     try self.emitByte(Reg.r1); // dst
     try self.emitByte(Reg.r3); // len
@@ -161,30 +162,30 @@ pub fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
     const name = self.source[e.ident.span.start..e.ident.span.end];
     if (self.locals.get(name)) |ofs| {
         // Local: address = fp + ofs (ofs is negative).
-        try self.movRegToReg(Reg.fp, Reg.acu);
+        try isa.movRegToReg(self, Reg.fp, Reg.acu);
         if (ofs < 0) {
             // @as: widen i8 → i16 so the negate doesn't trip on the minimum value.
             const widened: i16 = ofs;
             // @as: |ofs| ≤ 128 by allocLocal cap; result fits a u16.
             const neg: u16 = @intCast(-widened);
-            try self.subImmFromReg(neg, Reg.acu);
+            try isa.subImmFromReg(self, neg, Reg.acu);
         } else if (ofs > 0) {
             // @as: positive i8 → u16; cap by allocLocal layout.
             const pos: u16 = @intCast(ofs);
-            try self.addImmToReg(pos, Reg.acu);
+            try isa.addImmToReg(self, pos, Reg.acu);
         }
         return;
     }
     if (self.params.get(name)) |ofs| {
         // Param: address = fp + ofs (ofs is positive).
-        try self.movRegToReg(Reg.fp, Reg.acu);
+        try isa.movRegToReg(self, Reg.fp, Reg.acu);
         // @as: positive i8 → u16.
         const pos: u16 = @intCast(ofs);
-        try self.addImmToReg(pos, Reg.acu);
+        try isa.addImmToReg(self, pos, Reg.acu);
         return;
     }
     if (self.globals.get(name)) |g| {
-        try self.movImmToReg(g.address, Reg.acu);
+        try isa.movImmToReg(self, g.address, Reg.acu);
         return;
     }
     try self.unsupported(e.span(), "`addr_of` target not in scope");

--- a/src/lang/codegen/overflow.zig
+++ b/src/lang/codegen/overflow.zig
@@ -13,6 +13,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const types = @import("../types.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
 
 const Emitter = codegen_mod.Emitter;
@@ -76,9 +77,9 @@ pub fn emitOverflowTrap(self: *Emitter, signedness: Signedness) !void {
         .signed => Op.jvc_addr,
         .unsigned => Op.jcc_addr,
     };
-    const skip_patch = try self.emitJumpPlaceholder(skip_op);
+    const skip_patch = try isa.emitJumpPlaceholder(self, skip_op);
     try self.emitByte(Op.int_imm8);
     try self.emitByte(overflow_vector);
     const target = try self.currentOffset();
-    try self.patchJumpTo(skip_patch, target);
+    try isa.patchJumpTo(self, skip_patch, target);
 }

--- a/src/lang/codegen/pattern.zig
+++ b/src/lang/codegen/pattern.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -32,28 +33,28 @@ pub fn emitPatternTest(
             const name = self.source[ip.name.start..ip.name.end];
             const dup = try self.arena.dupe(u8, name);
             const ofs = try self.allocLocal(dup);
-            try self.movRegToRegOffset(Reg.acu, Reg.fp, ofs);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
         },
         .int_lit => |lit| {
             // @as: parser holds int_lit.value as i32; literals fit i16 by typecheck rule.
             const trimmed: i16 = @truncate(lit.value);
             // safety: i16 → u16 bit pattern preserved.
             const v: u16 = @bitCast(trimmed);
-            try self.cmpRegImm(Reg.acu, v);
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+            try isa.cmpRegImm(self, Reg.acu, v);
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
         },
         .char_lit => |c| {
-            try self.cmpRegImm(Reg.acu, c.value);
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+            try isa.cmpRegImm(self, Reg.acu, c.value);
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
         },
         .bool_lit => |b| {
             const v: u16 = if (b.value) 1 else 0;
-            try self.cmpRegImm(Reg.acu, v);
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+            try isa.cmpRegImm(self, Reg.acu, v);
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
         },
         .nil_lit => {
-            try self.cmpRegImm(Reg.acu, 0);
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+            try isa.cmpRegImm(self, Reg.acu, 0);
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
         },
         .range_pattern => |rp| {
             // Lower `start..end` as: cmp acu, start; jlt skip;
@@ -72,11 +73,11 @@ pub fn emitPatternTest(
             const end_i16: i16 = @truncate(rp.end.int_lit.value);
             // safety: i16 → u16 keeps the two's-complement bit pattern.
             const end_v: u16 = @bitCast(end_i16);
-            try self.cmpRegImm(Reg.acu, start_v);
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jlt_addr));
-            try self.cmpRegImm(Reg.acu, end_v);
+            try isa.cmpRegImm(self, Reg.acu, start_v);
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jlt_addr));
+            try isa.cmpRegImm(self, Reg.acu, end_v);
             const above_bound_op: u8 = if (rp.inclusive) Op.jgt_addr else Op.jge_addr;
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(above_bound_op));
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, above_bound_op));
         },
         .or_pattern => |op_| {
             // Each alt emits its own cmp + branch. A match jumps
@@ -92,19 +93,19 @@ pub fn emitPatternTest(
                 try emitPatternTest(self, alt.*, scrutinee_ofs, scrutinee_is_ident, &alt_skip);
                 // The alt matched if we reach this point — jump
                 // to the shared "body entry" label.
-                try match_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+                try match_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
                 // Failure-skips of this alt land at the next alt
                 // (or, after the final alt, at the outer skip).
                 const after_alt = try self.currentOffset();
-                for (alt_skip.items) |p| try self.patchJumpTo(p, after_alt);
+                for (alt_skip.items) |p| try isa.patchJumpTo(self, p, after_alt);
             }
             // None of the alts matched — punt to the outer skip
             // set.
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jmp_addr));
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
             // All match-patches resolve to the byte after the
             // outer skip jump — i.e. the body's first byte.
             const body_offset = try self.currentOffset();
-            for (match_patches.items) |p| try self.patchJumpTo(p, body_offset);
+            for (match_patches.items) |p| try isa.patchJumpTo(self, p, body_offset);
         },
         .variant_pattern => |vp| {
             if (vp.args.len > 0) {
@@ -122,8 +123,8 @@ pub fn emitPatternTest(
                 try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in match pattern");
                 return;
             };
-            try self.cmpRegImm(Reg.acu, tag);
-            try skip_patches.append(self.allocator, try self.emitJumpPlaceholder(Op.jne_addr));
+            try isa.cmpRegImm(self, Reg.acu, tag);
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
         },
         else => try self.unsupported(pat.span(), "this pattern shape"),
     }

--- a/src/lang/codegen/strings.zig
+++ b/src/lang/codegen/strings.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
 const archive = @import("archive.zig");
 
 const Emitter = codegen.Emitter;
@@ -140,16 +141,16 @@ pub fn emitStrLitExpr(self: *Emitter, sl: ast.StrLitExpr) !void {
     const buf_addr = reserveInterpBuffer(self, sl.span) orelse {
         // Diagnostic already emitted; produce a valid placeholder
         // so downstream codegen doesn't see a bad acu shape.
-        try self.movImmToReg(0, Reg.acu);
+        try isa.movImmToReg(self, 0, Reg.acu);
         return;
     };
 
     // r1 holds the moving write cursor. Initialize it to the
     // buffer's base address.
-    try self.movImmToReg(buf_addr, Reg.r1);
+    try isa.movImmToReg(self, buf_addr, Reg.r1);
     try emitInterpFill(self, sl);
-    try self.sys(Sys.format_terminate_buf);
-    try self.movImmToReg(buf_addr, Reg.acu);
+    try isa.sys(self, Sys.format_terminate_buf);
+    try isa.movImmToReg(self, buf_addr, Reg.acu);
 }
 
 /// Reserve `interp_buffer_size` bytes at the top of the data
@@ -183,7 +184,7 @@ pub fn emitInterpFill(self: *Emitter, sl: ast.StrLitExpr) !void {
             const decoded = try archive.decodeStringEscapes(self.arena, raw);
             const id = try internString(self, decoded);
             try emitMovStringAddrToReg(self, id, Reg.acu);
-            try self.sys(Sys.format_str_to_buf);
+            try isa.sys(self, Sys.format_str_to_buf);
         },
         .interp => |ip| {
             if (ip.format_spec != null) {
@@ -192,18 +193,18 @@ pub fn emitInterpFill(self: *Emitter, sl: ast.StrLitExpr) !void {
             }
             // Save the cursor — the interp-expression eval may
             // pop into r1 as scratch.
-            try self.pushReg(Reg.r1);
+            try isa.pushReg(self, Reg.r1);
             try self.emitExpr(ip.expr);
-            try self.popReg(Reg.r1);
+            try isa.popReg(self, Reg.r1);
 
             if (self.isPrimitiveType(ip.expr, .char)) {
-                try self.sys(Sys.format_char_to_buf);
+                try isa.sys(self, Sys.format_char_to_buf);
             } else if (self.isPrimitiveType(ip.expr, .fixed)) {
-                try self.sys(Sys.format_fixed_to_buf);
+                try isa.sys(self, Sys.format_fixed_to_buf);
             } else if (self.isPrimitiveType(ip.expr, .str)) {
-                try self.sys(Sys.format_str_to_buf);
+                try isa.sys(self, Sys.format_str_to_buf);
             } else {
-                try self.sys(Sys.format_int_to_buf);
+                try isa.sys(self, Sys.format_int_to_buf);
             }
         },
     };
@@ -222,7 +223,7 @@ pub fn emitPrintStrLit(self: *Emitter, sl: ast.StrLitExpr) !void {
             const decoded = try archive.decodeStringEscapes(self.arena, raw);
             const id = try internString(self, decoded);
             try emitMovStringAddrToReg(self, id, Reg.acu);
-            try self.sys(Sys.print_str);
+            try isa.sys(self, Sys.print_str);
         },
         .interp => |ip| {
             if (ip.format_spec != null) {
@@ -231,16 +232,16 @@ pub fn emitPrintStrLit(self: *Emitter, sl: ast.StrLitExpr) !void {
             }
             if (self.isPrimitiveType(ip.expr, .char)) {
                 try self.emitExpr(ip.expr);
-                try self.sys(Sys.print_char);
+                try isa.sys(self, Sys.print_char);
             } else if (self.isPrimitiveType(ip.expr, .fixed)) {
                 try self.emitExpr(ip.expr);
-                try self.sys(Sys.print_fixed);
+                try isa.sys(self, Sys.print_fixed);
             } else if (self.isPrimitiveType(ip.expr, .str)) {
                 try self.emitExpr(ip.expr);
-                try self.sys(Sys.print_str);
+                try isa.sys(self, Sys.print_str);
             } else {
                 try self.emitExpr(ip.expr);
-                try self.sys(Sys.print_int);
+                try isa.sys(self, Sys.print_int);
             }
         },
     };

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -166,6 +166,7 @@ const flow = @import("typecheck/flow.zig");
 const suggestions = @import("typecheck/suggestions.zig");
 const type_resolve = @import("typecheck/type_resolve.zig");
 const fields = @import("typecheck/fields.zig");
+const operators = @import("typecheck/operators.zig");
 
 const T = annotations.T;
 
@@ -329,7 +330,11 @@ pub const Checker = struct {
         });
     }
 
-    fn emitMismatch(
+    /// Emit `E_TYPE_MISMATCH` for a bare `expected vs actual`
+    /// type mismatch — no extra anchor span. Used by call-site /
+    /// operator / store checks where only the offending site is
+    /// useful context.
+    pub fn emitMismatch(
         self: *Checker,
         span: ast.Span,
         expected_ty: *const types.Type,
@@ -349,7 +354,7 @@ pub const Checker = struct {
     /// `: T` annotation that drove the expected type. Renderer
     /// surfaces it as the "expected `T` because of this annotation"
     /// label under the source line.
-    fn emitMismatchAnnotated(
+    pub fn emitMismatchAnnotated(
         self: *Checker,
         span: ast.Span,
         expected_ty: *const types.Type,
@@ -1499,8 +1504,8 @@ pub const Checker = struct {
                 return null;
             },
             .paren => |p| return try self.inferExpr(p.inner, hint),
-            .unary => |u| return try self.checkUnary(u, hint),
-            .binary => |b| return try self.checkBinary(b, hint),
+            .unary => |u| return try operators.checkUnary(self, u, hint),
+            .binary => |b| return try operators.checkBinary(self, b, hint),
             .range => |r| {
                 _ = try self.inferExpr(r.start, null);
                 _ = try self.inferExpr(r.end, null);
@@ -1639,7 +1644,7 @@ pub const Checker = struct {
                 _ = try self.inferExpr(it.lhs, null);
                 return try self.primitive(.bool_);
             },
-            .cast => |c| return try self.checkCast(c),
+            .cast => |c| return try operators.checkCast(self, c),
             .ref_of => |r| return try self.checkRefOf(r),
         }
     }
@@ -1768,174 +1773,6 @@ pub const Checker = struct {
             return try types.mkArray(self.arena, t, len_val);
         }
         return null;
-    }
-
-    // ---------- operator type rules (§4.2.1) ----------
-
-    fn checkUnary(self: *Checker, u: ast.UnaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
-        const op_hint: ?*const types.Type = if (u.op == .log_not)
-            try self.primitive(.bool_)
-        else
-            hint;
-        const operand_ty = try self.inferExpr(u.operand, op_hint);
-        if (operand_ty == null) return null;
-        const ot = operand_ty.?;
-        switch (u.op) {
-            .neg => {
-                if (!predicates.isNumericType(ot.*)) {
-                    try self.emitOperatorRequires(u.span, "negation `-`", "a numeric type", ot);
-                    return null;
-                }
-                return ot;
-            },
-            .log_not => {
-                if (!predicates.isBoolType(ot.*)) {
-                    try self.emitOperatorRequires(u.span, "logical `not`", "`bool`", ot);
-                    return null;
-                }
-                return try self.primitive(.bool_);
-            },
-            .bit_not => {
-                if (!predicates.isIntegerType(ot.*)) {
-                    try self.emitOperatorRequires(u.span, "bitwise `~`", "an integer type", ot);
-                    return null;
-                }
-                return ot;
-            },
-        }
-    }
-
-    fn checkBinary(self: *Checker, b: ast.BinaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
-        return switch (b.op) {
-            .add, .sub, .mul, .div, .mod => try self.checkArith(b, hint),
-            .shl, .shr => try self.checkShift(b, hint),
-            .bit_and, .bit_or, .bit_xor => try self.checkBitwise(b, hint),
-            .eq, .neq, .lt, .lte, .gt, .gte => try self.checkComparison(b),
-            .log_and, .log_or => try self.checkLogical(b),
-        };
-    }
-
-    fn checkArith(self: *Checker, b: ast.BinaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
-        const lhs_ty = try self.inferExpr(b.lhs, hint);
-        // Pin RHS to LHS once known; otherwise fall back to the outer hint.
-        const rhs_hint = lhs_ty orelse hint;
-        const rhs_ty = try self.inferExpr(b.rhs, rhs_hint);
-        if (lhs_ty == null or rhs_ty == null) return lhs_ty orelse rhs_ty;
-        // String concatenation: only `+`, both sides `str`.
-        if (b.op == .add and predicates.isStrType(lhs_ty.?.*) and predicates.isStrType(rhs_ty.?.*)) {
-            return try self.primitive(.str);
-        }
-        if (!predicates.isNumericType(lhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "a numeric type", lhs_ty.?);
-            return null;
-        }
-        if (!predicates.isNumericType(rhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "a numeric type", rhs_ty.?);
-            return null;
-        }
-        if (!lhs_ty.?.eql(rhs_ty.?.*)) {
-            try self.emitMismatch(b.rhs.span(), lhs_ty.?, rhs_ty.?);
-        }
-        return lhs_ty;
-    }
-
-    fn checkShift(self: *Checker, b: ast.BinaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
-        const lhs_ty = try self.inferExpr(b.lhs, hint);
-        // Shift count is itself an integer; default to u8-ish via i16 (no specific hint).
-        const rhs_ty = try self.inferExpr(b.rhs, null);
-        if (lhs_ty == null or rhs_ty == null) return lhs_ty;
-        if (!predicates.isIntegerType(lhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "an integer type", lhs_ty.?);
-            return null;
-        }
-        if (!predicates.isIntegerType(rhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "an integer shift count", rhs_ty.?);
-            return null;
-        }
-        return lhs_ty;
-    }
-
-    fn checkBitwise(self: *Checker, b: ast.BinaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
-        const lhs_ty = try self.inferExpr(b.lhs, hint);
-        const rhs_hint = lhs_ty orelse hint;
-        const rhs_ty = try self.inferExpr(b.rhs, rhs_hint);
-        if (lhs_ty == null or rhs_ty == null) return lhs_ty orelse rhs_ty;
-        if (!predicates.isIntegerType(lhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "an integer type", lhs_ty.?);
-            return null;
-        }
-        if (!predicates.isIntegerType(rhs_ty.?.*)) {
-            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "an integer type", rhs_ty.?);
-            return null;
-        }
-        if (!lhs_ty.?.eql(rhs_ty.?.*)) {
-            try self.emitMismatch(b.rhs.span(), lhs_ty.?, rhs_ty.?);
-        }
-        return lhs_ty;
-    }
-
-    fn checkComparison(self: *Checker, b: ast.BinaryExpr) WalkError!?*const types.Type {
-        const lhs_ty = try self.inferExpr(b.lhs, null);
-        const rhs_ty = try self.inferExpr(b.rhs, lhs_ty);
-        if (lhs_ty != null and rhs_ty != null) {
-            // Allow nil-comparison (`x != nil` / `nil == p`) — the
-            // canonical nullable idiom per §3.4.1. Strict-equality
-            // only when neither side is the nil literal.
-            const either_is_nil = predicates.isNilType(lhs_ty.?.*) or predicates.isNilType(rhs_ty.?.*);
-            if (!either_is_nil and !lhs_ty.?.eql(rhs_ty.?.*)) {
-                try self.emitMismatch(b.rhs.span(), lhs_ty.?, rhs_ty.?);
-            }
-        }
-        return try self.primitive(.bool_);
-    }
-
-    fn checkLogical(self: *Checker, b: ast.BinaryExpr) WalkError!?*const types.Type {
-        const bool_ty = try self.primitive(.bool_);
-        const lhs_ty = try self.inferExpr(b.lhs, bool_ty);
-        const rhs_ty = try self.inferExpr(b.rhs, bool_ty);
-        if (lhs_ty) |t| if (!predicates.isBoolType(t.*)) {
-            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "`bool`", t);
-        };
-        if (rhs_ty) |t| if (!predicates.isBoolType(t.*)) {
-            try self.emitOperatorRequires(b.span, predicates.opLexeme(b.op), "`bool`", t);
-        };
-        return bool_ty;
-    }
-
-    fn emitOperatorRequires(
-        self: *Checker,
-        span: ast.Span,
-        op_name: []const u8,
-        wants: []const u8,
-        actual: *const types.Type,
-    ) WalkError!void {
-        const actual_s = try types.render(self.arena, actual.*);
-        const msg = try std.fmt.allocPrint(
-            self.arena,
-            "operator {s} requires {s}, found `{s}`",
-            .{ op_name, wants, actual_s },
-        );
-        try self.emitSpan("E_TYPE_MISMATCH", span, msg);
-    }
-
-    // ---------- cast (`as T`) checking ----------
-
-    fn checkCast(self: *Checker, c: ast.CastExpr) WalkError!?*const types.Type {
-        const inner_ty = try self.inferExpr(c.inner, null);
-        const target_ty = try type_resolve.resolveType(self, c.target_type);
-        if (inner_ty) |it| {
-            if (!relations.canCast(it.*, target_ty.*)) {
-                const from_s = try types.render(self.arena, it.*);
-                const to_s = try types.render(self.arena, target_ty.*);
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "cannot cast `{s}` to `{s}`",
-                    .{ from_s, to_s },
-                );
-                try self.emitSpan("E_CAST_INVALID", c.span, msg);
-            }
-        }
-        return target_ty;
     }
 
     // ---------- function call ----------

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -165,6 +165,7 @@ const relations = @import("typecheck/relations.zig");
 const flow = @import("typecheck/flow.zig");
 const suggestions = @import("typecheck/suggestions.zig");
 const type_resolve = @import("typecheck/type_resolve.zig");
+const fields = @import("typecheck/fields.zig");
 
 const T = annotations.T;
 
@@ -381,7 +382,7 @@ pub const Checker = struct {
     /// — the typical shape for diagnostics with one context span.
     /// Lives long enough to back the `Diagnostic.secondary` field
     /// (arena released by `CheckedProgram.deinit`).
-    fn singleSecondary(
+    pub fn singleSecondary(
         self: *Checker,
         span: ast.Span,
         message: []const u8,
@@ -404,7 +405,7 @@ pub const Checker = struct {
     ///
     /// Keeps the four call sites uniform — none of them know about
     /// the precision-loss case directly.
-    fn checkStoreCompat(
+    pub fn checkStoreCompat(
         self: *Checker,
         span: ast.Span,
         expected: *const types.Type,
@@ -1470,7 +1471,7 @@ pub const Checker = struct {
                     // the regular `checkCall` path.
                     if (info.kind == .class) {
                         if (self.class_registry.get(name)) |cd| {
-                            return try self.constructorSignatureFor(cd, name, i.span);
+                            return try fields.constructorSignatureFor(self, cd, name, i.span);
                         }
                     }
                     return info.ty;
@@ -1513,12 +1514,12 @@ pub const Checker = struct {
                 if (m.receiver.* == .ident) {
                     const recv_name = self.lexeme(m.receiver.ident.span);
                     if (std.mem.eql(u8, recv_name, "mem")) {
-                        return try self.checkMemMethodCall(m);
+                        return try fields.checkMemMethodCall(self, m);
                     }
                 }
                 const recv_ty = try self.inferExpr(m.receiver, null);
                 try self.checkNotNullableDeref(m.receiver, recv_ty, m.span);
-                return try self.checkMethodCall(m, peelReference(recv_ty));
+                return try fields.checkMethodCall(self, m, peelReference(recv_ty));
             },
             .field => |f| {
                 // Special receivers (recognized before generic
@@ -1529,15 +1530,15 @@ pub const Checker = struct {
                 if (f.receiver.* == .ident) {
                     const recv_name = self.lexeme(f.receiver.ident.span);
                     if (self.enum_registry.get(recv_name)) |ed| {
-                        return try self.resolveEnumVariant(ed, recv_name, f);
+                        return try fields.resolveEnumVariant(self, ed, recv_name, f);
                     }
                     if (std.mem.eql(u8, recv_name, "mem")) {
-                        return try self.resolveMemBuiltin(f);
+                        return try fields.resolveMemBuiltin(self, f);
                     }
                 }
                 const recv_ty = try self.inferExpr(f.receiver, null);
                 try self.checkNotNullableDeref(f.receiver, recv_ty, f.span);
-                return try self.resolveFieldAccess(f, peelReference(recv_ty));
+                return try fields.resolveFieldAccess(self, f, peelReference(recv_ty));
             },
             .index => |ix| {
                 _ = try self.inferExpr(ix.receiver, null);
@@ -1614,7 +1615,7 @@ pub const Checker = struct {
             },
             .list_lit => |ll| return try self.inferListLit(ll, hint),
             .list_repeat => |lr| return try self.inferListRepeat(lr, hint),
-            .struct_lit => |sl| return try self.checkStructLit(sl),
+            .struct_lit => |sl| return try fields.checkStructLit(self, sl),
             .tuple_lit => |tl| {
                 // Bidirectional: when the hint is a same-arity
                 // tuple, each element pins to its slot's expected
@@ -1707,424 +1708,6 @@ pub const Checker = struct {
             return h;
         }
         return try self.primitive(.nil_);
-    }
-
-    // ---------- field / method resolution ----------
-
-    /// Look up `f.field` against the receiver's named-type decl.
-    /// Returns the field's declared type, or emits
-    /// `E_TYPE_UNDEFINED_FIELD` when the field is unknown. Returns
-    /// `null` when the receiver type isn't a resolvable named
-    /// struct / class — downstream callers treat that as "unknown
-    /// for now" rather than another error.
-    /// Resolve an enum-variant constructor expression
-    /// (`EnumName.Variant`). Nullary variants resolve directly to
-    /// the enum's `Named` type — `let s = Color.Red` infers as
-    /// `Color`. Payload-bearing variants resolve to the constructor
-    /// function type `fn(payload_types) -> Enum` so a wrapping
-    /// `CallExpr` (`Item.Potion(20)`) type-checks through the
-    /// regular `checkCall` path.
-    fn resolveEnumVariant(
-        self: *Checker,
-        ed: *const ast.EnumDecl,
-        enum_name: []const u8,
-        f: ast.FieldExpr,
-    ) WalkError!?*const types.Type {
-        const variant_name = self.lexeme(f.field);
-        const variant: ?*const ast.EnumVariant = blk: {
-            for (ed.variants) |*v| {
-                if (std.mem.eql(u8, self.lexeme(v.name), variant_name)) break :blk v;
-            }
-            break :blk null;
-        };
-        if (variant == null) {
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "enum `{s}` has no variant `{s}`",
-                .{ enum_name, variant_name },
-            );
-            try self.emitSpan("E_TYPE_UNDEFINED_VARIANT", f.field, msg);
-            return null;
-        }
-        const enum_ty = try types.mkNamed(self.arena, enum_name, f.receiver.ident.span);
-        if (variant.?.payload.len == 0) return enum_ty;
-
-        // Payload-bearing variant — synthesize a constructor
-        // function signature so call-site type-checking flows.
-        var param_tys: std.ArrayList(*const types.Type) = .empty;
-        errdefer param_tys.deinit(self.arena);
-        for (variant.?.payload) |pf| {
-            const pt = try type_resolve.resolveType(self, pf.type_ann);
-            try param_tys.append(self.arena, pt);
-        }
-        const fn_ty = try self.arena.create(types.Type);
-        fn_ty.* = .{ .function = .{
-            .params = try param_tys.toOwnedSlice(self.arena),
-            .ret = enum_ty,
-        } };
-        return fn_ty;
-    }
-
-    /// Type-check `mem.X(args)` as a method-call expression
-    /// (delegates to `typecheck/mem_builtin.zig`).
-    fn checkMemMethodCall(self: *Checker, m: ast.MethodCallExpr) WalkError!?*const types.Type {
-        return mem_builtin.checkMemMethodCall(self, m);
-    }
-
-    /// Resolve `mem.X` builtin field expressions (delegates to
-    /// `typecheck/mem_builtin.zig`).
-    fn resolveMemBuiltin(self: *Checker, f: ast.FieldExpr) WalkError!?*const types.Type {
-        return mem_builtin.resolveMemBuiltin(self, f);
-    }
-
-    fn resolveFieldAccess(
-        self: *Checker,
-        f: ast.FieldExpr,
-        recv_ty: ?*const types.Type,
-    ) WalkError!?*const types.Type {
-        const rt = recv_ty orelse return null;
-        const named_name = flow.namedNameOf(rt.*) orelse return null;
-        const field_name = self.lexeme(f.field);
-        if (self.struct_registry.get(named_name)) |sd| {
-            for (sd.fields) |fld| {
-                if (std.mem.eql(u8, self.lexeme(fld.name), field_name)) {
-                    return try type_resolve.resolveType(self, fld.type_ann);
-                }
-            }
-            try self.emitUndefinedField(named_name, field_name, f.field);
-            return null;
-        }
-        if (self.class_registry.get(named_name)) |cd| {
-            if (self.lookupClassFieldOwner(cd, field_name)) |hit| {
-                if (annotations.hasAnnotation(self, hit.field.annotations, "private")) {
-                    const owner_name = self.lexeme(hit.owner.name);
-                    const visible = if (self.current_class_name) |cn| std.mem.eql(u8, cn, owner_name) else false;
-                    if (!visible) {
-                        const msg = try std.fmt.allocPrint(
-                            self.arena,
-                            "field `{s}.{s}` is `@private` — only accessible from inside `{s}`",
-                            .{ named_name, field_name, owner_name },
-                        );
-                        try self.emitSpan("E_PRIVATE_ACCESS", f.field, msg);
-                    }
-                }
-                if (hit.field.type_ann) |t| return try type_resolve.resolveType(self, t);
-                return null;
-            }
-            try self.emitUndefinedField(named_name, field_name, f.field);
-            return null;
-        }
-        return null;
-    }
-
-    /// Walk a class's inherited chain looking for a field named
-    /// `field_name`. Returns the resolved type when found.
-    fn lookupClassFieldType(
-        self: *Checker,
-        cd: *const ast.ClassDecl,
-        field_name: []const u8,
-    ) WalkError!?*const types.Type {
-        for (cd.fields) |fld| {
-            if (std.mem.eql(u8, self.lexeme(fld.name), field_name)) {
-                if (fld.type_ann) |t| return try type_resolve.resolveType(self, t);
-                return null;
-            }
-        }
-        if (cd.extends) |ext| if (self.class_registry.get(self.lexeme(ext))) |parent| {
-            return try self.lookupClassFieldType(parent, field_name);
-        };
-        return null;
-    }
-
-    fn emitUndefinedField(self: *Checker, type_name: []const u8, field_name: []const u8, span: ast.Span) WalkError!void {
-        const msg = try std.fmt.allocPrint(
-            self.arena,
-            "type `{s}` has no field `{s}`",
-            .{ type_name, field_name },
-        );
-        // Suggestion across struct + class registries — whichever
-        // resolves the type name supplies the field pool. Misses
-        // (no candidate within distance 2, or unknown type) fall
-        // through to the bare diagnostic. The same lookup yields
-        // the type's declaration span, which doubles as the
-        // secondary "type defined here" anchor.
-        var candidate: ?[]const u8 = null;
-        var type_decl_span: ?ast.Span = null;
-        if (self.struct_registry.get(type_name)) |sd| {
-            candidate = try self.suggestStructField(sd, field_name);
-            type_decl_span = sd.name;
-        } else if (self.class_registry.get(type_name)) |cd| {
-            candidate = try self.suggestClassField(cd, field_name);
-            type_decl_span = cd.name;
-        }
-        const help: ?[]const u8 = if (candidate) |c|
-            try std.fmt.allocPrint(self.arena, "did you mean `{s}`?", .{c})
-        else
-            null;
-        const secondary: []const diag_mod.SpanLabel = if (type_decl_span) |ts|
-            try self.singleSecondary(ts, try std.fmt.allocPrint(self.arena, "type `{s}` defined here", .{type_name}), .underline)
-        else
-            &.{};
-        try self.diagnostics.append(self.diag_alloc, .{
-            .severity = .fatal,
-            .code = "E_TYPE_UNDEFINED_FIELD",
-            .message = msg,
-            .span = span,
-            .help = help,
-            .secondary = secondary,
-        });
-    }
-
-    /// Type-check a method call against the class registry.
-    /// Walks args regardless so unrelated diagnostics still fire.
-    /// Emits `E_TYPE_UNDEFINED_METHOD` when the named method is
-    /// missing on the receiver class. Otherwise behaves like a
-    /// regular call: arity + per-arg type check against the method's
-    /// signature.
-    fn checkMethodCall(
-        self: *Checker,
-        m: ast.MethodCallExpr,
-        recv_ty: ?*const types.Type,
-    ) WalkError!?*const types.Type {
-        const rt = recv_ty orelse {
-            for (m.args) |a| _ = try self.inferExpr(a, null);
-            return null;
-        };
-        const named_name = flow.namedNameOf(rt.*) orelse {
-            for (m.args) |a| _ = try self.inferExpr(a, null);
-            return null;
-        };
-        const cd = self.class_registry.get(named_name) orelse {
-            for (m.args) |a| _ = try self.inferExpr(a, null);
-            return null;
-        };
-        const method_name = self.lexeme(m.method);
-        const hit = self.lookupClassMethodOwner(cd, method_name) orelse {
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "class `{s}` has no method `{s}`",
-                .{ named_name, method_name },
-            );
-            try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", m.method, msg, try self.suggestClassMethod(cd, method_name));
-            for (m.args) |a| _ = try self.inferExpr(a, null);
-            return null;
-        };
-        const method = hit.method;
-        if (annotations.hasAnnotation(self, method.annotations, "private")) {
-            const owner_name = self.lexeme(hit.owner.name);
-            const visible = if (self.current_class_name) |cn| std.mem.eql(u8, cn, owner_name) else false;
-            if (!visible) {
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "method `{s}.{s}` is `@private` — only callable from inside `{s}`",
-                    .{ named_name, method_name, owner_name },
-                );
-                try self.emitSpan("E_PRIVATE_ACCESS", m.method, msg);
-            }
-        }
-        // Build the method signature on the fly. Skip the `self`
-        // param when matching args.
-        var has_self = false;
-        if (method.params.len > 0 and std.mem.eql(u8, self.lexeme(method.params[0].name), "self")) has_self = true;
-        const skip_count: usize = if (has_self) 1 else 0;
-        const sig_params = method.params[skip_count..];
-        if (m.args.len != sig_params.len) {
-            const suffix: []const u8 = if (sig_params.len == 1) "" else "s";
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "method `{s}.{s}` takes {d} argument{s}, called with {d}",
-                .{ named_name, method_name, sig_params.len, suffix, m.args.len },
-            );
-            try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
-            for (m.args) |a| _ = try self.inferExpr(a, null);
-        } else {
-            for (m.args, sig_params) |arg, p| {
-                const param_ty: ?*const types.Type = if (p.type_ann) |t|
-                    try type_resolve.resolveType(self, t)
-                else
-                    null;
-                const skip = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
-                const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-                if (!skip and param_ty != null and arg_ty != null) {
-                    try self.checkStoreCompat(arg.span(), param_ty.?, arg_ty.?);
-                }
-            }
-        }
-        if (method.ret_type) |r| return try type_resolve.resolveType(self, r);
-        return try self.primitive(.nil_);
-    }
-
-    /// Validate a struct literal against its decl. Reports
-    /// unknown / missing / mistyped fields and returns the named
-    /// type so the surrounding expression continues to type-check.
-    fn checkStructLit(self: *Checker, sl: ast.StructLit) WalkError!?*const types.Type {
-        const type_name = self.lexeme(sl.type_name);
-        const named_ty = try types.mkNamed(self.arena, type_name, sl.type_name);
-
-        // Struct literals can be used to construct classes too
-        // (`Player { name: "Cecil" }` shorthand) — try both
-        // registries.
-        if (self.struct_registry.get(type_name)) |sd| {
-            try self.checkStructLitFields(sl, type_name, sd.fields);
-            return named_ty;
-        }
-        if (self.class_registry.get(type_name)) |cd| {
-            try self.checkClassLitFields(sl, type_name, cd);
-            return named_ty;
-        }
-        // Unknown type — emit the standard undefined-type code so
-        // the user gets one consistent diagnostic, then walk the
-        // values defensively to surface inner errors.
-        const msg = try std.fmt.allocPrint(
-            self.arena,
-            "undefined type `{s}`",
-            .{type_name},
-        );
-        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", sl.type_name, msg, try self.suggestTypeName(type_name));
-        for (sl.fields) |f| _ = try self.inferExpr(f.value, null);
-        return named_ty;
-    }
-
-    fn checkStructLitFields(
-        self: *Checker,
-        sl: ast.StructLit,
-        type_name: []const u8,
-        decl_fields: []const ast.StructField,
-    ) WalkError!void {
-        var seen: std.StringHashMapUnmanaged(void) = .{};
-        defer seen.deinit(self.arena);
-        for (sl.fields) |lit_field| {
-            const field_name = self.lexeme(lit_field.name);
-            const decl_field = flow.findStructField(self, decl_fields, field_name) orelse {
-                try self.emitUndefinedField(type_name, field_name, lit_field.name);
-                _ = try self.inferExpr(lit_field.value, null);
-                continue;
-            };
-            const expected_ty = try type_resolve.resolveType(self, decl_field.type_ann);
-            const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
-            if (actual_ty) |at| try self.checkStoreCompat(lit_field.value.span(), expected_ty, at);
-            _ = try seen.put(self.arena, field_name, {});
-        }
-        // Missing fields.
-        for (decl_fields) |df| {
-            const dn = self.lexeme(df.name);
-            if (!seen.contains(dn)) {
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "missing field `{s}` in `{s}` literal",
-                    .{ dn, type_name },
-                );
-                try self.emitSpan("E_TYPE_MISSING_FIELD", sl.span, msg);
-            }
-        }
-    }
-
-    fn checkClassLitFields(
-        self: *Checker,
-        sl: ast.StructLit,
-        type_name: []const u8,
-        cd: *const ast.ClassDecl,
-    ) WalkError!void {
-        for (sl.fields) |lit_field| {
-            const field_name = self.lexeme(lit_field.name);
-            // Search the inheritance chain. Class fields are
-            // optional-typed, so an untyped field accepts anything.
-            const expected_ty: ?*const types.Type = try self.lookupClassFieldType(cd, field_name);
-            if (expected_ty == null and flow.findClassField(self, cd, field_name) == null) {
-                try self.emitUndefinedField(type_name, field_name, lit_field.name);
-                _ = try self.inferExpr(lit_field.value, null);
-                continue;
-            }
-            const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
-            if (expected_ty) |et| if (actual_ty) |at| try self.checkStoreCompat(lit_field.value.span(), et, at);
-        }
-        // Class literals don't require every field to be set
-        // (constructors fill defaults). Slice 7 may tighten this
-        // when annotation rules pin field requiredness.
-    }
-
-    /// Synthesize a constructor signature for a class. Uses the
-    /// `init` method's params (sans implicit `self`) when present;
-    /// otherwise the constructor is nullary. Return type is always
-    /// `Named(class_name)`.
-    fn constructorSignatureFor(
-        self: *Checker,
-        cd: *const ast.ClassDecl,
-        class_name: []const u8,
-        name_span: ast.Span,
-    ) WalkError!*const types.Type {
-        var param_types: std.ArrayList(*const types.Type) = .empty;
-        errdefer param_types.deinit(self.arena);
-        if (self.lookupClassMethod(cd, "init")) |init_method| {
-            var has_self = false;
-            if (init_method.params.len > 0 and std.mem.eql(u8, self.lexeme(init_method.params[0].name), "self")) has_self = true;
-            const skip: usize = if (has_self) 1 else 0;
-            for (init_method.params[skip..]) |p| {
-                const pt: *const types.Type = if (p.type_ann) |t|
-                    try type_resolve.resolveType(self, t)
-                else
-                    try self.primitive(.nil_);
-                try param_types.append(self.arena, pt);
-            }
-        }
-        const ret = try types.mkNamed(self.arena, class_name, name_span);
-        const sig = try self.arena.create(types.Type);
-        sig.* = .{ .function = .{
-            .params = try param_types.toOwnedSlice(self.arena),
-            .ret = ret,
-        } };
-        return sig;
-    }
-
-    /// Walk a class's inheritance chain looking for a method by
-    /// name. Returns the first match.
-    fn lookupClassMethod(
-        self: *const Checker,
-        cd: *const ast.ClassDecl,
-        method_name: []const u8,
-    ) ?*const ast.DefDecl {
-        if (self.lookupClassMethodOwner(cd, method_name)) |hit| return hit.method;
-        return null;
-    }
-
-    /// Walk a class's inheritance chain looking for a method by
-    /// name and return both the method decl and the class that
-    /// owns it (needed for `@private` visibility checks since
-    /// the owner is what determines who can see the member).
-    fn lookupClassMethodOwner(
-        self: *const Checker,
-        cd: *const ast.ClassDecl,
-        method_name: []const u8,
-    ) ?struct { method: *const ast.DefDecl, owner: *const ast.ClassDecl } {
-        for (cd.methods) |*method| {
-            if (std.mem.eql(u8, self.lexeme(method.name), method_name)) {
-                return .{ .method = method, .owner = cd };
-            }
-        }
-        if (cd.extends) |ext| if (self.class_registry.get(self.lexeme(ext))) |parent| {
-            return self.lookupClassMethodOwner(parent, method_name);
-        };
-        return null;
-    }
-
-    /// Walk a class's inheritance chain looking for a field by
-    /// name and return both the field decl and the owning class.
-    /// Owner identity drives `@private` enforcement (subclasses
-    /// don't see private parent fields).
-    fn lookupClassFieldOwner(
-        self: *const Checker,
-        cd: *const ast.ClassDecl,
-        field_name: []const u8,
-    ) ?struct { field: *const ast.ClassField, owner: *const ast.ClassDecl } {
-        for (cd.fields) |*fld| {
-            if (std.mem.eql(u8, self.lexeme(fld.name), field_name)) {
-                return .{ .field = fld, .owner = cd };
-            }
-        }
-        if (cd.extends) |ext| if (self.class_registry.get(self.lexeme(ext))) |parent| {
-            return self.lookupClassFieldOwner(parent, field_name);
-        };
-        return null;
     }
 
     // ---------- literal inference with bidirectional hint ----------
@@ -2626,8 +2209,8 @@ fn anyExprMentions(c: *const Checker, exprs: []const *ast.Expr, name: []const u8
     return false;
 }
 
-fn structLitMentions(c: *const Checker, fields: []const ast.StructLitField, name: []const u8) bool {
-    for (fields) |f| if (c.exprMentions(f.value, name)) return true;
+fn structLitMentions(c: *const Checker, lit_fields: []const ast.StructLitField, name: []const u8) bool {
+    for (lit_fields) |f| if (c.exprMentions(f.value, name)) return true;
     return false;
 }
 

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -164,6 +164,7 @@ const annotations = @import("typecheck/annotations.zig");
 const relations = @import("typecheck/relations.zig");
 const flow = @import("typecheck/flow.zig");
 const suggestions = @import("typecheck/suggestions.zig");
+const type_resolve = @import("typecheck/type_resolve.zig");
 
 const T = annotations.T;
 
@@ -311,7 +312,7 @@ pub const Checker = struct {
 
     /// Same as `emitSpan` plus an optional `help:` block printed
     /// after the caret snippet.
-    fn emitSpanHelp(
+    pub fn emitSpanHelp(
         self: *Checker,
         code: []const u8,
         span: ast.Span,
@@ -450,7 +451,7 @@ pub const Checker = struct {
     /// the closest Levenshtein match within `suggestions.max_distance`.
     /// Used for `E_UNDEFINED_SYMBOL` — covers locals, params,
     /// globals, defs, classes, structs, enums.
-    fn suggestSymbol(self: *Checker, name: []const u8) WalkError!?[]const u8 {
+    pub fn suggestSymbol(self: *Checker, name: []const u8) WalkError!?[]const u8 {
         var pool: std.ArrayList([]const u8) = .empty;
         defer pool.deinit(self.arena);
         var scope: ?*const Scope = self.current_scope;
@@ -464,7 +465,7 @@ pub const Checker = struct {
     /// Same pool as `suggestSymbol` plus the primitive type names —
     /// used by `E_TYPE_UNDEFINED` when an unknown type name shows
     /// up in an annotation / struct-lit position.
-    fn suggestTypeName(self: *Checker, name: []const u8) WalkError!?[]const u8 {
+    pub fn suggestTypeName(self: *Checker, name: []const u8) WalkError!?[]const u8 {
         var pool: std.ArrayList([]const u8) = .empty;
         defer pool.deinit(self.arena);
         // Primitive types — must be matched first so `let x: i8`
@@ -482,7 +483,7 @@ pub const Checker = struct {
 
     /// Collect the field names of a struct decl into the candidate
     /// pool for an `E_TYPE_UNDEFINED_FIELD` suggestion.
-    fn suggestStructField(self: *Checker, sd: *const ast.StructDecl, name: []const u8) WalkError!?[]const u8 {
+    pub fn suggestStructField(self: *Checker, sd: *const ast.StructDecl, name: []const u8) WalkError!?[]const u8 {
         var pool: std.ArrayList([]const u8) = .empty;
         defer pool.deinit(self.arena);
         for (sd.fields) |f| try pool.append(self.arena, self.lexeme(f.name));
@@ -493,7 +494,7 @@ pub const Checker = struct {
     /// inheritance chain — for `E_TYPE_UNDEFINED_FIELD` on a class
     /// receiver. Walks parents so suggestions can land on inherited
     /// fields.
-    fn suggestClassField(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
+    pub fn suggestClassField(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
         var pool: std.ArrayList([]const u8) = .empty;
         defer pool.deinit(self.arena);
         var cur: ?*const ast.ClassDecl = cd;
@@ -506,7 +507,7 @@ pub const Checker = struct {
 
     /// Collect every method reachable from a class via its
     /// inheritance chain — for `E_TYPE_UNDEFINED_METHOD`.
-    fn suggestClassMethod(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
+    pub fn suggestClassMethod(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
         var pool: std.ArrayList([]const u8) = .empty;
         defer pool.deinit(self.arena);
         var cur: ?*const ast.ClassDecl = cd;
@@ -584,7 +585,7 @@ pub const Checker = struct {
         switch (pat.*) {
             .ident => |i| {
                 const ty: ?*const types.Type = if (type_ann) |t|
-                    try self.resolveType(t)
+                    try type_resolve.resolveType(self, t)
                 else
                     null;
                 try self.registerName(self.lexeme(i.name), .{
@@ -671,13 +672,13 @@ pub const Checker = struct {
         errdefer param_types.deinit(self.arena);
         for (d.params) |p| {
             const pt: *const types.Type = if (p.type_ann) |t|
-                try self.resolveType(t)
+                try type_resolve.resolveType(self, t)
             else
                 try self.primitive(.nil_); // unknown until call-site inference
             try param_types.append(self.arena, pt);
         }
         const ret_ty: *const types.Type = if (d.ret_type) |r|
-            try self.resolveType(r)
+            try type_resolve.resolveType(self, r)
         else
             try self.primitive(.nil_);
         const sig = try self.arena.create(types.Type);
@@ -780,7 +781,7 @@ pub const Checker = struct {
     fn checkLetDecl(self: *Checker, d: ast.LetDecl) WalkError!void {
         try annotations.validateAnnotations(self, d.annotations, T.LET);
         const ann_ty: ?*const types.Type = if (d.type_ann) |t|
-            try self.resolveType(t)
+            try type_resolve.resolveType(self, t)
         else
             null;
         // Pass annotation type as a hint so int literals pin to the
@@ -889,7 +890,7 @@ pub const Checker = struct {
     fn checkConstDecl(self: *Checker, d: ast.ConstDecl) WalkError!void {
         try annotations.validateAnnotations(self, d.annotations, T.CONST);
         const ann_ty: ?*const types.Type = if (d.type_ann) |t|
-            try self.resolveType(t)
+            try type_resolve.resolveType(self, t)
         else
             null;
         const init_ty = try self.inferExpr(d.init, ann_ty);
@@ -1128,7 +1129,7 @@ pub const Checker = struct {
         // Bake fn return type must be bakeable. `Vec(T)` and `&T`
         // are runtime-only.
         if (d.is_bake) if (d.ret_type) |r| {
-            const rt = try self.resolveType(r);
+            const rt = try type_resolve.resolveType(self, r);
             if (!predicates.isBakeableType(rt.*)) {
                 const ty_s = try types.render(self.arena, rt.*);
                 const msg = try std.fmt.allocPrint(
@@ -1142,7 +1143,7 @@ pub const Checker = struct {
 
         for (d.params) |p| {
             const pt: ?*const types.Type = if (p.type_ann) |t|
-                try self.resolveType(t)
+                try type_resolve.resolveType(self, t)
             else
                 null;
             try self.registerName(self.lexeme(p.name), .{
@@ -1163,7 +1164,7 @@ pub const Checker = struct {
 
         // Track ret type for `return expr` checking inside the body.
         const saved_ret = self.current_ret_ty;
-        self.current_ret_ty = if (d.ret_type) |r| try self.resolveType(r) else null;
+        self.current_ret_ty = if (d.ret_type) |r| try type_resolve.resolveType(self, r) else null;
         defer self.current_ret_ty = saved_ret;
 
         try self.walkStatementSequence(d.body);
@@ -1198,7 +1199,7 @@ pub const Checker = struct {
         for (d.fields) |f| {
             try annotations.validateAnnotations(self, f.annotations, T.CLASS_FIELD);
             const ty: ?*const types.Type = if (f.type_ann) |t|
-                try self.resolveType(t)
+                try type_resolve.resolveType(self, t)
             else
                 null;
             try self.registerName(self.lexeme(f.name), .{
@@ -1415,109 +1416,11 @@ pub const Checker = struct {
         };
     }
 
-    // ---------- type resolution ----------
-
-    fn resolveType(self: *Checker, t: *const ast.TypeAnn) WalkError!*const types.Type {
-        switch (t.*) {
-            .named => |n| {
-                const name = self.lexeme(n.name);
-                if (types.primitiveFromName(name)) |p| {
-                    return try self.primitive(p);
-                }
-                if (self.current_scope.lookup(name)) |_| {
-                    return try types.mkNamed(self.arena, name, n.span);
-                }
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "undefined type `{s}`",
-                    .{name},
-                );
-                try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", n.name, msg, try self.suggestTypeName(name));
-                return try types.mkNamed(self.arena, name, n.span);
-            },
-            .nullable => |n| {
-                const inner = try self.resolveType(n.inner);
-                if (!self.isPointerLike(inner.*)) {
-                    const inner_s = try types.render(self.arena, inner.*);
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "type `{s}?` is invalid — `T?` only applies to pointer-like types (`str`, class, fn-pointer, references)",
-                        .{inner_s},
-                    );
-                    try self.emitSpan("E_NULL_NON_POINTER", n.span, msg);
-                }
-                return try types.mkOptional(self.arena, inner);
-            },
-            .array => |a| {
-                const elem = try self.resolveType(a.elem);
-                const len_val: u32 = if (a.len_expr.* == .int_lit)
-                    // safety: parser stores array lengths as i32; §3.4 requires non-negative comptime int. Slice 3+ will range-check; bit-cast preserves bytes.
-                    @bitCast(a.len_expr.int_lit.value)
-                else
-                    0;
-                return try types.mkArray(self.arena, elem, len_val);
-            },
-            .vec => |v| {
-                const elem = try self.resolveType(v.elem);
-                return try types.mkVec(self.arena, elem);
-            },
-            .tuple => |tu| {
-                var elems: std.ArrayList(*const types.Type) = .empty;
-                errdefer elems.deinit(self.arena);
-                for (tu.elems) |e| try elems.append(self.arena, try self.resolveType(e));
-                const out = try self.arena.create(types.Type);
-                out.* = .{ .tuple = try elems.toOwnedSlice(self.arena) };
-                return out;
-            },
-            .fn_type => |f| {
-                var params: std.ArrayList(*const types.Type) = .empty;
-                errdefer params.deinit(self.arena);
-                for (f.params) |p| try params.append(self.arena, try self.resolveType(p));
-                const ret: *const types.Type = if (f.ret) |r|
-                    try self.resolveType(r)
-                else
-                    try self.primitive(.nil_);
-                const out = try self.arena.create(types.Type);
-                out.* = .{ .function = .{
-                    .params = try params.toOwnedSlice(self.arena),
-                    .ret = ret,
-                } };
-                return out;
-            },
-            .reference => |r| {
-                const inner = try self.resolveType(r.inner);
-                return try types.mkReference(self.arena, inner);
-            },
-        }
-    }
-
     /// Allocate (or reuse) a `Type` value for the given primitive
     /// tag. Sub-modules call this to construct argument / return
     /// types for the function signatures they synthesize.
     pub fn primitive(self: *Checker, p: types.Primitive) WalkError!*const types.Type {
         return try types.mkPrimitive(self.arena, p);
-    }
-
-    /// Pointer-like types per §3.4.1 — `str`, references, function
-    /// pointers, and class names. Struct / enum / numeric / bool /
-    /// fixed are by-value and therefore not nullable-eligible.
-    fn isPointerLike(self: *const Checker, t: types.Type) bool {
-        return switch (t) {
-            .primitive => |p| p == .str,
-            .reference, .function => true,
-            .named => |n| {
-                if (self.current_scope.lookup(n.name)) |info| {
-                    return switch (info.kind) {
-                        .class, .module_alias, .imported => true,
-                        else => false,
-                    };
-                }
-                // Unresolved named type — accept defensively so the
-                // diagnostic surfaces from the resolution step.
-                return true;
-            },
-            else => false,
-        };
     }
 
     // ---------- expression walking + inference + checking ----------
@@ -1677,7 +1580,7 @@ pub const Checker = struct {
                 errdefer param_types.deinit(self.arena);
                 for (l.params, 0..) |p, i| {
                     const pt: *const types.Type = if (p.type_ann) |t|
-                        try self.resolveType(t)
+                        try type_resolve.resolveType(self, t)
                     else if (hint_fn) |hf|
                         if (i < hf.params.len) hf.params[i] else try self.primitive(.nil_)
                     else
@@ -1690,7 +1593,7 @@ pub const Checker = struct {
                     try param_types.append(self.arena, pt);
                 }
                 const ret_ty: *const types.Type = if (l.ret_type) |r|
-                    try self.resolveType(r)
+                    try type_resolve.resolveType(self, r)
                 else if (hint_fn) |hf|
                     hf.ret
                 else
@@ -1851,7 +1754,7 @@ pub const Checker = struct {
         var param_tys: std.ArrayList(*const types.Type) = .empty;
         errdefer param_tys.deinit(self.arena);
         for (variant.?.payload) |pf| {
-            const pt = try self.resolveType(pf.type_ann);
+            const pt = try type_resolve.resolveType(self, pf.type_ann);
             try param_tys.append(self.arena, pt);
         }
         const fn_ty = try self.arena.create(types.Type);
@@ -1885,7 +1788,7 @@ pub const Checker = struct {
         if (self.struct_registry.get(named_name)) |sd| {
             for (sd.fields) |fld| {
                 if (std.mem.eql(u8, self.lexeme(fld.name), field_name)) {
-                    return try self.resolveType(fld.type_ann);
+                    return try type_resolve.resolveType(self, fld.type_ann);
                 }
             }
             try self.emitUndefinedField(named_name, field_name, f.field);
@@ -1905,7 +1808,7 @@ pub const Checker = struct {
                         try self.emitSpan("E_PRIVATE_ACCESS", f.field, msg);
                     }
                 }
-                if (hit.field.type_ann) |t| return try self.resolveType(t);
+                if (hit.field.type_ann) |t| return try type_resolve.resolveType(self, t);
                 return null;
             }
             try self.emitUndefinedField(named_name, field_name, f.field);
@@ -1923,7 +1826,7 @@ pub const Checker = struct {
     ) WalkError!?*const types.Type {
         for (cd.fields) |fld| {
             if (std.mem.eql(u8, self.lexeme(fld.name), field_name)) {
-                if (fld.type_ann) |t| return try self.resolveType(t);
+                if (fld.type_ann) |t| return try type_resolve.resolveType(self, t);
                 return null;
             }
         }
@@ -2037,7 +1940,7 @@ pub const Checker = struct {
         } else {
             for (m.args, sig_params) |arg, p| {
                 const param_ty: ?*const types.Type = if (p.type_ann) |t|
-                    try self.resolveType(t)
+                    try type_resolve.resolveType(self, t)
                 else
                     null;
                 const skip = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
@@ -2047,7 +1950,7 @@ pub const Checker = struct {
                 }
             }
         }
-        if (method.ret_type) |r| return try self.resolveType(r);
+        if (method.ret_type) |r| return try type_resolve.resolveType(self, r);
         return try self.primitive(.nil_);
     }
 
@@ -2097,7 +2000,7 @@ pub const Checker = struct {
                 _ = try self.inferExpr(lit_field.value, null);
                 continue;
             };
-            const expected_ty = try self.resolveType(decl_field.type_ann);
+            const expected_ty = try type_resolve.resolveType(self, decl_field.type_ann);
             const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
             if (actual_ty) |at| try self.checkStoreCompat(lit_field.value.span(), expected_ty, at);
             _ = try seen.put(self.arena, field_name, {});
@@ -2158,7 +2061,7 @@ pub const Checker = struct {
             const skip: usize = if (has_self) 1 else 0;
             for (init_method.params[skip..]) |p| {
                 const pt: *const types.Type = if (p.type_ann) |t|
-                    try self.resolveType(t)
+                    try type_resolve.resolveType(self, t)
                 else
                     try self.primitive(.nil_);
                 try param_types.append(self.arena, pt);
@@ -2436,7 +2339,7 @@ pub const Checker = struct {
 
     fn checkCast(self: *Checker, c: ast.CastExpr) WalkError!?*const types.Type {
         const inner_ty = try self.inferExpr(c.inner, null);
-        const target_ty = try self.resolveType(c.target_type);
+        const target_ty = try type_resolve.resolveType(self, c.target_type);
         if (inner_ty) |it| {
             if (!relations.canCast(it.*, target_ty.*)) {
                 const from_s = try types.render(self.arena, it.*);

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -167,6 +167,7 @@ const suggestions = @import("typecheck/suggestions.zig");
 const type_resolve = @import("typecheck/type_resolve.zig");
 const fields = @import("typecheck/fields.zig");
 const operators = @import("typecheck/operators.zig");
+const calls = @import("typecheck/calls.zig");
 
 const T = annotations.T;
 
@@ -1103,8 +1104,8 @@ pub const Checker = struct {
 
     fn checkDefDecl(self: *Checker, d: ast.DefDecl) WalkError!void {
         try annotations.validateAnnotations(self, d.annotations, T.DEF);
-        if (d.is_bake) try self.checkBakeAnnotationConflicts(d.annotations);
-        try self.checkVariadicPosition(d);
+        if (d.is_bake) try calls.checkBakeAnnotationConflicts(self, d.annotations);
+        try calls.checkVariadicPosition(self, d);
         const saved_scope = self.current_scope;
         var fn_scope: Scope = .init(self.arena, saved_scope);
         self.current_scope = &fn_scope;
@@ -1511,7 +1512,7 @@ pub const Checker = struct {
                 _ = try self.inferExpr(r.end, null);
                 return null;
             },
-            .call => |c| return try self.checkCall(c, hint),
+            .call => |c| return try calls.checkCall(self, c, hint),
             .method_call => |m| {
                 // `mem.X(args)` parses as a method call on the
                 // synthetic `mem` module — dispatch through the
@@ -1774,244 +1775,6 @@ pub const Checker = struct {
         }
         return null;
     }
-
-    // ---------- function call ----------
-
-    fn checkCall(self: *Checker, c: ast.CallExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
-        _ = hint;
-        // `assert` / `debug_assert` always-in-scope builtins
-        // (§5.3) — no underlying `def`, so they skip the regular
-        // callee-resolution path.
-        if (c.callee.* == .ident) {
-            const callee_name = self.lexeme(c.callee.ident.span);
-            if (isAssertBuiltinName(callee_name)) {
-                return try self.checkAssertBuiltin(c, callee_name);
-            }
-        }
-        // Abstract-class instantiation: `ClassName(args)` where
-        // `ClassName` is abstract is rejected.
-        if (c.callee.* == .ident) {
-            const callee_name = self.lexeme(c.callee.ident.span);
-            if (self.class_registry.get(callee_name)) |cd| {
-                if (annotations.classIsAbstract(self, cd)) {
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "cannot instantiate `{s}` — class is `@abstract`",
-                        .{callee_name},
-                    );
-                    try self.emitSpan("E_CLASS_ABSTRACT_INSTANTIATE", c.callee.span(), msg);
-                }
-            }
-        }
-        const callee_ty = try self.inferExpr(c.callee, null);
-        // Bake-context rule: only `bake def` fns may be called.
-        if (self.in_bake) try self.checkBakeCall(c);
-        if (callee_ty == null) {
-            for (c.args) |a| _ = try self.inferExpr(a, null);
-            return null;
-        }
-        if (callee_ty.?.* != .function) {
-            const ty_s = try types.render(self.arena, callee_ty.?.*);
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "called value has type `{s}`, expected a function",
-                .{ty_s},
-            );
-            try self.emitSpan("E_TYPE_MISMATCH", c.callee.span(), msg);
-            for (c.args) |a| _ = try self.inferExpr(a, null);
-            return null;
-        }
-        const f = callee_ty.?.function;
-
-        // Variadic call: when the callee resolves to a `def` whose
-        // last param is variadic, the arity / per-arg checks pivot
-        // on the leading fixed params; the trailing args must share
-        // a single type.
-        if (variadicCalleeDecl(self, c.callee)) |decl| {
-            return try self.checkVariadicCall(c, decl, f);
-        }
-
-        if (c.args.len != f.params.len) {
-            const suffix: []const u8 = if (f.params.len == 1) "" else "s";
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "function takes {d} argument{s}, called with {d}",
-                .{ f.params.len, suffix, c.args.len },
-            );
-            try self.emitSpan("E_TYPE_ARG_COUNT", c.span, msg);
-            for (c.args) |a| _ = try self.inferExpr(a, null);
-            return f.ret;
-        }
-        for (c.args, 0..) |arg, i| {
-            const param_ty = f.params[i];
-            // Skip the type check when the param's type is the
-            // `nil_` placeholder used for unannotated `def` params —
-            // those params accept any caller-supplied type.
-            const skip = predicates.isNilType(param_ty.*);
-            const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-            if (!skip and arg_ty != null) {
-                try self.checkStoreCompat(arg.span(), param_ty, arg_ty.?);
-            }
-        }
-        return f.ret;
-    }
-
-    // ---------- assert builtins (§5.3) ----------
-
-    /// Type-check `assert(cond, msg?)` / `debug_assert(cond, msg?)`.
-    /// Validates arity (1 or 2 args), bool cond, str msg, and
-    /// warns when a `debug_assert` arg looks side-effecting (any
-    /// nested `CallExpr` is the proxy). Returns `nil` — the
-    /// builtins are statement-shaped even when called in expression
-    /// position.
-    fn checkAssertBuiltin(
-        self: *Checker,
-        c: ast.CallExpr,
-        name: []const u8,
-    ) WalkError!?*const types.Type {
-        if (c.args.len == 0 or c.args.len > 2) {
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "`{s}` takes 1 or 2 arguments (cond, msg?), called with {d}",
-                .{ name, c.args.len },
-            );
-            try self.emitSpan("E_ASSERT_ARG_COUNT", c.span, msg);
-            for (c.args) |a| _ = try self.inferExpr(a, null);
-            return try self.primitive(.nil_);
-        }
-        const bool_ty = try self.primitive(.bool_);
-        const cond_ty = try self.inferExpr(c.args[0], bool_ty);
-        if (cond_ty != null and !relations.assignable(cond_ty.?.*, bool_ty.*)) {
-            try self.emitMismatch(c.args[0].span(), bool_ty, cond_ty.?);
-        }
-        if (c.args.len == 2) {
-            const str_ty = try self.primitive(.str);
-            const msg_ty = try self.inferExpr(c.args[1], str_ty);
-            if (msg_ty != null and !relations.assignable(msg_ty.?.*, str_ty.*)) {
-                try self.emitMismatch(c.args[1].span(), str_ty, msg_ty.?);
-            }
-        }
-        // `debug_assert` is elided in release — surface any
-        // observable side effect (a nested call) so the user
-        // doesn't rely on it firing in shipped builds.
-        if (std.mem.eql(u8, name, "debug_assert")) {
-            for (c.args) |a| if (exprContainsCall(a)) {
-                try self.diagnostics.append(self.diag_alloc, .{
-                    .severity = .warning,
-                    .code = "W_DEBUG_ASSERT_SIDE_EFFECT",
-                    .message = "`debug_assert` arguments are elided in release builds — any side effects here will not occur",
-                    .span = a.span(),
-                });
-                break;
-            };
-        }
-        return try self.primitive(.nil_);
-    }
-
-    // ---------- variadic (§4.6.2) ----------
-
-    /// Verify a `def`'s param list places the (optional) variadic
-    /// param last. Parser may already enforce; this check routes
-    /// any out-of-place variadic through `E_VAR_NOT_LAST`.
-    fn checkVariadicPosition(self: *Checker, d: ast.DefDecl) WalkError!void {
-        for (d.params, 0..) |p, i| {
-            if (p.variadic and i != d.params.len - 1) {
-                try self.emitSpan("E_VAR_NOT_LAST", p.span, "variadic parameter must be the last in the parameter list");
-                return;
-            }
-        }
-    }
-
-    /// Type-check a call whose callee has a trailing variadic
-    /// param. The leading fixed params match positionally; every
-    /// arg passed into the variadic slot must share a single type.
-    fn checkVariadicCall(
-        self: *Checker,
-        c: ast.CallExpr,
-        decl: *const ast.DefDecl,
-        f: types.Function,
-    ) WalkError!?*const types.Type {
-        const fixed_count = decl.params.len - 1;
-        if (c.args.len < fixed_count) {
-            const suffix: []const u8 = if (fixed_count == 1) "" else "s";
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "variadic function requires at least {d} fixed argument{s}, called with {d}",
-                .{ fixed_count, suffix, c.args.len },
-            );
-            try self.emitSpan("E_TYPE_ARG_COUNT", c.span, msg);
-            for (c.args) |a| _ = try self.inferExpr(a, null);
-            return f.ret;
-        }
-        // Fixed params: standard per-arg type check.
-        for (c.args[0..fixed_count], 0..) |arg, i| {
-            const param_ty = f.params[i];
-            const skip = predicates.isNilType(param_ty.*);
-            const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
-            if (!skip and arg_ty != null) {
-                try self.checkStoreCompat(arg.span(), param_ty, arg_ty.?);
-            }
-        }
-        // Variadic slot: all trailing args must share a type.
-        var pivot: ?*const types.Type = null;
-        for (c.args[fixed_count..]) |arg| {
-            const arg_ty = try self.inferExpr(arg, pivot);
-            const at = arg_ty orelse continue;
-            if (pivot) |p| {
-                if (!relations.assignable(at.*, p.*)) {
-                    const exp_s = try types.render(self.arena, p.*);
-                    const got_s = try types.render(self.arena, at.*);
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "variadic argument has type `{s}` but earlier variadic arg was `{s}` — all variadic args must share a single type",
-                        .{ got_s, exp_s },
-                    );
-                    try self.emitSpan("E_VAR_HETEROGENEOUS", arg.span(), msg);
-                }
-            } else {
-                pivot = at;
-            }
-        }
-        return f.ret;
-    }
-
-    // ---------- bake-context rules (§3.8) ----------
-
-    fn checkBakeCall(self: *Checker, c: ast.CallExpr) WalkError!void {
-        const callee_name = directCalleeName(self, c.callee) orelse return;
-        const decl = self.def_registry.get(callee_name) orelse return;
-        if (!decl.is_bake) {
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "cannot call non-`bake` function `{s}` from inside a `bake` context",
-                .{callee_name},
-            );
-            try self.emitSpan("E_BAKE_FORBIDDEN_CALL", c.callee.span(), msg);
-        }
-    }
-
-    /// Per spec §3.8, `bake` cannot combine with `@cold`,
-    /// `@inline`, `@interrupt`, `@bank`, or `@no_capture` —
-    /// those describe runtime codegen and have no meaning at
-    /// compile-time evaluation. Reuses `E_ANN_CONFLICT` with a
-    /// bake-flavored message so editors / filters match the
-    /// same code as other mutual-exclusion checks.
-    fn checkBakeAnnotationConflicts(self: *Checker, anns: []const ast.Annotation) WalkError!void {
-        const forbidden = [_][]const u8{ "cold", "inline", "interrupt", "bank", "no_capture" };
-        for (anns) |ann| {
-            const name = self.lexeme(ann.name);
-            for (forbidden) |f| {
-                if (std.mem.eql(u8, name, f)) {
-                    const msg = try std.fmt.allocPrint(
-                        self.arena,
-                        "annotation `@{s}` cannot be combined with `bake` — `@{s}` describes runtime codegen, which has no meaning for compile-time evaluation (§3.8)",
-                        .{ name, name },
-                    );
-                    try self.emitSpan("E_ANN_CONFLICT", ann.name, msg);
-                }
-            }
-        }
-    }
 };
 
 // ---------- module-level helpers ----------
@@ -2051,26 +1814,6 @@ fn structLitMentions(c: *const Checker, lit_fields: []const ast.StructLitField, 
     return false;
 }
 
-// ---------- callee resolution helpers ----------
-
-/// Extract the lexeme of a callee that is a bare ident (possibly
-/// wrapped in `paren`). Used by call-site rules that need to find
-/// the underlying decl (bake-call check, variadic detection).
-fn directCalleeName(c: *const Checker, callee: *const ast.Expr) ?[]const u8 {
-    return flow.identName(c, callee);
-}
-
-/// When `callee` resolves to a `def` decl whose last param is
-/// variadic, return that decl. Returns `null` otherwise — callers
-/// fall back to the regular fixed-arity path.
-fn variadicCalleeDecl(c: *const Checker, callee: *const ast.Expr) ?*const ast.DefDecl {
-    const name = flow.identName(c, callee) orelse return null;
-    const decl = c.def_registry.get(name) orelse return null;
-    if (decl.params.len == 0) return null;
-    if (!decl.params[decl.params.len - 1].variadic) return null;
-    return decl;
-}
-
 // ---------- place expression check ----------
 
 /// `true` when `e` is a valid assignment target — `ident`, `field`,
@@ -2091,31 +1834,4 @@ fn isPlaceExpr(e: *const ast.Expr) bool {
 fn peelReference(t: ?*const types.Type) ?*const types.Type {
     const ty = t orelse return null;
     return if (ty.* == .reference) ty.reference else ty;
-}
-
-/// `true` when `name` is one of the always-in-scope assert
-/// builtins per spec §5.3. Recognized at call sites before any
-/// generic callee resolution.
-fn isAssertBuiltinName(name: []const u8) bool {
-    return std.mem.eql(u8, name, "assert") or std.mem.eql(u8, name, "debug_assert");
-}
-
-/// `true` when `e` contains a `CallExpr` anywhere in its
-/// sub-tree. Used as a side-effect proxy for the
-/// `W_DEBUG_ASSERT_SIDE_EFFECT` warning — observable mutations
-/// happen through function calls in gero, so any call inside a
-/// `debug_assert` arg is worth flagging.
-fn exprContainsCall(e: *const ast.Expr) bool {
-    return switch (e.*) {
-        .call, .method_call => true,
-        .paren => |p| exprContainsCall(p.inner),
-        .unary => |u| exprContainsCall(u.operand),
-        .binary => |b| exprContainsCall(b.lhs) or exprContainsCall(b.rhs),
-        .field => |f| exprContainsCall(f.receiver),
-        .index => |ix| exprContainsCall(ix.receiver) or exprContainsCall(ix.index),
-        .cast => |c| exprContainsCall(c.inner),
-        .ref_of => |r| exprContainsCall(r.inner),
-        .is_test => |it| exprContainsCall(it.lhs),
-        else => false,
-    };
 }

--- a/src/lang/typecheck/calls.zig
+++ b/src/lang/typecheck/calls.zig
@@ -1,0 +1,298 @@
+/// Function-call type-checking: regular calls, assert / debug_assert
+/// builtins (§5.3), variadic param + call rules (§4.6.2), and
+/// bake-context rules (§3.8). Splits out of `typecheck.zig` so the
+/// walker file stays scannable. Every entry takes a `*Checker`.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const typecheck = @import("../typecheck.zig");
+const predicates = @import("predicates.zig");
+const relations = @import("relations.zig");
+const annotations = @import("annotations.zig");
+const flow = @import("flow.zig");
+
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+/// Type-check a regular call expression. Routes `assert` /
+/// `debug_assert` through their dedicated path, validates abstract-
+/// class instantiation, dispatches variadic callees to
+/// `checkVariadicCall`, and otherwise performs the standard arity +
+/// per-arg checks.
+pub fn checkCall(self: *Checker, c: ast.CallExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
+    _ = hint;
+    // `assert` / `debug_assert` always-in-scope builtins
+    // (§5.3) — no underlying `def`, so they skip the regular
+    // callee-resolution path.
+    if (c.callee.* == .ident) {
+        const callee_name = self.lexeme(c.callee.ident.span);
+        if (isAssertBuiltinName(callee_name)) {
+            return try checkAssertBuiltin(self, c, callee_name);
+        }
+    }
+    // Abstract-class instantiation: `ClassName(args)` where
+    // `ClassName` is abstract is rejected.
+    if (c.callee.* == .ident) {
+        const callee_name = self.lexeme(c.callee.ident.span);
+        if (self.class_registry.get(callee_name)) |cd| {
+            if (annotations.classIsAbstract(self, cd)) {
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "cannot instantiate `{s}` — class is `@abstract`",
+                    .{callee_name},
+                );
+                try self.emitSpan("E_CLASS_ABSTRACT_INSTANTIATE", c.callee.span(), msg);
+            }
+        }
+    }
+    const callee_ty = try self.inferExpr(c.callee, null);
+    // Bake-context rule: only `bake def` fns may be called.
+    if (self.in_bake) try checkBakeCall(self, c);
+    if (callee_ty == null) {
+        for (c.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    }
+    if (callee_ty.?.* != .function) {
+        const ty_s = try types.render(self.arena, callee_ty.?.*);
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "called value has type `{s}`, expected a function",
+            .{ty_s},
+        );
+        try self.emitSpan("E_TYPE_MISMATCH", c.callee.span(), msg);
+        for (c.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    }
+    const f = callee_ty.?.function;
+
+    // Variadic call: when the callee resolves to a `def` whose
+    // last param is variadic, the arity / per-arg checks pivot
+    // on the leading fixed params; the trailing args must share
+    // a single type.
+    if (variadicCalleeDecl(self, c.callee)) |decl| {
+        return try checkVariadicCall(self, c, decl, f);
+    }
+
+    if (c.args.len != f.params.len) {
+        const suffix: []const u8 = if (f.params.len == 1) "" else "s";
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "function takes {d} argument{s}, called with {d}",
+            .{ f.params.len, suffix, c.args.len },
+        );
+        try self.emitSpan("E_TYPE_ARG_COUNT", c.span, msg);
+        for (c.args) |a| _ = try self.inferExpr(a, null);
+        return f.ret;
+    }
+    for (c.args, 0..) |arg, i| {
+        const param_ty = f.params[i];
+        // Skip the type check when the param's type is the
+        // `nil_` placeholder used for unannotated `def` params —
+        // those params accept any caller-supplied type.
+        const skip = predicates.isNilType(param_ty.*);
+        const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
+        if (!skip and arg_ty != null) {
+            try self.checkStoreCompat(arg.span(), param_ty, arg_ty.?);
+        }
+    }
+    return f.ret;
+}
+
+/// Type-check `assert(cond, msg?)` / `debug_assert(cond, msg?)`.
+/// Validates arity (1 or 2 args), bool cond, str msg, and warns
+/// when a `debug_assert` arg looks side-effecting (any nested
+/// `CallExpr` is the proxy). Returns `nil` — the builtins are
+/// statement-shaped even when called in expression position.
+pub fn checkAssertBuiltin(
+    self: *Checker,
+    c: ast.CallExpr,
+    name: []const u8,
+) WalkError!?*const types.Type {
+    if (c.args.len == 0 or c.args.len > 2) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "`{s}` takes 1 or 2 arguments (cond, msg?), called with {d}",
+            .{ name, c.args.len },
+        );
+        try self.emitSpan("E_ASSERT_ARG_COUNT", c.span, msg);
+        for (c.args) |a| _ = try self.inferExpr(a, null);
+        return try self.primitive(.nil_);
+    }
+    const bool_ty = try self.primitive(.bool_);
+    const cond_ty = try self.inferExpr(c.args[0], bool_ty);
+    if (cond_ty != null and !relations.assignable(cond_ty.?.*, bool_ty.*)) {
+        try self.emitMismatch(c.args[0].span(), bool_ty, cond_ty.?);
+    }
+    if (c.args.len == 2) {
+        const str_ty = try self.primitive(.str);
+        const msg_ty = try self.inferExpr(c.args[1], str_ty);
+        if (msg_ty != null and !relations.assignable(msg_ty.?.*, str_ty.*)) {
+            try self.emitMismatch(c.args[1].span(), str_ty, msg_ty.?);
+        }
+    }
+    // `debug_assert` is elided in release — surface any
+    // observable side effect (a nested call) so the user
+    // doesn't rely on it firing in shipped builds.
+    if (std.mem.eql(u8, name, "debug_assert")) {
+        for (c.args) |a| if (exprContainsCall(a)) {
+            try self.diagnostics.append(self.diag_alloc, .{
+                .severity = .warning,
+                .code = "W_DEBUG_ASSERT_SIDE_EFFECT",
+                .message = "`debug_assert` arguments are elided in release builds — any side effects here will not occur",
+                .span = a.span(),
+            });
+            break;
+        };
+    }
+    return try self.primitive(.nil_);
+}
+
+/// Verify a `def`'s param list places the (optional) variadic
+/// param last. Parser may already enforce; this check routes any
+/// out-of-place variadic through `E_VAR_NOT_LAST`.
+pub fn checkVariadicPosition(self: *Checker, d: ast.DefDecl) WalkError!void {
+    for (d.params, 0..) |p, i| {
+        if (p.variadic and i != d.params.len - 1) {
+            try self.emitSpan("E_VAR_NOT_LAST", p.span, "variadic parameter must be the last in the parameter list");
+            return;
+        }
+    }
+}
+
+/// Type-check a call whose callee has a trailing variadic param.
+/// The leading fixed params match positionally; every arg passed
+/// into the variadic slot must share a single type.
+pub fn checkVariadicCall(
+    self: *Checker,
+    c: ast.CallExpr,
+    decl: *const ast.DefDecl,
+    f: types.Function,
+) WalkError!?*const types.Type {
+    const fixed_count = decl.params.len - 1;
+    if (c.args.len < fixed_count) {
+        const suffix: []const u8 = if (fixed_count == 1) "" else "s";
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "variadic function requires at least {d} fixed argument{s}, called with {d}",
+            .{ fixed_count, suffix, c.args.len },
+        );
+        try self.emitSpan("E_TYPE_ARG_COUNT", c.span, msg);
+        for (c.args) |a| _ = try self.inferExpr(a, null);
+        return f.ret;
+    }
+    // Fixed params: standard per-arg type check.
+    for (c.args[0..fixed_count], 0..) |arg, i| {
+        const param_ty = f.params[i];
+        const skip = predicates.isNilType(param_ty.*);
+        const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
+        if (!skip and arg_ty != null) {
+            try self.checkStoreCompat(arg.span(), param_ty, arg_ty.?);
+        }
+    }
+    // Variadic slot: all trailing args must share a type.
+    var pivot: ?*const types.Type = null;
+    for (c.args[fixed_count..]) |arg| {
+        const arg_ty = try self.inferExpr(arg, pivot);
+        const at = arg_ty orelse continue;
+        if (pivot) |p| {
+            if (!relations.assignable(at.*, p.*)) {
+                const exp_s = try types.render(self.arena, p.*);
+                const got_s = try types.render(self.arena, at.*);
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "variadic argument has type `{s}` but earlier variadic arg was `{s}` — all variadic args must share a single type",
+                    .{ got_s, exp_s },
+                );
+                try self.emitSpan("E_VAR_HETEROGENEOUS", arg.span(), msg);
+            }
+        } else {
+            pivot = at;
+        }
+    }
+    return f.ret;
+}
+
+/// Bake-context call rule (§3.8): only `bake def` functions may be
+/// called from inside a `bake` body. Emits `E_BAKE_FORBIDDEN_CALL`
+/// for any other callee resolvable to a registered def.
+pub fn checkBakeCall(self: *Checker, c: ast.CallExpr) WalkError!void {
+    const callee_name = directCalleeName(self, c.callee) orelse return;
+    const decl = self.def_registry.get(callee_name) orelse return;
+    if (!decl.is_bake) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "cannot call non-`bake` function `{s}` from inside a `bake` context",
+            .{callee_name},
+        );
+        try self.emitSpan("E_BAKE_FORBIDDEN_CALL", c.callee.span(), msg);
+    }
+}
+
+/// Per spec §3.8, `bake` cannot combine with `@cold`, `@inline`,
+/// `@interrupt`, `@bank`, or `@no_capture` — those describe
+/// runtime codegen and have no meaning at compile-time evaluation.
+/// Reuses `E_ANN_CONFLICT` with a bake-flavored message so editors
+/// / filters match the same code as other mutual-exclusion checks.
+pub fn checkBakeAnnotationConflicts(self: *Checker, anns: []const ast.Annotation) WalkError!void {
+    const forbidden = [_][]const u8{ "cold", "inline", "interrupt", "bank", "no_capture" };
+    for (anns) |ann| {
+        const name = self.lexeme(ann.name);
+        for (forbidden) |f| {
+            if (std.mem.eql(u8, name, f)) {
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "annotation `@{s}` cannot be combined with `bake` — `@{s}` describes runtime codegen, which has no meaning for compile-time evaluation (§3.8)",
+                    .{ name, name },
+                );
+                try self.emitSpan("E_ANN_CONFLICT", ann.name, msg);
+            }
+        }
+    }
+}
+
+// ---------- callee resolution helpers ----------
+
+/// Extract the lexeme of a callee that is a bare ident (possibly
+/// wrapped in `paren`). Used by call-site rules that need to find
+/// the underlying decl (bake-call check, variadic detection).
+fn directCalleeName(c: *const Checker, callee: *const ast.Expr) ?[]const u8 {
+    return flow.identName(c, callee);
+}
+
+/// When `callee` resolves to a `def` decl whose last param is
+/// variadic, return that decl. Returns `null` otherwise — callers
+/// fall back to the regular fixed-arity path.
+fn variadicCalleeDecl(c: *const Checker, callee: *const ast.Expr) ?*const ast.DefDecl {
+    const name = flow.identName(c, callee) orelse return null;
+    const decl = c.def_registry.get(name) orelse return null;
+    if (decl.params.len == 0) return null;
+    if (!decl.params[decl.params.len - 1].variadic) return null;
+    return decl;
+}
+
+/// `true` when `name` is one of the always-in-scope assert
+/// builtins per spec §5.3. Recognized at call sites before any
+/// generic callee resolution.
+fn isAssertBuiltinName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "assert") or std.mem.eql(u8, name, "debug_assert");
+}
+
+/// `true` when `e` contains a `CallExpr` anywhere in its sub-tree.
+/// Used as a side-effect proxy for the
+/// `W_DEBUG_ASSERT_SIDE_EFFECT` warning — observable mutations
+/// happen through function calls in gero, so any call inside a
+/// `debug_assert` arg is worth flagging.
+fn exprContainsCall(e: *const ast.Expr) bool {
+    return switch (e.*) {
+        .call, .method_call => true,
+        .paren => |p| exprContainsCall(p.inner),
+        .unary => |u| exprContainsCall(u.operand),
+        .binary => |b| exprContainsCall(b.lhs) or exprContainsCall(b.rhs),
+        .field => |f| exprContainsCall(f.receiver),
+        .index => |ix| exprContainsCall(ix.receiver) or exprContainsCall(ix.index),
+        .cast => |c| exprContainsCall(c.inner),
+        .ref_of => |r| exprContainsCall(r.inner),
+        .is_test => |it| exprContainsCall(it.lhs),
+        else => false,
+    };
+}

--- a/src/lang/typecheck/fields.zig
+++ b/src/lang/typecheck/fields.zig
@@ -1,0 +1,449 @@
+/// Field + method resolution for struct + class types, plus
+/// struct-literal / class-literal field validation and the
+/// per-class layout helpers (`lookupClassMethodOwner` etc.).
+/// Lives next to `typecheck.zig` since every entry takes a
+/// `*Checker` and threads through its registry maps.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const diag_mod = @import("../diagnostic.zig");
+const typecheck = @import("../typecheck.zig");
+const type_resolve = @import("type_resolve.zig");
+const annotations = @import("annotations.zig");
+const flow = @import("flow.zig");
+const predicates = @import("predicates.zig");
+const mem_builtin = @import("mem_builtin.zig");
+
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+/// Resolve an enum-variant constructor expression
+/// (`EnumName.Variant`). Nullary variants resolve directly to
+/// the enum's `Named` type — `let s = Color.Red` infers as
+/// `Color`. Payload-bearing variants resolve to the constructor
+/// function type `fn(payload_types) -> Enum` so a wrapping
+/// `CallExpr` (`Item.Potion(20)`) type-checks through the
+/// regular `checkCall` path.
+pub fn resolveEnumVariant(
+    self: *Checker,
+    ed: *const ast.EnumDecl,
+    enum_name: []const u8,
+    f: ast.FieldExpr,
+) WalkError!?*const types.Type {
+    const variant_name = self.lexeme(f.field);
+    const variant: ?*const ast.EnumVariant = blk: {
+        for (ed.variants) |*v| {
+            if (std.mem.eql(u8, self.lexeme(v.name), variant_name)) break :blk v;
+        }
+        break :blk null;
+    };
+    if (variant == null) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "enum `{s}` has no variant `{s}`",
+            .{ enum_name, variant_name },
+        );
+        try self.emitSpan("E_TYPE_UNDEFINED_VARIANT", f.field, msg);
+        return null;
+    }
+    const enum_ty = try types.mkNamed(self.arena, enum_name, f.receiver.ident.span);
+    if (variant.?.payload.len == 0) return enum_ty;
+
+    // Payload-bearing variant — synthesize a constructor
+    // function signature so call-site type-checking flows.
+    var param_tys: std.ArrayList(*const types.Type) = .empty;
+    errdefer param_tys.deinit(self.arena);
+    for (variant.?.payload) |pf| {
+        const pt = try type_resolve.resolveType(self, pf.type_ann);
+        try param_tys.append(self.arena, pt);
+    }
+    const fn_ty = try self.arena.create(types.Type);
+    fn_ty.* = .{ .function = .{
+        .params = try param_tys.toOwnedSlice(self.arena),
+        .ret = enum_ty,
+    } };
+    return fn_ty;
+}
+
+/// Type-check `mem.X(args)` as a method-call expression
+/// (delegates to `typecheck/mem_builtin.zig`).
+pub fn checkMemMethodCall(self: *Checker, m: ast.MethodCallExpr) WalkError!?*const types.Type {
+    return mem_builtin.checkMemMethodCall(self, m);
+}
+
+/// Resolve `mem.X` builtin field expressions (delegates to
+/// `typecheck/mem_builtin.zig`).
+pub fn resolveMemBuiltin(self: *Checker, f: ast.FieldExpr) WalkError!?*const types.Type {
+    return mem_builtin.resolveMemBuiltin(self, f);
+}
+
+/// Look up `f.field` against the receiver's named-type decl.
+/// Returns the field's declared type, or emits
+/// `E_TYPE_UNDEFINED_FIELD` when the field is unknown. Returns
+/// `null` when the receiver type isn't a resolvable named
+/// struct / class — downstream callers treat that as "unknown
+/// for now" rather than another error.
+pub fn resolveFieldAccess(
+    self: *Checker,
+    f: ast.FieldExpr,
+    recv_ty: ?*const types.Type,
+) WalkError!?*const types.Type {
+    const rt = recv_ty orelse return null;
+    const named_name = flow.namedNameOf(rt.*) orelse return null;
+    const field_name = self.lexeme(f.field);
+    if (self.struct_registry.get(named_name)) |sd| {
+        for (sd.fields) |fld| {
+            if (std.mem.eql(u8, self.lexeme(fld.name), field_name)) {
+                return try type_resolve.resolveType(self, fld.type_ann);
+            }
+        }
+        try emitUndefinedField(self, named_name, field_name, f.field);
+        return null;
+    }
+    if (self.class_registry.get(named_name)) |cd| {
+        if (lookupClassFieldOwner(self, cd, field_name)) |hit| {
+            if (annotations.hasAnnotation(self, hit.field.annotations, "private")) {
+                const owner_name = self.lexeme(hit.owner.name);
+                const visible = if (self.current_class_name) |cn| std.mem.eql(u8, cn, owner_name) else false;
+                if (!visible) {
+                    const msg = try std.fmt.allocPrint(
+                        self.arena,
+                        "field `{s}.{s}` is `@private` — only accessible from inside `{s}`",
+                        .{ named_name, field_name, owner_name },
+                    );
+                    try self.emitSpan("E_PRIVATE_ACCESS", f.field, msg);
+                }
+            }
+            if (hit.field.type_ann) |t| return try type_resolve.resolveType(self, t);
+            return null;
+        }
+        try emitUndefinedField(self, named_name, field_name, f.field);
+        return null;
+    }
+    return null;
+}
+
+/// Walk a class's inherited chain looking for a field named
+/// `field_name`. Returns the resolved type when found.
+pub fn lookupClassFieldType(
+    self: *Checker,
+    cd: *const ast.ClassDecl,
+    field_name: []const u8,
+) WalkError!?*const types.Type {
+    for (cd.fields) |fld| {
+        if (std.mem.eql(u8, self.lexeme(fld.name), field_name)) {
+            if (fld.type_ann) |t| return try type_resolve.resolveType(self, t);
+            return null;
+        }
+    }
+    if (cd.extends) |ext| if (self.class_registry.get(self.lexeme(ext))) |parent| {
+        return try lookupClassFieldType(self, parent, field_name);
+    };
+    return null;
+}
+
+/// Emit `E_TYPE_UNDEFINED_FIELD` for a missing struct / class
+/// field access. Suggests a near-spelling field name when one
+/// exists (Levenshtein, distance ≤ 2) and attaches the owning
+/// type's declaration span as the secondary anchor.
+pub fn emitUndefinedField(self: *Checker, type_name: []const u8, field_name: []const u8, span: ast.Span) WalkError!void {
+    const msg = try std.fmt.allocPrint(
+        self.arena,
+        "type `{s}` has no field `{s}`",
+        .{ type_name, field_name },
+    );
+    // Suggestion across struct + class registries — whichever
+    // resolves the type name supplies the field pool. Misses
+    // (no candidate within distance 2, or unknown type) fall
+    // through to the bare diagnostic. The same lookup yields
+    // the type's declaration span, which doubles as the
+    // secondary "type defined here" anchor.
+    var candidate: ?[]const u8 = null;
+    var type_decl_span: ?ast.Span = null;
+    if (self.struct_registry.get(type_name)) |sd| {
+        candidate = try self.suggestStructField(sd, field_name);
+        type_decl_span = sd.name;
+    } else if (self.class_registry.get(type_name)) |cd| {
+        candidate = try self.suggestClassField(cd, field_name);
+        type_decl_span = cd.name;
+    }
+    const help: ?[]const u8 = if (candidate) |c|
+        try std.fmt.allocPrint(self.arena, "did you mean `{s}`?", .{c})
+    else
+        null;
+    const secondary: []const diag_mod.SpanLabel = if (type_decl_span) |ts|
+        try self.singleSecondary(ts, try std.fmt.allocPrint(self.arena, "type `{s}` defined here", .{type_name}), .underline)
+    else
+        &.{};
+    try self.diagnostics.append(self.diag_alloc, .{
+        .severity = .fatal,
+        .code = "E_TYPE_UNDEFINED_FIELD",
+        .message = msg,
+        .span = span,
+        .help = help,
+        .secondary = secondary,
+    });
+}
+
+/// Type-check a method call against the class registry.
+/// Walks args regardless so unrelated diagnostics still fire.
+/// Emits `E_TYPE_UNDEFINED_METHOD` when the named method is
+/// missing on the receiver class. Otherwise behaves like a
+/// regular call: arity + per-arg type check against the method's
+/// signature.
+pub fn checkMethodCall(
+    self: *Checker,
+    m: ast.MethodCallExpr,
+    recv_ty: ?*const types.Type,
+) WalkError!?*const types.Type {
+    const rt = recv_ty orelse {
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    };
+    const named_name = flow.namedNameOf(rt.*) orelse {
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    };
+    const cd = self.class_registry.get(named_name) orelse {
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    };
+    const method_name = self.lexeme(m.method);
+    const hit = lookupClassMethodOwner(self, cd, method_name) orelse {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "class `{s}` has no method `{s}`",
+            .{ named_name, method_name },
+        );
+        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", m.method, msg, try self.suggestClassMethod(cd, method_name));
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    };
+    const method = hit.method;
+    if (annotations.hasAnnotation(self, method.annotations, "private")) {
+        const owner_name = self.lexeme(hit.owner.name);
+        const visible = if (self.current_class_name) |cn| std.mem.eql(u8, cn, owner_name) else false;
+        if (!visible) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "method `{s}.{s}` is `@private` — only callable from inside `{s}`",
+                .{ named_name, method_name, owner_name },
+            );
+            try self.emitSpan("E_PRIVATE_ACCESS", m.method, msg);
+        }
+    }
+    // Build the method signature on the fly. Skip the `self`
+    // param when matching args.
+    var has_self = false;
+    if (method.params.len > 0 and std.mem.eql(u8, self.lexeme(method.params[0].name), "self")) has_self = true;
+    const skip_count: usize = if (has_self) 1 else 0;
+    const sig_params = method.params[skip_count..];
+    if (m.args.len != sig_params.len) {
+        const suffix: []const u8 = if (sig_params.len == 1) "" else "s";
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "method `{s}.{s}` takes {d} argument{s}, called with {d}",
+            .{ named_name, method_name, sig_params.len, suffix, m.args.len },
+        );
+        try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+    } else {
+        for (m.args, sig_params) |arg, p| {
+            const param_ty: ?*const types.Type = if (p.type_ann) |t|
+                try type_resolve.resolveType(self, t)
+            else
+                null;
+            const skip = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
+            const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
+            if (!skip and param_ty != null and arg_ty != null) {
+                try self.checkStoreCompat(arg.span(), param_ty.?, arg_ty.?);
+            }
+        }
+    }
+    if (method.ret_type) |r| return try type_resolve.resolveType(self, r);
+    return try self.primitive(.nil_);
+}
+
+/// Validate a struct literal against its decl. Reports
+/// unknown / missing / mistyped fields and returns the named
+/// type so the surrounding expression continues to type-check.
+pub fn checkStructLit(self: *Checker, sl: ast.StructLit) WalkError!?*const types.Type {
+    const type_name = self.lexeme(sl.type_name);
+    const named_ty = try types.mkNamed(self.arena, type_name, sl.type_name);
+
+    // Struct literals can be used to construct classes too
+    // (`Player { name: "Cecil" }` shorthand) — try both
+    // registries.
+    if (self.struct_registry.get(type_name)) |sd| {
+        try checkStructLitFields(self, sl, type_name, sd.fields);
+        return named_ty;
+    }
+    if (self.class_registry.get(type_name)) |cd| {
+        try checkClassLitFields(self, sl, type_name, cd);
+        return named_ty;
+    }
+    // Unknown type — emit the standard undefined-type code so
+    // the user gets one consistent diagnostic, then walk the
+    // values defensively to surface inner errors.
+    const msg = try std.fmt.allocPrint(
+        self.arena,
+        "undefined type `{s}`",
+        .{type_name},
+    );
+    try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", sl.type_name, msg, try self.suggestTypeName(type_name));
+    for (sl.fields) |f| _ = try self.inferExpr(f.value, null);
+    return named_ty;
+}
+
+fn checkStructLitFields(
+    self: *Checker,
+    sl: ast.StructLit,
+    type_name: []const u8,
+    decl_fields: []const ast.StructField,
+) WalkError!void {
+    var seen: std.StringHashMapUnmanaged(void) = .{};
+    defer seen.deinit(self.arena);
+    for (sl.fields) |lit_field| {
+        const field_name = self.lexeme(lit_field.name);
+        const decl_field = flow.findStructField(self, decl_fields, field_name) orelse {
+            try emitUndefinedField(self, type_name, field_name, lit_field.name);
+            _ = try self.inferExpr(lit_field.value, null);
+            continue;
+        };
+        const expected_ty = try type_resolve.resolveType(self, decl_field.type_ann);
+        const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
+        if (actual_ty) |at| try self.checkStoreCompat(lit_field.value.span(), expected_ty, at);
+        _ = try seen.put(self.arena, field_name, {});
+    }
+    // Missing fields.
+    for (decl_fields) |df| {
+        const dn = self.lexeme(df.name);
+        if (!seen.contains(dn)) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "missing field `{s}` in `{s}` literal",
+                .{ dn, type_name },
+            );
+            try self.emitSpan("E_TYPE_MISSING_FIELD", sl.span, msg);
+        }
+    }
+}
+
+fn checkClassLitFields(
+    self: *Checker,
+    sl: ast.StructLit,
+    type_name: []const u8,
+    cd: *const ast.ClassDecl,
+) WalkError!void {
+    for (sl.fields) |lit_field| {
+        const field_name = self.lexeme(lit_field.name);
+        // Search the inheritance chain. Class fields are
+        // optional-typed, so an untyped field accepts anything.
+        const expected_ty: ?*const types.Type = try lookupClassFieldType(self, cd, field_name);
+        if (expected_ty == null and flow.findClassField(self, cd, field_name) == null) {
+            try emitUndefinedField(self, type_name, field_name, lit_field.name);
+            _ = try self.inferExpr(lit_field.value, null);
+            continue;
+        }
+        const actual_ty = try self.inferExpr(lit_field.value, expected_ty);
+        if (expected_ty) |et| if (actual_ty) |at| try self.checkStoreCompat(lit_field.value.span(), et, at);
+    }
+    // Class literals don't require every field to be set
+    // (constructors fill defaults). Slice 7 may tighten this
+    // when annotation rules pin field requiredness.
+}
+
+/// Synthesize a constructor signature for a class. Uses the
+/// `init` method's params (sans implicit `self`) when present;
+/// otherwise the constructor is nullary. Return type is always
+/// `Named(class_name)`.
+pub fn constructorSignatureFor(
+    self: *Checker,
+    cd: *const ast.ClassDecl,
+    class_name: []const u8,
+    name_span: ast.Span,
+) WalkError!*const types.Type {
+    var param_types: std.ArrayList(*const types.Type) = .empty;
+    errdefer param_types.deinit(self.arena);
+    if (lookupClassMethod(self, cd, "init")) |init_method| {
+        var has_self = false;
+        if (init_method.params.len > 0 and std.mem.eql(u8, self.lexeme(init_method.params[0].name), "self")) has_self = true;
+        const skip: usize = if (has_self) 1 else 0;
+        for (init_method.params[skip..]) |p| {
+            const pt: *const types.Type = if (p.type_ann) |t|
+                try type_resolve.resolveType(self, t)
+            else
+                try self.primitive(.nil_);
+            try param_types.append(self.arena, pt);
+        }
+    }
+    const ret = try types.mkNamed(self.arena, class_name, name_span);
+    const sig = try self.arena.create(types.Type);
+    sig.* = .{ .function = .{
+        .params = try param_types.toOwnedSlice(self.arena),
+        .ret = ret,
+    } };
+    return sig;
+}
+
+/// Walk a class's inheritance chain looking for a method by
+/// name. Returns the first match.
+pub fn lookupClassMethod(
+    self: *const Checker,
+    cd: *const ast.ClassDecl,
+    method_name: []const u8,
+) ?*const ast.DefDecl {
+    if (lookupClassMethodOwner(self, cd, method_name)) |hit| return hit.method;
+    return null;
+}
+
+/// Result of `lookupClassMethodOwner` — the method decl plus the
+/// class that owns it (needed for `@private` visibility checks).
+pub const MethodHit = struct {
+    method: *const ast.DefDecl,
+    owner: *const ast.ClassDecl,
+};
+
+/// Walk a class's inheritance chain looking for a method by
+/// name and return both the method decl and the class that
+/// owns it.
+pub fn lookupClassMethodOwner(
+    self: *const Checker,
+    cd: *const ast.ClassDecl,
+    method_name: []const u8,
+) ?MethodHit {
+    for (cd.methods) |*method| {
+        if (std.mem.eql(u8, self.lexeme(method.name), method_name)) {
+            return .{ .method = method, .owner = cd };
+        }
+    }
+    if (cd.extends) |ext| if (self.class_registry.get(self.lexeme(ext))) |parent| {
+        return lookupClassMethodOwner(self, parent, method_name);
+    };
+    return null;
+}
+
+/// Result of `lookupClassFieldOwner` — the field decl plus the
+/// class that owns it.
+pub const FieldHit = struct {
+    field: *const ast.ClassField,
+    owner: *const ast.ClassDecl,
+};
+
+/// Walk a class's inheritance chain looking for a field by
+/// name and return both the field decl and the owning class.
+pub fn lookupClassFieldOwner(
+    self: *const Checker,
+    cd: *const ast.ClassDecl,
+    field_name: []const u8,
+) ?FieldHit {
+    for (cd.fields) |*fld| {
+        if (std.mem.eql(u8, self.lexeme(fld.name), field_name)) {
+            return .{ .field = fld, .owner = cd };
+        }
+    }
+    if (cd.extends) |ext| if (self.class_registry.get(self.lexeme(ext))) |parent| {
+        return lookupClassFieldOwner(self, parent, field_name);
+    };
+    return null;
+}

--- a/src/lang/typecheck/operators.zig
+++ b/src/lang/typecheck/operators.zig
@@ -1,0 +1,188 @@
+/// Operator type rules (§4.2.1) + `as T` cast checking. Splits
+/// the unary / binary operator family out of `typecheck.zig` so
+/// the walker file stays scannable. Every entry takes a
+/// `*Checker` and threads through its arena / diagnostic sink.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const typecheck = @import("../typecheck.zig");
+const type_resolve = @import("type_resolve.zig");
+const predicates = @import("predicates.zig");
+const relations = @import("relations.zig");
+
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+/// Type-check a unary expression. Routes `neg` / `log_not` /
+/// `bit_not` through their primitive-class constraint and
+/// returns the operand type (or `bool` for `not`).
+pub fn checkUnary(self: *Checker, u: ast.UnaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
+    const op_hint: ?*const types.Type = if (u.op == .log_not)
+        try self.primitive(.bool_)
+    else
+        hint;
+    const operand_ty = try self.inferExpr(u.operand, op_hint);
+    if (operand_ty == null) return null;
+    const ot = operand_ty.?;
+    switch (u.op) {
+        .neg => {
+            if (!predicates.isNumericType(ot.*)) {
+                try emitOperatorRequires(self, u.span, "negation `-`", "a numeric type", ot);
+                return null;
+            }
+            return ot;
+        },
+        .log_not => {
+            if (!predicates.isBoolType(ot.*)) {
+                try emitOperatorRequires(self, u.span, "logical `not`", "`bool`", ot);
+                return null;
+            }
+            return try self.primitive(.bool_);
+        },
+        .bit_not => {
+            if (!predicates.isIntegerType(ot.*)) {
+                try emitOperatorRequires(self, u.span, "bitwise `~`", "an integer type", ot);
+                return null;
+            }
+            return ot;
+        },
+    }
+}
+
+/// Type-check a binary expression. Dispatches per operator
+/// class — arithmetic / shift / bitwise / comparison / logical.
+pub fn checkBinary(self: *Checker, b: ast.BinaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
+    return switch (b.op) {
+        .add, .sub, .mul, .div, .mod => try checkArith(self, b, hint),
+        .shl, .shr => try checkShift(self, b, hint),
+        .bit_and, .bit_or, .bit_xor => try checkBitwise(self, b, hint),
+        .eq, .neq, .lt, .lte, .gt, .gte => try checkComparison(self, b),
+        .log_and, .log_or => try checkLogical(self, b),
+    };
+}
+
+fn checkArith(self: *Checker, b: ast.BinaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
+    const lhs_ty = try self.inferExpr(b.lhs, hint);
+    // Pin RHS to LHS once known; otherwise fall back to the outer hint.
+    const rhs_hint = lhs_ty orelse hint;
+    const rhs_ty = try self.inferExpr(b.rhs, rhs_hint);
+    if (lhs_ty == null or rhs_ty == null) return lhs_ty orelse rhs_ty;
+    // String concatenation: only `+`, both sides `str`.
+    if (b.op == .add and predicates.isStrType(lhs_ty.?.*) and predicates.isStrType(rhs_ty.?.*)) {
+        return try self.primitive(.str);
+    }
+    if (!predicates.isNumericType(lhs_ty.?.*)) {
+        try emitOperatorRequires(self, b.span, predicates.opLexeme(b.op), "a numeric type", lhs_ty.?);
+        return null;
+    }
+    if (!predicates.isNumericType(rhs_ty.?.*)) {
+        try emitOperatorRequires(self, b.span, predicates.opLexeme(b.op), "a numeric type", rhs_ty.?);
+        return null;
+    }
+    if (!lhs_ty.?.eql(rhs_ty.?.*)) {
+        try self.emitMismatch(b.rhs.span(), lhs_ty.?, rhs_ty.?);
+    }
+    return lhs_ty;
+}
+
+fn checkShift(self: *Checker, b: ast.BinaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
+    const lhs_ty = try self.inferExpr(b.lhs, hint);
+    // Shift count is itself an integer; default to u8-ish via i16 (no specific hint).
+    const rhs_ty = try self.inferExpr(b.rhs, null);
+    if (lhs_ty == null or rhs_ty == null) return lhs_ty;
+    if (!predicates.isIntegerType(lhs_ty.?.*)) {
+        try emitOperatorRequires(self, b.span, predicates.opLexeme(b.op), "an integer type", lhs_ty.?);
+        return null;
+    }
+    if (!predicates.isIntegerType(rhs_ty.?.*)) {
+        try emitOperatorRequires(self, b.span, predicates.opLexeme(b.op), "an integer shift count", rhs_ty.?);
+        return null;
+    }
+    return lhs_ty;
+}
+
+fn checkBitwise(self: *Checker, b: ast.BinaryExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
+    const lhs_ty = try self.inferExpr(b.lhs, hint);
+    const rhs_hint = lhs_ty orelse hint;
+    const rhs_ty = try self.inferExpr(b.rhs, rhs_hint);
+    if (lhs_ty == null or rhs_ty == null) return lhs_ty orelse rhs_ty;
+    if (!predicates.isIntegerType(lhs_ty.?.*)) {
+        try emitOperatorRequires(self, b.span, predicates.opLexeme(b.op), "an integer type", lhs_ty.?);
+        return null;
+    }
+    if (!predicates.isIntegerType(rhs_ty.?.*)) {
+        try emitOperatorRequires(self, b.span, predicates.opLexeme(b.op), "an integer type", rhs_ty.?);
+        return null;
+    }
+    if (!lhs_ty.?.eql(rhs_ty.?.*)) {
+        try self.emitMismatch(b.rhs.span(), lhs_ty.?, rhs_ty.?);
+    }
+    return lhs_ty;
+}
+
+fn checkComparison(self: *Checker, b: ast.BinaryExpr) WalkError!?*const types.Type {
+    const lhs_ty = try self.inferExpr(b.lhs, null);
+    const rhs_ty = try self.inferExpr(b.rhs, lhs_ty);
+    if (lhs_ty != null and rhs_ty != null) {
+        // Allow nil-comparison (`x != nil` / `nil == p`) — the
+        // canonical nullable idiom per §3.4.1. Strict-equality
+        // only when neither side is the nil literal.
+        const either_is_nil = predicates.isNilType(lhs_ty.?.*) or predicates.isNilType(rhs_ty.?.*);
+        if (!either_is_nil and !lhs_ty.?.eql(rhs_ty.?.*)) {
+            try self.emitMismatch(b.rhs.span(), lhs_ty.?, rhs_ty.?);
+        }
+    }
+    return try self.primitive(.bool_);
+}
+
+fn checkLogical(self: *Checker, b: ast.BinaryExpr) WalkError!?*const types.Type {
+    const bool_ty = try self.primitive(.bool_);
+    const lhs_ty = try self.inferExpr(b.lhs, bool_ty);
+    const rhs_ty = try self.inferExpr(b.rhs, bool_ty);
+    if (lhs_ty) |t| if (!predicates.isBoolType(t.*)) {
+        try emitOperatorRequires(self, b.span, predicates.opLexeme(b.op), "`bool`", t);
+    };
+    if (rhs_ty) |t| if (!predicates.isBoolType(t.*)) {
+        try emitOperatorRequires(self, b.span, predicates.opLexeme(b.op), "`bool`", t);
+    };
+    return bool_ty;
+}
+
+fn emitOperatorRequires(
+    self: *Checker,
+    span: ast.Span,
+    op_name: []const u8,
+    wants: []const u8,
+    actual: *const types.Type,
+) WalkError!void {
+    const actual_s = try types.render(self.arena, actual.*);
+    const msg = try std.fmt.allocPrint(
+        self.arena,
+        "operator {s} requires {s}, found `{s}`",
+        .{ op_name, wants, actual_s },
+    );
+    try self.emitSpan("E_TYPE_MISMATCH", span, msg);
+}
+
+/// Type-check a cast expression (`expr as T`). Resolves `T` via
+/// `type_resolve` and validates convertibility through
+/// `relations.canCast`. Emits `E_CAST_INVALID` on failure and
+/// returns the target type so the surrounding expression keeps
+/// type-checking.
+pub fn checkCast(self: *Checker, c: ast.CastExpr) WalkError!?*const types.Type {
+    const inner_ty = try self.inferExpr(c.inner, null);
+    const target_ty = try type_resolve.resolveType(self, c.target_type);
+    if (inner_ty) |it| {
+        if (!relations.canCast(it.*, target_ty.*)) {
+            const from_s = try types.render(self.arena, it.*);
+            const to_s = try types.render(self.arena, target_ty.*);
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "cannot cast `{s}` to `{s}`",
+                .{ from_s, to_s },
+            );
+            try self.emitSpan("E_CAST_INVALID", c.span, msg);
+        }
+    }
+    return target_ty;
+}

--- a/src/lang/typecheck/type_resolve.zig
+++ b/src/lang/typecheck/type_resolve.zig
@@ -1,0 +1,113 @@
+/// Type-annotation resolution. Walks an `ast.TypeAnn` and builds
+/// the equivalent `types.Type` allocated on the `Checker`'s
+/// arena. Splits out of `typecheck.zig` so the walker file stays
+/// scannable; the resolver itself is purely recursive over the
+/// AST + the typecheck arena.
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const typecheck = @import("../typecheck.zig");
+
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+/// Resolve `t` against the active scope chain. Unknown named
+/// types emit `E_TYPE_UNDEFINED` (with a "did you mean…?"
+/// suggestion when a near-spelling candidate exists) and fall
+/// back to a placeholder `Named` so subsequent typecheck steps
+/// can keep walking without further errors at that site.
+pub fn resolveType(self: *Checker, t: *const ast.TypeAnn) WalkError!*const types.Type {
+    switch (t.*) {
+        .named => |n| {
+            const name = self.lexeme(n.name);
+            if (types.primitiveFromName(name)) |p| {
+                return try self.primitive(p);
+            }
+            if (self.current_scope.lookup(name)) |_| {
+                return try types.mkNamed(self.arena, name, n.span);
+            }
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "undefined type `{s}`",
+                .{name},
+            );
+            try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", n.name, msg, try self.suggestTypeName(name));
+            return try types.mkNamed(self.arena, name, n.span);
+        },
+        .nullable => |n| {
+            const inner = try resolveType(self, n.inner);
+            if (!isPointerLike(self, inner.*)) {
+                const inner_s = try types.render(self.arena, inner.*);
+                const msg = try std.fmt.allocPrint(
+                    self.arena,
+                    "type `{s}?` is invalid — `T?` only applies to pointer-like types (`str`, class, fn-pointer, references)",
+                    .{inner_s},
+                );
+                try self.emitSpan("E_NULL_NON_POINTER", n.span, msg);
+            }
+            return try types.mkOptional(self.arena, inner);
+        },
+        .array => |a| {
+            const elem = try resolveType(self, a.elem);
+            const len_val: u32 = if (a.len_expr.* == .int_lit)
+                // safety: parser stores array lengths as i32; §3.4 requires non-negative comptime int. Slice 3+ will range-check; bit-cast preserves bytes.
+                @bitCast(a.len_expr.int_lit.value)
+            else
+                0;
+            return try types.mkArray(self.arena, elem, len_val);
+        },
+        .vec => |v| {
+            const elem = try resolveType(self, v.elem);
+            return try types.mkVec(self.arena, elem);
+        },
+        .tuple => |tu| {
+            var elems: std.ArrayList(*const types.Type) = .empty;
+            errdefer elems.deinit(self.arena);
+            for (tu.elems) |e| try elems.append(self.arena, try resolveType(self, e));
+            const out = try self.arena.create(types.Type);
+            out.* = .{ .tuple = try elems.toOwnedSlice(self.arena) };
+            return out;
+        },
+        .fn_type => |f| {
+            var params: std.ArrayList(*const types.Type) = .empty;
+            errdefer params.deinit(self.arena);
+            for (f.params) |p| try params.append(self.arena, try resolveType(self, p));
+            const ret: *const types.Type = if (f.ret) |r|
+                try resolveType(self, r)
+            else
+                try self.primitive(.nil_);
+            const out = try self.arena.create(types.Type);
+            out.* = .{ .function = .{
+                .params = try params.toOwnedSlice(self.arena),
+                .ret = ret,
+            } };
+            return out;
+        },
+        .reference => |r| {
+            const inner = try resolveType(self, r.inner);
+            return try types.mkReference(self.arena, inner);
+        },
+    }
+}
+
+/// Pointer-like types per §3.4.1 — `str`, references, function
+/// pointers, and class names. Struct / enum / numeric / bool /
+/// fixed are by-value and therefore not nullable-eligible.
+pub fn isPointerLike(self: *const Checker, t: types.Type) bool {
+    return switch (t) {
+        .primitive => |p| p == .str,
+        .reference, .function => true,
+        .named => |n| {
+            if (self.current_scope.lookup(n.name)) |info| {
+                return switch (info.kind) {
+                    .class, .module_alias, .imported => true,
+                    else => false,
+                };
+            }
+            // Unresolved named type — accept defensively so the
+            // diagnostic surfaces from the resolution step.
+            return true;
+        },
+        else => false,
+    };
+}

--- a/tests/lang/codegen/isa.test.zig
+++ b/tests/lang/codegen/isa.test.zig
@@ -1,0 +1,11 @@
+//! Mirror file for `src/lang/codegen/isa.zig`.
+//! Behavioral coverage of every ISA-instruction emitter lives in
+//! `tests/lang/codegen.test.zig` (and the VM-side handler tests)
+//! — this file exists to satisfy the mirror-layout lint rule.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/isa: module reachable through the barrel" {
+    _ = gero.lang.internal.codegen.isa;
+}

--- a/tests/lang/typecheck/calls.test.zig
+++ b/tests/lang/typecheck/calls.test.zig
@@ -1,0 +1,11 @@
+//! Mirror file for `src/lang/typecheck/calls.zig`.
+//! Behavioral coverage of call / assert / variadic / bake-call
+//! rules lives in `tests/lang/typecheck.test.zig` — this file
+//! exists to satisfy the mirror-layout lint rule.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/calls: module reachable through the barrel" {
+    _ = gero.lang.internal.typechecker.calls;
+}

--- a/tests/lang/typecheck/fields.test.zig
+++ b/tests/lang/typecheck/fields.test.zig
@@ -1,0 +1,11 @@
+//! Mirror file for `src/lang/typecheck/fields.zig`.
+//! Behavioral coverage of field / method resolution lives in
+//! `tests/lang/typecheck.test.zig` — this file exists to satisfy
+//! the mirror-layout lint rule.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/fields: module reachable through the barrel" {
+    _ = gero.lang.internal.typechecker.fields;
+}

--- a/tests/lang/typecheck/operators.test.zig
+++ b/tests/lang/typecheck/operators.test.zig
@@ -1,0 +1,11 @@
+//! Mirror file for `src/lang/typecheck/operators.zig`.
+//! Behavioral coverage of operator + cast type rules lives in
+//! `tests/lang/typecheck.test.zig` — this file exists to satisfy
+//! the mirror-layout lint rule.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/operators: module reachable through the barrel" {
+    _ = gero.lang.internal.typechecker.operators;
+}

--- a/tests/lang/typecheck/type_resolve.test.zig
+++ b/tests/lang/typecheck/type_resolve.test.zig
@@ -1,0 +1,12 @@
+//! Mirror file for `src/lang/typecheck/type_resolve.zig`.
+//! Behavioral coverage of `resolveType` lives in
+//! `tests/lang/typecheck.test.zig` (and the other typecheck
+//! tests) — this file exists to satisfy the mirror-layout lint
+//! rule.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/type_resolve: module reachable through the barrel" {
+    _ = gero.lang.internal.typechecker.type_resolve;
+}


### PR DESCRIPTION
## Summary

- Splits `src/lang/typecheck.zig` (2798 → 1837 lines, **-34%**) and `src/lang/codegen.zig` (2441 → 2140 lines, **-12%**) into focused submodules under `typecheck/` and `codegen/`. Six commits, each one extraction + mirror test + barrel entry.
- Five new submodules: `typecheck/type_resolve.zig`, `typecheck/fields.zig`, `typecheck/operators.zig`, `typecheck/calls.zig`, `codegen/isa.zig`. Each takes `*Checker` / `*Emitter` as the first param of every public entry, threads through existing state.
- Five `pub` promotions on `Checker` (`checkStoreCompat`, `singleSecondary`, `emitMismatch`, `emitMismatchAnnotated`, plus auto-promoted `emitMismatchAnnotated`) + one on `Emitter` (`currentCode`) so sub-modules can reach them. `pub fn currentBufferBase` stays on `Emitter` (state-query, not instruction emission).
- Plus a follow-up self-review commit that drops three pre-existing duplicate `///` doc blocks (pre-existing drift, surfaced once method-clustering brought them next to each other).

Refactor commits — no API surface change, no behavioral change. Mirror tests are stubs per the CLAUDE.md "Refactor commits" rule (only the bare minimum the lint requires).

## Test plan

- [x] `zig build verify` green
- [x] `zig build ci` green (full matrix — test-modes + test-all + examples)
- [x] Self-review loop clean (5 steps × 2 passes; second pass surfaced zero items)