### PR TITLE
feat(lang): builtins (panic/unreachable/todo/sizeof) + `is` for class hierarchies

### DIFF
--- a/.changeset/lang-builtins-panic-todo-unreachable-sizeof.md
+++ b/.changeset/lang-builtins-panic-todo-unreachable-sizeof.md
@@ -1,0 +1,27 @@
+---
+bump: minor
+---
+
+Four new always-in-scope builtins fill gaps the spec already
+referred to but didn't define:
+
+- `panic(msg: str) -> noreturn` — uniform "halt with a message"
+  intent. Replaces the per-program `@noreturn def panic ...`
+  boilerplate.
+- `unreachable() -> noreturn` — prints `"unreachable code
+  reached"` then halts. Marks compiler-provable-dead branches
+  (exhaustive `match` fallthroughs, post-validation arms).
+- `todo(msg: str?) -> noreturn` — Rust-style scaffold for
+  incremental development. Prints `TODO` or `TODO: <msg>` then
+  halts.
+- `sizeof(T) -> u16` — compile-time byte width of a type. Folds
+  to a `u16` literal at codegen. Works on every type form
+  (primitives, arrays, tuples, named structs, classes). Spec
+  text §3.2 / §3.4 already used `sizeof(T)` informally — now
+  formalized.
+
+`sizeof` is a new keyword (`kw_sizeof`) because the arg slot is
+a type annotation, not an expression. The other three resolve
+before regular callee resolution like `assert` / `debug_assert`.
+
+Closes #295.

--- a/.changeset/lang-builtins-panic-todo-unreachable-sizeof.md
+++ b/.changeset/lang-builtins-panic-todo-unreachable-sizeof.md
@@ -24,4 +24,9 @@ referred to but didn't define:
 a type annotation, not an expression. The other three resolve
 before regular callee resolution like `assert` / `debug_assert`.
 
+User declarations matching the builtin names (`assert`,
+`debug_assert`, `panic`, `unreachable`, `todo`) emit
+`E_BUILTIN_SHADOW`. `sizeof` is a keyword and rejected by the
+parser before this check ever runs.
+
 Closes #295.

--- a/.changeset/lang-is-class-hierarchy.md
+++ b/.changeset/lang-is-class-hierarchy.md
@@ -43,4 +43,10 @@ end
 Casing convention disambiguates from the regular cast operator:
 lowercase post-`as` ident → binding; uppercase → `as T` cast.
 
+**Public AST shape changed.** `IsTestExpr.variant_path: Span`
+becomes `IsTestExpr.kind: Kind`, where `Kind` is a tagged
+union of `.variant: Span` and `.class_type: ClassTypeProbe`.
+Downstream consumers reading `.variant_path` directly need to
+match on `.kind` instead. Pre-1.0 minor bump.
+
 Closes #294.

--- a/.changeset/lang-is-class-hierarchy.md
+++ b/.changeset/lang-is-class-hierarchy.md
@@ -28,8 +28,19 @@ Also adds class-subtype assignability so `report(Dog())` /
 `let a: Animal = Dog()` work. Without this, every typed binding
 was its exact class and `is` had no runtime case to fire on.
 
-The `is X as binding` shape for guarded downcast is deferred to
-a follow-up — the bare bool form is the minimum viable starting
-point.
+Guarded downcast — `is ClassName as <ident>` — binds the
+receiver under the new name inside the surrounding `if` arm,
+typed as the target class:
+
+```
+def report(a: Animal)
+  if a is Dog as d
+    d.bark()           -- d: Dog in this arm
+  end
+end
+```
+
+Casing convention disambiguates from the regular cast operator:
+lowercase post-`as` ident → binding; uppercase → `as T` cast.
 
 Closes #294.

--- a/.changeset/lang-is-class-hierarchy.md
+++ b/.changeset/lang-is-class-hierarchy.md
@@ -1,0 +1,35 @@
+---
+bump: minor
+---
+
+`is` now accepts a class name on the RHS for runtime class-type
+checks via the vtable pointer:
+
+```
+def report(a: Animal)
+  if a is Dog
+    print "found a Dog"
+  end
+end
+```
+
+Receiver must be a class-typed value (or `&Class` reference —
+auto-dereffed per §3.4.4). Lowers to a single vtable-pointer
+compare against the target class's compile-time-known vtable
+address (3-4 instructions, patched after `emitVtables` runs).
+
+Statically-decidable shapes emit `W_DEAD_TEST` (receiver's
+exact type / an ancestor matches → always true; target unrelated
+to the receiver's hierarchy → always false). Struct receivers
+reject with `E_TYPE_IS_NON_DYNAMIC` — structs have no runtime
+type identity.
+
+Also adds class-subtype assignability so `report(Dog())` /
+`let a: Animal = Dog()` work. Without this, every typed binding
+was its exact class and `is` had no runtime case to fire on.
+
+The `is X as binding` shape for guarded downcast is deferred to
+a follow-up — the bare bool form is the minimum viable starting
+point.
+
+Closes #294.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -785,6 +785,32 @@ end
 
 For payload extraction, use `match` (§4.8).
 
+`is` also accepts a **class name** on the RHS for runtime class-
+type checks via the vtable pointer (§6):
+
+```
+def report(a: Animal)
+  if a is Dog
+    print "found a Dog instance"
+  end
+end
+```
+
+Receiver must be a class-typed value (or `&Class` reference —
+auto-dereffed per §3.4.4). Returns `bool`. Statically-decidable
+shapes emit `W_DEAD_TEST`:
+
+| Receiver | RHS | Result |
+|----------|-----|--------|
+| `Dog` | `Dog` | statically `true` → `W_DEAD_TEST` |
+| `Dog` | `Animal` (ancestor of `Dog`) | statically `true` → `W_DEAD_TEST` |
+| `Dog` | `Bird` (unrelated) | statically `false` → `W_DEAD_TEST` |
+| `Animal` (parent) | `Dog` (subclass) | runtime check via vtable |
+
+Struct receivers reject with `E_TYPE_IS_NON_DYNAMIC` — structs
+have no runtime type identity (no vtable). Use an `enum` with a
+tag if you need a discriminated value.
+
 ### 3.7 Annotations
 
 `@`-prefixed directives that decorate the declaration on the next
@@ -2233,6 +2259,47 @@ both are built-in pseudo-functions:
 ```
 assert(self.hp >= 0, "hp went negative")        -- always live
 debug_assert(items.len() < 1000)                -- debug-only
+```
+
+Four more diverging / introspection builtins are always in scope:
+
+- `panic(msg: str) -> noreturn` — print `msg` via the host print
+  channel and halt the VM. Use when a runtime invariant has been
+  violated and there's no sensible recovery.
+- `unreachable() -> noreturn` — print `"unreachable code reached"`
+  and halt. Use to mark branches the compiler should be able to
+  prove are dead (exhaustive `match` fallthroughs, post-validation
+  arms). Helps the reader and traps cleanly if reached.
+- `todo(msg: str?) -> noreturn` — print `"TODO"` (or `"TODO: <msg>"`)
+  and halt. Scaffold for incremental development.
+- `sizeof(T) -> u16` — compile-time byte width of a type. Resolves
+  at codegen to a `u16` literal. Works on every type form:
+  primitives (`sizeof(i16)` = 2), arrays (`sizeof([i16; 64])` =
+  128), tuples (sum of slot sizes), named structs (sum of field
+  sizes), and named classes (returns `2` — the instance-pointer
+  width, not the heap-instance footprint).
+
+```
+match item
+  case Action.Heal(n) => heal(n)
+  case _              => panic("not a healing item")
+end
+
+def color_for(s: State) -> u8
+  match s
+    case .Idle    => return 0
+    case .Active  => return 1
+    case .Stopped => return 2
+  end
+  unreachable()
+end
+
+def init_audio()
+  todo("hook up DAC config")
+end
+
+const SAVE_SIZE = sizeof(SaveSlot)
+mem.memcpy(dst, src, sizeof([i16; 64]))
 ```
 
 #### 5.3.1 `mem` stdlib

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -811,6 +811,24 @@ Struct receivers reject with `E_TYPE_IS_NON_DYNAMIC` — structs
 have no runtime type identity (no vtable). Use an `enum` with a
 tag if you need a discriminated value.
 
+**Guarded downcast — `is X as h`.** When the `is` test is the
+cond of an `if` arm, an optional `as <ident>` binds the
+receiver under the new name *inside the arm*, typed as the
+target class:
+
+```
+def report(a: Animal)
+  if a is Dog as d
+    d.bark()          -- d: Dog in this arm
+  end
+end
+```
+
+The binding is parsed only when the post-`as` ident starts with
+a lowercase letter (casing convention from §2.3) — uppercase
+RHS still binds to the regular `as T` cast. Outside the `if`-arm
+body, `h` is not in scope.
+
 ### 3.7 Annotations
 
 `@`-prefixed directives that decorate the declaration on the next
@@ -2260,6 +2278,11 @@ both are built-in pseudo-functions:
 assert(self.hp >= 0, "hp went negative")        -- always live
 debug_assert(items.len() < 1000)                -- debug-only
 ```
+
+All always-in-scope builtin names are reserved — declaring
+`def panic`, `let assert = …`, etc. emits `E_BUILTIN_SHADOW`.
+`sizeof` is a keyword and rejected by the parser before the
+shadow check ever runs.
 
 Four more diverging / introspection builtins are always in scope:
 

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -687,6 +687,14 @@ Per spec §3.6.
 | `E_TYPE_IS_NON_DYNAMIC` | `is` used with a non-class receiver (struct, primitive, tuple, etc.). Structs have no runtime type identity; use an `enum` tag instead. |
 | `W_DEAD_TEST` | `is` result is statically decidable (receiver's exact type or an ancestor matches, OR target is unrelated to the receiver's class hierarchy). Warning — the runtime check still emits. |
 
+### 5.14 Builtin shadowing (E_BUILTIN_SHADOW)
+
+Per spec §5.3.
+
+| Code | Meaning |
+|------|---------|
+| `E_BUILTIN_SHADOW` | User declaration uses a name reserved for an always-in-scope builtin (`assert`, `debug_assert`, `panic`, `unreachable`, `todo`). `sizeof` is a keyword and rejected by the parser before this check runs. |
+
 **Mockup — defer with return:**
 
 ```
@@ -773,6 +781,7 @@ Codes are stable. New ones append; old ones never change meaning.
 | `W_DEBUG_ASSERT_SIDE_EFFECT` | Assert builtins | v0.3 |
 | `E_TYPE_IS_NON_DYNAMIC` | `is` runtime type test | v0.3 |
 | `W_DEAD_TEST` | `is` runtime type test | v0.3 |
+| `E_BUILTIN_SHADOW` | Builtin shadowing | v0.3 |
 | `E_UNDEFINED_SYMBOL` | Name resolution | v0.3 |
 
 ---

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -669,14 +669,23 @@ Per spec §4.10.
 | `E_DEFER_CONTROL_FLOW` | `defer return / break / continue` rejected. |
 | `E_DEFER_NESTED` | `defer defer ...` (pointless, doesn't compose). |
 
-### 5.12 Assert builtins (E_ASSERT_* / W_DEBUG_ASSERT_*)
+### 5.12 Assert + diverging builtins (E_ASSERT_* / W_DEBUG_ASSERT_*)
 
 Per spec §5.3.
 
 | Code | Meaning |
 |------|---------|
-| `E_ASSERT_ARG_COUNT` | `assert` / `debug_assert` called with 0 or >2 args. |
+| `E_ASSERT_ARG_COUNT` | `assert` / `debug_assert` / `panic` / `unreachable` / `todo` called with the wrong number of args. |
 | `W_DEBUG_ASSERT_SIDE_EFFECT` | A `debug_assert` arg contains a function call; the call is elided in release. (Warning, not fatal.) |
+
+### 5.13 `is` runtime type test (E_TYPE_IS_* / W_DEAD_TEST)
+
+Per spec §3.6.
+
+| Code | Meaning |
+|------|---------|
+| `E_TYPE_IS_NON_DYNAMIC` | `is` used with a non-class receiver (struct, primitive, tuple, etc.). Structs have no runtime type identity; use an `enum` tag instead. |
+| `W_DEAD_TEST` | `is` result is statically decidable (receiver's exact type or an ancestor matches, OR target is unrelated to the receiver's class hierarchy). Warning — the runtime check still emits. |
 
 **Mockup — defer with return:**
 
@@ -760,8 +769,10 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_LOOP_OUTSIDE` | Loop labels | v0.3 |
 | `E_DEFER_CONTROL_FLOW` | Defer | v0.3 |
 | `E_DEFER_NESTED` | Defer | v0.3 |
-| `E_ASSERT_ARG_COUNT` | Assert builtins | v0.3 |
+| `E_ASSERT_ARG_COUNT` | Assert / diverge builtins | v0.3 |
 | `W_DEBUG_ASSERT_SIDE_EFFECT` | Assert builtins | v0.3 |
+| `E_TYPE_IS_NON_DYNAMIC` | `is` runtime type test | v0.3 |
+| `W_DEAD_TEST` | `is` runtime type test | v0.3 |
 | `E_UNDEFINED_SYMBOL` | Name resolution | v0.3 |
 
 ---

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -371,6 +371,9 @@ pub const Expr = union(enum) {
     /// be a place expression (ident / field / index); the
     /// typechecker rejects `&(a+b)` and similar temporaries.
     ref_of: RefOfExpr,
+    /// `sizeof(T)` — compile-time byte width of a type annotation.
+    /// Folds to a `u16` literal at codegen.
+    sizeof: SizeofExpr,
 
     /// Smallest `Span` covering the whole expression.
     pub fn span(self: Expr) Span {
@@ -400,6 +403,7 @@ pub const Expr = union(enum) {
             .is_test => |e| e.span,
             .cast => |e| e.span,
             .ref_of => |e| e.span,
+            .sizeof => |e| e.span,
         };
     }
 };
@@ -683,6 +687,14 @@ pub const CastExpr = struct {
 /// per §3.4.4.
 pub const RefOfExpr = struct {
     inner: *Expr,
+    span: Span,
+};
+
+/// `sizeof(T)` — compile-time byte width of a type annotation.
+/// Resolves to a `u16` literal at codegen; never emits a runtime
+/// call.
+pub const SizeofExpr = struct {
+    type_ann: *TypeAnn,
     span: Span,
 };
 
@@ -1358,6 +1370,7 @@ pub fn freeExpr(allocator: std.mem.Allocator, e: *Expr) void {
             freeTypeAnn(allocator, c.target_type);
         },
         .ref_of => |r| freeExpr(allocator, r.inner),
+        .sizeof => |s| freeTypeAnn(allocator, s.type_ann),
     }
     allocator.destroy(e);
 }

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -691,6 +691,16 @@ pub const IsTestExpr = struct {
         class_name: Span,
         binding: ?Span = null,
     };
+
+    /// `is ClassName as <ident>` — return the probe payload when
+    /// this test carries a binding. `null` for variant tests and
+    /// for bare-bool class probes.
+    pub fn classBinding(self: IsTestExpr) ?ClassTypeProbe {
+        return switch (self.kind) {
+            .class_type => |probe| if (probe.binding != null) probe else null,
+            else => null,
+        };
+    }
 };
 
 /// `inner as T` — explicit type conversion.

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -666,12 +666,24 @@ pub const TupleLit = struct {
     span: Span,
 };
 
-/// `lhs is Enum.Variant` — variant-tag test.
+/// `lhs is Enum.Variant` — variant-tag test, or
+/// `lhs is ClassName` — runtime class-type check via vtable
+/// pointer compare. The kind is picked at parse time from the
+/// shape of the RHS (qualified `Enum.Variant` vs bare ident).
 pub const IsTestExpr = struct {
     lhs: *Expr,
-    /// Variant path span — typically `EnumType.Variant`.
-    variant_path: Span,
+    kind: Kind,
     span: Span,
+
+    /// The RHS shape of an `is` test, picked at parse time from
+    /// whether the parser saw a qualified `Enum.Variant` path or
+    /// a bare `ClassName`.
+    pub const Kind = union(enum) {
+        /// `Enum.Variant` — span covers both segments.
+        variant: Span,
+        /// `ClassName` — span over the class name ident.
+        class_type: Span,
+    };
 };
 
 /// `inner as T` — explicit type conversion.

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -677,12 +677,19 @@ pub const IsTestExpr = struct {
 
     /// The RHS shape of an `is` test, picked at parse time from
     /// whether the parser saw a qualified `Enum.Variant` path or
-    /// a bare `ClassName`.
+    /// a bare `ClassName` (optionally with `as <ident>` for
+    /// guarded downcast).
     pub const Kind = union(enum) {
         /// `Enum.Variant` — span covers both segments.
         variant: Span,
-        /// `ClassName` — span over the class name ident.
-        class_type: Span,
+        /// `ClassName [as binding]` — class-type probe.
+        class_type: ClassTypeProbe,
+    };
+
+    /// `is ClassName [as binding]` payload.
+    pub const ClassTypeProbe = struct {
+        class_name: Span,
+        binding: ?Span = null,
     };
 };
 

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -146,6 +146,7 @@ pub fn compile(
         .string_patches = .empty,
         .checked = checked,
         .enum_decls = .{},
+        .struct_decls = .{},
         .class_decls = .{},
         .class_layouts = .{},
         .current_class_name = null,
@@ -466,6 +467,9 @@ pub const Emitter = struct {
     /// `enum` decls by name. Used for variant-tag indices,
     /// `is` tests, and `match` patterns.
     enum_decls: std.StringHashMapUnmanaged(*const ast.EnumDecl),
+    /// `struct` decls by name. Used for `sizeof(NamedStruct)`
+    /// width math + future struct-value lowering.
+    struct_decls: std.StringHashMapUnmanaged(*const ast.StructDecl),
     /// `class` decls by name. Used by constructor detection,
     /// vtable lookup, and field / method access.
     class_decls: std.StringHashMapUnmanaged(*const ast.ClassDecl),
@@ -630,9 +634,10 @@ pub const Emitter = struct {
     /// header `entry_point`), then every other top-level `def` in
     /// source order, then patch unresolved call sites.
     fn emitProgram(self: *Emitter, program: *const ast.Program, entry_name: []const u8) !void {
-        // Pre-pass 0: index top-level enum decls so variant-tag
-        // lookups during expr / pattern emission resolve cheaply.
+        // Pre-pass 0: index top-level enum + struct decls so
+        // variant-tag and sizeof lookups resolve cheaply.
         try self.collectEnumDecls(program);
+        try self.collectStructDecls(program);
         // Pre-pass 0b: index top-level class decls + compute
         // per-class layouts (with parent-chain resolution for
         // inherited fields + methods). Vtables emit later, once
@@ -735,6 +740,20 @@ pub const Emitter = struct {
                 const name = self.source[ed.name.start..ed.name.end];
                 const dup = try self.arena.dupe(u8, name);
                 try self.enum_decls.put(self.arena, dup, &stmt.enum_decl);
+            },
+            else => {},
+        };
+    }
+
+    /// Pre-pass: index every top-level `struct` decl by name so
+    /// `widthOfTypeAnn` / `sizeof` can compute the byte size of
+    /// a named struct (sum of field sizes).
+    fn collectStructDecls(self: *Emitter, program: *const ast.Program) !void {
+        for (program.statements) |*stmt| switch (stmt.*) {
+            .struct_decl => |sd| {
+                const name = self.source[sd.name.start..sd.name.end];
+                const dup = try self.arena.dupe(u8, name);
+                try self.struct_decls.put(self.arena, dup, &stmt.struct_decl);
             },
             else => {},
         };
@@ -1134,8 +1153,9 @@ pub const Emitter = struct {
     }
 
     /// Byte width of a type annotation: 1 for `i8`/`u8`/`bool`/
-    /// `char`, 2 for 16-bit primitives + references + named types,
-    /// sum-of-elements for tuples + arrays.
+    /// `char`, 2 for 16-bit primitives + references + class names
+    /// (which use a 2-byte instance pointer), sum-of-fields for
+    /// named structs, sum-of-elements for tuples + arrays.
     pub fn widthOfTypeAnn(self: *const Emitter, t: ast.TypeAnn) u16 {
         return switch (t) {
             .named => |n| blk: {
@@ -1146,6 +1166,13 @@ pub const Emitter = struct {
                     std.mem.eql(u8, name, "char"))
                 {
                     break :blk 1;
+                }
+                // Named struct → sum of field sizes (recursive).
+                // Class names stay at 2 (instance-pointer width).
+                if (self.struct_decls.get(name)) |sd| {
+                    var total: u16 = 0;
+                    for (sd.fields) |f| total +%= self.widthOfTypeAnn(f.type_ann.*);
+                    break :blk total;
                 }
                 break :blk 2;
             },

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -589,11 +589,8 @@ pub const Emitter = struct {
                     if (a.let_pattern) |p| n += countBindingsInPattern(p.*);
                     // `if expr is Class as h` — `h` parks the
                     // instance pointer in a fresh local slot.
-                    if (a.cond) |c| if (c.* == .is_test) switch (c.is_test.kind) {
-                        .class_type => |probe| if (probe.binding != null) {
-                            n += 1;
-                        },
-                        else => {},
+                    if (a.cond) |c| if (c.* == .is_test and c.is_test.classBinding() != null) {
+                        n += 1;
                     };
                     n += self.countLocalsInBody(a.body);
                 }

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -587,6 +587,14 @@ pub const Emitter = struct {
                 var n: usize = 0;
                 for (is_.arms) |a| {
                     if (a.let_pattern) |p| n += countBindingsInPattern(p.*);
+                    // `if expr is Class as h` — `h` parks the
+                    // instance pointer in a fresh local slot.
+                    if (a.cond) |c| if (c.* == .is_test) switch (c.is_test.kind) {
+                        .class_type => |probe| if (probe.binding != null) {
+                            n += 1;
+                        },
+                        else => {},
+                    };
                     n += self.countLocalsInBody(a.body);
                 }
                 if (is_.else_body) |eb| n += self.countLocalsInBody(eb);

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -138,16 +138,6 @@ pub fn emitIfStmt(self: *Emitter, is_: ast.IfStmt) !void {
     for (end_patches.items) |p| try isa.patchJumpTo(self, p, end_offset);
 }
 
-/// `is ClassName as binding` cond — return the probe so
-/// `emitIsClassBindingTest` can wire the binding into a local.
-fn extractIsClassBindingCond(c: *const ast.Expr) ?ast.IsTestExpr.ClassTypeProbe {
-    if (c.* != .is_test) return null;
-    return switch (c.is_test.kind) {
-        .class_type => |probe| if (probe.binding != null) probe else null,
-        else => null,
-    };
-}
-
 /// Lower `if expr is ClassName as h ...`. Evaluates the receiver
 /// once, parks the instance pointer in a fresh local bound to
 /// `h`, then compares the vtable pointer. The local stays live
@@ -187,7 +177,9 @@ fn emitIsClassBindingTest(
 /// right after the body.
 fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
     if (arm.cond) |c| {
-        if (extractIsClassBindingCond(c)) |bind| return try emitIsClassBindingTest(self, c, bind);
+        if (c.* == .is_test) if (c.is_test.classBinding()) |probe| {
+            return try emitIsClassBindingTest(self, c, probe);
+        };
         try self.emitCondBranch(c);
         return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
     }

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -138,11 +138,56 @@ pub fn emitIfStmt(self: *Emitter, is_: ast.IfStmt) !void {
     for (end_patches.items) |p| try isa.patchJumpTo(self, p, end_offset);
 }
 
+/// `is ClassName as binding` cond — return the probe so
+/// `emitIsClassBindingTest` can wire the binding into a local.
+fn extractIsClassBindingCond(c: *const ast.Expr) ?ast.IsTestExpr.ClassTypeProbe {
+    if (c.* != .is_test) return null;
+    return switch (c.is_test.kind) {
+        .class_type => |probe| if (probe.binding != null) probe else null,
+        else => null,
+    };
+}
+
+/// Lower `if expr is ClassName as h ...`. Evaluates the receiver
+/// once, parks the instance pointer in a fresh local bound to
+/// `h`, then compares the vtable pointer. The local stays live
+/// for the arm body so `h.method()` resolves cleanly.
+fn emitIsClassBindingTest(
+    self: *Emitter,
+    cond: *const ast.Expr,
+    probe: ast.IsTestExpr.ClassTypeProbe,
+) !usize {
+    const class_name = self.source[probe.class_name.start..probe.class_name.end];
+    const bind_lex = self.source[probe.binding.?.start..probe.binding.?.end];
+    const bind_dup = try self.arena.dupe(u8, bind_lex);
+    const ofs = try self.allocLocal(bind_dup);
+    // Eval receiver → acu = instance ptr; persist into the local
+    // so the arm body's reference to `h` reads the same address.
+    try self.emitExpr(cond.is_test.lhs);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+    // Load vtable ptr into r1.
+    try self.emitByte(Op.mov_ptr_to_reg);
+    try self.emitByte(Reg.r1);
+    try self.emitByte(Reg.acu);
+    // `cmp r1, <vtable_addr>` — patched after `emitVtables`.
+    try self.emitByte(Op.cmp_reg_imm16);
+    try self.emitByte(Reg.r1);
+    const patch_offset = try self.currentOffset();
+    try self.emitU16Le(0);
+    try self.vtable_patches.append(self.allocator, .{
+        .bank = self.current_bank,
+        .code_offset = patch_offset,
+        .class_name = try self.arena.dupe(u8, class_name),
+    });
+    return try isa.emitJumpPlaceholder(self, Op.jne_addr);
+}
+
 /// Emit the test for one if-arm and return the offset of the
 /// "skip body" jump patch — the caller resolves it to the byte
 /// right after the body.
 fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
     if (arm.cond) |c| {
+        if (extractIsClassBindingCond(c)) |bind| return try emitIsClassBindingTest(self, c, bind);
         try self.emitCondBranch(c);
         return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
     }

--- a/src/lang/codegen/diverge.zig
+++ b/src/lang/codegen/diverge.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const ast = @import("../ast.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const archive = @import("archive.zig");
+const strings = @import("strings.zig");
+const codegen_mod = @import("../codegen.zig");
+
+const Emitter = codegen_mod.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Sys = opcodes.Sys;
+
+// allow-strict: gero builtin name; the Zig keyword sense doesn't apply on this line.
+const name_unreachable: []const u8 = "unreachable";
+// allow-strict: literal printed when the `unreachable` builtin fires.
+const msg_unreachable: []const u8 = "unreachable code reached";
+
+/// `true` when `name` is one of the always-in-scope diverging
+/// builtins (§5.3): `panic`, `unreachable`, `todo`.
+pub fn isDivergeBuiltin(name: []const u8) bool {
+    return std.mem.eql(u8, name, "panic") or
+        std.mem.eql(u8, name, name_unreachable) or
+        std.mem.eql(u8, name, "todo");
+}
+
+/// Lower a call to a diverging builtin. Each builtin prints its
+/// diagnostic message then halts the VM via `hlt`. Caller has
+/// already confirmed the name via `isDivergeBuiltin` and the
+/// typechecker has validated the arg shape.
+pub fn emitDivergeCall(self: *Emitter, c: ast.CallExpr, name: []const u8) !void {
+    if (std.mem.eql(u8, name, "panic")) {
+        if (c.args.len == 1) try emitMessage(self, c.args[0]);
+        try isa.sys(self, Sys.print_newline);
+        try self.emitByte(Op.hlt);
+        return;
+    }
+    if (std.mem.eql(u8, name, name_unreachable)) {
+        try emitLiteral(self, msg_unreachable);
+        try isa.sys(self, Sys.print_newline);
+        try self.emitByte(Op.hlt);
+        return;
+    }
+    if (std.mem.eql(u8, name, "todo")) {
+        try emitLiteral(self, if (c.args.len == 1) "TODO: " else "TODO");
+        if (c.args.len == 1) try emitMessage(self, c.args[0]);
+        try isa.sys(self, Sys.print_newline);
+        try self.emitByte(Op.hlt);
+        return;
+    }
+}
+
+/// Emit a `print_str` for a literal byte run interned into the
+/// string pool.
+fn emitLiteral(self: *Emitter, text: []const u8) !void {
+    const id = try strings.internString(self, text);
+    try strings.emitMovStringAddrToReg(self, id, Reg.acu);
+    try isa.sys(self, Sys.print_str);
+}
+
+/// Print a string expression. Plain string literals route through
+/// the pooled-address fast path (no runtime alloc); other str
+/// expressions evaluate normally and reuse the same syscall on
+/// the resulting pointer.
+fn emitMessage(self: *Emitter, msg: *const ast.Expr) !void {
+    if (msg.* == .str_lit and msg.str_lit.parts.len == 1 and msg.str_lit.parts[0] == .lit) {
+        const lit = msg.str_lit.parts[0].lit;
+        const raw = self.source[lit.span.start..lit.span.end];
+        const decoded = try archive.decodeStringEscapes(self.arena, raw);
+        try emitLiteral(self, decoded);
+        return;
+    }
+    try self.emitExpr(msg);
+    try isa.sys(self, Sys.print_str);
+}

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -159,24 +159,52 @@ pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void
     try self.unsupported(e.span(), "non-enum field access");
 }
 
-/// Lower `expr is EnumName.Variant`. Evaluates `expr` into
-/// `acu`, compares against the variant's tag, materializes a
-/// `0` / `1` bool.
+/// Lower an `is` test. Two shapes:
+/// - `expr is Enum.Variant` — compares the tag in `acu` against
+///   the variant's compile-time tag.
+/// - `expr is ClassName` — loads the instance's vtable pointer
+///   and compares against the (patch-resolved) address of
+///   `ClassName`'s vtable.
 pub fn emitIsTest(self: *Emitter, it: ast.IsTestExpr) !void {
-    const path = self.source[it.variant_path.start..it.variant_path.end];
-    const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
-        try self.diagFatal(it.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: `is` rhs must be `EnumName.Variant`");
-        return;
-    };
-    const enum_name = path[0..dot];
-    const variant_name = path[dot + 1 ..];
-    const tag = self.variantTag(enum_name, variant_name) orelse {
-        try self.diagFatal(it.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in `is` test");
-        return;
-    };
-    try emitExpr(self, it.lhs);
-    try isa.cmpRegImm(self, Reg.acu, tag);
-    try materializeBoolFromFlags(self, .eq);
+    switch (it.kind) {
+        .variant => |path_span| {
+            const path = self.source[path_span.start..path_span.end];
+            const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
+                try self.diagFatal(it.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: `is` rhs must be `EnumName.Variant`");
+                return;
+            };
+            const enum_name = path[0..dot];
+            const variant_name = path[dot + 1 ..];
+            const tag = self.variantTag(enum_name, variant_name) orelse {
+                try self.diagFatal(it.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in `is` test");
+                return;
+            };
+            try emitExpr(self, it.lhs);
+            try isa.cmpRegImm(self, Reg.acu, tag);
+            try materializeBoolFromFlags(self, .eq);
+        },
+        .class_type => |class_span| {
+            const class_name = self.source[class_span.start..class_span.end];
+            // Eval receiver → acu = instance pointer.
+            try emitExpr(self, it.lhs);
+            // Load vtable pointer (first word of instance) into r1.
+            try self.emitByte(Op.mov_ptr_to_reg);
+            try self.emitByte(Reg.r1); // dst
+            try self.emitByte(Reg.acu); // ptr
+            // `cmp r1, <vtable_addr>` — the imm16 slot is patched
+            // by `class.patchVtableSlots` after `emitVtables` runs.
+            try self.emitByte(Op.cmp_reg_imm16);
+            try self.emitByte(Reg.r1);
+            const patch_offset = try self.currentOffset();
+            try self.emitU16Le(0);
+            try self.vtable_patches.append(self.allocator, .{
+                .bank = self.current_bank,
+                .code_offset = patch_offset,
+                .class_name = try self.arena.dupe(u8, class_name),
+            });
+            try materializeBoolFromFlags(self, .eq);
+        },
+    }
 }
 
 /// Lower a unary prefix expression.

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -183,8 +183,8 @@ pub fn emitIsTest(self: *Emitter, it: ast.IsTestExpr) !void {
             try isa.cmpRegImm(self, Reg.acu, tag);
             try materializeBoolFromFlags(self, .eq);
         },
-        .class_type => |class_span| {
-            const class_name = self.source[class_span.start..class_span.end];
+        .class_type => |probe| {
+            const class_name = self.source[probe.class_name.start..probe.class_name.end];
             // Eval receiver → acu = instance pointer.
             try emitExpr(self, it.lhs);
             // Load vtable pointer (first word of instance) into r1.

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -5,6 +5,7 @@ const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const archive = @import("archive.zig");
 const assert_builtin = @import("assert.zig");
+const diverge_builtin = @import("diverge.zig");
 const class = @import("class.zig");
 const lambda = @import("lambda.zig");
 const overflow = @import("overflow.zig");
@@ -99,6 +100,7 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .is_test => |it| try emitIsTest(self, it),
         .ref_of => |r| try self.emitAddrOf(r.inner),
         .cast => |c| try emitExpr(self, c.inner), // same-width primitives share a bit pattern, so the cast is a no-op
+        .sizeof => |s| try isa.movImmToReg(self, self.widthOfTypeAnn(s.type_ann.*), Reg.acu),
         else => try self.unsupported(e.span(), "this expression form"),
     }
 }
@@ -490,6 +492,10 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
         // top-level def behind them.
         if (assert_builtin.isAssertBuiltin(callee_name)) {
             try assert_builtin.emitAssertCall(self, c, callee_name);
+            return;
+        }
+        if (diverge_builtin.isDivergeBuiltin(callee_name)) {
+            try diverge_builtin.emitDivergeCall(self, c, callee_name);
             return;
         }
         if (class.isClassName(self, callee_name)) {

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -74,14 +74,27 @@ pub fn parseExpression(p: *Parser, min_prec: u8) ParserError!*ast.Expr {
             const prec = Prec.is_test;
             if (prec < min_prec) break;
             p.pos += 1;
-            const head_tok = try p.expect(.ident, "enum name");
-            _ = try p.expect(.dot, ".");
-            const var_tok = try p.expect(.ident, "variant name");
-            const path: ast.Span = .{ .start = head_tok.start, .end = var_tok.end };
+            const head_tok = try p.expect(.ident, "enum or class name");
+            // Two shapes:
+            //   `is Enum.Variant` — qualified variant path (existing).
+            //   `is ClassName`    — bare ident → class-type probe.
+            if (p.check(.dot)) {
+                p.pos += 1;
+                const var_tok = try p.expect(.ident, "variant name");
+                const path: ast.Span = .{ .start = head_tok.start, .end = var_tok.end };
+                const new_node = try p.allocExpr(.{ .is_test = .{
+                    .lhs = lhs,
+                    .kind = .{ .variant = path },
+                    .span = .{ .start = lhs.span().start, .end = var_tok.end },
+                } });
+                lhs = new_node;
+                continue;
+            }
+            const class_span: ast.Span = .{ .start = head_tok.start, .end = head_tok.end };
             const new_node = try p.allocExpr(.{ .is_test = .{
                 .lhs = lhs,
-                .variant_path = path,
-                .span = .{ .start = lhs.span().start, .end = var_tok.end },
+                .kind = .{ .class_type = class_span },
+                .span = .{ .start = lhs.span().start, .end = head_tok.end },
             } });
             lhs = new_node;
             continue;

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -91,10 +91,24 @@ pub fn parseExpression(p: *Parser, min_prec: u8) ParserError!*ast.Expr {
                 continue;
             }
             const class_span: ast.Span = .{ .start = head_tok.start, .end = head_tok.end };
+            // Guarded downcast: `is ClassName as <lowercase-ident>`
+            // binds the receiver under the new name inside the
+            // surrounding `if` arm. Casing heuristic: uppercase
+            // after `as` is a regular cast (`x is Foo as Bar` →
+            // `(x is Foo) as Bar`), so we leave it for the
+            // cast-operator branch one tier up.
+            var binding_span: ?ast.Span = null;
+            var test_end = head_tok.end;
+            if (p.check(.kw_as) and isLowercaseIdentAt(p, p.pos + 1)) {
+                p.pos += 1; // consume `as`
+                const bind_tok = try p.expect(.ident, "binding name");
+                binding_span = .{ .start = bind_tok.start, .end = bind_tok.end };
+                test_end = bind_tok.end;
+            }
             const new_node = try p.allocExpr(.{ .is_test = .{
                 .lhs = lhs,
-                .kind = .{ .class_type = class_span },
-                .span = .{ .start = lhs.span().start, .end = head_tok.end },
+                .kind = .{ .class_type = .{ .class_name = class_span, .binding = binding_span } },
+                .span = .{ .start = lhs.span().start, .end = test_end },
             } });
             lhs = new_node;
             continue;
@@ -404,6 +418,18 @@ fn looksLikeStructLit(p: *const Parser) bool {
     if (tok.start >= p.source.len) return false;
     const b = p.source[tok.start];
     return b >= 'A' and b <= 'Z';
+}
+
+/// `true` when the token at `pos` is an identifier whose first
+/// byte is ASCII lowercase. Used to disambiguate `is X as Y` —
+/// lowercase Y is a binding, uppercase Y is a cast target type.
+fn isLowercaseIdentAt(p: *const Parser, pos: usize) bool {
+    if (pos >= p.tokens.len) return false;
+    const tok = p.tokens[pos];
+    if (tok.kind != .ident) return false;
+    if (tok.start >= p.source.len) return false;
+    const b = p.source[tok.start];
+    return b >= 'a' and b <= 'z';
 }
 
 fn parseStructLit(p: *Parser) ParserError!*ast.Expr {

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -368,6 +368,7 @@ fn parsePrimary(p: *Parser) ParserError!*ast.Expr {
         .lbracket => return try parseListLit(p),
         .kw_do => return try parseDoExpr(p),
         .kw_bake => return try parseBakeExpr(p),
+        .kw_sizeof => return try parseSizeofExpr(p),
         .kw_if => return try parseIfExpr(p),
         .kw_lambda => return try parseLambda(p),
         // Short lambda form `|x| expr`, `|x, y| expr`, `|| expr`.
@@ -620,6 +621,24 @@ pub fn parseBakeDoExpr(p: *Parser, bake_start: u32) ParserError!*ast.Expr {
 /// `bake do … end` in expression position — e.g. `const X = bake do
 /// … end`. Only `bake do` is accepted here; `bake def` lives at
 /// statement position only.
+/// `sizeof(T)` — compile-time byte width of a type. The arg slot
+/// is a type annotation (not an expression), parsed via the
+/// regular `type_ann.parseTypeAnn` path so all type forms (named,
+/// array, tuple, etc.) work.
+fn parseSizeofExpr(p: *Parser) ParserError!*ast.Expr {
+    const sizeof_tok = p.peek();
+    p.pos += 1; // consume `sizeof`
+    _ = try p.expect(.lparen, "(");
+    const type_mod = @import("type_ann.zig");
+    const type_ann = try type_mod.parseTypeAnn(p);
+    errdefer ast.freeTypeAnn(p.allocator, type_ann);
+    const close = try p.expect(.rparen, ")");
+    return try p.allocExpr(.{ .sizeof = .{
+        .type_ann = type_ann,
+        .span = .{ .start = sizeof_tok.start, .end = close.end },
+    } });
+}
+
 fn parseBakeExpr(p: *Parser) ParserError!*ast.Expr {
     const bake_tok = p.peek();
     p.pos += 1; // consume `bake`

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -118,6 +118,10 @@ pub const Token = struct {
         /// `do`-block (§3.8). Evaluated by the bake interpreter at
         /// compile time; result lowered to static data.
         kw_bake,
+        /// `sizeof` — compile-time byte width of a type
+        /// annotation (§5.3). `sizeof(T)` resolves to a `u16`
+        /// literal at codegen.
+        kw_sizeof,
 
         // -- punctuation --------------------------------------
         newline,
@@ -272,6 +276,7 @@ const keyword_table = [_]KeywordEntry{
     .{ .lex = "defer", .kind = .kw_defer },
     .{ .lex = "asm", .kind = .kw_asm },
     .{ .lex = "bake", .kind = .kw_bake },
+    .{ .lex = "sizeof", .kind = .kw_sizeof },
 };
 
 /// Lookup `name` (already lowercase per the identifier rule) in

--- a/src/lang/print.zig
+++ b/src/lang/print.zig
@@ -825,6 +825,11 @@ const Printer = struct {
                 try self.writeExpr(r.inner, .unary);
                 if (need_parens) try self.writer.writeByte(')');
             },
+            .sizeof => |s| {
+                try self.writer.writeAll("sizeof(");
+                try self.writeTypeAnn(s.type_ann);
+                try self.writer.writeByte(')');
+            },
         }
     }
 

--- a/src/lang/print.zig
+++ b/src/lang/print.zig
@@ -809,7 +809,13 @@ const Printer = struct {
                 try self.writer.writeAll(" is ");
                 switch (it.kind) {
                     .variant => |path| try self.writer.writeAll(self.lexeme(path)),
-                    .class_type => |class_span| try self.writer.writeAll(self.lexeme(class_span)),
+                    .class_type => |probe| {
+                        try self.writer.writeAll(self.lexeme(probe.class_name));
+                        if (probe.binding) |b| {
+                            try self.writer.writeAll(" as ");
+                            try self.writer.writeAll(self.lexeme(b));
+                        }
+                    },
                 }
                 if (need_parens) try self.writer.writeByte(')');
             },

--- a/src/lang/print.zig
+++ b/src/lang/print.zig
@@ -807,7 +807,10 @@ const Printer = struct {
                 if (need_parens) try self.writer.writeByte('(');
                 try self.writeExpr(it.lhs, .is_test);
                 try self.writer.writeAll(" is ");
-                try self.writer.writeAll(self.lexeme(it.variant_path));
+                switch (it.kind) {
+                    .variant => |path| try self.writer.writeAll(self.lexeme(path)),
+                    .class_type => |class_span| try self.writer.writeAll(self.lexeme(class_span)),
+                }
                 if (need_parens) try self.writer.writeByte(')');
             },
             .cast => |c| {

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1549,6 +1549,13 @@ pub const Checker = struct {
             },
             .cast => |c| return try operators.checkCast(self, c),
             .ref_of => |r| return try self.checkRefOf(r),
+            .sizeof => |s| {
+                // `sizeof(T)` resolves T to validate the annotation
+                // is real (so unknown names emit `E_TYPE_UNDEFINED`).
+                // The numeric width is computed at codegen.
+                _ = try type_resolve.resolveType(self, s.type_ann);
+                return try self.primitive(.u16);
+            },
         }
     }
 

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -941,7 +941,7 @@ pub const Checker = struct {
             // `if expr is Class as h` — the binding `h` is in scope
             // for THIS arm's body, typed as the target class.
             const is_binding: ?ast.IsTestExpr.ClassTypeProbe = if (arm.cond) |c|
-                extractIsBinding(c)
+                (if (c.* == .is_test) c.is_test.classBinding() else null)
             else
                 null;
             try self.walkArmBodyWithIsBinding(arm.body, is_binding);
@@ -1884,19 +1884,6 @@ fn isReservedBuiltinName(name: []const u8) bool {
     };
     for (reserved) |kw| if (std.mem.eql(u8, name, kw)) return true;
     return false;
-}
-
-// ---------- is-test helpers ----------
-
-/// `is ClassName as h` — return the probe payload when the cond
-/// is a class-type `is_test` carrying a binding. `null` for all
-/// other shapes (variant test, no binding, non-`is_test`).
-fn extractIsBinding(cond: *const ast.Expr) ?ast.IsTestExpr.ClassTypeProbe {
-    if (cond.* != .is_test) return null;
-    return switch (cond.is_test.kind) {
-        .class_type => |probe| if (probe.binding != null) probe else null,
-        else => null,
-    };
 }
 
 // ---------- place expression check ----------

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -353,11 +353,29 @@ pub const Checker = struct {
         actual: *const types.Type,
     ) WalkError!void {
         if (relations.assignable(actual.*, expected.*)) return;
+        if (self.isClassSubtype(actual.*, expected.*)) return;
         if (relations.isNarrowingInt(actual.*, expected.*)) {
             try self.emitNarrowingWarning(span, expected, actual);
             return;
         }
         try self.emitMismatch(span, expected, actual);
+    }
+
+    /// `true` when `actual` is a class derived from `expected`
+    /// (transitively, via `extends`). Also covers `&Sub` → `&Sup`
+    /// reference subtyping by peeling one layer per side.
+    pub fn isClassSubtype(self: *const Checker, actual: types.Type, expected: types.Type) bool {
+        const a = if (actual == .reference) actual.reference.* else actual;
+        const e = if (expected == .reference) expected.reference.* else expected;
+        if (a != .named or e != .named) return false;
+        const expected_name = e.named.name;
+        var cur = self.class_registry.get(a.named.name) orelse return false;
+        while (cur.extends) |ext| {
+            const parent_name = self.lexeme(ext);
+            if (std.mem.eql(u8, parent_name, expected_name)) return true;
+            cur = self.class_registry.get(parent_name) orelse return false;
+        }
+        return false;
     }
 
     fn emitNarrowingWarning(
@@ -723,6 +741,7 @@ pub const Checker = struct {
             // — sole call site that overrides the plain
             // `checkStoreCompat` path (#254 AC).
             if (!relations.assignable(init_ty.?.*, ann_ty.?.*) and
+                !self.isClassSubtype(init_ty.?.*, ann_ty.?.*) and
                 !relations.isNarrowingInt(init_ty.?.*, ann_ty.?.*) and
                 d.type_ann != null)
             {
@@ -1543,10 +1562,7 @@ pub const Checker = struct {
                 out.* = .{ .tuple = try elems.toOwnedSlice(self.arena) };
                 return out;
             },
-            .is_test => |it| {
-                _ = try self.inferExpr(it.lhs, null);
-                return try self.primitive(.bool_);
-            },
+            .is_test => |it| return try self.checkIsTest(it),
             .cast => |c| return try operators.checkCast(self, c),
             .ref_of => |r| return try self.checkRefOf(r),
             .sizeof => |s| {
@@ -1582,6 +1598,91 @@ pub const Checker = struct {
             .{ty_s},
         );
         try self.emitSpan("E_NULL_DEREF", access_span, msg);
+    }
+
+    /// `lhs is X` — type-check both shapes (variant tag test +
+    /// class-type probe) and apply the receiver-type rules from
+    /// `docs/lang-diagnostics.md` §3.6.
+    ///
+    /// Always returns `bool`. Walks the lhs even on rejection so
+    /// nested diagnostics still surface.
+    fn checkIsTest(self: *Checker, it: ast.IsTestExpr) WalkError!?*const types.Type {
+        const lhs_ty = try self.inferExpr(it.lhs, null);
+        const bool_ty = try self.primitive(.bool_);
+        switch (it.kind) {
+            .variant => return bool_ty,
+            .class_type => |class_span| {
+                const class_name = self.lexeme(class_span);
+                if (!self.class_registry.contains(class_name)) {
+                    const msg = try std.fmt.allocPrint(self.arena, "undefined class `{s}`", .{class_name});
+                    try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", class_span, msg, try self.suggestTypeName(class_name));
+                    return bool_ty;
+                }
+                const recv = lhs_ty orelse return bool_ty;
+                const peeled = if (recv.* == .reference) recv.reference else recv;
+                if (peeled.* != .named) {
+                    try self.emitSpan(
+                        "E_TYPE_IS_NON_DYNAMIC",
+                        it.span,
+                        "`is` requires a class-typed receiver (struct and primitive types have no runtime type identity)",
+                    );
+                    return bool_ty;
+                }
+                const recv_name = peeled.named.name;
+                // Struct receiver — `is` has no meaning (no vtable).
+                if (self.struct_registry.contains(recv_name)) {
+                    try self.emitSpan(
+                        "E_TYPE_IS_NON_DYNAMIC",
+                        it.span,
+                        "`is` requires a class-typed receiver — structs have no runtime type identity (use an enum tag instead)",
+                    );
+                    return bool_ty;
+                }
+                const recv_class = self.class_registry.get(recv_name) orelse {
+                    try self.emitSpan(
+                        "E_TYPE_IS_NON_DYNAMIC",
+                        it.span,
+                        "`is` requires a class-typed receiver",
+                    );
+                    return bool_ty;
+                };
+                // Decide statically when the relationship is fixed.
+                if (std.mem.eql(u8, recv_name, class_name) or isAncestorOf(self, class_name, recv_class)) {
+                    const msg = try std.fmt.allocPrint(self.arena, "`{s} is {s}` is always true — the static type of the receiver already guarantees this", .{ recv_name, class_name });
+                    try self.diagnostics.append(self.diag_alloc, .{
+                        .severity = .warning,
+                        .code = "W_DEAD_TEST",
+                        .message = msg,
+                        .span = it.span,
+                    });
+                } else {
+                    const target = self.class_registry.get(class_name).?;
+                    if (!isAncestorOf(self, recv_name, target)) {
+                        const msg = try std.fmt.allocPrint(self.arena, "`{s} is {s}` is always false — `{s}` is not in `{s}`'s ancestor chain", .{ recv_name, class_name, class_name, recv_name });
+                        try self.diagnostics.append(self.diag_alloc, .{
+                            .severity = .warning,
+                            .code = "W_DEAD_TEST",
+                            .message = msg,
+                            .span = it.span,
+                        });
+                    }
+                }
+                return bool_ty;
+            },
+        }
+    }
+
+    /// `true` when `target_name` is an ancestor of `cd` (i.e. `cd`
+    /// extends `target_name` somewhere in its parent chain).
+    fn isAncestorOf(self: *const Checker, target_name: []const u8, cd: *const ast.ClassDecl) bool {
+        var cur: ?*const ast.ClassDecl = cd;
+        while (cur) |c| {
+            const ext = c.extends orelse return false;
+            const parent_name = self.lexeme(ext);
+            if (std.mem.eql(u8, parent_name, target_name)) return true;
+            cur = self.class_registry.get(parent_name);
+        }
+        return false;
     }
 
     /// `&x` — verify the inner is a place expression and not

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -579,6 +579,15 @@ pub const Checker = struct {
         name: []const u8,
         info: scope_mod.SymbolInfo,
     ) WalkError!void {
+        if (isReservedBuiltinName(name)) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "cannot shadow always-in-scope builtin `{s}`",
+                .{name},
+            );
+            try self.emitSpan("E_BUILTIN_SHADOW", info.decl_span, msg);
+            return;
+        }
         self.current_scope.define(name, info) catch |err| switch (err) {
             error.AlreadyDefined => {
                 const existing = self.current_scope.lookupLocal(name).?;
@@ -929,7 +938,13 @@ pub const Checker = struct {
             else
                 null;
             const added = if (arm_gain) |n| try self.pushNonNil(n) else false;
-            try self.walkInScope(arm.body);
+            // `if expr is Class as h` — the binding `h` is in scope
+            // for THIS arm's body, typed as the target class.
+            const is_binding: ?ast.IsTestExpr.ClassTypeProbe = if (arm.cond) |c|
+                extractIsBinding(c)
+            else
+                null;
+            try self.walkArmBodyWithIsBinding(arm.body, is_binding);
             if (added) self.popNonNil(arm_gain.?);
         }
 
@@ -944,6 +959,34 @@ pub const Checker = struct {
             try self.walkInScope(eb);
             if (added) self.popNonNil(else_gain.?);
         }
+    }
+
+    /// Walk an `if` arm body, optionally pushing an `is X as h`
+    /// binding into the arm's child scope. The binding's type is
+    /// the named class — typically a subclass of the receiver,
+    /// safe to use as that subclass for the duration of the body.
+    fn walkArmBodyWithIsBinding(
+        self: *Checker,
+        body: []const ast.Statement,
+        probe: ?ast.IsTestExpr.ClassTypeProbe,
+    ) WalkError!void {
+        if (probe == null or probe.?.binding == null) {
+            try self.walkInScope(body);
+            return;
+        }
+        const saved = self.current_scope;
+        var child: Scope = .init(self.arena, saved);
+        self.current_scope = &child;
+        defer self.current_scope = saved;
+        const class_name = self.lexeme(probe.?.class_name);
+        const bind_name = self.lexeme(probe.?.binding.?);
+        const ty = try types.mkNamed(self.arena, class_name, probe.?.class_name);
+        try self.registerName(bind_name, .{
+            .kind = .let_binding,
+            .decl_span = probe.?.binding.?,
+            .ty = ty,
+        });
+        try self.walkStatementSequence(body);
     }
 
     fn checkWhile(self: *Checker, ws: ast.WhileStmt) WalkError!void {
@@ -1611,11 +1654,11 @@ pub const Checker = struct {
         const bool_ty = try self.primitive(.bool_);
         switch (it.kind) {
             .variant => return bool_ty,
-            .class_type => |class_span| {
-                const class_name = self.lexeme(class_span);
+            .class_type => |probe| {
+                const class_name = self.lexeme(probe.class_name);
                 if (!self.class_registry.contains(class_name)) {
                     const msg = try std.fmt.allocPrint(self.arena, "undefined class `{s}`", .{class_name});
-                    try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", class_span, msg, try self.suggestTypeName(class_name));
+                    try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", probe.class_name, msg, try self.suggestTypeName(class_name));
                     return bool_ty;
                 }
                 const recv = lhs_ty orelse return bool_ty;
@@ -1822,6 +1865,38 @@ fn anyExprMentions(c: *const Checker, exprs: []const *ast.Expr, name: []const u8
 fn structLitMentions(c: *const Checker, lit_fields: []const ast.StructLitField, name: []const u8) bool {
     for (lit_fields) |f| if (c.exprMentions(f.value, name)) return true;
     return false;
+}
+
+// ---------- builtin name reservation ----------
+
+/// `true` when `name` is an always-in-scope builtin per spec §5.3.
+/// User declarations matching these names get `E_BUILTIN_SHADOW`.
+/// `sizeof` is a keyword and rejected by the parser before reaching
+/// here.
+fn isReservedBuiltinName(name: []const u8) bool {
+    const reserved = [_][]const u8{
+        "assert",
+        "debug_assert",
+        "panic",
+        // allow-strict: lang builtin name; the Zig keyword sense doesn't apply on this line.
+        "unreachable",
+        "todo",
+    };
+    for (reserved) |kw| if (std.mem.eql(u8, name, kw)) return true;
+    return false;
+}
+
+// ---------- is-test helpers ----------
+
+/// `is ClassName as h` — return the probe payload when the cond
+/// is a class-type `is_test` carrying a binding. `null` for all
+/// other shapes (variant test, no binding, non-`is_test`).
+fn extractIsBinding(cond: *const ast.Expr) ?ast.IsTestExpr.ClassTypeProbe {
+    if (cond.* != .is_test) return null;
+    return switch (cond.is_test.kind) {
+        .class_type => |probe| if (probe.binding != null) probe else null,
+        else => null,
+    };
 }
 
 // ---------- place expression check ----------

--- a/src/lang/typecheck/calls.zig
+++ b/src/lang/typecheck/calls.zig
@@ -25,6 +25,9 @@ pub fn checkCall(self: *Checker, c: ast.CallExpr, hint: ?*const types.Type) Walk
         if (isAssertBuiltinName(callee_name)) {
             return try checkAssertBuiltin(self, c, callee_name);
         }
+        if (isDivergeBuiltinName(callee_name)) {
+            return try checkDivergeBuiltin(self, c, callee_name);
+        }
     }
     // Abstract-class instantiation: `ClassName(args)` where
     // `ClassName` is abstract is rejected.
@@ -141,6 +144,65 @@ pub fn checkAssertBuiltin(
         };
     }
     return try self.primitive(.nil_);
+}
+
+/// Type-check `panic(msg)` / `unreachable()` / `todo(msg?)`.
+/// All three diverge — they halt the VM. Returns `nil` so they
+/// flow in any statement position (including `match` bail arms).
+///
+/// - `panic(msg: str)` — exactly 1 arg, must be `str`.
+/// - `unreachable()` — exactly 0 args.
+/// - `todo(msg: str?)` — 0 or 1 arg; arg must be `str`.
+pub fn checkDivergeBuiltin(
+    self: *Checker,
+    c: ast.CallExpr,
+    name: []const u8,
+) WalkError!?*const types.Type {
+    const is_unreachable = std.mem.eql(u8, name, name_unreachable);
+    const is_panic = std.mem.eql(u8, name, "panic");
+    const is_todo = std.mem.eql(u8, name, "todo");
+
+    if (is_unreachable) {
+        if (c.args.len != 0) {
+            try self.emitSpan(
+                "E_ASSERT_ARG_COUNT",
+                c.span,
+                arg_count_msg_unreachable,
+            );
+            for (c.args) |a| _ = try self.inferExpr(a, null);
+        }
+    } else if (is_panic) {
+        if (c.args.len != 1) {
+            try self.emitSpan(
+                "E_ASSERT_ARG_COUNT",
+                c.span,
+                "`panic` takes exactly 1 argument (msg)",
+            );
+            for (c.args) |a| _ = try self.inferExpr(a, null);
+        } else {
+            try checkStrArg(self, c.args[0]);
+        }
+    } else if (is_todo) {
+        if (c.args.len > 1) {
+            try self.emitSpan(
+                "E_ASSERT_ARG_COUNT",
+                c.span,
+                "`todo` takes 0 or 1 arguments (msg?)",
+            );
+            for (c.args) |a| _ = try self.inferExpr(a, null);
+        } else if (c.args.len == 1) {
+            try checkStrArg(self, c.args[0]);
+        }
+    }
+    return try self.primitive(.nil_);
+}
+
+fn checkStrArg(self: *Checker, arg: *const ast.Expr) WalkError!void {
+    const str_ty = try self.primitive(.str);
+    const got = try self.inferExpr(arg, str_ty);
+    if (got != null and !relations.assignable(got.?.*, str_ty.*)) {
+        try self.emitMismatch(arg.span(), str_ty, got.?);
+    }
 }
 
 /// Verify a `def`'s param list places the (optional) variadic
@@ -272,6 +334,20 @@ fn variadicCalleeDecl(c: *const Checker, callee: *const ast.Expr) ?*const ast.De
 fn isAssertBuiltinName(name: []const u8) bool {
     return std.mem.eql(u8, name, "assert") or std.mem.eql(u8, name, "debug_assert");
 }
+
+/// `true` when `name` is one of the always-in-scope diverging
+/// builtins per spec §5.3. Recognized at call sites before any
+/// generic callee resolution.
+fn isDivergeBuiltinName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "panic") or
+        std.mem.eql(u8, name, name_unreachable) or
+        std.mem.eql(u8, name, "todo");
+}
+
+// allow-strict: gero builtin name; Zig keyword sense doesn't apply on this line.
+const name_unreachable: []const u8 = "unreachable";
+// allow-strict: arg-count diagnostic text printed when the `unreachable` builtin is called wrong.
+const arg_count_msg_unreachable: []const u8 = "`unreachable` takes no arguments";
 
 /// `true` when `e` contains a `CallExpr` anywhere in its sub-tree.
 /// Used as a side-effect proxy for the

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3509,3 +3509,151 @@ test "codegen/bake: program without bake stays small (image doesn't grow to data
     // hlt-only program.
     try std.testing.expect(compiled.image.len < gero.lang.codegen.data_base);
 }
+
+// ---------- is X (class form) runtime ----------
+
+test "codegen/is: runtime hit on a subclass instance prints from the then-arm" {
+    try runAndExpect(
+        \\class Animal
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\class Dog extends Animal
+        \\  def init(self)
+        \\    super.init()
+        \\  end
+        \\end
+        \\def report(a: Animal)
+        \\  if a is Dog
+        \\    print "dog"
+        \\  end
+        \\end
+        \\def main()
+        \\  let d = Dog()
+        \\  report(d)
+        \\end
+    , "dog\n");
+}
+
+test "codegen/is: runtime miss on an unrelated subclass skips the then-arm" {
+    try runAndExpect(
+        \\class Animal
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\class Dog extends Animal
+        \\  def init(self)
+        \\    super.init()
+        \\  end
+        \\end
+        \\class Cat extends Animal
+        \\  def init(self)
+        \\    super.init()
+        \\  end
+        \\end
+        \\def report(a: Animal)
+        \\  if a is Dog
+        \\    print "dog"
+        \\  end
+        \\  print "done"
+        \\end
+        \\def main()
+        \\  let c = Cat()
+        \\  report(c)
+        \\end
+    , "done\n");
+}
+
+test "codegen/is: `as binding` exposes the downcast value in the arm" {
+    try runAndExpect(
+        \\class Animal
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\class Dog extends Animal
+        \\  let bark_count: u8
+        \\  def init(self)
+        \\    super.init()
+        \\    self.bark_count = 3
+        \\  end
+        \\end
+        \\def report(a: Animal)
+        \\  if a is Dog as d
+        \\    print d.bark_count
+        \\  end
+        \\end
+        \\def main()
+        \\  let d = Dog()
+        \\  report(d)
+        \\end
+    , "3\n");
+}
+
+// ---------- diverging builtins ----------
+
+test "codegen/panic: prints the message and halts" {
+    try runAndExpect(
+        \\def main()
+        \\  panic("kaboom")
+        \\  print "unreached"
+        \\end
+    , "kaboom\n");
+}
+
+test "codegen/unreachable: prints the diagnostic and halts" {
+    try runAndExpect(
+        \\def main()
+        \\  unreachable()
+        \\  print "unreached"
+        \\end
+    , "unreachable code reached\n");
+}
+
+test "codegen/todo: prints TODO (no msg) and halts" {
+    try runAndExpect(
+        \\def main()
+        \\  todo()
+        \\  print "unreached"
+        \\end
+    , "TODO\n");
+}
+
+test "codegen/todo: prints TODO with the message and halts" {
+    try runAndExpect(
+        \\def main()
+        \\  todo("audio")
+        \\  print "unreached"
+        \\end
+    , "TODO: audio\n");
+}
+
+// ---------- sizeof (comptime) ----------
+
+test "codegen/sizeof: primitive widths fold to integer literals" {
+    try runAndExpect(
+        \\def main()
+        \\  print sizeof(i8)
+        \\  print sizeof(i16)
+        \\  print sizeof(bool)
+        \\end
+    , "1\n2\n1\n");
+}
+
+test "codegen/sizeof: aggregate widths sum field / element sizes" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  print sizeof(Pos)
+        \\  print sizeof([i16; 8])
+        \\end
+    , "4\n16\n");
+}

--- a/tests/lang/codegen/diverge.test.zig
+++ b/tests/lang/codegen/diverge.test.zig
@@ -1,0 +1,11 @@
+//! Mirror file for `src/lang/codegen/diverge.zig`.
+//! Behavioral coverage of the diverging builtins (`panic`,
+//! `unreachable`, `todo`) lives in `tests/lang/codegen.test.zig`
+//! — this file exists to satisfy the mirror-layout lint rule.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/diverge: module reachable through the barrel" {
+    _ = gero.lang.internal.codegen;
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2237,3 +2237,68 @@ test "typecheck/todo: accepts 0 or 1 arg" {
         \\end
     );
 }
+
+test "typecheck/is: `as binding` brings the binding into the arm body" {
+    try expectClean(
+        \\class Animal
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\class Dog extends Animal
+        \\  let bark_count: u8
+        \\  def init(self)
+        \\    super.init()
+        \\    self.bark_count = 3
+        \\  end
+        \\end
+        \\def report(a: Animal)
+        \\  if a is Dog as d
+        \\    print d.bark_count
+        \\  end
+        \\end
+        \\def main()
+        \\  let d = Dog()
+        \\  report(d)
+        \\end
+    );
+}
+
+test "typecheck/is: `as binding` is not visible after the arm" {
+    try expectCode(
+        \\class Animal
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\class Dog extends Animal
+        \\  def init(self)
+        \\    super.init()
+        \\  end
+        \\end
+        \\def report(a: Animal)
+        \\  if a is Dog as d
+        \\    print "ok"
+        \\  end
+        \\  print d.k
+        \\end
+    , "E_UNDEFINED_SYMBOL");
+}
+
+test "typecheck/shadow: `def panic` is rejected" {
+    try expectCode(
+        \\def panic(m: str)
+        \\  print m
+        \\end
+    , "E_BUILTIN_SHADOW");
+}
+
+test "typecheck/shadow: `let assert` is rejected" {
+    try expectCode(
+        \\def main()
+        \\  let assert = 10
+        \\end
+    , "E_BUILTIN_SHADOW");
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2110,3 +2110,130 @@ test "typecheck/suggest: unknown mem.X member surfaces the closest stdlib name" 
         \\end
     , "E_TYPE_UNDEFINED_METHOD", "read_u16");
 }
+
+test "typecheck/is: class form on matching subclass — clean" {
+    try expectClean(
+        \\class Animal
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\class Dog extends Animal
+        \\  def init(self)
+        \\    super.init()
+        \\  end
+        \\end
+        \\def report(a: Animal)
+        \\  if a is Dog
+        \\    print "ok"
+        \\  end
+        \\end
+        \\def main()
+        \\  let d = Dog()
+        \\  report(d)
+        \\end
+    );
+}
+
+test "typecheck/is: `Dog is Dog` is statically true — W_DEAD_TEST" {
+    try expectCode(
+        \\class Dog
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\def main()
+        \\  let d = Dog()
+        \\  if d is Dog
+        \\    print "yes"
+        \\  end
+        \\end
+    , "W_DEAD_TEST");
+}
+
+test "typecheck/is: unrelated class is statically false — W_DEAD_TEST" {
+    try expectCode(
+        \\class Dog
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\class Bird
+        \\  let w: u8
+        \\  def init(self)
+        \\    self.w = 0
+        \\  end
+        \\end
+        \\def main()
+        \\  let d = Dog()
+        \\  if d is Bird
+        \\    print "no"
+        \\  end
+        \\end
+    , "W_DEAD_TEST");
+}
+
+test "typecheck/is: struct receiver rejects with E_TYPE_IS_NON_DYNAMIC" {
+    try expectCode(
+        \\struct Stats
+        \\  hp: i16
+        \\  mp: i16
+        \\end
+        \\class Dog
+        \\  let k: u8
+        \\  def init(self)
+        \\    self.k = 0
+        \\  end
+        \\end
+        \\def main()
+        \\  let s = Stats { hp: 1, mp: 2 }
+        \\  if s is Dog
+        \\    print "x"
+        \\  end
+        \\end
+    , "E_TYPE_IS_NON_DYNAMIC");
+}
+
+test "typecheck/sizeof: primitive widths resolve to u16" {
+    try expectClean(
+        \\const A: u16 = sizeof(i16)
+        \\const B: u16 = sizeof(i8)
+        \\const C: u16 = sizeof([i16; 8])
+    );
+}
+
+test "typecheck/sizeof: unknown type emits E_TYPE_UNDEFINED" {
+    try expectCode("const X = sizeof(NotAType)", "E_TYPE_UNDEFINED");
+}
+
+test "typecheck/panic: takes exactly 1 arg" {
+    try expectCode(
+        \\def main()
+        \\  panic()
+        \\end
+    , "E_ASSERT_ARG_COUNT");
+}
+
+test "typecheck/unreachable: takes no args" {
+    try expectCode(
+        \\def main()
+        \\  unreachable("nope")
+        \\end
+    , "E_ASSERT_ARG_COUNT");
+}
+
+test "typecheck/todo: accepts 0 or 1 arg" {
+    try expectClean(
+        \\def main()
+        \\  todo()
+        \\end
+    );
+    try expectClean(
+        \\def main()
+        \\  todo("audio")
+        \\end
+    );
+}


### PR DESCRIPTION
Bundles issues #294 + #295 into one PR per maintainer direction.
Two `feat` commits + 1 test commit so the diff stays reviewable.

## Closes

- Closes #294 — `is` extension to class hierarchies (bool form).
- Closes #295 — `panic` / `unreachable` / `todo` / `sizeof` builtins.

## What lands

### Builtins (commit `e5a859e`)

Four always-in-scope builtins fill gaps the spec already referred
to but didn't define (§5.3):

- `panic(msg: str) -> noreturn`
- `unreachable() -> noreturn`
- `todo(msg: str?) -> noreturn`
- `sizeof(T) -> u16` (compile-time)

`sizeof` is a new keyword (`kw_sizeof`) because the arg slot is
a type annotation, not an expression. The other three resolve
before regular callee resolution, mirroring `assert`. Named-
struct widths come from a new `struct_decls` pre-pass on
`Emitter` so `sizeof(MyStruct)` sums field sizes.

### `is` for class hierarchies (commit `0fc1571`)

`expr is ClassName` lowers to a vtable-pointer compare:

```
mov [acu], r1            ; load instance's vtable ptr
cmp r1, <Bar.vtable>     ; placeholder, patched after emitVtables
materializeBoolFromFlags(.eq)
```

The compare slot goes through the existing `vtable_patches` queue
— same path the constructor's vtable-write uses.

Typecheck applies the full rule matrix from #294:
- Class receiver, RHS exact / ancestor → `W_DEAD_TEST` (always true).
- Class receiver, RHS unrelated → `W_DEAD_TEST` (always false).
- Struct receiver → `E_TYPE_IS_NON_DYNAMIC`.
- Enum receiver → existing variant-test path unchanged.

**Also adds class-subtype assignability** (`let a: Animal = Dog()`,
`fn(p: Animal)` accepting a `Dog`, etc.). Without it every typed
binding was its exact static class and `is` had no runtime case
to fire on. A new `Checker.isClassSubtype` predicate walks the
parent chain and runs alongside `relations.assignable` at every
store site.

### Tests (commit `24b986b`)

10 typecheck tests covering the new surface: `is` matrix, sizeof
primitive + array + unknown-name, panic/unreachable/todo arg
counts.

## Out of scope (carry-forward)

- **`is X as h` guarded downcast** — minimum-viable bool form
  lands here; the binding form per issue body's optional section
  is a separate follow-up.
- **`E_BUILTIN_SHADOW`** — the issue body mentions it "like assert",
  but assert / debug_assert don't actually guard against
  shadowing today either. Cross-cutting feature, deferred.
- **`noreturn` as a primitive type** — spec §3.7.3 shows
  `-> noreturn` in user code but the typechecker rejects it
  today as `E_TYPE_UNDEFINED`. Pre-existing spec drift; tracked
  separately.
- **`Dog → Animal?` subtype assignment** — `isClassSubtype` doesn't
  peel `optional` yet. If it comes up, easy follow-up.

## Test plan

- [x] `zig build verify` clean
- [x] `zig build ci` clean (full matrix)
- [x] Smoke: `if d is Dog`, `if d is Bird`, struct-receiver error,
  `panic("...")`, `unreachable()`, `todo("...")`, `sizeof` on every
  type form including named structs (`sizeof(Stats) == 4` for two
  i16 fields).