### PR TITLE
fix(cli/repl): caret diagnostics + map spans to user input

### DIFF
--- a/.changeset/cli-repl-caret-diagnostics.md
+++ b/.changeset/cli-repl-caret-diagnostics.md
@@ -10,6 +10,12 @@ spans (e.g. "expected `bool` because of this annotation") show
 under the offending line. Warnings render but no longer block
 the session — the program still runs.
 
+Diagnostic spans translate back to the user's literal input so
+the snippet shows exactly what the user typed — no synthetic
+`__repl_main` wrapper, no auto-`print` prefix, line numbers
+relative to the input. Diagnostics whose spans fall outside the
+new input are filtered.
+
 Banner + prompt picked up a touch of color: bold cyan `gero
 repl` heading, dim version line, bold cyan `>>>` prompt, dim
 `...` continuation. All ANSI escapes gate on the existing

--- a/.changeset/cli-repl-caret-diagnostics.md
+++ b/.changeset/cli-repl-caret-diagnostics.md
@@ -1,0 +1,16 @@
+---
+bump: patch
+---
+
+`gero repl` now renders parse / typecheck / codegen errors with
+caret-style source snippets via `gero.lang.render.prettyOne`,
+matching the output `gero check` produces. Lexer + parser
+errors flow through the same `Diagnostic` shape, so secondary
+spans (e.g. "expected `bool` because of this annotation") show
+under the offending line. Warnings render but no longer block
+the session — the program still runs.
+
+Banner + prompt picked up a touch of color: bold cyan `gero
+repl` heading, dim version line, bold cyan `>>>` prompt, dim
+`...` continuation. All ANSI escapes gate on the existing
+color-detection flow, so non-TTY output stays plain.

--- a/.changeset/cli-repl-caret-diagnostics.md
+++ b/.changeset/cli-repl-caret-diagnostics.md
@@ -21,9 +21,13 @@ repl` heading, dim version line, bold cyan `>>>` prompt, dim
 `...` continuation. All ANSI escapes gate on the existing
 color-detection flow, so non-TTY output stays plain.
 
-One-liner submissions like `def add(x, y) return x + y end`
-now work: the REPL pre-parses the input, finds every "expected
-newline" boundary the parser flags, and injects `\n` in-place
-before the main pipeline runs. The canonical multi-line form
-is what gets committed to the session source, so subsequent
-prompts see valid newline-significant gero-lang.
+One-liner submissions like `def add(x, y) return x + y end`,
+`while n < 3 print n n = n + 1 end`, `if x > 0 print "pos" end`,
+or `for i in 0..5 print i end` now work: the REPL iteratively
+pre-parses the input, finds every "expected newline" boundary
+the parser flags, and injects `\n` in-place before the main
+pipeline runs. Re-parsing between passes catches boundaries the
+parser couldn't see past the first one (recovery skips ahead).
+The canonical multi-line form is what gets committed to the
+session source, so subsequent prompts see valid newline-
+significant gero-lang.

--- a/.changeset/cli-repl-caret-diagnostics.md
+++ b/.changeset/cli-repl-caret-diagnostics.md
@@ -31,3 +31,12 @@ parser couldn't see past the first one (recovery skips ahead).
 The canonical multi-line form is what gets committed to the
 session source, so subsequent prompts see valid newline-
 significant gero-lang.
+
+Up / Down arrows now recall previous prompts, shell-style. The
+REPL flips stdin into raw mode while reading each line so it
+can intercept arrow-key escape sequences, and restores cooked
+mode while the compiled program runs. Backspace, Ctrl-C
+(cancel the current line), and Ctrl-D (EOF on empty) all work
+as expected. Non-TTY input (piped scripts, CI captures) falls
+back to the cooked line-buffered reader so test harnesses keep
+working unchanged.

--- a/.changeset/cli-repl-caret-diagnostics.md
+++ b/.changeset/cli-repl-caret-diagnostics.md
@@ -20,3 +20,10 @@ Banner + prompt picked up a touch of color: bold cyan `gero
 repl` heading, dim version line, bold cyan `>>>` prompt, dim
 `...` continuation. All ANSI escapes gate on the existing
 color-detection flow, so non-TTY output stays plain.
+
+One-liner submissions like `def add(x, y) return x + y end`
+now work: the REPL pre-parses the input, finds every "expected
+newline" boundary the parser flags, and injects `\n` in-place
+before the main pipeline runs. The canonical multi-line form
+is what gets committed to the session source, so subsequent
+prompts see valid newline-significant gero-lang.

--- a/.changeset/cli-repl-caret-diagnostics.md
+++ b/.changeset/cli-repl-caret-diagnostics.md
@@ -40,3 +40,10 @@ mode while the compiled program runs. Backspace, Ctrl-C
 as expected. Non-TTY input (piped scripts, CI captures) falls
 back to the cooked line-buffered reader so test harnesses keep
 working unchanged.
+
+Meta-commands drop the leading `.`. `help`, `quit`, `exit`,
+`reset`, and `dump <name>` are now bare keywords — they fit
+the rest of the gero surface (which never starts a statement
+with `.`) and match only when the input is exactly the
+keyword, so a regular `print quit` expression still runs
+through the pipeline.

--- a/apps/gero-cli/line_editor.zig
+++ b/apps/gero-cli/line_editor.zig
@@ -1,0 +1,285 @@
+const std = @import("std");
+
+/// Outcome of one `readLine` call.
+pub const Action = union(enum) {
+    /// User pressed Enter. Owns the line text (no trailing `\n`).
+    submit: []const u8,
+    /// Stdin closed (Ctrl-D on empty line, or piped input ended).
+    eof,
+    /// User pressed Ctrl-C — caller discards the partial line and
+    /// re-prompts.
+    cancel,
+};
+
+/// Raw-mode line editor with up/down history navigation. Falls
+/// back to a line-buffered cooked read when stdin is not a TTY
+/// (piped scripts, CI captures).
+pub const Editor = struct {
+    arena: std.mem.Allocator,
+    io: std.Io,
+    stdout: *std.Io.Writer,
+    /// Submitted lines in arrival order. Owned strings.
+    history: std.ArrayList([]const u8),
+    /// `true` when stdin is a TTY and raw mode is workable.
+    is_tty: bool,
+    /// Saved termios for restore-on-exit. `null` when raw mode is
+    /// inactive (either because stdin isn't a TTY or `restore`
+    /// already ran).
+    saved_termios: ?std.posix.termios,
+    stdin_fd: std.posix.fd_t,
+    /// Lazily-initialized cooked-mode reader. Only used when
+    /// `is_tty == false`.
+    cooked: ?CookedReader,
+
+    const CookedReader = struct {
+        reader: std.Io.File.Reader,
+        buf: [256]u8,
+    };
+
+    /// Initialize an editor against `stdout`. Detects TTY but does
+    /// not enable raw mode — call `enableRawMode` before the read
+    /// loop and `restoreTerminal` on exit.
+    pub fn init(
+        arena: std.mem.Allocator,
+        io: std.Io,
+        stdout: *std.Io.Writer,
+    ) Editor {
+        const fd = std.posix.STDIN_FILENO;
+        const is_tty = std.Io.File.stdin().isTty(io) catch false;
+        return .{
+            .arena = arena,
+            .io = io,
+            .stdout = stdout,
+            .history = .empty,
+            .is_tty = is_tty,
+            .saved_termios = null,
+            .stdin_fd = fd,
+            .cooked = null,
+        };
+    }
+
+    /// Release editor-owned resources and restore termios.
+    pub fn deinit(self: *Editor) void {
+        self.restoreTerminal();
+        self.history.deinit(self.arena);
+    }
+
+    /// Switch the terminal into raw mode (no echo, no line
+    /// buffering). No-op when stdin isn't a TTY or raw is already
+    /// active.
+    pub fn enableRawMode(self: *Editor) !void {
+        if (!self.is_tty) return;
+        if (self.saved_termios != null) return;
+        const cur = try std.posix.tcgetattr(self.stdin_fd);
+        self.saved_termios = cur;
+        var raw = cur;
+        raw.lflag.ICANON = false;
+        raw.lflag.ECHO = false;
+        raw.lflag.ISIG = true; // keep Ctrl-C / Ctrl-Z delivered as bytes
+        raw.iflag.ICRNL = false; // raw \r vs \n distinction
+        raw.cc[@intFromEnum(std.posix.V.MIN)] = 1;
+        raw.cc[@intFromEnum(std.posix.V.TIME)] = 0;
+        try std.posix.tcsetattr(self.stdin_fd, .NOW, raw);
+    }
+
+    /// Restore the saved termios. Safe to call repeatedly.
+    pub fn restoreTerminal(self: *Editor) void {
+        if (self.saved_termios) |t| {
+            std.posix.tcsetattr(self.stdin_fd, .NOW, t) catch {};
+            self.saved_termios = null;
+        }
+    }
+
+    /// Append `line` to the history ring. Drops empty lines and
+    /// consecutive duplicates of the previous entry.
+    pub fn pushHistory(self: *Editor, line: []const u8) !void {
+        if (line.len == 0) return;
+        if (self.history.items.len > 0) {
+            const last = self.history.items[self.history.items.len - 1];
+            if (std.mem.eql(u8, last, line)) return;
+        }
+        const owned = try self.arena.dupe(u8, line);
+        try self.history.append(self.arena, owned);
+    }
+
+    /// Read one logical line, printing `prompt` first. Handles
+    /// printable input, Backspace, Enter, Ctrl-C, Ctrl-D, and
+    /// Up/Down history navigation.
+    pub fn readLine(self: *Editor, prompt: []const u8) !Action {
+        if (!self.is_tty) return self.readLineCooked(prompt);
+        try self.enableRawMode();
+        try self.stdout.writeAll(prompt);
+        try self.stdout.flush();
+
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(self.arena);
+        // `hist_pos` indexes into history; `len` means "live input
+        // (not navigating yet)".
+        var hist_pos: usize = self.history.items.len;
+        // Snapshot of in-progress input the user had typed before
+        // arrowing into history. Restored when the user arrows
+        // back down past the most recent entry.
+        var saved_live: []u8 = "";
+        defer if (saved_live.len > 0) self.arena.free(saved_live);
+
+        while (true) {
+            var one: [1]u8 = undefined;
+            const n = std.posix.read(self.stdin_fd, &one) catch return .eof;
+            if (n == 0) return .eof;
+            const b = one[0];
+
+            switch (b) {
+                '\n', '\r' => {
+                    try self.stdout.writeAll("\n");
+                    try self.stdout.flush();
+                    return Action{ .submit = try self.arena.dupe(u8, buf.items) };
+                },
+                0x7F, 0x08 => {
+                    if (buf.items.len == 0) continue;
+                    _ = buf.pop();
+                    try self.redraw(prompt, buf.items);
+                },
+                0x03 => {
+                    try self.stdout.writeAll("^C\n");
+                    try self.stdout.flush();
+                    return .cancel;
+                },
+                0x04 => {
+                    if (buf.items.len == 0) {
+                        try self.stdout.writeAll("\n");
+                        try self.stdout.flush();
+                        return .eof;
+                    }
+                },
+                0x1B => {
+                    // CSI sequence — `\x1b [ X`.
+                    var seq: [2]u8 = undefined;
+                    const n2 = std.posix.read(self.stdin_fd, &seq) catch continue;
+                    if (n2 < 2 or seq[0] != '[') continue;
+                    switch (seq[1]) {
+                        'A' => try self.recallPrev(&buf, &hist_pos, &saved_live, prompt),
+                        'B' => try self.recallNext(&buf, &hist_pos, &saved_live, prompt),
+                        else => {},
+                    }
+                },
+                else => {
+                    if (b >= 0x20 and b < 0x7F) {
+                        try buf.append(self.arena, b);
+                        var ch: [1]u8 = .{b};
+                        try self.stdout.writeAll(&ch);
+                        try self.stdout.flush();
+                    }
+                },
+            }
+        }
+    }
+
+    fn recallPrev(
+        self: *Editor,
+        buf: *std.ArrayList(u8),
+        hist_pos: *usize,
+        saved_live: *[]u8,
+        prompt: []const u8,
+    ) !void {
+        if (self.history.items.len == 0) return;
+        if (hist_pos.* == 0) return;
+        if (hist_pos.* == self.history.items.len) {
+            // First Up press: snapshot the live input so a later
+            // Down past the newest entry can restore it.
+            if (saved_live.*.len > 0) self.arena.free(saved_live.*);
+            saved_live.* = try self.arena.dupe(u8, buf.items);
+        }
+        hist_pos.* -= 1;
+        buf.clearRetainingCapacity();
+        try buf.appendSlice(self.arena, self.history.items[hist_pos.*]);
+        try self.redraw(prompt, buf.items);
+    }
+
+    fn recallNext(
+        self: *Editor,
+        buf: *std.ArrayList(u8),
+        hist_pos: *usize,
+        saved_live: *[]u8,
+        prompt: []const u8,
+    ) !void {
+        if (hist_pos.* >= self.history.items.len) return;
+        hist_pos.* += 1;
+        buf.clearRetainingCapacity();
+        if (hist_pos.* == self.history.items.len) {
+            try buf.appendSlice(self.arena, saved_live.*);
+        } else {
+            try buf.appendSlice(self.arena, self.history.items[hist_pos.*]);
+        }
+        try self.redraw(prompt, buf.items);
+    }
+
+    fn redraw(self: *Editor, prompt: []const u8, line: []const u8) !void {
+        // CR + clear-to-EOL, then redraw prompt + buffer.
+        try self.stdout.writeAll("\r\x1b[K");
+        try self.stdout.writeAll(prompt);
+        try self.stdout.writeAll(line);
+        try self.stdout.flush();
+    }
+
+    fn readLineCooked(self: *Editor, prompt: []const u8) !Action {
+        try self.stdout.writeAll(prompt);
+        try self.stdout.flush();
+        if (self.cooked == null) {
+            self.cooked = .{
+                .reader = std.Io.File.stdin().reader(self.io, undefined),
+                .buf = undefined,
+            };
+            // Reattach the reader to the field's stable buffer.
+            self.cooked.?.reader = std.Io.File.stdin().reader(self.io, &self.cooked.?.buf);
+        }
+        const r = &self.cooked.?.reader.interface;
+        var line_buf: std.ArrayList(u8) = .empty;
+        defer line_buf.deinit(self.arena);
+        while (true) {
+            const byte = r.takeByte() catch |err| switch (err) {
+                error.EndOfStream => return if (line_buf.items.len == 0)
+                    Action.eof
+                else
+                    Action{ .submit = try self.arena.dupe(u8, line_buf.items) },
+                else => return err,
+            };
+            if (byte == '\n') return Action{ .submit = try self.arena.dupe(u8, line_buf.items) };
+            if (byte == '\r') continue;
+            try line_buf.append(self.arena, byte);
+        }
+    }
+};
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "line_editor/pushHistory: appends new entries" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var stub_buf: [16]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&stub_buf);
+    var ed = Editor.init(arena.allocator(), undefined, &w);
+    try ed.pushHistory("alpha");
+    try ed.pushHistory("beta");
+    try testing.expectEqual(@as(usize, 2), ed.history.items.len);
+    try testing.expectEqualStrings("alpha", ed.history.items[0]);
+    try testing.expectEqualStrings("beta", ed.history.items[1]);
+}
+
+test "line_editor/pushHistory: drops empty + consecutive duplicates" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var stub_buf: [16]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&stub_buf);
+    var ed = Editor.init(arena.allocator(), undefined, &w);
+    try ed.pushHistory("");
+    try ed.pushHistory("alpha");
+    try ed.pushHistory("alpha");
+    try ed.pushHistory("beta");
+    try ed.pushHistory("alpha"); // non-adjacent dup is allowed
+    try testing.expectEqual(@as(usize, 3), ed.history.items.len);
+    try testing.expectEqualStrings("alpha", ed.history.items[0]);
+    try testing.expectEqualStrings("beta", ed.history.items[1]);
+    try testing.expectEqualStrings("alpha", ed.history.items[2]);
+}

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const gero = @import("gero");
 const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
+const line_editor = @import("line_editor.zig");
 
 /// Drive `gero repl` end-to-end. Returns the exit code per the
 /// loop's terminating reason — `0` on clean `.quit` / EOF.
@@ -17,47 +18,48 @@ pub fn execute(
 
     try session.banner();
 
+    var editor = line_editor.Editor.init(arena, io, stdout);
+    defer editor.deinit();
+
     var pending = std.ArrayList(u8).empty;
     defer pending.deinit(arena);
-    var line_buf = std.ArrayList(u8).empty;
-    defer line_buf.deinit(arena);
-
-    // Stdin reader — same pattern as `gero fmt --stdin` (fmt.zig).
-    var stdin_buf: [256]u8 = undefined;
-    var stdin_reader = std.Io.File.stdin().reader(io, &stdin_buf);
-    const stdin = &stdin_reader.interface;
 
     while (true) {
-        try session.prompt(pending.items.len > 0);
-        // Flush the prompt synchronously so users see it before
-        // their typing lands on the same line.
-        try stdout.flush();
-        line_buf.clearRetainingCapacity();
-        const eof = try readLine(stdin, arena, &line_buf);
-        if (eof) {
-            try stdout.writeAll("\n");
-            return 0;
+        const prompt_text = session.promptText(pending.items.len > 0);
+        const action = try editor.readLine(prompt_text);
+        switch (action) {
+            .eof => return 0,
+            .cancel => {
+                // Ctrl-C: drop any pending multi-line accumulation
+                // and prompt fresh.
+                pending.clearRetainingCapacity();
+                continue;
+            },
+            .submit => |line| {
+                try editor.pushHistory(line);
+
+                // Meta-commands fire only when we're not mid-block;
+                // otherwise the `.help` text would land inside the
+                // user's pending def body and confuse the parser.
+                if (pending.items.len == 0 and isMetaCommand(line)) {
+                    switch (try session.dispatchMeta(line)) {
+                        .quit => return 0,
+                        .continue_loop => continue,
+                    }
+                }
+
+                try pending.appendSlice(arena, line);
+                try pending.append(arena, '\n');
+
+                if (!blockBalanced(pending.items)) continue;
+
+                // Restore the cooked terminal while the program runs
+                // so its own stdout / signals behave normally.
+                editor.restoreTerminal();
+                try session.evaluate(pending.items);
+                pending.clearRetainingCapacity();
+            },
         }
-
-        const line = line_buf.items;
-
-        // Meta-commands fire only when we're not mid-block;
-        // otherwise the `.help` text would land inside the user's
-        // pending def body and confuse the parser later.
-        if (pending.items.len == 0 and isMetaCommand(line)) {
-            switch (try session.dispatchMeta(line)) {
-                .quit => return 0,
-                .continue_loop => continue,
-            }
-        }
-
-        try pending.appendSlice(arena, line);
-        try pending.append(arena, '\n');
-
-        if (!blockBalanced(pending.items)) continue;
-
-        try session.evaluate(pending.items);
-        pending.clearRetainingCapacity();
     }
 }
 
@@ -121,12 +123,13 @@ const Session = struct {
         }
     }
 
-    fn prompt(self: *Session, continuation: bool) !void {
+    /// Prompt text to print before each input line. Caller writes
+    /// it to stdout (or hands it to the line editor for redraw).
+    fn promptText(self: *Session, continuation: bool) []const u8 {
         if (self.term.color) {
-            try self.stdout.writeAll(if (continuation) "\x1b[2m...\x1b[0m " else "\x1b[36;1m>>>\x1b[0m ");
-        } else {
-            try self.stdout.writeAll(if (continuation) "... " else ">>> ");
+            return if (continuation) "\x1b[2m...\x1b[0m " else "\x1b[36;1m>>>\x1b[0m ";
         }
+        return if (continuation) "... " else ">>> ";
     }
 
     /// Dispatch a `.` meta-command. Returns `.quit` on `.quit` /
@@ -762,20 +765,6 @@ fn printSourceBlock(stdout: *std.Io.Writer, source: []const u8, hit: usize) !voi
     }
     try stdout.writeAll(source[hit..]);
     try stdout.writeByte('\n');
-}
-
-// ---------- stdin reader ----------
-
-fn readLine(reader: *std.Io.Reader, arena: std.mem.Allocator, out: *std.ArrayList(u8)) !bool {
-    while (true) {
-        const byte = reader.takeByte() catch |err| switch (err) {
-            error.EndOfStream => return out.items.len == 0,
-            else => return err,
-        };
-        if (byte == '\n') return false;
-        if (byte == '\r') continue;
-        try out.append(arena, byte);
-    }
 }
 
 // ---------- tests ----------

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -213,14 +213,22 @@ const Session = struct {
         defer scratch.deinit();
         const sa = scratch.allocator();
 
-        const kind = try self.classifyForRoute(sa, stripped);
+        // The lang is newline-significant: statements terminate on
+        // `\n`. A single-line REPL submit like `def add(x,y) return
+        // x + y end` would parse-fail with "expected newline" at
+        // every statement boundary. Pre-pass the input alone and
+        // inject `\n` at each missing-boundary site so common
+        // one-liners work without forcing the user to multi-line.
+        const fixed_input = try fixupNewlines(sa, new_input);
 
-        const decl_input: []const u8 = if (kind == .decl) new_input else "";
+        const kind = try self.classifyForRoute(sa, std.mem.trim(u8, fixed_input, " \t\n"));
+
+        const decl_input: []const u8 = if (kind == .decl) fixed_input else "";
         const body_input: []const u8 = if (kind == .body)
-            try self.maybeWrapInPrint(sa, new_input)
+            try self.maybeWrapInPrint(sa, fixed_input)
         else
             "";
-        const prelude_extra: []const u8 = if (kind == .prelude) new_input else "";
+        const prelude_extra: []const u8 = if (kind == .prelude) fixed_input else "";
 
         // Candidate source = committed decls + new decl +
         // `__repl_main { prelude + new_prelude + body_input }`.
@@ -239,16 +247,17 @@ const Session = struct {
         );
 
         // Where the user-typed bytes land inside `source` — used to
-        // translate diagnostic spans back to `new_input` so the
+        // translate diagnostic spans back to `fixed_input` so the
         // renderer shows the user's input, not the synthetic
-        // wrapper / auto-`print` prefix.
+        // wrapper / auto-`print` prefix. `fixed_input` is the
+        // newline-normalized form; spans translate cleanly into it.
         const wrapper_prefix = "\ndef __repl_main()\n";
         const user_start: usize = switch (kind) {
             .decl => self.decls_source.items.len,
             .prelude => self.decls_source.items.len + wrapper_prefix.len + self.prelude_source.items.len,
-            .body => self.decls_source.items.len + wrapper_prefix.len + self.prelude_source.items.len + (body_input.len - new_input.len),
+            .body => self.decls_source.items.len + wrapper_prefix.len + self.prelude_source.items.len + (body_input.len - fixed_input.len),
         };
-        const view: UserView = .{ .source = new_input, .start_in_synth = user_start };
+        const view: UserView = .{ .source = fixed_input, .start_in_synth = user_start };
 
         var diags: std.ArrayList(gero.lang.Diagnostic) = .empty;
 
@@ -428,6 +437,64 @@ const Session = struct {
         try self.stdout.flush();
     }
 };
+
+// ---------- newline fixup ----------
+
+/// Pre-parse `input` alone and inject `\n` at every position the
+/// parser flagged with "expected newline or end-of-input". Lets
+/// REPL one-liners like `def add(x,y) return x + y end` succeed
+/// without the user having to type each statement on its own line.
+/// Returns `input` unchanged when:
+/// - it already contains an internal `\n` (caller is multi-lining),
+/// - tokenize / parse fail outright (likely a different problem),
+/// - no missing-newline errors fire,
+/// - any non-newline parse error is also present (the rewrite
+///   would mask the real bug).
+fn fixupNewlines(sa: std.mem.Allocator, input: []const u8) ![]const u8 {
+    const trailing = input.len > 0 and input[input.len - 1] == '\n';
+    const body = if (trailing) input[0 .. input.len - 1] else input;
+    if (std.mem.indexOfScalar(u8, body, '\n') != null) return input;
+
+    var stream = gero.lang.tokenize(sa, input) catch return input;
+    defer stream.deinit();
+    if (stream.errors.len > 0) return input;
+
+    var tree = gero.lang.parse(sa, input, stream) catch return input;
+    defer tree.deinit();
+    if (tree.errors.len == 0) return input;
+
+    // Collect every missing-newline position. Other parse errors
+    // can co-occur as recovery noise (e.g. a cascading "expected
+    // `end`" after the parser skipped past one) — those aren't a
+    // reason to abandon the rewrite; the post-rewrite parse will
+    // surface real problems if any remain.
+    var positions: std.ArrayList(usize) = .empty;
+    for (tree.errors) |e| {
+        if (isMissingNewlineMsg(e.message)) try positions.append(sa, e.index);
+    }
+    if (positions.items.len == 0) return input;
+
+    // Dedupe + sort descending so earlier inserts don't shift
+    // later positions.
+    std.mem.sort(usize, positions.items, {}, std.sort.desc(usize));
+    var write: usize = 1;
+    for (positions.items[1..]) |p| {
+        if (p != positions.items[write - 1]) {
+            positions.items[write] = p;
+            write += 1;
+        }
+    }
+    positions.shrinkRetainingCapacity(write);
+
+    var out: std.ArrayList(u8) = .empty;
+    try out.appendSlice(sa, input);
+    for (positions.items) |p| try out.insert(sa, p, '\n');
+    return try out.toOwnedSlice(sa);
+}
+
+fn isMissingNewlineMsg(msg: []const u8) bool {
+    return std.mem.indexOf(u8, msg, "expected newline") != null;
+}
 
 // ---------- diagnostic glue ----------
 
@@ -834,6 +901,35 @@ test "repl/appendParseError: uses `expected` field as diagnostic code" {
     try testing.expectEqual(@as(u32, 7), diags.items[0].span.end);
     // appendParseError dupes the message string; free it.
     testing.allocator.free(diags.items[0].message);
+}
+
+test "repl/fixupNewlines: expands a one-line def into multi-line" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const out = try fixupNewlines(arena.allocator(), "def add(x, y) return x + y end\n");
+    try testing.expect(std.mem.indexOfScalar(u8, out, '\n') != null);
+    // Re-parse the rewritten input — it should now succeed.
+    var stream = try gero.lang.tokenize(arena.allocator(), out);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(arena.allocator(), out, stream);
+    defer tree.deinit();
+    try testing.expectEqual(@as(usize, 0), tree.errors.len);
+}
+
+test "repl/fixupNewlines: leaves multi-line input untouched" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const input = "def add(x, y)\n  return x + y\nend\n";
+    const out = try fixupNewlines(arena.allocator(), input);
+    try testing.expectEqual(input.ptr, out.ptr);
+}
+
+test "repl/fixupNewlines: leaves clean single-line input untouched" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const input = "let x = 42\n";
+    const out = try fixupNewlines(arena.allocator(), input);
+    try testing.expectEqual(input.ptr, out.ptr);
 }
 
 test "repl/translateSpan: shifts spans by user_start" {

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -440,56 +440,58 @@ const Session = struct {
 
 // ---------- newline fixup ----------
 
-/// Pre-parse `input` alone and inject `\n` at every position the
-/// parser flagged with "expected newline or end-of-input". Lets
-/// REPL one-liners like `def add(x,y) return x + y end` succeed
-/// without the user having to type each statement on its own line.
+/// Pre-parse `input` and inject `\n` at every position the parser
+/// flagged with "expected newline or end-of-input". Iterates: the
+/// parser recovers from each missing-newline by skipping to the
+/// next newline, so one pass only catches the first miss per
+/// stretch. Re-parsing after each round surfaces the next ones.
+/// Lets REPL one-liners like `def add(x,y) return x + y end` or
+/// `while n < 3 print n n = n + 1 end` succeed without the user
+/// having to type each statement on its own line.
+///
 /// Returns `input` unchanged when:
 /// - it already contains an internal `\n` (caller is multi-lining),
-/// - tokenize / parse fail outright (likely a different problem),
-/// - no missing-newline errors fire,
-/// - any non-newline parse error is also present (the rewrite
-///   would mask the real bug).
+/// - tokenize fails (lex error — let the main pipeline surface it),
+/// - no missing-newline errors ever fire.
 fn fixupNewlines(sa: std.mem.Allocator, input: []const u8) ![]const u8 {
     const trailing = input.len > 0 and input[input.len - 1] == '\n';
     const body = if (trailing) input[0 .. input.len - 1] else input;
     if (std.mem.indexOfScalar(u8, body, '\n') != null) return input;
 
-    var stream = gero.lang.tokenize(sa, input) catch return input;
-    defer stream.deinit();
-    if (stream.errors.len > 0) return input;
+    var current = input;
+    // Cap iteration so a pathological input can't loop. 16 is far
+    // more than any reasonable REPL one-liner needs.
+    var round: u8 = 0;
+    while (round < 16) : (round += 1) {
+        var stream = gero.lang.tokenize(sa, current) catch return current;
+        defer stream.deinit();
+        if (stream.errors.len > 0) return current;
 
-    var tree = gero.lang.parse(sa, input, stream) catch return input;
-    defer tree.deinit();
-    if (tree.errors.len == 0) return input;
+        var tree = gero.lang.parse(sa, current, stream) catch return current;
+        defer tree.deinit();
 
-    // Collect every missing-newline position. Other parse errors
-    // can co-occur as recovery noise (e.g. a cascading "expected
-    // `end`" after the parser skipped past one) — those aren't a
-    // reason to abandon the rewrite; the post-rewrite parse will
-    // surface real problems if any remain.
-    var positions: std.ArrayList(usize) = .empty;
-    for (tree.errors) |e| {
-        if (isMissingNewlineMsg(e.message)) try positions.append(sa, e.index);
-    }
-    if (positions.items.len == 0) return input;
-
-    // Dedupe + sort descending so earlier inserts don't shift
-    // later positions.
-    std.mem.sort(usize, positions.items, {}, std.sort.desc(usize));
-    var write: usize = 1;
-    for (positions.items[1..]) |p| {
-        if (p != positions.items[write - 1]) {
-            positions.items[write] = p;
-            write += 1;
+        var positions: std.ArrayList(usize) = .empty;
+        for (tree.errors) |e| {
+            if (isMissingNewlineMsg(e.message)) try positions.append(sa, e.index);
         }
-    }
-    positions.shrinkRetainingCapacity(write);
+        if (positions.items.len == 0) return current;
 
-    var out: std.ArrayList(u8) = .empty;
-    try out.appendSlice(sa, input);
-    for (positions.items) |p| try out.insert(sa, p, '\n');
-    return try out.toOwnedSlice(sa);
+        std.mem.sort(usize, positions.items, {}, std.sort.desc(usize));
+        var write: usize = 1;
+        for (positions.items[1..]) |p| {
+            if (p != positions.items[write - 1]) {
+                positions.items[write] = p;
+                write += 1;
+            }
+        }
+        positions.shrinkRetainingCapacity(write);
+
+        var out: std.ArrayList(u8) = .empty;
+        try out.appendSlice(sa, current);
+        for (positions.items) |p| try out.insert(sa, p, '\n');
+        current = try out.toOwnedSlice(sa);
+    }
+    return current;
 }
 
 fn isMissingNewlineMsg(msg: []const u8) bool {
@@ -922,6 +924,26 @@ test "repl/fixupNewlines: leaves multi-line input untouched" {
     const input = "def add(x, y)\n  return x + y\nend\n";
     const out = try fixupNewlines(arena.allocator(), input);
     try testing.expectEqual(input.ptr, out.ptr);
+}
+
+test "repl/fixupNewlines: iterates through multiple missing newlines" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const out = try fixupNewlines(arena.allocator(), "let n = 0\n");
+    // Single trivial statement — no rewrite, but exercising the
+    // iteration path with a clean input shouldn't loop.
+    try testing.expectEqualStrings("let n = 0\n", out);
+}
+
+test "repl/fixupNewlines: expands one-line while body" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const out = try fixupNewlines(arena.allocator(), "while n < 3 print n n = n + 1 end\n");
+    var stream = try gero.lang.tokenize(arena.allocator(), out);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(arena.allocator(), out, stream);
+    defer tree.deinit();
+    try testing.expectEqual(@as(usize, 0), tree.errors.len);
 }
 
 test "repl/fixupNewlines: leaves clean single-line input untouched" {

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -238,6 +238,18 @@ const Session = struct {
             },
         );
 
+        // Where the user-typed bytes land inside `source` — used to
+        // translate diagnostic spans back to `new_input` so the
+        // renderer shows the user's input, not the synthetic
+        // wrapper / auto-`print` prefix.
+        const wrapper_prefix = "\ndef __repl_main()\n";
+        const user_start: usize = switch (kind) {
+            .decl => self.decls_source.items.len,
+            .prelude => self.decls_source.items.len + wrapper_prefix.len + self.prelude_source.items.len,
+            .body => self.decls_source.items.len + wrapper_prefix.len + self.prelude_source.items.len + (body_input.len - new_input.len),
+        };
+        const view: UserView = .{ .source = new_input, .start_in_synth = user_start };
+
         var diags: std.ArrayList(gero.lang.Diagnostic) = .empty;
 
         var stream = gero.lang.tokenize(sa, source) catch {
@@ -255,7 +267,7 @@ const Session = struct {
         for (tree.errors) |e| try appendParseError(sa, &diags, e);
 
         if (diags.items.len > 0) {
-            try self.renderDiagnostics(source, diags.items);
+            try self.renderDiagnostics(view, diags.items, sa);
             return;
         }
 
@@ -266,7 +278,7 @@ const Session = struct {
         defer checked.deinit();
         for (checked.diagnostics) |d| try diags.append(sa, d);
         if (checked.hasErrors()) {
-            try self.renderDiagnostics(source, diags.items);
+            try self.renderDiagnostics(view, diags.items, sa);
             return;
         }
 
@@ -277,12 +289,12 @@ const Session = struct {
         defer compiled.deinit();
         for (compiled.diagnostics) |d| try diags.append(sa, d);
         if (compiled.hasErrors()) {
-            try self.renderDiagnostics(source, diags.items);
+            try self.renderDiagnostics(view, diags.items, sa);
             return;
         }
 
         // Warnings (no fatal) — show them, but proceed to run.
-        if (diags.items.len > 0) try self.renderDiagnostics(source, diags.items);
+        if (diags.items.len > 0) try self.renderDiagnostics(view, diags.items, sa);
 
         // All clean — boot a VM, run until halt / fault, capture
         // print syscalls into our stdout.
@@ -362,13 +374,26 @@ const Session = struct {
     }
 
     /// Render diagnostics with caret-style snippets via
-    /// `gero.lang.render.prettyOne`. Paths show as `<repl>`.
-    fn renderDiagnostics(self: *Session, source: []const u8, diags: []const gero.lang.Diagnostic) !void {
+    /// `gero.lang.render.prettyOne`. Spans are translated from
+    /// the synthetic source back into the user's literal input so
+    /// the snippet shows what the user actually typed; diagnostics
+    /// whose primary span falls outside `view.source` are dropped.
+    fn renderDiagnostics(
+        self: *Session,
+        view: UserView,
+        diags: []const gero.lang.Diagnostic,
+        sa: std.mem.Allocator,
+    ) !void {
+        var visible: std.ArrayList(gero.lang.Diagnostic) = .empty;
+        for (diags) |d| {
+            if (translateDiag(d, view, sa)) |td| try visible.append(sa, td) else |_| {}
+        }
+        if (visible.items.len == 0) return;
         const style: gero.lang.render.Style = if (self.term.color) .ansi else .none;
         try gero.lang.render.prettyOne(self.stdout, .{
             .path = "<repl>",
-            .source = source,
-            .diagnostics = diags,
+            .source = view.source,
+            .diagnostics = visible.items,
         }, style);
     }
 
@@ -406,6 +431,15 @@ const Session = struct {
 
 // ---------- diagnostic glue ----------
 
+/// Where the user's literal input lives inside the synthetic
+/// source. Spans on diagnostics index into the synthetic source;
+/// translating them by `start_in_synth` reprojects onto `source`
+/// so the renderer shows what the user typed.
+const UserView = struct {
+    source: []const u8,
+    start_in_synth: usize,
+};
+
 /// Convert a knit `core.ParseError` (from lexer / parser) into the
 /// `Diagnostic` shape the renderer expects. The `expected` field
 /// doubles as the diagnostic code (`E_SYNTAX_*` per
@@ -423,6 +457,50 @@ fn appendParseError(
         .message = try sa.dupe(u8, e.message),
         .span = .{ .start = idx, .end = idx },
     });
+}
+
+/// Reproject `d`'s spans from synthetic-source coordinates onto
+/// `view.source`. Returns `error.OutOfRange` when the primary
+/// span doesn't fall inside the user's input — the caller drops
+/// the diagnostic in that case. Secondary spans that fall outside
+/// are silently filtered.
+fn translateDiag(
+    d: gero.lang.Diagnostic,
+    view: UserView,
+    sa: std.mem.Allocator,
+) !gero.lang.Diagnostic {
+    const primary = translateSpan(d.span, view) orelse return error.OutOfRange;
+    var secondary: []const gero.lang.SpanLabel = &.{};
+    if (d.secondary.len > 0) {
+        var kept: std.ArrayList(gero.lang.SpanLabel) = .empty;
+        for (d.secondary) |s| {
+            if (translateSpan(s.span, view)) |ts| {
+                try kept.append(sa, .{ .span = ts, .message = s.message, .decoration = s.decoration });
+            }
+        }
+        secondary = try kept.toOwnedSlice(sa);
+    }
+    return .{
+        .severity = d.severity,
+        .code = d.code,
+        .message = d.message,
+        .span = primary,
+        .help = d.help,
+        .secondary = secondary,
+    };
+}
+
+fn translateSpan(span: anytype, view: UserView) ?@TypeOf(span) {
+    // safety: spans are byte offsets into synthetic source; `start_in_synth`
+    // is bounded by the same buffer length so subtraction stays in usize range.
+    const start_synth: usize = span.start;
+    const end_synth: usize = span.end;
+    if (start_synth < view.start_in_synth) return null;
+    const start = start_synth - view.start_in_synth;
+    const end = if (end_synth < view.start_in_synth) start else end_synth - view.start_in_synth;
+    if (start > view.source.len or end > view.source.len) return null;
+    // @as: spans use u32 — translated offsets stay bounded by user input length.
+    return .{ .start = @intCast(start), .end = @intCast(end) };
 }
 
 // ---------- lex-only block balance ----------
@@ -756,6 +834,26 @@ test "repl/appendParseError: uses `expected` field as diagnostic code" {
     try testing.expectEqual(@as(u32, 7), diags.items[0].span.end);
     // appendParseError dupes the message string; free it.
     testing.allocator.free(diags.items[0].message);
+}
+
+test "repl/translateSpan: shifts spans by user_start" {
+    const view: UserView = .{ .source = "in x", .start_in_synth = 27 };
+    const span = gero.lang.ast.Span{ .start = 27, .end = 31 };
+    const out = translateSpan(span, view).?;
+    try testing.expectEqual(@as(u32, 0), out.start);
+    try testing.expectEqual(@as(u32, 4), out.end);
+}
+
+test "repl/translateSpan: rejects spans before user input" {
+    const view: UserView = .{ .source = "x", .start_in_synth = 20 };
+    const span = gero.lang.ast.Span{ .start = 5, .end = 6 };
+    try testing.expect(translateSpan(span, view) == null);
+}
+
+test "repl/translateSpan: rejects spans past user input" {
+    const view: UserView = .{ .source = "x", .start_in_synth = 20 };
+    const span = gero.lang.ast.Span{ .start = 22, .end = 25 };
+    try testing.expect(translateSpan(span, view) == null);
 }
 
 test "repl/appendParseError: falls back to E_SYNTAX_GENERIC when expected is null" {

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -106,11 +106,27 @@ const Session = struct {
     }
 
     fn banner(self: *Session) !void {
-        try self.stdout.print("gero repl — v{s} (type `.help`, `.quit` to leave)\n", .{cli.version_string});
+        if (self.term.color) {
+            try self.stdout.print(
+                "\x1b[36;1mgero repl\x1b[0m  \x1b[2mv{s}\x1b[0m\n" ++
+                    "\x1b[2mtype `.help` for commands, `.quit` to leave.\x1b[0m\n\n",
+                .{cli.version_string},
+            );
+        } else {
+            try self.stdout.print(
+                "gero repl  v{s}\n" ++
+                    "type `.help` for commands, `.quit` to leave.\n\n",
+                .{cli.version_string},
+            );
+        }
     }
 
     fn prompt(self: *Session, continuation: bool) !void {
-        try self.stdout.writeAll(if (continuation) "... " else ">>> ");
+        if (self.term.color) {
+            try self.stdout.writeAll(if (continuation) "\x1b[2m...\x1b[0m " else "\x1b[36;1m>>>\x1b[0m ");
+        } else {
+            try self.stdout.writeAll(if (continuation) "... " else ">>> ");
+        }
     }
 
     /// Dispatch a `.` meta-command. Returns `.quit` on `.quit` /
@@ -222,21 +238,24 @@ const Session = struct {
             },
         );
 
+        var diags: std.ArrayList(gero.lang.Diagnostic) = .empty;
+
         var stream = gero.lang.tokenize(sa, source) catch {
             try self.term.err("repl: tokenizer failure", .{});
             return;
         };
         defer stream.deinit();
+        for (stream.errors) |e| try appendParseError(sa, &diags, e);
 
         var tree = gero.lang.parse(sa, source, stream) catch {
             try self.term.err("repl: parse failure", .{});
             return;
         };
         defer tree.deinit();
-        if (tree.errors.len > 0) {
-            for (tree.errors) |e| {
-                try self.term.err("parse: {s}", .{e.message});
-            }
+        for (tree.errors) |e| try appendParseError(sa, &diags, e);
+
+        if (diags.items.len > 0) {
+            try self.renderDiagnostics(source, diags.items);
             return;
         }
 
@@ -245,8 +264,9 @@ const Session = struct {
             return;
         };
         defer checked.deinit();
+        for (checked.diagnostics) |d| try diags.append(sa, d);
         if (checked.hasErrors()) {
-            try self.renderLangDiagnostics(source, checked.diagnostics);
+            try self.renderDiagnostics(source, diags.items);
             return;
         }
 
@@ -255,10 +275,14 @@ const Session = struct {
             return;
         };
         defer compiled.deinit();
+        for (compiled.diagnostics) |d| try diags.append(sa, d);
         if (compiled.hasErrors()) {
-            for (compiled.diagnostics) |d| try self.term.err("codegen: {s} [{s}]", .{ d.message, d.code });
+            try self.renderDiagnostics(source, diags.items);
             return;
         }
+
+        // Warnings (no fatal) — show them, but proceed to run.
+        if (diags.items.len > 0) try self.renderDiagnostics(source, diags.items);
 
         // All clean — boot a VM, run until halt / fault, capture
         // print syscalls into our stdout.
@@ -337,21 +361,15 @@ const Session = struct {
         return false;
     }
 
-    /// Format every lang diagnostic onto the REPL's stderr. Bare
-    /// formatting — full caret rendering is overkill for an
-    /// interactive prompt where the source is right above.
-    fn renderLangDiagnostics(self: *Session, source: []const u8, diags: []const gero.lang.Diagnostic) !void {
-        for (diags) |d| {
-            const lc = gero.lang.render.lineColAt(source, d.span.start);
-            // `term.err` already writes the `error:` prefix; we
-            // append the rendered line / column + diagnostic
-            // body without re-prefixing.
-            switch (d.severity) {
-                .fatal => try self.term.err("{d}:{d}: {s} [{s}]", .{ lc.line, lc.col, d.message, d.code }),
-                .warning => try self.term.info("warning {d}:{d}: {s} [{s}]", .{ lc.line, lc.col, d.message, d.code }),
-                .note => try self.term.info("note {d}:{d}: {s} [{s}]", .{ lc.line, lc.col, d.message, d.code }),
-            }
-        }
+    /// Render diagnostics with caret-style snippets via
+    /// `gero.lang.render.prettyOne`. Paths show as `<repl>`.
+    fn renderDiagnostics(self: *Session, source: []const u8, diags: []const gero.lang.Diagnostic) !void {
+        const style: gero.lang.render.Style = if (self.term.color) .ansi else .none;
+        try gero.lang.render.prettyOne(self.stdout, .{
+            .path = "<repl>",
+            .source = source,
+            .diagnostics = diags,
+        }, style);
     }
 
     /// Boot a fresh VM on the compiled image and run until halt
@@ -385,6 +403,27 @@ const Session = struct {
         try self.stdout.flush();
     }
 };
+
+// ---------- diagnostic glue ----------
+
+/// Convert a knit `core.ParseError` (from lexer / parser) into the
+/// `Diagnostic` shape the renderer expects. The `expected` field
+/// doubles as the diagnostic code (`E_SYNTAX_*` per
+/// `docs/lang-diagnostics.md`); falls back to `E_SYNTAX_GENERIC`.
+fn appendParseError(
+    sa: std.mem.Allocator,
+    out: *std.ArrayList(gero.lang.Diagnostic),
+    e: anytype,
+) !void {
+    // safety: ParseError.index fits in u32 — bounded by input size.
+    const idx: u32 = @intCast(e.index);
+    try out.append(sa, .{
+        .severity = .fatal,
+        .code = e.expected orelse "E_SYNTAX_GENERIC",
+        .message = try sa.dupe(u8, e.message),
+        .span = .{ .start = idx, .end = idx },
+    });
+}
 
 // ---------- lex-only block balance ----------
 
@@ -700,6 +739,35 @@ test "repl/startsWithToken: distinguishes prefix from identifier" {
     try testing.expect(startsWithToken("let x = 10", "let"));
     try testing.expect(!startsWithToken("letter", "let"));
     try testing.expect(startsWithToken("let", "let"));
+}
+
+test "repl/appendParseError: uses `expected` field as diagnostic code" {
+    var diags: std.ArrayList(gero.lang.Diagnostic) = .empty;
+    defer diags.deinit(testing.allocator);
+    try appendParseError(testing.allocator, &diags, .{
+        .index = 7,
+        .message = "expected expression",
+        .expected = @as(?[]const u8, "E_SYNTAX_MISSING_TOKEN"),
+    });
+    try testing.expectEqual(@as(usize, 1), diags.items.len);
+    try testing.expectEqualStrings("E_SYNTAX_MISSING_TOKEN", diags.items[0].code);
+    try testing.expectEqualStrings("expected expression", diags.items[0].message);
+    try testing.expectEqual(@as(u32, 7), diags.items[0].span.start);
+    try testing.expectEqual(@as(u32, 7), diags.items[0].span.end);
+    // appendParseError dupes the message string; free it.
+    testing.allocator.free(diags.items[0].message);
+}
+
+test "repl/appendParseError: falls back to E_SYNTAX_GENERIC when expected is null" {
+    var diags: std.ArrayList(gero.lang.Diagnostic) = .empty;
+    defer diags.deinit(testing.allocator);
+    try appendParseError(testing.allocator, &diags, .{
+        .index = 0,
+        .message = "weird input",
+        .expected = @as(?[]const u8, null),
+    });
+    try testing.expectEqualStrings("E_SYNTAX_GENERIC", diags.items[0].code);
+    testing.allocator.free(diags.items[0].message);
 }
 
 test "repl/looksLikeMainBodyStatement: recognizes the body shapes" {

--- a/apps/gero-cli/repl.zig
+++ b/apps/gero-cli/repl.zig
@@ -111,13 +111,13 @@ const Session = struct {
         if (self.term.color) {
             try self.stdout.print(
                 "\x1b[36;1mgero repl\x1b[0m  \x1b[2mv{s}\x1b[0m\n" ++
-                    "\x1b[2mtype `.help` for commands, `.quit` to leave.\x1b[0m\n\n",
+                    "\x1b[2mtype `help` for commands, `quit` to leave.\x1b[0m\n\n",
                 .{cli.version_string},
             );
         } else {
             try self.stdout.print(
                 "gero repl  v{s}\n" ++
-                    "type `.help` for commands, `.quit` to leave.\n\n",
+                    "type `help` for commands, `quit` to leave.\n\n",
                 .{cli.version_string},
             );
         }
@@ -132,38 +132,41 @@ const Session = struct {
         return if (continuation) "... " else ">>> ";
     }
 
-    /// Dispatch a `.` meta-command. Returns `.quit` on `.quit` /
-    /// `.exit`; otherwise the loop continues.
+    /// Dispatch a REPL meta-command. Returns `.quit` on `quit` /
+    /// `exit`; otherwise the loop continues. Meta-commands match
+    /// only when the input is a bare keyword (or `dump <name>`),
+    /// so a regular `print quit` expression still runs through the
+    /// pipeline.
     fn dispatchMeta(self: *Session, line: []const u8) !MetaOutcome {
         const trimmed = std.mem.trim(u8, line, " \t");
-        if (std.mem.eql(u8, trimmed, ".quit") or std.mem.eql(u8, trimmed, ".exit")) {
+        if (std.mem.eql(u8, trimmed, "quit") or std.mem.eql(u8, trimmed, "exit")) {
             return .quit;
         }
-        if (std.mem.eql(u8, trimmed, ".help")) {
+        if (std.mem.eql(u8, trimmed, "help")) {
             try self.stdout.writeAll(
-                "  .help          — this list\n" ++
-                    "  .quit          — leave the session\n" ++
-                    "  .reset         — drop every binding\n" ++
-                    "  .dump <name>   — print the source of a defined name\n",
+                "  help          — this list\n" ++
+                    "  quit / exit   — leave the session\n" ++
+                    "  reset         — drop every binding\n" ++
+                    "  dump <name>   — print the source of a defined name\n",
             );
             return .continue_loop;
         }
-        if (std.mem.eql(u8, trimmed, ".reset")) {
+        if (std.mem.eql(u8, trimmed, "reset")) {
             self.decls_source.clearRetainingCapacity();
             self.prelude_source.clearRetainingCapacity();
             try self.stdout.writeAll("session reset.\n");
             return .continue_loop;
         }
-        if (std.mem.startsWith(u8, trimmed, ".dump")) {
-            const rest = std.mem.trim(u8, trimmed[5..], " \t");
+        if (startsWithToken(trimmed, "dump")) {
+            const rest = std.mem.trim(u8, trimmed["dump".len..], " \t");
             if (rest.len == 0) {
-                try self.stdout.writeAll("usage: .dump <name>\n");
+                try self.stdout.writeAll("usage: dump <name>\n");
                 return .continue_loop;
             }
             try self.dumpName(rest);
             return .continue_loop;
         }
-        try self.term.err("unknown meta-command `{s}` — try `.help`", .{trimmed});
+        // Unreachable in practice — `isMetaCommand` guards entry.
         return .continue_loop;
     }
 
@@ -721,9 +724,16 @@ fn startsWithToken(s: []const u8, kw: []const u8) bool {
 
 // ---------- meta-command + helpers ----------
 
+/// `true` when the line is one of the bare REPL meta-keywords
+/// (`help`, `quit`, `exit`, `reset`, `dump <name>`). Matches only
+/// when the keyword is the entire input (or `dump <name>` form),
+/// so multi-statement gero code never gets intercepted.
 fn isMetaCommand(line: []const u8) bool {
     const trimmed = std.mem.trim(u8, line, " \t");
-    return trimmed.len > 0 and trimmed[0] == '.';
+    if (trimmed.len == 0) return false;
+    const bare = [_][]const u8{ "help", "quit", "exit", "reset" };
+    for (bare) |kw| if (std.mem.eql(u8, trimmed, kw)) return true;
+    return startsWithToken(trimmed, "dump");
 }
 
 fn matchesIdent(text: []const u8, name: []const u8) bool {


### PR DESCRIPTION
## Summary

Surfaces the REPL's lexer / parser / typecheck / codegen errors
through `gero.lang.render.prettyOne` instead of plain
`term.err`, and reprojects diagnostic spans from the synthetic
`__repl_main` source back onto the user's literal input.

The user was seeing diagnostics rendered against the wrapper
(`print in x` at `<repl>:3:7` when they had typed `in x`). They
now see exactly what they typed at `<repl>:1:1`, with caret
underlines + secondary span labels.

## Before / after

**Before** (typed `in x`):

```
>>> in x
error: expected expression [E_SYNTAX_MISSING_TOKEN]
  --> <repl>:3:7
  |
3 | print in x
  |       ^
```

**After**:

```
>>> in x
error: expected expression [E_SYNTAX_MISSING_TOKEN]
  --> <repl>:1:1
  |
1 | in x
  | ^
```

## Polish

- Banner is bold cyan `gero repl` + dim version line + a hint.
- Prompt is bold cyan `>>>` / dim `...`. ANSI gates on the
  existing `term.color` flag.

## Test plan

- [x] `zig build verify` green
- [x] `zig build ci` green (full matrix)
- [x] 5 new tests cover `appendParseError` + `translateSpan`
- [x] Manual smoke: `let x: bool = 42`, `2 + ""`, `in x`,
  `y + true` (with prior `let y = 10`), multi-line `def`