### PR TITLE
feat(tooling): zig build clean-cache — age-based .zig-cache prune

### DIFF
--- a/.changeset/tooling-clean-cache-prune.md
+++ b/.changeset/tooling-clean-cache-prune.md
@@ -1,0 +1,18 @@
+---
+bump: patch
+---
+
+`zig build clean-cache` prunes stale Zig build outputs without a full
+wipe. Zig content-hashes every output into `.zig-cache/o/<hash>` and
+never reclaims old ones, so a cross-target / multi-mode workflow
+(`zig build ci` — 4 release modes × 5 targets) grows the cache without
+bound across commits; left alone it reaches tens of GB.
+
+The new step (`scripts/clean-cache.sh`) drops only output dirs not
+modified in the last `MAX_AGE_DAYS` (default 3), leaving the warm
+working set intact — so the next build is *not* cold, unlike the
+existing full-wipe `zig build clean`. A pruned output is just a cache
+miss; Zig rebuilds it on demand. Override the window with
+`MAX_AGE_DAYS=N zig build clean-cache`, or point a scheduled job at the
+script for hands-off upkeep. Documented under "Cache maintenance" in
+`docs/development.md`.

--- a/build.zig
+++ b/build.zig
@@ -429,6 +429,10 @@ pub fn build(b: *std.Build) void {
     const clean_step = b.step("clean", "Remove zig-out and .zig-cache (Unix only)");
     const clean_cmd = b.addSystemCommand(&.{ "rm", "-rf", "zig-out", ".zig-cache" });
     clean_step.dependOn(&clean_cmd.step);
+
+    const clean_cache_step = b.step("clean-cache", "Prune .zig-cache/o dirs older than MAX_AGE_DAYS (default 3), keeping the warm working set (Unix only)");
+    const clean_cache_cmd = b.addSystemCommand(&.{ "bash", "scripts/clean-cache.sh" });
+    clean_cache_step.dependOn(&clean_cache_cmd.step);
 }
 
 /// Walk tests/ at build time and collect every relative path ending in

--- a/docs/development.md
+++ b/docs/development.md
@@ -163,6 +163,30 @@ git push origin main --tags
 
 ---
 
+## Cache maintenance
+
+Zig content-hashes every build output into its own `.zig-cache/o/<hash>`
+dir and **never reclaims old ones** — there is no built-in GC. A
+cross-target / multi-mode workflow (`zig build ci` runs 4 release modes
+× 5 targets) mints fresh outputs every commit, so the cache grows without
+bound. Left alone it reaches tens or hundreds of GB.
+
+```bash
+zig build clean         # full wipe of zig-out + .zig-cache → next build is cold
+zig build clean-cache   # prune only .zig-cache/o dirs older than MAX_AGE_DAYS
+```
+
+`clean-cache` (`scripts/clean-cache.sh`) is the routine maintenance one:
+it drops stale output dirs while leaving the warm working set intact, so
+the next build is *not* cold. Active builds keep a fresh mtime and
+survive; only artifacts from commits you haven't touched in
+`MAX_AGE_DAYS` (default 3) go. A pruned output is just a cache miss —
+Zig rebuilds it on demand. Override with `MAX_AGE_DAYS=N zig build
+clean-cache`, or wire a scheduled job to the script for hands-off
+upkeep.
+
+---
+
 ## Tech stack (one-liner reference)
 
 Zig 0.16.0 minimum (pinned in `build.zig.zon`), zero runtime deps,

--- a/scripts/clean-cache.sh
+++ b/scripts/clean-cache.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Prune stale build outputs from `.zig-cache/o/` without nuking the
+# warm working set. Zig content-hashes every build output into its own
+# `o/<hash>` dir and never reclaims old ones, so a cross-target /
+# multi-mode workflow (`zig build ci`) grows the cache without bound
+# across commits. This drops output dirs not modified in the last
+# MAX_AGE_DAYS; Zig treats a missing output as a cache miss and rebuilds
+# it on demand, so pruning is always safe. Dirs touched by recent builds
+# keep a fresh mtime and survive — only stale commits' artifacts go.
+#
+# Unlike `zig build clean` (full wipe → next build is cold), this keeps
+# active work warm. Run it periodically, or wire a scheduled job to it.
+#
+# Env knobs:
+#   CACHE_DIR      — cache root to prune (default ./.zig-cache)
+#   MAX_AGE_DAYS   — prune o/ dirs older than this many days (default 3)
+#   NO_COLOR       — disable ANSI colors (auto-off when stdout is not a TTY)
+#
+# Exit codes:
+#   0 — pruned cleanly, or nothing to prune (cache absent)
+#   1 — a precondition is missing (bad MAX_AGE_DAYS)
+
+set -euo pipefail
+
+CACHE_DIR="${CACHE_DIR:-./.zig-cache}"
+MAX_AGE_DAYS="${MAX_AGE_DAYS:-3}"
+
+if ! [[ "$MAX_AGE_DAYS" =~ ^[0-9]+$ ]]; then
+    printf 'clean-cache: MAX_AGE_DAYS must be a non-negative integer, got %q\n' "$MAX_AGE_DAYS" >&2
+    exit 1
+fi
+
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    GREEN=$'\033[32m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+    GREEN=''; BOLD=''; RESET=''
+fi
+
+outputs_dir="$CACHE_DIR/o"
+if [[ ! -d "$outputs_dir" ]]; then
+    printf '%sclean-cache:%s no %s — nothing to prune\n' "$BOLD" "$RESET" "$outputs_dir"
+    exit 0
+fi
+
+# `du -sk` is portable across macOS/Linux; KiB avoids float math in bash.
+before_kb="$(du -sk "$CACHE_DIR" 2>/dev/null | cut -f1)"
+
+# -mtime +N matches dirs last modified strictly more than N days ago.
+# -maxdepth 1 keeps us at the o/<hash> granularity — never descends to
+# prune individual files out from under an otherwise-warm output dir.
+mapfile -t -d '' stale < <(
+    find "$outputs_dir" -mindepth 1 -maxdepth 1 -type d -mtime "+$MAX_AGE_DAYS" -print0
+)
+
+pruned=${#stale[@]}
+if (( pruned > 0 )); then
+    rm -rf "${stale[@]}"
+fi
+
+after_kb="$(du -sk "$CACHE_DIR" 2>/dev/null | cut -f1)"
+freed_mb=$(( (before_kb - after_kb) / 1024 ))
+
+printf '%sclean-cache:%s pruned %d stale output dir(s) older than %d day(s), freed %s%d MB%s\n' \
+    "$BOLD" "$RESET" "$pruned" "$MAX_AGE_DAYS" "$GREEN" "$freed_mb" "$RESET"


### PR DESCRIPTION
## What

Adds `zig build clean-cache` — an age-based prune of `.zig-cache/o/` that reclaims stale build outputs without forcing a cold rebuild.

## Why

Zig content-hashes every build output into its own `.zig-cache/o/<hash>` dir and **never reclaims old ones** — there's no built-in GC. The cross-target / multi-mode workflow (`zig build ci` = 4 release modes × 5 targets) mints fresh outputs every commit, so the cache grows without bound. In practice it reached **130 GB** in one local checkout (and 35 GB in a sibling repo) before this surfaced.

## How

- `scripts/clean-cache.sh` drops only `o/<hash>` dirs not modified in the last `MAX_AGE_DAYS` (default 3). The warm working set keeps a fresh mtime and survives, so the next build is **not** cold — unlike the existing full-wipe `zig build clean`. A pruned output is just a cache miss; Zig rebuilds it on demand.
- New `clean-cache` build step wraps the script. Deliberately does **not** `dependOn(getInstallStep())` like the other script-backed steps — it needs no binary, and building first would re-warm the very cache being pruned.
- Window overridable: `MAX_AGE_DAYS=N zig build clean-cache`. Point a scheduled job at the script for hands-off upkeep.
- Documented under "Cache maintenance" in `docs/development.md`.

## Test

Script exercised across all paths: bad `MAX_AGE_DAYS` → exit 1; fresh cache → 0 pruned; synthetic backdated dir → pruned while the recent one survives; absent cache → no-op exit 0. `zig build verify` green.

No issue tracked — standalone dev-tooling change.