### PR TITLE
feat(cli): gero compile — single-file + multi-file .gr → .gx

### DIFF
--- a/.changeset/cli-gero-compile.md
+++ b/.changeset/cli-gero-compile.md
@@ -4,8 +4,12 @@ bump: minor
 
 `gero compile <file.gr>` is wired end-to-end: resolves `use
 "..."` imports, tokenizes, parses, type-checks, lowers, writes
-a `.gx` archive next to the source (or to `--out <path>` when
-given).
+a `.gx` archive. Output precedence: `--out <path>` wins; else
+`<project_root>/<[build].out>/<optimize>/<basename>.gx` when a
+`gero.toml` exists in an ancestor (mirrors `gero build`'s
+Cargo-style layout, creates the profile dir on demand); else
+sibling-default next to the source. A malformed manifest exits 3
+rather than silently falling back.
 
 Multi-file is real — `use "./util"` recursively loads each
 referenced `.gr` (with `.gr` extension auto-added when missing),

--- a/.changeset/cli-gero-compile.md
+++ b/.changeset/cli-gero-compile.md
@@ -24,4 +24,12 @@ Re-exports surfaced on `gero.lang`: `resolveUseImports`,
 `FusedSource`, `SourceMap`, `FileInfo`, `Located`,
 `IncludeError`, `IncludeErrorKind`.
 
+`gero run` now wires `vm.host.out` to stdout so the lang's
+`print` (which lowers to `sys print_str` / `print_int` /
+`print_char` / `print_newline`) actually surfaces in the
+terminal. Previously those syscalls were silently no-op'd —
+only `gero asm`'s `int $10` print syscall reached stdout, so
+nothing produced by `gero compile` was demoable. The asm-level
+intercept stays in place untouched.
+
 Closes #198.

--- a/.changeset/cli-gero-compile.md
+++ b/.changeset/cli-gero-compile.md
@@ -1,0 +1,27 @@
+---
+bump: minor
+---
+
+`gero compile <file.gr>` is wired end-to-end: resolves `use
+"..."` imports, tokenizes, parses, type-checks, lowers, writes
+a `.gx` archive next to the source (or to `--out <path>` when
+given).
+
+Multi-file is real — `use "./util"` recursively loads each
+referenced `.gr` (with `.gr` extension auto-added when missing),
+fuses sources into one buffer + `SourceMap`, and threads the
+spans through every later phase so diagnostics still render
+against the right file with caret context.
+
+Include-phase errors (cycle / depth-exceeded / not-found) get
+their own diagnostic codes — `E_USE_CYCLE`, `E_USE_DEPTH`,
+`E_USE_NOT_FOUND`.
+
+Exit codes per cli.md §5: 0 clean, 1 host IO, 2 usage, 3 parse
+error, 4 type error.
+
+Re-exports surfaced on `gero.lang`: `resolveUseImports`,
+`FusedSource`, `SourceMap`, `FileInfo`, `Located`,
+`IncludeError`, `IncludeErrorKind`.
+
+Closes #198.

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -396,7 +396,8 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .init => &.{ .help, .quiet, .color, .no_color },
         .build => &.{ .help, .target, .quiet, .verbose, .color, .no_color },
         .repl => &.{ .help, .color, .no_color },
-        .compile, .bench => &.{.help},
+        .compile => &.{ .help, .out, .optimize, .quiet, .verbose, .color, .no_color },
+        .bench => &.{.help},
     };
 }
 

--- a/apps/gero-cli/compile.zig
+++ b/apps/gero-cli/compile.zig
@@ -3,6 +3,7 @@ const gero = @import("gero");
 const cli = @import("cli.zig");
 const term_mod = @import("term.zig");
 const footer = @import("footer.zig");
+const manifest_loader = @import("manifest_loader.zig");
 
 /// Run `gero compile <file.gr>` end-to-end:
 /// resolve `use "..."` imports → tokenize → parse → typecheck →
@@ -98,7 +99,11 @@ pub fn execute(
     if (checked.diagnostics.len > 0) try renderLangDiagnostics(stdout, arena, fused, checked.diagnostics, style);
     if (compiled.diagnostics.len > 0) try renderLangDiagnostics(stdout, arena, fused, compiled.diagnostics, style);
 
-    const out_path = try resolveOutputPath(io, arena, src_path, opts.out);
+    const out_path = resolveOutputPath(io, arena, term, src_path, opts.out, opts.optimize) catch |err| switch (err) {
+        error.ManifestFailed => return 3,
+        error.CreateDirFailed => return 1,
+        else => |e| return e,
+    };
     std.Io.Dir.cwd().writeFile(io, .{ .sub_path = out_path, .data = compiled.image }) catch |err| {
         try term.err("gero compile: cannot write {s} ({s})", .{ out_path, @errorName(err) });
         return 1;
@@ -251,12 +256,22 @@ fn renderIncludeErrors(
     try renderLangDiagnostics(stdout, arena, fused, diags_list.items, style);
 }
 
-/// Resolve the `.gx` output path from `--out` plus the source.
+/// Resolve the `.gx` output path. Precedence:
+/// 1. `--out <path>` — explicit user flag wins.
+/// 2. `gero.toml` in the cwd's ancestor chain — `<root>/<[build].out>/<optimize>/<basename>.gx`.
+/// 3. Sibling default — next to the source.
+///
+/// Returns `error.ManifestFailed` (after printing via `term`) when
+/// a manifest exists but is unreadable / malformed — silently
+/// falling back to the sibling default in that case would mask the
+/// real configuration error.
 fn resolveOutputPath(
     io: std.Io,
     arena: std.mem.Allocator,
+    term: *term_mod.Term,
     src_path: []const u8,
     out_opt: ?[]const u8,
+    cli_optimize: cli.Optimize,
 ) ![]const u8 {
     const base = try gxBasename(arena, src_path);
     if (out_opt) |out| {
@@ -264,6 +279,32 @@ fn resolveOutputPath(
             return std.fs.path.join(arena, &.{ out, base });
         }
         return arena.dupe(u8, out);
+    }
+    switch (try manifest_loader.load(io, arena, term, "gero compile")) {
+        .ok => |loaded| {
+            var manifest = loaded.manifest;
+            defer manifest.deinit(arena);
+            const out_root = try manifest_loader.joinUnderRoot(arena, loaded.project_root, manifest.build.out);
+            // CLI's `--optimize` overrides the manifest's
+            // `[build].optimize` — explicit user intent at the
+            // call site beats the project default.
+            const opt_name: []const u8 = switch (cli_optimize) {
+                .debug => "debug",
+                .release => "release",
+                .size => "size",
+            };
+            const out_dir = try std.fs.path.join(arena, &.{ out_root, opt_name });
+            // Create the per-profile dir up front. `createDirPath`
+            // is idempotent and only walked for the manifest layout
+            // — `--out` paths stay the user's responsibility.
+            std.Io.Dir.cwd().createDirPath(io, out_dir) catch |err| {
+                try term.err("gero compile: cannot create {s} ({s})", .{ out_dir, @errorName(err) });
+                return error.CreateDirFailed;
+            };
+            return try std.fs.path.join(arena, &.{ out_dir, base });
+        },
+        .not_found => {},
+        .failed => return error.ManifestFailed,
     }
     const dir = std.fs.path.dirname(src_path) orelse "";
     if (dir.len == 0) return base;

--- a/apps/gero-cli/compile.zig
+++ b/apps/gero-cli/compile.zig
@@ -1,0 +1,310 @@
+const std = @import("std");
+const gero = @import("gero");
+const cli = @import("cli.zig");
+const term_mod = @import("term.zig");
+const footer = @import("footer.zig");
+
+/// Run `gero compile <file.gr>` end-to-end:
+/// resolve `use "..."` imports → tokenize → parse → typecheck →
+/// codegen → write `.gx`. Diagnostics route through
+/// `gero.lang.render.pretty` for caret-style output, grouped by
+/// origin file via the include-resolver's `SourceMap`.
+pub fn execute(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    opts: cli.Options,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+) !u8 {
+    const t_start = std.Io.Timestamp.now(io, .awake);
+    const positionals = opts.positional();
+    if (positionals.len < 1) {
+        try term.err("gero compile: missing .gr file path", .{});
+        return 2;
+    }
+    const src_path = positionals[0];
+
+    var fused = gero.lang.resolveUseImports(io, arena, src_path) catch |err| {
+        try term.err("gero compile: cannot read {s} ({s})", .{ src_path, @errorName(err) });
+        return 1;
+    };
+    defer fused.deinit();
+
+    const style: gero.lang.render.Style = if (term.color) .ansi else .none;
+    const cargo_style: gero.asm_.Style = if (term.color) .ansi else .plain;
+
+    if (fused.hasErrors()) {
+        try renderIncludeErrors(stdout, arena, fused, style);
+        try footer.writeFooter(stdout, io, cargo_style, t_start, .failed);
+        return 3;
+    }
+
+    var stream = gero.lang.tokenize(arena, fused.source) catch |err| {
+        try term.err("gero compile: tokenizer failure ({s})", .{@errorName(err)});
+        return 1;
+    };
+    defer stream.deinit();
+
+    var tree = gero.lang.parse(arena, fused.source, stream) catch |err| {
+        try term.err("gero compile: parser failure ({s})", .{@errorName(err)});
+        return 1;
+    };
+    defer tree.deinit();
+
+    var pre_check_diags: std.ArrayList(gero.lang.Diagnostic) = .empty;
+    for (stream.errors) |e| try appendParseError(arena, &pre_check_diags, e);
+    for (tree.errors) |e| try appendParseError(arena, &pre_check_diags, e);
+
+    if (pre_check_diags.items.len > 0) {
+        try renderLangDiagnostics(stdout, arena, fused, pre_check_diags.items, style);
+        try footer.writeFooter(stdout, io, cargo_style, t_start, .failed);
+        return 3;
+    }
+
+    var checked = gero.lang.typecheck(arena, fused.source, &tree.program) catch |err| {
+        try term.err("gero compile: typecheck failure ({s})", .{@errorName(err)});
+        return 1;
+    };
+    defer checked.deinit();
+
+    if (checked.hasErrors()) {
+        try renderLangDiagnostics(stdout, arena, fused, checked.diagnostics, style);
+        try footer.writeFooter(stdout, io, cargo_style, t_start, .failed);
+        return 4;
+    }
+
+    var compiled = gero.lang.compile(arena, fused.source, &checked, .{
+        .optimize = mapOptimize(opts.optimize),
+    }) catch |err| switch (err) {
+        error.EntryNotFound => {
+            try term.err("gero compile: no top-level `def main()` — every program needs an entry point", .{});
+            return 4;
+        },
+        else => {
+            try term.err("gero compile: codegen failure ({s})", .{@errorName(err)});
+            return 1;
+        },
+    };
+    defer compiled.deinit();
+
+    if (compiled.hasErrors()) {
+        try renderLangDiagnostics(stdout, arena, fused, compiled.diagnostics, style);
+        try footer.writeFooter(stdout, io, cargo_style, t_start, .failed);
+        return 4;
+    }
+
+    // Surface non-fatal warnings (e.g. W_DEAD_TEST) even when
+    // the build succeeded.
+    if (checked.diagnostics.len > 0) try renderLangDiagnostics(stdout, arena, fused, checked.diagnostics, style);
+    if (compiled.diagnostics.len > 0) try renderLangDiagnostics(stdout, arena, fused, compiled.diagnostics, style);
+
+    const out_path = try resolveOutputPath(io, arena, src_path, opts.out);
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = out_path, .data = compiled.image }) catch |err| {
+        try term.err("gero compile: cannot write {s} ({s})", .{ out_path, @errorName(err) });
+        return 1;
+    };
+
+    if (!opts.quiet) {
+        try stdout.print("{s} ({d} bytes)\n", .{ out_path, compiled.image.len });
+        try footer.writeFooter(stdout, io, cargo_style, t_start, .ok);
+    }
+
+    return 0;
+}
+
+fn mapOptimize(cli_opt: cli.Optimize) gero.lang.Optimize {
+    return switch (cli_opt) {
+        .debug => .debug,
+        .release => .release,
+        .size => .size,
+    };
+}
+
+/// Translate a knit lexer / parser `ParseError` into the lang's
+/// `Diagnostic` shape so it renders through the same caret path
+/// as typecheck / codegen errors.
+fn appendParseError(
+    arena: std.mem.Allocator,
+    out: *std.ArrayList(gero.lang.Diagnostic),
+    e: anytype,
+) !void {
+    // safety: ParseError.index fits in u32 — bounded by file size.
+    const idx: u32 = @intCast(e.index);
+    try out.append(arena, .{
+        .severity = .fatal,
+        .code = e.expected orelse "E_SYNTAX_GENERIC",
+        .message = try arena.dupe(u8, e.message),
+        .span = .{ .start = idx, .end = idx },
+    });
+}
+
+/// Render lang diagnostics through `gero.lang.render.pretty`,
+/// translating each diagnostic's fused-source span back into a
+/// per-file local span via the `SourceMap`. Diagnostics group
+/// by file so each file's snippets render under its own
+/// `--> path:line:col` header.
+fn renderLangDiagnostics(
+    stdout: *std.Io.Writer,
+    arena: std.mem.Allocator,
+    fused: gero.lang.FusedSource,
+    diags: []const gero.lang.Diagnostic,
+    style: gero.lang.render.Style,
+) !void {
+    // Map file_id → list of locally-spanned diagnostics.
+    var per_file: std.AutoHashMapUnmanaged(u16, std.ArrayList(gero.lang.Diagnostic)) = .{};
+    defer per_file.deinit(arena);
+
+    for (diags) |d| {
+        const lookup = fused.source_map.lookup(d.span.start) orelse continue;
+        const file_id = findFileId(fused.source_map, lookup.file) orelse continue;
+        const end_local = blk: {
+            if (fused.source_map.lookup(d.span.end)) |end_loc| {
+                if (std.mem.eql(u8, end_loc.file.path, lookup.file.path)) break :blk end_loc.file_offset;
+            }
+            // End offset crossed a file boundary — clamp to start.
+            break :blk lookup.file_offset;
+        };
+        var local = d;
+        local.span = .{ .start = lookup.file_offset, .end = end_local };
+        if (d.secondary.len > 0) {
+            local.secondary = try translateSecondary(arena, fused.source_map, lookup.file, d.secondary);
+        }
+        const gop = try per_file.getOrPut(arena, file_id);
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+        try gop.value_ptr.append(arena, local);
+    }
+
+    var files: std.ArrayList(gero.lang.render.FileDiagnostics) = .empty;
+    var it = per_file.iterator();
+    while (it.next()) |entry| {
+        const file = fused.source_map.files.items[entry.key_ptr.*];
+        try files.append(arena, .{
+            .path = file.path,
+            .source = file.content,
+            .diagnostics = entry.value_ptr.items,
+        });
+    }
+
+    try gero.lang.render.pretty(stdout, files.items, style);
+}
+
+fn findFileId(map: gero.lang.SourceMap, file: gero.lang.FileInfo) ?u16 {
+    for (map.files.items, 0..) |f, i| {
+        if (std.mem.eql(u8, f.path, file.path)) return @intCast(i);
+    }
+    return null;
+}
+
+fn translateSecondary(
+    arena: std.mem.Allocator,
+    map: gero.lang.SourceMap,
+    primary_file: gero.lang.FileInfo,
+    secondary: []const gero.lang.SpanLabel,
+) ![]gero.lang.SpanLabel {
+    var kept: std.ArrayList(gero.lang.SpanLabel) = .empty;
+    for (secondary) |s| {
+        const lookup = map.lookup(s.span.start) orelse continue;
+        // Only keep secondaries that land in the same file as
+        // the primary span — cross-file secondaries don't render
+        // cleanly with the current renderer.
+        if (!std.mem.eql(u8, lookup.file.path, primary_file.path)) continue;
+        const end_local: u32 = blk: {
+            if (map.lookup(s.span.end)) |e| {
+                if (std.mem.eql(u8, e.file.path, primary_file.path)) break :blk e.file_offset;
+            }
+            break :blk lookup.file_offset;
+        };
+        try kept.append(arena, .{
+            .span = .{ .start = lookup.file_offset, .end = end_local },
+            .message = s.message,
+            .decoration = s.decoration,
+        });
+    }
+    return try kept.toOwnedSlice(arena);
+}
+
+fn renderIncludeErrors(
+    stdout: *std.Io.Writer,
+    arena: std.mem.Allocator,
+    fused: gero.lang.FusedSource,
+    style: gero.lang.render.Style,
+) !void {
+    var diags_list: std.ArrayList(gero.lang.Diagnostic) = .empty;
+    for (fused.errors) |e| {
+        const code: []const u8 = switch (e.kind) {
+            .cycle => "E_USE_CYCLE",
+            .depth_exceeded => "E_USE_DEPTH",
+            .not_found => "E_USE_NOT_FOUND",
+        };
+        const msg = switch (e.kind) {
+            .cycle => try std.fmt.allocPrint(arena, "`use` cycle detected on `{s}`", .{e.requested}),
+            .depth_exceeded => try std.fmt.allocPrint(arena, "`use` depth exceeds 32 on `{s}` — likely runaway recursion", .{e.requested}),
+            .not_found => try std.fmt.allocPrint(arena, "`use` target file not found: `{s}`", .{e.requested}),
+        };
+        try diags_list.append(arena, .{
+            .severity = .fatal,
+            .code = code,
+            .message = msg,
+            .span = .{ .start = e.site_offset, .end = e.site_offset },
+        });
+    }
+    try renderLangDiagnostics(stdout, arena, fused, diags_list.items, style);
+}
+
+/// Resolve the `.gx` output path from `--out` plus the source.
+fn resolveOutputPath(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    src_path: []const u8,
+    out_opt: ?[]const u8,
+) ![]const u8 {
+    const base = try gxBasename(arena, src_path);
+    if (out_opt) |out| {
+        if (isDirLike(io, out)) {
+            return std.fs.path.join(arena, &.{ out, base });
+        }
+        return arena.dupe(u8, out);
+    }
+    const dir = std.fs.path.dirname(src_path) orelse "";
+    if (dir.len == 0) return base;
+    return std.fs.path.join(arena, &.{ dir, base });
+}
+
+fn gxBasename(arena: std.mem.Allocator, src_path: []const u8) ![]const u8 {
+    const file = std.fs.path.basename(src_path);
+    if (std.mem.endsWith(u8, file, ".gx")) return arena.dupe(u8, file);
+    const stem = if (std.mem.lastIndexOfScalar(u8, file, '.')) |dot| file[0..dot] else file;
+    return std.fmt.allocPrint(arena, "{s}.gx", .{stem});
+}
+
+fn isDirLike(io: std.Io, path: []const u8) bool {
+    if (endsWithSep(path)) return true;
+    const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch return false;
+    return stat.kind == .directory;
+}
+
+fn endsWithSep(path: []const u8) bool {
+    return path.len > 0 and (path[path.len - 1] == '/' or path[path.len - 1] == std.fs.path.sep);
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "compile: gxBasename swaps extension" {
+    const out = try gxBasename(testing.allocator, "src/main.gr");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("main.gx", out);
+}
+
+test "compile: gxBasename keeps `.gx` verbatim" {
+    const out = try gxBasename(testing.allocator, "out/main.gx");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("main.gx", out);
+}
+
+test "compile: gxBasename appends `.gx` when no extension" {
+    const out = try gxBasename(testing.allocator, "scratch");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("scratch.gx", out);
+}

--- a/apps/gero-cli/main.zig
+++ b/apps/gero-cli/main.zig
@@ -13,6 +13,7 @@ const new_cmd = @import("new.zig");
 const init_cmd = @import("init.zig");
 const build_cmd = @import("build.zig");
 const repl_cmd = @import("repl.zig");
+const compile_cmd = @import("compile.zig");
 
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
@@ -87,6 +88,7 @@ pub fn main(init: std.process.Init) !u8 {
         .init => init_cmd.execute(io, arena, parsed.options, stdout, &term),
         .build => build_cmd.execute(io, arena, parsed.options, stdout, &term),
         .repl => repl_cmd.execute(io, arena, parsed.options, stdout, &term),
+        .compile => compile_cmd.execute(io, arena, parsed.options, stdout, &term),
         else => blk: {
             try term.err("gero {s}: not yet implemented", .{cli.commandName(cmd)});
             break :blk 1;

--- a/apps/gero-cli/run.zig
+++ b/apps/gero-cli/run.zig
@@ -40,6 +40,12 @@ pub fn execute(
     var vm = gero.vm.VM.init(allocator);
     defer vm.deinit();
     try vm.boot(allocator, loaded);
+    // Route lang `print` (`sys print_str` / `print_int` /
+    // `print_char` / `print_newline`) through stdout. The asm-
+    // level `int $10` syscall is intercepted below regardless;
+    // wiring host.out makes `.gx` images produced by
+    // `gero compile` runnable end-to-end.
+    vm.host = .{ .out = stdout };
 
     while (true) {
         const ip = vm.regs.read(.ip);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,10 +69,16 @@ gero asm hello.gas --optimize=release
 
 Compiles a single gero-lang module (and its imports) into a `.gx`.
 
-**Default output:** `<basename>.gx`.
+**Default output** — precedence:
+1. `--out <path>` — explicit wins.
+2. `gero.toml` in an ancestor of the cwd — writes to
+   `<project_root>/<[build].out>/<optimize>/<basename>.gx`
+   (mirrors `gero build`'s Cargo-style layout). A malformed
+   manifest exits 3 rather than silently falling back.
+3. Sibling default — `<basename>.gx` next to the source.
 
 ```bash
-gero compile main.gr            # → main.gx
+gero compile main.gr                       # manifest or sibling
 gero compile main.gr -o game.gx --optimize=release
 ```
 
@@ -82,7 +88,8 @@ gero compile main.gr -o game.gx --optimize=release
   bytecode directly (no asm intermediate — speed).
 - Same error format as `gero asm`.
 
-**Exit:** 0 on success; 3 on parse error; 4 on type error.
+**Exit:** 0 on success; 3 on parse error or malformed manifest;
+4 on type error.
 
 ### 3.3 `gero run <file.gx>` — execute
 

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -9,6 +9,7 @@ const typecheck_mod = @import("lang/typecheck.zig");
 const diag_mod = @import("lang/diagnostic.zig");
 const render_mod = @import("lang/render.zig");
 const codegen_mod = @import("lang/codegen.zig");
+const include_mod = @import("lang/include.zig");
 
 const tc_mem_builtin = @import("lang/typecheck/mem_builtin.zig");
 const tc_match = @import("lang/typecheck/match.zig");
@@ -54,6 +55,24 @@ pub const parse = parser_mod.parse;
 /// Pretty-print an `ast.Program` to canonical `.gr`.
 /// Round-trip safe: `parse(print(parse(s))) == parse(s)`.
 pub const print = print_mod.print;
+
+// ---------- include resolver (multi-file `use "..."`) ----------
+
+/// Fused-source output from `resolveUseImports`.
+pub const FusedSource = include_mod.FusedSource;
+/// Fused offset → (file, file_offset) resolver.
+pub const SourceMap = include_mod.SourceMap;
+/// One file's metadata in the include graph.
+pub const FileInfo = include_mod.FileInfo;
+/// Result of `SourceMap.lookup`.
+pub const Located = include_mod.Located;
+/// One error from include resolution (cycle / depth / not-found).
+pub const IncludeError = include_mod.IncludeError;
+/// Discriminator for `IncludeError`.
+pub const IncludeErrorKind = include_mod.IncludeErrorKind;
+/// Walk the `use "..."` graph from `root_path`, returning fused
+/// source + source map.
+pub const resolveUseImports = include_mod.resolveUseImports;
 
 // ---------- typechecker ----------
 

--- a/src/lang/include.zig
+++ b/src/lang/include.zig
@@ -1,0 +1,428 @@
+const std = @import("std");
+
+const Io = std.Io;
+const Dir = Io.Dir;
+
+const max_include_depth: u8 = 32;
+const max_file_size: usize = 16 * 1024 * 1024;
+
+/// One source file's metadata. Files dedupe by canonical path
+/// inside `SourceMap`; a module referenced multiple times shares
+/// one entry, several `Region`s pointing into it.
+pub const FileInfo = struct {
+    path: [:0]const u8,
+    content: []const u8,
+};
+
+/// Contiguous fused-source byte range mapped back to a slice of
+/// one original file. A file with N `use "..."` lines produces
+/// N+1 regions (between each directive).
+pub const Region = struct {
+    fused_start: u32,
+    fused_end: u32,
+    file_id: u16,
+    file_offset: u32,
+};
+
+/// Resolves a fused-source offset back to `(file, file_offset)`.
+pub const SourceMap = struct {
+    files: std.ArrayList(FileInfo),
+    regions: std.ArrayList(Region),
+    allocator: std.mem.Allocator,
+
+    /// Release every owned path + content buffer and the lists.
+    pub fn deinit(self: *SourceMap) void {
+        for (self.files.items) |f| {
+            self.allocator.free(f.path);
+            self.allocator.free(f.content);
+        }
+        self.files.deinit(self.allocator);
+        self.regions.deinit(self.allocator);
+    }
+
+    /// Find which file + offset `fused_offset` resolves to.
+    /// `null` when the offset is outside every region.
+    pub fn lookup(self: SourceMap, fused_offset: u32) ?Located {
+        for (self.regions.items) |r| {
+            if (fused_offset >= r.fused_start and fused_offset < r.fused_end) {
+                const file = self.files.items[r.file_id];
+                return .{
+                    .file = file,
+                    .file_offset = r.file_offset + (fused_offset - r.fused_start),
+                };
+            }
+        }
+        return null;
+    }
+
+    fn intern(
+        self: *SourceMap,
+        caller_path: [:0]const u8,
+        caller_content: []const u8,
+    ) !u16 {
+        for (self.files.items, 0..) |f, i| {
+            if (std.mem.eql(u8, f.path, caller_path)) {
+                self.allocator.free(caller_path);
+                self.allocator.free(caller_content);
+                // safety: file_id fits in u16; runaway include graphs hit max_include_depth long before this overflows.
+                return @intCast(i);
+            }
+        }
+        // safety: file_id fits in u16; bounded by max_include_depth.
+        const id: u16 = @intCast(self.files.items.len);
+        try self.files.append(self.allocator, .{
+            .path = caller_path,
+            .content = caller_content,
+        });
+        return id;
+    }
+
+    fn appendRegion(
+        self: *SourceMap,
+        fused_start: u32,
+        fused_end: u32,
+        file_id: u16,
+        file_offset: u32,
+    ) !void {
+        try self.regions.append(self.allocator, .{
+            .fused_start = fused_start,
+            .fused_end = fused_end,
+            .file_id = file_id,
+            .file_offset = file_offset,
+        });
+    }
+};
+
+/// Result of resolving a fused offset back to its origin file.
+pub const Located = struct {
+    file: FileInfo,
+    file_offset: u32,
+};
+
+/// Reason an `IncludeError` fired.
+pub const IncludeErrorKind = enum {
+    cycle,
+    depth_exceeded,
+    not_found,
+};
+
+/// One error from the include-resolution phase. Carries the
+/// fused-source offset of the offending `use` directive so the
+/// CLI can render with caret context.
+pub const IncludeError = struct {
+    kind: IncludeErrorKind,
+    /// Fused-source offset of the `use` directive that triggered
+    /// the error.
+    site_offset: u32,
+    /// Path the user requested (verbatim, no resolution).
+    requested: []const u8,
+};
+
+/// `resolveUseImports` output. Caller owns the buffers — call
+/// `deinit` once done.
+pub const FusedSource = struct {
+    /// Reachable files' contents concatenated in dependency
+    /// order, with `use "..."` lines elided.
+    source: []const u8,
+    source_map: SourceMap,
+    errors: []IncludeError,
+    allocator: std.mem.Allocator,
+
+    /// Release the fused buffer, source map, and errors list.
+    pub fn deinit(self: *FusedSource) void {
+        self.allocator.free(self.source);
+        self.source_map.deinit();
+        for (self.errors) |e| self.allocator.free(e.requested);
+        self.allocator.free(self.errors);
+    }
+
+    /// `true` when at least one include-phase error was recorded.
+    pub fn hasErrors(self: FusedSource) bool {
+        return self.errors.len > 0;
+    }
+};
+
+/// Errors surfaced through the result `union` rather than the
+/// error set: cycle / depth / not-found.
+/// Host failures (OOM, I/O) propagate through the error union.
+pub const ResolveError = Dir.RealPathFileAllocError || Dir.ReadFileAllocError;
+
+const Context = struct {
+    io: Io,
+    allocator: std.mem.Allocator,
+    fused: *std.ArrayList(u8),
+    source_map: *SourceMap,
+    errors: *std.ArrayList(IncludeError),
+    in_progress: *std.ArrayList([]const u8),
+};
+
+/// Resolve every `use "./path"` reachable from `root_path` into
+/// a fused source buffer. Quoted-path imports load the named
+/// file; bare-ident imports (`use mem`) are left in source as-is
+/// — they bind to compiler-recognized stdlib modules at
+/// typecheck time.
+pub fn resolveUseImports(
+    io: Io,
+    allocator: std.mem.Allocator,
+    root_path: []const u8,
+) ResolveError!FusedSource {
+    var fused: std.ArrayList(u8) = .empty;
+    errdefer fused.deinit(allocator);
+
+    var source_map: SourceMap = .{
+        .files = .empty,
+        .regions = .empty,
+        .allocator = allocator,
+    };
+    errdefer source_map.deinit();
+
+    var errors: std.ArrayList(IncludeError) = .empty;
+    errdefer {
+        for (errors.items) |e| allocator.free(e.requested);
+        errors.deinit(allocator);
+    }
+
+    var in_progress: std.ArrayList([]const u8) = .empty;
+    defer in_progress.deinit(allocator);
+
+    var ctx = Context{
+        .io = io,
+        .allocator = allocator,
+        .fused = &fused,
+        .source_map = &source_map,
+        .errors = &errors,
+        .in_progress = &in_progress,
+    };
+
+    try resolveOne(&ctx, root_path, null, 0, 0);
+
+    return .{
+        .source = try fused.toOwnedSlice(allocator),
+        .source_map = source_map,
+        .errors = try errors.toOwnedSlice(allocator),
+        .allocator = allocator,
+    };
+}
+
+fn resolveOne(
+    ctx: *Context,
+    requested: []const u8,
+    base_dir: ?[]const u8,
+    depth: u8,
+    site_offset: u32,
+) ResolveError!void {
+    if (depth > max_include_depth) {
+        try recordError(ctx, .depth_exceeded, site_offset, requested);
+        return;
+    }
+
+    // Append `.gr` when missing so `use "./util"` resolves to
+    // `util.gr`. Absolute paths pass through unchanged when
+    // already qualified.
+    var owned_requested: ?[]const u8 = null;
+    defer if (owned_requested) |o| ctx.allocator.free(o);
+    const with_ext: []const u8 = if (std.mem.endsWith(u8, requested, ".gr"))
+        requested
+    else blk: {
+        owned_requested = try std.fmt.allocPrint(ctx.allocator, "{s}.gr", .{requested});
+        break :blk owned_requested.?;
+    };
+
+    const absolute = if (std.fs.path.isAbsolute(with_ext))
+        try ctx.allocator.dupe(u8, with_ext)
+    else if (base_dir) |dir|
+        try std.fs.path.join(ctx.allocator, &.{ dir, with_ext })
+    else
+        try std.fs.path.join(ctx.allocator, &.{ ".", with_ext });
+    defer ctx.allocator.free(absolute);
+
+    const canonical = Dir.cwd().realPathFileAlloc(ctx.io, absolute, ctx.allocator) catch |err| switch (err) {
+        error.FileNotFound => {
+            try recordError(ctx, .not_found, site_offset, requested);
+            return;
+        },
+        else => return err,
+    };
+
+    for (ctx.in_progress.items) |p| {
+        if (std.mem.eql(u8, p, canonical)) {
+            try recordError(ctx, .cycle, site_offset, requested);
+            ctx.allocator.free(canonical);
+            return;
+        }
+    }
+
+    const content = Dir.cwd().readFileAlloc(ctx.io, canonical, ctx.allocator, Io.Limit.limited(max_file_size)) catch |err| {
+        ctx.allocator.free(canonical);
+        return err;
+    };
+
+    const file_id = ctx.source_map.intern(canonical, content) catch |err| {
+        ctx.allocator.free(canonical);
+        ctx.allocator.free(content);
+        return err;
+    };
+
+    const file = ctx.source_map.files.items[file_id];
+
+    try ctx.in_progress.append(ctx.allocator, file.path);
+    defer _ = ctx.in_progress.pop();
+
+    try processSource(ctx, file.content, file.path, file_id, depth);
+}
+
+/// Walk one file: copy non-`use` lines into the fused buffer,
+/// recursing on each `use "..."`. Lines containing `--` comments
+/// or string literals are scanned carefully so directives inside
+/// strings or comments don't get matched.
+fn processSource(
+    ctx: *Context,
+    content: []const u8,
+    canonical: [:0]const u8,
+    file_id: u16,
+    depth: u8,
+) ResolveError!void {
+    var seg_file_start: u32 = 0;
+    var seg_fused_start: u32 = @intCast(ctx.fused.items.len);
+
+    var i: usize = 0;
+    while (i < content.len) {
+        const line_start = i;
+        var in_string = false;
+        while (i < content.len and content[i] != '\n') : (i += 1) {
+            const b = content[i];
+            if (in_string) {
+                if (b == '\\' and i + 1 < content.len) {
+                    i += 1;
+                } else if (b == '"') {
+                    in_string = false;
+                }
+                continue;
+            }
+            if (b == '"') {
+                in_string = true;
+            } else if (b == '-' and i + 1 < content.len and content[i + 1] == '-') {
+                // gero-lang line comment — skip the rest of the line.
+                while (i < content.len and content[i] != '\n') : (i += 1) {}
+                break;
+            }
+        }
+        const line_end = i;
+        const line = content[line_start..line_end];
+
+        if (matchUseQuotedLine(line)) |target| {
+            const seg_file_end: u32 = @intCast(line_start);
+            if (seg_file_end > seg_file_start) {
+                try ctx.source_map.appendRegion(
+                    seg_fused_start,
+                    @intCast(ctx.fused.items.len),
+                    file_id,
+                    seg_file_start,
+                );
+            }
+            // 1-byte sentinel for the directive position so any
+            // error attached to the `use` line has a mappable
+            // fused offset.
+            const sentinel_start: u32 = @intCast(ctx.fused.items.len);
+            try ctx.fused.append(ctx.allocator, '\n');
+            try ctx.source_map.appendRegion(
+                sentinel_start,
+                sentinel_start + 1,
+                file_id,
+                @intCast(line_start),
+            );
+            const this_dir = std.fs.path.dirname(canonical) orelse ".";
+            try resolveOne(ctx, target, this_dir, depth + 1, sentinel_start);
+            const after_newline = if (i < content.len) i + 1 else i;
+            seg_file_start = @intCast(after_newline);
+            seg_fused_start = @intCast(ctx.fused.items.len);
+            i = after_newline;
+            continue;
+        }
+
+        try ctx.fused.appendSlice(ctx.allocator, line);
+        if (i < content.len) try ctx.fused.append(ctx.allocator, '\n');
+        if (i < content.len) i += 1;
+    }
+
+    const seg_file_end: u32 = @intCast(content.len);
+    if (seg_file_end > seg_file_start) {
+        try ctx.source_map.appendRegion(
+            seg_fused_start,
+            @intCast(ctx.fused.items.len),
+            file_id,
+            seg_file_start,
+        );
+    }
+}
+
+fn recordError(
+    ctx: *Context,
+    kind: IncludeErrorKind,
+    site_offset: u32,
+    requested: []const u8,
+) !void {
+    try ctx.errors.append(ctx.allocator, .{
+        .kind = kind,
+        .site_offset = site_offset,
+        .requested = try ctx.allocator.dupe(u8, requested),
+    });
+}
+
+/// If `line` is a `use "path"` directive, return the path
+/// (without quotes). Otherwise `null`. Bare-ident `use math` and
+/// the selective form `use foo from "./bar"` don't match — the
+/// quoted-path form is what triggers file resolution. Selective
+/// imports (`use a, b from "./bar"`) DO match — we strip
+/// everything up to `from` first and apply the same quoted-path
+/// rule on the right.
+fn matchUseQuotedLine(line: []const u8) ?[]const u8 {
+    var i: usize = 0;
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) i += 1;
+    const kw = "use";
+    if (i + kw.len > line.len) return null;
+    if (!std.mem.eql(u8, line[i .. i + kw.len], kw)) return null;
+    i += kw.len;
+    if (i >= line.len or (line[i] != ' ' and line[i] != '\t')) return null;
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) i += 1;
+    // Skip past `<items> from ` if a selective import is present.
+    if (std.mem.indexOf(u8, line[i..], " from ")) |from_off| {
+        i += from_off + " from ".len;
+        while (i < line.len and (line[i] == ' ' or line[i] == '\t')) i += 1;
+    }
+    if (i >= line.len or line[i] != '"') return null;
+    const path_start = i + 1;
+    var j = path_start;
+    while (j < line.len and line[j] != '"') : (j += 1) {}
+    if (j >= line.len) return null;
+    const path_end = j;
+    var k = j + 1;
+    while (k < line.len and (line[k] == ' ' or line[k] == '\t')) k += 1;
+    // Trailing content allowed only if it's a comment.
+    if (k < line.len and !(k + 1 < line.len and line[k] == '-' and line[k + 1] == '-')) return null;
+    return line[path_start..path_end];
+}
+
+// ---------- tests ----------
+
+const testing = std.testing;
+
+test "include/matchUseQuotedLine: bare `use math` does not match" {
+    try testing.expect(matchUseQuotedLine("use math") == null);
+}
+
+test "include/matchUseQuotedLine: `use \"./util\"` returns ./util" {
+    try testing.expectEqualStrings("./util", matchUseQuotedLine("use \"./util\"").?);
+}
+
+test "include/matchUseQuotedLine: selective `use foo from \"./bar\"`" {
+    try testing.expectEqualStrings("./bar", matchUseQuotedLine("use foo from \"./bar\"").?);
+}
+
+test "include/matchUseQuotedLine: trailing `--` comment is allowed" {
+    try testing.expectEqualStrings("./util", matchUseQuotedLine("use \"./util\"  -- core helpers").?);
+}
+
+test "include/matchUseQuotedLine: trailing non-comment garbage rejects" {
+    try testing.expect(matchUseQuotedLine("use \"./util\" let x = 0") == null);
+}

--- a/tests/lang/include.test.zig
+++ b/tests/lang/include.test.zig
@@ -1,0 +1,13 @@
+//! Mirror file for `src/lang/include.zig`.
+//! Unit tests for `matchUseQuotedLine` live alongside the source;
+//! end-to-end include-resolution coverage lives in the
+//! `gero compile` integration tests.
+
+const std = @import("std");
+const gero = @import("gero");
+
+test "include: module reachable through the barrel" {
+    _ = gero.lang.resolveUseImports;
+    _ = gero.lang.FusedSource;
+    _ = gero.lang.SourceMap;
+}


### PR DESCRIPTION
## Summary

Wires `gero compile <file.gr>` end-to-end: resolves `use \"...\"`
imports, tokenizes, parses, type-checks, lowers, writes a `.gx`
archive next to the source (or to `--out <path>` when given).

Multi-file is real — `use \"./util\"` recursively loads each
referenced `.gr` (auto-appending `.gr` when missing), fuses
sources into one buffer + `SourceMap`, and threads spans through
every later phase so diagnostics still render against the right
file with caret context. Renderer groups diagnostics by origin
file before handing to `gero.lang.render.pretty`.

`gero run` also gets a one-liner fix to wire `vm.host.out` to
stdout so the lang's \`print\` actually surfaces — without this
the `.gx` produced by \`gero compile\` wasn't demoable end-to-end.

## Smoke

\`\`\`
\$ ./zig-out/bin/gero compile /tmp/hello.gr -o /tmp/hello.gx
/tmp/hello.gx (4399 bytes)
    Finished in 1.3 ms

\$ ./zig-out/bin/gero run /tmp/hello.gx
hello, gero

\$ ./zig-out/bin/gero compile /tmp/multi/main.gr  # has \`use \"./util\"\`
/tmp/multi/main.gx (4434 bytes)
    Finished in < 1 ms

\$ ./zig-out/bin/gero compile /tmp/cycle/a.gr     # has a cycle a → b → a
error: \`use\` cycle detected on \`./a\` [E_USE_CYCLE]
  --> b.gr:1:1
   |
 1 | use \"./a\"
   | ^
\`\`\`

## Notes

- **\`--debug\` flag deferred.** The AC mentions \`--debug\` for
  debug-symbol emission. \`gero asm\` defaults debug symbols on
  and has no toggle; lang's \`CompileOptions.debug_symbols\`
  defaults \`true\` likewise, so symbols are emitted by default.
  Adding an opt-out / opt-in flag would diverge from \`gero asm\`
  — left for a follow-up issue if the asymmetry matters.
- **Stdlib \`use\` (\`use mem\`) is left in source.** The include
  resolver only loads quoted-path imports; bare-name imports
  pass through and bind to compiler-recognized stdlib modules
  at typecheck time (existing behavior).

## Test plan

- [x] \`zig build verify\` clean
- [x] \`zig build ci\` clean (full matrix)
- [x] End-to-end: \`gero compile hello.gr && gero run hello.gx\`
  prints \`hello, gero\`, exits 0
- [x] Cross-file: \`use \"./util\"\` resolves a fn from the
  imported module
- [x] Cross-file type error renders against the importing file
  at the right line/col
- [x] Missing import → \`E_USE_NOT_FOUND\` with caret on \`use\` line
- [x] Cycle → \`E_USE_CYCLE\`
- [x] Unit: \`matchUseQuotedLine\` (bare ident, quoted path,
  selective \`from\`, trailing comment, trailing garbage)

Closes #198.