### PR TITLE
feat(apps/gero-cli): gero fmt + gero check extend to .gr

### DIFF
--- a/.changeset/cli-fmt-check-gr.md
+++ b/.changeset/cli-fmt-check-gr.md
@@ -1,0 +1,25 @@
+---
+bump: minor
+---
+
+`gero fmt` and `gero check` now cover `.gr` (gero-lang) sources, not
+just `.gas`.
+
+`gero fmt main.gr` parses via the gero-lang front-end and re-emits
+through the AST printer, with the same in-place / `--check` (exit 8) /
+directory-walk UX as the asm path. `gero fmt --stdin --lang=gr` formats
+gero-lang from stdin for editor format-on-save — stdin carries no
+filename to dispatch on, so the new `--lang=<gas|gr>` flag picks the
+front-end explicitly (defaults to `gas`; ignored in path mode, where
+the extension decides). Directory walks format `.gas` and `.gr`
+together.
+
+`gero check main.gr` routes to the parser + type checker (no codegen)
+and renders the same caret diagnostics and `--format=json` jsonl as the
+asm path. Mixed `gero check src/` invocations walk both file kinds.
+
+Fixes a double-reporting bug in the `.gr` check path: `parse` already
+folds the lexer's `stream.errors` into `tree.errors`, so the previous
+code surfaced every lexer diagnostic twice.
+
+Closes #200.

--- a/.changeset/lang-fmt-preserve-comments.md
+++ b/.changeset/lang-fmt-preserve-comments.md
@@ -1,0 +1,21 @@
+---
+bump: minor
+---
+
+`gero fmt` on `.gr` sources now preserves comments. The lexer captures
+each `-- …` line comment as a side-table (off the token stream, so the
+grammar is unaffected), the parser carries it on `ParseTree.comments`,
+and the printer re-emits leading, standalone, and trailing comments at
+their statement / field / case / arm boundaries. Formatting is lossless
+and idempotent — previously every comment was silently dropped.
+
+Also fixes a formatter bug where an abstract method (`@abstract def
+f(self) -> T` with no body) was emitted with a spurious `end`,
+corrupting the enclosing class. `hasAnnotationNamed` was a stub that
+always returned `false`; it now actually inspects the annotation so a
+body-less `@abstract` def round-trips without an `end` while an
+empty-bodied regular `def f() end` keeps its `end`.
+
+`gero.lang.print` takes an additional `comments` slice; pass `&.{}` when
+comment fidelity isn't needed (AST round-trip callers). `gero.lang.Comment`
+is re-exported on the barrel.

--- a/.changeset/lang-typecheck-iflet-binding.md
+++ b/.changeset/lang-typecheck-iflet-binding.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+`if let` and `while let` now bind their pattern variables into the
+guard and body scope. Previously the typechecker inferred the matched
+expression but never registered the bindings, so `if let E.A(n) = e
+when n > 0` reported `n` as an undefined symbol in both the `when`
+guard and the body (§4.4.1 / §4.5.1). The checkers now open a child
+scope and register the pattern bindings before walking the guard and
+body — mirroring `match`-arm scoping.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,15 @@ Never a third "LGTM with footnotes" shape.
 - **Version markers** (`v0.X`, `Phase Y`, `Roadmap:`) — code
   describes what works today, factually. Versioning lives in
   CHANGELOG / git tags / project board.
+- **Change-history narration** — comments document the code as it
+  stands, never how it got there. No `previously`, `used to`, `was
+  a bug`, `Regression:`, `now fixed`, `surfaced while…`,
+  `predates the retrofit`. A reader needs the invariant the code
+  upholds, not the story of the fix that produced it. This includes
+  test comments: state the property the test pins (e.g. "the `when`
+  guard resolves the pattern's bindings"), not the bug it once
+  caught. Write every comment as if the code had always been this
+  way — the fix narrative lives in the commit / changeset / PR.
 - **AI attribution** (see "The contract").
 
 ### Tests

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -333,25 +333,23 @@ fn checkOneGr(
     const src = std.Io.Dir.cwd().readFileAlloc(io, path, arena, .unlimited) catch {
         return .{ .source = "", .diagnostics = &.{}, .read_error = true };
     };
+    return .{ .source = src, .diagnostics = try collectGrDiagnostics(arena, src) };
+}
 
+/// Tokenize + parse + typecheck a gero-lang source into one flat
+/// diagnostic slice. Pure over `src` (no IO) so `checkOneGr` and the
+/// tests share it. The lexer + parser populate `expected` with the
+/// stable `E_SYNTAX_*` code (see `docs/lang-diagnostics.md`); we fall
+/// back to a generic code only when an emission site predates the
+/// retrofit.
+fn collectGrDiagnostics(arena: std.mem.Allocator, src: []const u8) ![]gero.lang.Diagnostic {
     const stream = try gero.lang.tokenize(arena, src);
-    // Tokenizer / parser errors travel through the same lang.Diagnostic
-    // shape so the renderer surfaces them in the canonical layout.
-    // The lexer + parser populate `expected` with the stable
-    // `E_SYNTAX_*` code (see `docs/lang-diagnostics.md`); we fall
-    // back to a generic code only when an emission site predates
-    // the retrofit.
     var combined: std.ArrayList(gero.lang.Diagnostic) = .empty;
-    for (stream.errors) |e| {
-        try combined.append(arena, .{
-            .severity = .fatal,
-            .code = e.expected orelse "E_SYNTAX_GENERIC",
-            // safety: ParseError.index fits in u32 — bounded by file size.
-            .message = try arena.dupe(u8, e.message),
-            .span = .{ .start = @intCast(e.index), .end = @intCast(e.index) },
-        });
-    }
 
+    // `parse` folds the lexer's `stream.errors` into `tree.errors`
+    // (src/lang/parser.zig), so iterating `tree.errors` alone covers
+    // both phases — appending `stream.errors` separately would
+    // double-report every lexer diagnostic.
     const tree = try gero.lang.parse(arena, src, stream);
     for (tree.errors) |e| {
         try combined.append(arena, .{
@@ -370,10 +368,7 @@ fn checkOneGr(
         for (checked.diagnostics) |d| try combined.append(arena, d);
     }
 
-    return .{
-        .source = src,
-        .diagnostics = try combined.toOwnedSlice(arena),
-    };
+    return combined.toOwnedSlice(arena);
 }
 
 fn printPassGr(
@@ -478,4 +473,31 @@ fn writePhaseTimings(
         try footer.writeDuration(stdout, p.ns);
         try stdout.writeByte('\n');
     }
+}
+
+test "collectGrDiagnostics: clean source yields no diagnostics" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "def add(x, y)\n  return x + y\nend\n");
+    try std.testing.expectEqual(@as(usize, 0), diags.len);
+}
+
+test "collectGrDiagnostics: lexer diagnostic is not double-counted" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    // `parse` folds the lexer's `0x`-prefix error into `tree.errors`;
+    // appending `stream.errors` separately used to surface it twice.
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "let x = 0x1\n");
+    var hex_count: usize = 0;
+    for (diags) |d| {
+        if (std.mem.eql(u8, d.code, "E_SYNTAX_HEX_PREFIX")) hex_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), hex_count);
+}
+
+test "collectGrDiagnostics: type error surfaces when parse succeeds" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "def f()\n  return undefined_name\nend\n");
+    try std.testing.expect(diags.len > 0);
 }

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -338,18 +338,16 @@ fn checkOneGr(
 
 /// Tokenize + parse + typecheck a gero-lang source into one flat
 /// diagnostic slice. Pure over `src` (no IO) so `checkOneGr` and the
-/// tests share it. The lexer + parser populate `expected` with the
-/// stable `E_SYNTAX_*` code (see `docs/lang-diagnostics.md`); we fall
-/// back to a generic code only when an emission site predates the
-/// retrofit.
+/// tests share it. Each diagnostic's `code` is the lexer/parser's
+/// stable `E_SYNTAX_*` code (see `docs/lang-diagnostics.md`), or
+/// `E_SYNTAX_GENERIC` when the emission site carries none.
 fn collectGrDiagnostics(arena: std.mem.Allocator, src: []const u8) ![]gero.lang.Diagnostic {
     const stream = try gero.lang.tokenize(arena, src);
     var combined: std.ArrayList(gero.lang.Diagnostic) = .empty;
 
     // `parse` folds the lexer's `stream.errors` into `tree.errors`
-    // (src/lang/parser.zig), so iterating `tree.errors` alone covers
-    // both phases — appending `stream.errors` separately would
-    // double-report every lexer diagnostic.
+    // (src/lang/parser.zig), so `tree.errors` is the complete set —
+    // iterate it alone, never `stream.errors` as well.
     const tree = try gero.lang.parse(arena, src, stream);
     for (tree.errors) |e| {
         try combined.append(arena, .{
@@ -485,8 +483,8 @@ test "collectGrDiagnostics: clean source yields no diagnostics" {
 test "collectGrDiagnostics: lexer diagnostic is not double-counted" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
-    // `parse` folds the lexer's `0x`-prefix error into `tree.errors`;
-    // appending `stream.errors` separately used to surface it twice.
+    // A lexer diagnostic (the `0x`-prefix error) surfaces exactly
+    // once, not once per phase — `tree.errors` already includes it.
     const diags = try collectGrDiagnostics(arena_state.allocator(), "let x = 0x1\n");
     var hex_count: usize = 0;
     for (diags) |d| {

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -32,8 +32,8 @@ pub const Format = enum { human, json };
 
 /// `--lang=<l>` for `gero fmt --stdin` — which front-end parses the
 /// piped source. File-path mode dispatches on extension instead;
-/// stdin has no filename, so the language is explicit (default
-/// `gas` preserves the original stdin behavior).
+/// stdin has no filename, so the language is explicit. `gas` is the
+/// default, so a bare `--stdin` formats asm.
 pub const Lang = enum { gas, gr };
 
 /// Maximum positional args a single invocation can hold. Today's
@@ -85,8 +85,7 @@ pub const Options = struct {
     werror: bool = false,
     /// `--lang=<gas|gr>` for `gero fmt --stdin` — selects the
     /// front-end for piped source. Ignored outside stdin mode, where
-    /// the file extension decides. `gas` (default) keeps prior stdin
-    /// behavior.
+    /// the file extension decides. Defaults to `gas`.
     lang: Lang = .gas,
     /// `--target=<vm|gtx-16>` for `gero build` — overrides the
     /// manifest's `package.target`. `null` = inherit from manifest;
@@ -765,8 +764,8 @@ test "parse: --lang defaults to gas, --lang=gr selects the lang front-end" {
 }
 
 test "parse: --lang with an unknown value errors" {
-    // Regression: `--lang` must be in `needsValue`, else an inline
-    // `=value` is rejected as a no-value flag before `parseLang` runs.
+    // `--lang` takes a value, so an inline `--lang=<bad>` reaches
+    // `parseLang` and rejects unknown languages with InvalidEnumValue.
     const args = [_][]const u8{ "fmt", "--stdin", "--lang=python" };
     try testing.expectError(error.InvalidEnumValue, parse(&args));
 }

--- a/apps/gero-cli/cli.zig
+++ b/apps/gero-cli/cli.zig
@@ -30,6 +30,12 @@ pub const ColorChoice = enum { auto, always, never };
 /// consume.
 pub const Format = enum { human, json };
 
+/// `--lang=<l>` for `gero fmt --stdin` — which front-end parses the
+/// piped source. File-path mode dispatches on extension instead;
+/// stdin has no filename, so the language is explicit (default
+/// `gas` preserves the original stdin behavior).
+pub const Lang = enum { gas, gr };
+
 /// Maximum positional args a single invocation can hold. Today's
 /// commands top out at 1-2; keep it generous to absorb future
 /// `gero build` multi-source forms without re-architecting.
@@ -77,6 +83,11 @@ pub const Options = struct {
     /// integrations can surface warnings without blocking the
     /// build; CI gates set this for zero-warning policies.
     werror: bool = false,
+    /// `--lang=<gas|gr>` for `gero fmt --stdin` — selects the
+    /// front-end for piped source. Ignored outside stdin mode, where
+    /// the file extension decides. `gas` (default) keeps prior stdin
+    /// behavior.
+    lang: Lang = .gas,
     /// `--target=<vm|gtx-16>` for `gero build` — overrides the
     /// manifest's `package.target`. `null` = inherit from manifest;
     /// `gtx-16` is reserved (errors with "not yet implemented").
@@ -306,12 +317,13 @@ pub fn commandHelp(out: *std.Io.Writer, cmd: Command, color: bool) std.Io.Writer
             try out.print("  {s}gero check prog.gas -v{s}          {s}# per-phase timings (include / parse / codegen){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         .fmt => {
-            try out.print("  {s}gero fmt{s} <path...> [--check] [--stdin] [--quiet]\n\n", .{ a.cyan, a.reset });
+            try out.print("  {s}gero fmt{s} <path...> [--check] [--stdin] [--lang=<gas|gr>] [--quiet]\n\n", .{ a.cyan, a.reset });
             try out.print("{s}EXAMPLES{s}\n", .{ a.yellow, a.reset });
             try out.print("  {s}gero fmt prog.gas{s}               {s}# rewrite in place if not canonical{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
-            try out.print("  {s}gero fmt src/{s}                   {s}# recurse + format every .gas{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}gero fmt src/{s}                   {s}# recurse + format every .gas / .gr{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}gero fmt --check src/{s}           {s}# CI mode — exit 8 if any file would change{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
             try out.print("  {s}cat prog.gas | gero fmt --stdin{s} {s}# editor format-on-save (stdin → stdout){s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
+            try out.print("  {s}cat prog.gr | gero fmt --stdin --lang=gr{s} {s}# format gero-lang from stdin{s}\n", .{ a.cyan, a.reset, a.dim, a.reset });
         },
         .new => {
             try out.print("  {s}gero new{s} <name> [--quiet]\n\n", .{ a.cyan, a.reset });
@@ -377,6 +389,7 @@ fn flagHelpLine(kind: FlagKind) FlagHelpLine {
         .format => .{ .sig = "--format=<m>", .desc = "human (default) / json. JSON output suppresses human messages." },
         .target => .{ .sig = "--target=<m>", .desc = "vm (default) / gtx-16. Overrides manifest's [package].target." },
         .werror => .{ .sig = "--werror", .desc = "Treat warnings as errors (escalates exit code to 4)." },
+        .lang => .{ .sig = "--lang=<l>", .desc = "gas (default) / gr. Picks the front-end for --stdin (paths use the extension)." },
     };
 }
 
@@ -391,7 +404,7 @@ fn flagsForCommand(cmd: Command) []const FlagKind {
         .disasm => &.{ .help, .bank, .no_show_bytes, .check_roundtrip, .quiet, .color, .no_color },
         .test_ => &.{ .help, .verbose, .color, .no_color },
         .check => &.{ .help, .format, .werror, .quiet, .verbose, .color, .no_color },
-        .fmt => &.{ .help, .check, .stdin, .quiet, .color, .no_color },
+        .fmt => &.{ .help, .check, .stdin, .lang, .quiet, .color, .no_color },
         .new => &.{ .help, .quiet, .color, .no_color },
         .init => &.{ .help, .quiet, .color, .no_color },
         .build => &.{ .help, .target, .quiet, .verbose, .color, .no_color },
@@ -426,7 +439,13 @@ fn parseFormat(s: []const u8) ParseError!Format {
     return error.InvalidEnumValue;
 }
 
-const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check, stdin, format, target, werror };
+fn parseLang(s: []const u8) ParseError!Lang {
+    if (std.mem.eql(u8, s, "gas")) return .gas;
+    if (std.mem.eql(u8, s, "gr")) return .gr;
+    return error.InvalidEnumValue;
+}
+
+const FlagKind = enum { help, version, quiet, verbose, optimize, out, color, no_color, bank, show_bytes, no_show_bytes, check_roundtrip, check, stdin, format, target, werror, lang };
 
 fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "help")) return .help;
@@ -446,6 +465,7 @@ fn longFlag(s: []const u8) ?FlagKind {
     if (std.mem.eql(u8, s, "format")) return .format;
     if (std.mem.eql(u8, s, "target")) return .target;
     if (std.mem.eql(u8, s, "werror")) return .werror;
+    if (std.mem.eql(u8, s, "lang")) return .lang;
     return null;
 }
 
@@ -479,6 +499,7 @@ fn applyFlag(opts: *Options, kind: FlagKind, value: ?[]const u8) ParseError!void
         .format => opts.format = try parseFormat(value orelse return error.MissingFlagValue),
         .target => opts.target = value orelse return error.MissingFlagValue,
         .werror => opts.werror = true,
+        .lang => opts.lang = try parseLang(value orelse return error.MissingFlagValue),
     }
 }
 
@@ -488,7 +509,7 @@ fn parseBank(s: []const u8) ParseError!u8 {
 
 fn needsValue(kind: FlagKind) bool {
     return switch (kind) {
-        .optimize, .out, .color, .bank, .format, .target => true,
+        .optimize, .out, .color, .bank, .format, .target, .lang => true,
         else => false,
     };
 }
@@ -733,6 +754,21 @@ test "parse: --optimize=release accepted" {
     const args = [_][]const u8{ "asm", "--optimize=release" };
     const p = try parse(&args);
     try testing.expectEqual(Optimize.release, p.options.optimize);
+}
+
+test "parse: --lang defaults to gas, --lang=gr selects the lang front-end" {
+    const default_p = try parse(&[_][]const u8{ "fmt", "--stdin" });
+    try testing.expectEqual(Lang.gas, default_p.options.lang);
+
+    const gr_p = try parse(&[_][]const u8{ "fmt", "--stdin", "--lang=gr" });
+    try testing.expectEqual(Lang.gr, gr_p.options.lang);
+}
+
+test "parse: --lang with an unknown value errors" {
+    // Regression: `--lang` must be in `needsValue`, else an inline
+    // `=value` is rejected as a no-value flag before `parseLang` runs.
+    const args = [_][]const u8{ "fmt", "--stdin", "--lang=python" };
+    try testing.expectError(error.InvalidEnumValue, parse(&args));
 }
 
 test "parse: --show-bytes default is true, --no-show-bytes disables" {

--- a/apps/gero-cli/fmt.zig
+++ b/apps/gero-cli/fmt.zig
@@ -39,7 +39,7 @@ pub fn execute(
             try term.err("gero fmt: --stdin is mutually exclusive with positional paths", .{});
             return 2;
         }
-        return try formatStdin(io, arena, stdout, term, style, opts.check);
+        return try formatStdin(io, arena, stdout, term, opts.check, opts.lang);
     }
 
     // Always try to load gero.toml — both [fmt] overrides and the
@@ -144,9 +144,11 @@ pub fn printOptionsFromManifest(fmt: project.Manifest.Fmt) gero.asm_.PrintOption
     };
 }
 
-/// `--stdin` mode: read source from stdin, run the canonical
-/// printer, write the result to stdout. `check_mode` flips behavior
-/// to exit 8 (no stdout) when the input would reformat.
+/// `--stdin` mode: read source from stdin, run the canonical printer
+/// for `lang`, write the result to stdout. `check_mode` flips behavior
+/// to exit 8 (no stdout) when the input would reformat. The language
+/// is explicit (`--lang`) because stdin carries no extension to
+/// dispatch on; `.gas` is the default.
 ///
 /// The manifest's `[fmt]` overrides are **not** consulted — stdin
 /// mode has no project root context. Always uses compile-time
@@ -160,11 +162,9 @@ fn formatStdin(
     arena: std.mem.Allocator,
     stdout: *std.Io.Writer,
     term: *term_mod.Term,
-    style: gero.asm_.Style,
     check_mode: bool,
+    lang: cli.Lang,
 ) !u8 {
-    _ = style;
-
     // 16 MiB ceiling matches src/asm/include.zig::max_file_size.
     const max_stdin_bytes: usize = 16 * 1024 * 1024;
     var read_buf: [4096]u8 = undefined;
@@ -174,6 +174,20 @@ fn formatStdin(
         return 1;
     };
 
+    return switch (lang) {
+        .gas => formatStdinGas(arena, stdout, term, src, check_mode),
+        .gr => formatStdinGr(arena, stdout, term, src, check_mode),
+    };
+}
+
+/// Asm stdin path: parse, drop include-line noise, print canonically.
+fn formatStdinGas(
+    arena: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+    src: []const u8,
+    check_mode: bool,
+) !u8 {
     var pt = try gero.asm_.parse(arena, src);
 
     var real_errors: std.ArrayList(gero.asm_.Diagnostic) = .empty;
@@ -192,13 +206,44 @@ fn formatStdin(
 
     var allocating = std.Io.Writer.Allocating.init(arena);
     try gero.asm_.printProgram(&allocating.writer, &pt.program, src, gero.asm_.default_print_options);
-    const formatted = allocating.written();
+    return emitStdin(stdout, src, allocating.written(), check_mode);
+}
 
+/// Lang stdin path: tokenize + parse via the gero-lang front-end,
+/// re-emit through the AST printer. `parse` folds lexer errors into
+/// `tree.errors`, so a single pass over it covers both phases.
+fn formatStdinGr(
+    arena: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    term: *term_mod.Term,
+    src: []const u8,
+    check_mode: bool,
+) !u8 {
+    var stream = try gero.lang.tokenize(arena, src);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(arena, src, stream);
+    defer tree.deinit();
+    if (tree.errors.len > 0) {
+        for (tree.errors) |d| {
+            // @as: ParseError.index fits in u32 — bounded by max_stdin_bytes.
+            const lc = lineColAt(src, @as(u32, @intCast(d.index)));
+            try term.err("{d}:{d}: {s}", .{ lc.line, lc.col, d.message });
+        }
+        return 3;
+    }
+
+    var allocating = std.Io.Writer.Allocating.init(arena);
+    try gero.lang.print(&allocating.writer, &tree.program, src);
+    return emitStdin(stdout, src, allocating.written(), check_mode);
+}
+
+/// Shared stdin tail: in `--check` mode report would-reformat via the
+/// exit code (8) without writing; otherwise stream the formatted bytes.
+fn emitStdin(stdout: *std.Io.Writer, src: []const u8, formatted: []const u8, check_mode: bool) !u8 {
     if (check_mode) {
         // Canonical → exit 0 silent; otherwise exit 8, also silent.
         return if (std.mem.eql(u8, src, formatted)) 0 else 8;
     }
-
     try stdout.writeAll(formatted);
     return 0;
 }
@@ -485,4 +530,20 @@ fn mkDiag(index: u32) gero.asm_.Diagnostic {
             .kind = .semantic,
         },
     };
+}
+
+test "fmt: emitStdin writes formatted bytes and exits 0 outside check mode" {
+    var out = std.Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    const code = try emitStdin(&out.writer, "src", "formatted", false);
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expectEqualStrings("formatted", out.written());
+}
+
+test "fmt: emitStdin --check exits 8 when reformatting, 0 when canonical, never writes" {
+    var out = std.Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    try testing.expectEqual(@as(u8, 8), try emitStdin(&out.writer, "messy", "clean", true));
+    try testing.expectEqual(@as(u8, 0), try emitStdin(&out.writer, "same", "same", true));
+    try testing.expectEqual(@as(usize, 0), out.written().len);
 }

--- a/apps/gero-cli/fmt.zig
+++ b/apps/gero-cli/fmt.zig
@@ -233,7 +233,7 @@ fn formatStdinGr(
     }
 
     var allocating = std.Io.Writer.Allocating.init(arena);
-    try gero.lang.print(&allocating.writer, &tree.program, src);
+    try gero.lang.print(&allocating.writer, &tree.program, src, tree.comments);
     return emitStdin(stdout, src, allocating.written(), check_mode);
 }
 
@@ -348,7 +348,7 @@ fn formatOneGr(
     }
 
     var allocating = std.Io.Writer.Allocating.init(arena);
-    try gero.lang.print(&allocating.writer, &tree.program, src);
+    try gero.lang.print(&allocating.writer, &tree.program, src, tree.comments);
     const formatted = allocating.written();
 
     if (std.mem.eql(u8, src, formatted)) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -252,18 +252,20 @@ debug:       yes (symbols: 142)
 
 ### 3.8 `gero fmt <files...>` — format source
 
-Canonical formatter for `.gas` (and eventually `.gr`). Style is
-fixed per-invocation — no `--option`s, no `.editorconfig` lookup.
-Inside a gero project, the manifest's `[fmt]` section overrides
-the compile-time defaults (see below).
+Canonical formatter for `.gas` and `.gr`. Style is fixed
+per-invocation — no `--option`s, no `.editorconfig` lookup. Inside
+a gero project, the manifest's `[fmt]` section overrides the
+compile-time defaults (see below).
 
 ```bash
 gero fmt main.gas                 # format in place
+gero fmt main.gr                  # gero-lang source — same UX
 gero fmt --check main.gas         # check only (exit 8 if changes needed)
-gero fmt src/                     # recurse into directory
-gero fmt a.gas b.gas src/         # any mix of files and directories
+gero fmt src/                     # recurse into directory (.gas + .gr)
+gero fmt a.gas b.gr src/          # any mix of files and directories
 gero fmt                          # project-aware: [build].entry + [test].include
-cat main.gas | gero fmt --stdin   # editor format-on-save (stdin → stdout)
+cat main.gas | gero fmt --stdin             # editor format-on-save (stdin → stdout)
+cat main.gr | gero fmt --stdin --lang=gr    # gero-lang from stdin
 ```
 
 **Behavior:**
@@ -283,9 +285,15 @@ cat main.gas | gero fmt --stdin   # editor format-on-save (stdin → stdout)
   apply. `--stdin --check` exits 0 if already canonical, 8 if it
   would reformat (no stdout in `--check` mode). Use case: editor
   format-on-save (VS Code / Neovim / Helix).
-- Recurses into directories, formats every `.gas` found. `.gr`
-  sources route to "not yet implemented" until the
-  gero-lang front-end.
+- `--lang=<gas|gr>` selects the front-end for `--stdin` — stdin
+  carries no filename to dispatch on, so the language is explicit.
+  Defaults to `gas`. Ignored outside stdin mode (path mode
+  dispatches on the file extension). Editors pass `--lang=gr` when
+  formatting a gero-lang buffer on save.
+- Recurses into directories, formats every `.gas` and `.gr` found.
+  `.gr` sources parse via the gero-lang front-end and re-emit
+  through the AST printer; `.gas` round-trips through the asm
+  printer.
 - `include "..."` directives round-trip verbatim — fmt doesn't
   expand includes (that's `gero asm`'s job).
 

--- a/docs/examples/playground.gr
+++ b/docs/examples/playground.gr
@@ -1,14 +1,11 @@
 -- Small canonical sample exercising the gero-lang v1 surface.
 -- Round-trips through `gero fmt docs/examples/playground.gr --check`
 -- and produces zero diff.
-
 use math
 use input as keys from "./io"
-
 const MAX_HP = 100
 const SEED = $C0DE
-
-@addr $FE40
+@addr($FE40)
 @volatile
 let DISPCTL: u8 = 0
 

--- a/docs/examples/syntax_overview.gr
+++ b/docs/examples/syntax_overview.gr
@@ -1,34 +1,31 @@
 -- syntax_overview.gr
 --
--- A near-complete tour of gero-lang v0.1 syntax. Compiles to a
--- minimal turn-based monster-battle harness — picked because it
--- exercises most language features in one cohesive program.
+-- A near-complete tour of gero-lang syntax. Compiles to a minimal
+-- turn-based monster-battle harness — picked because it exercises
+-- most language features in one cohesive program.
 --
 -- Read this top-to-bottom to see every construct from the spec at
 -- least once. Annotations refer to spec section numbers.
-
 ------------------------------------------------------------
 -- §5.2  Imports
 ------------------------------------------------------------
-use math                    -- stdlib module, whole import
-use rng from math           -- selective import
-use display from "./io"     -- relative path import
-use input as keys from "./io"  -- selective + rename
-
+use math -- stdlib module, whole import
+use rng from math -- selective import
+use display from "./io" -- relative path import
+use input as keys from "./io" -- selective + rename
 ------------------------------------------------------------
 -- §4.1  Constants and module-level state
 ------------------------------------------------------------
 const MAX_HP = 100
 const HEAL_AMOUNT = 25
-const ENCOUNTER_RATE = 6      -- 6/256 chance per step
-
-@zero_page                    -- §3.7.1 — fast access for hot global
+const ENCOUNTER_RATE = 6 -- 6/256 chance per step
+-- §3.7.1 — fast access for hot global
+@zero_page
 let frame_count: u16 = 0
-
-@addr $FEE0                   -- §3.7.1 — bound to gtx-16 gamepad input register
+-- §3.7.1 — bound to gtx-16 gamepad input register
+@addr($FEE0)
 let P1_STATE: u8 = 0
-
-local const SECRET = 42       -- §5.1 — module-private
+local const SECRET = 42 -- §5.1 — module-private
 
 ------------------------------------------------------------
 -- §3.6  Enums (tagged unions)
@@ -54,13 +51,14 @@ struct Stats
   hp: i16
   mp: i16
   atk: u8
-  def: u8
+  defense: u8
 end
 
 ------------------------------------------------------------
 -- §6  Classes with inheritance
 ------------------------------------------------------------
-@abstract                     -- §3.7.6
+-- §3.7.6
+@abstract
 class Entity
   let stats: Stats
   let name: str
@@ -72,21 +70,24 @@ class Entity
     self.element = element
   end
 
-  @abstract                   -- subclasses must implement
+  -- subclasses must implement
+  @abstract
   def take_turn(self) -> Action
 
-  @final                      -- can't be overridden (devirt)
+  -- can't be overridden (devirt)
+  @final
   def is_alive(self) -> bool
     return self.stats.hp > 0
   end
 
-  @static                     -- class-level, no self
+  -- class-level, no self
+  @static
   def random_element() -> Element
     match rng() % 4
-      case 0 then return Element.Fire
-      case 1 then return Element.Water
-      case 2 then return Element.Earth
-      case _ then return Element.Air
+      case 0 => return Element.Fire
+      case 1 => return Element.Water
+      case 2 => return Element.Earth
+      case _ => return Element.Air
     end
   end
 
@@ -101,22 +102,23 @@ class Hero extends Entity
   let _xp: i16
 
   def init(self, name: str)
-    super.init(name, Stats { hp: MAX_HP, mp: 30, atk: 12, def: 8 }, Element.Fire)
+    super.init(name, Stats { hp: MAX_HP, mp: 30, atk: 12, defense: 8 }, Element.Fire)
     self._xp = 0
   end
 
   @override
   def take_turn(self) -> Action
     -- Hero turns are driven by player input
-    if let true = keys.button_pressed(0) then    -- §4.4.1  if let
+    if let true = keys.button_pressed(0)
+      -- §4.4.1  if let
       return Action.Attack(0, self.stats.atk)
     end
     return Action.Defend
   end
 
   def gain_xp(self, amount: i16)
-    self._xp += amount                           -- §4.2  compound assign
-    if self._xp >= 100 then
+    self._xp += amount -- §4.2  compound assign
+    if self._xp >= 100
       self.level_up()
     end
   end
@@ -125,25 +127,24 @@ class Hero extends Entity
   def level_up(self)
     self._xp = 0
     self.stats.atk += 2
-    self.stats.def += 1
-    print "level up! $(self.name)"      -- §3.2.2 interpolation
+    self.stats.defense += 1
+    print "level up! $(self.name)" -- §3.2.2 interpolation
   end
 end
 
-@bank 5                       -- §3.7.1 — sprite/dialog data lives in bank 5
 @final
 class Monster extends Entity
   let drop_table: [u8; 4]
 
   def init(self, name: str, hp: i16, atk: u8, drops: [u8; 4])
-    super.init(name, Stats { hp: hp, mp: 0, atk: atk, def: 4 }, Entity.random_element())
+    super.init(name, Stats { hp: hp, mp: 0, atk: atk, defense: 4 }, Entity.random_element())
     self.drop_table = drops
   end
 
   @override
   def take_turn(self) -> Action
     -- Monster AI: flee at low HP, otherwise attack
-    if self.stats.hp < 10 then
+    if self.stats.hp < 10
       return Action.Flee
     end
     return Action.Attack(0, self.stats.atk)
@@ -156,39 +157,59 @@ end
 ------------------------------------------------------------
 def damage(attacker: Stats, target: Stats, power: i16) -> i16
   -- explicit annotations: public API, intent matters
-  let raw = power + attacker.atk - target.def
-  return math.max(1, raw)        -- min 1 damage
+  let raw = power + (attacker.atk as i16) - (target.defense as i16)
+  return math.max(1, raw) -- min 1 damage
 end
 
-def short_log(name, dmg)         -- annotations omitted: inferred from call sites
+def short_log(name, dmg)
+  -- annotations omitted: inferred from call sites
   print "$(name) → $(dmg)"
+end
+
+-- minimal numeric parsers — stubbed; a real impl would scan digits
+def parse_u8(s: str) -> (u8, str?)
+  return (0, nil)
+end
+
+def parse_i16(s: str) -> (i16, str?)
+  return (0, nil)
 end
 
 -- §3.4.1 multi-return for fallible ops (no Result<T, E> in v0.1)
 def parse_attack_command(s: str) -> ((u8, i16), str?)
   -- success: ((target, power), nil) ; failure: ((0, 0), "message")
   let parts = s.split(" ")
-  if parts.len != 3 then
+  if parts.len != 3
     return ((0, 0), "usage: attack <target> <power>")
   end
   let (target, e1) = parse_u8(parts.at(1))
-  if e1 != nil then return ((0, 0), e1) end
+  if e1 != nil
+    return ((0, 0), e1)
+  end
   let (power, e2) = parse_i16(parts.at(2))
-  if e2 != nil then return ((0, 0), e2) end
+  if e2 != nil
+    return ((0, 0), e2)
+  end
   return ((target, power), nil)
 end
 
-@inline                          -- §3.7.2 — perf hint
+-- §3.7.2 — perf hint
+@inline
 def clamp(x: i16, lo: i16, hi: i16) -> i16
-  if x < lo then return lo end
-  if x > hi then return hi end
+  if x < lo
+    return lo
+  end
+  if x > hi
+    return hi
+  end
   return x
 end
 
 -- First-class function, passed as argument
 def apply_to_each(items: [i16; 4], op: fn(i16) -> i16) -> [i16; 4]
   let result: [i16; 4] = [0; 4]
-  for i in 0..4 do                              -- §4.5  range expr
+  for i in 0..4
+    -- §4.5  range expr
     result[i] = op(items[i])
   end
   return result
@@ -202,44 +223,31 @@ def battle(hero: Hero, monster: Monster) -> bool
   let initial_hp: (i16, i16) = do
     (hero.stats.hp, monster.stats.hp)
   end
-
-  let (hero_start, monster_start) = initial_hp  -- §4.1.1  destructuring let
-
+  let (hero_start, monster_start) = initial_hp -- §4.1.1  destructuring let
   -- Closure capturing hero (by-value snapshot in v0.1 — §4.7.1)
-  let report = lambda () -> str
-    return "Hero went from " + hero_start + " to " + hero.stats.hp + " HP"
-  end
-
-  while hero.is_alive() and monster.is_alive() do
+  let report = || -> str "Hero went from $(hero_start) to $(hero.stats.hp) HP"
+  while hero.is_alive() and monster.is_alive()
     let h_action = hero.take_turn()
     let m_action = monster.take_turn()
-
     -- §4.8  Rust-style match with guards + destructuring
     match h_action
-      case Action.Attack(_, power) when power > 0 then
+      case Action.Attack(_, power) when power > 0 =>
         let dmg = damage(hero.stats, monster.stats, power)
         monster.take_damage(dmg)
-        print "$(hero.name) hits for $(dmg:3d)"     -- format spec
-      case Action.Defend then
-        print "$(hero.name) defends"
-      case Action.Heal(amount) then
-        hero.stats.hp = clamp(hero.stats.hp + amount, 0, MAX_HP)
-      case Action.Flee then
+        print "$(hero.name) hits for $(dmg:3d)" -- format spec
+      case Action.Defend => print "$(hero.name) defends"
+      case Action.Heal(amount) => hero.stats.hp = clamp(hero.stats.hp + amount, 0, MAX_HP)
+      case Action.Flee =>
         print "$(hero.name) fled!"
         return false
-      case _ then
-        -- compiler error if not exhaustive — wildcard discharges it
     end
-
     -- §4.4.1  if let with guard
-    if let Action.Attack(_, p) = m_action when p > 0 then
+    if let Action.Attack(_, p) = m_action when p > 0
       let dmg = damage(monster.stats, hero.stats, p)
       hero.take_damage(dmg)
     end
-
     frame_count += 1
   end
-
   print report()
   return hero.is_alive()
 end
@@ -248,13 +256,14 @@ end
 -- §4.8  Pattern match worked over enum
 ------------------------------------------------------------
 def element_advantage(attacker: Element, defender: Element) -> fixed
-  match (attacker, defender)                    -- tuple pattern
-    case (Element.Fire,  Element.Earth) then return 1.5
-    case (Element.Water, Element.Fire)  then return 1.5
-    case (Element.Earth, Element.Air)   then return 1.5
-    case (Element.Air,   Element.Water) then return 1.5
-    case (a, b) when a == b              then return 0.5
-    case _                               then return 1.0
+  match (attacker, defender)
+    -- tuple pattern
+    case (Element.Fire, Element.Earth) => return 1.5
+    case (Element.Water, Element.Fire) => return 1.5
+    case (Element.Earth, Element.Air) => return 1.5
+    case (Element.Air, Element.Water) => return 1.5
+    case (a, b) when a == b => return 0.5
+    case _ => return 1.0
   end
 end
 
@@ -263,7 +272,7 @@ end
 ------------------------------------------------------------
 def process_events(queue: fn() -> Action) -> u8
   let count: u8 = 0
-  while let Action.Attack(_, _) = queue() do
+  while let Action.Attack(_, _) = queue()
     count += 1
   end
   -- Action.Defend / .Heal / .Flee fall through and exit the loop
@@ -275,24 +284,27 @@ end
 ------------------------------------------------------------
 def use_potion(item: Action)
   match item
-    case Action.Heal(amount) then print "healed for $(amount)"
-    case _                   then print "not a healing item"
+    case Action.Heal(amount) => print "healed for $(amount)"
+    case _ => print "not a healing item"
   end
 end
 
 ------------------------------------------------------------
 -- §3.7.4  @interrupt — hardware handler binding
 ------------------------------------------------------------
-@interrupt 0x06               -- vblank vector (gtx-16)
+-- vblank vector (gtx-16)
+@interrupt($06)
 def on_vblank()
   -- 60Hz tick — keep tight
   frame_count += 1
-  if frame_count == 0 then    -- wrapped past 0xFFFF
+  if frame_count == 0
+    -- wrapped past 0xFFFF
     print "1092 minutes uptime, you ok?"
   end
 end
 
-@interrupt 0x21               -- save-flush convention
+-- save-flush convention
+@interrupt($21)
 def on_save_request()
   print "saving..."
   -- host writes SRAM banks back to disk on rti
@@ -303,26 +315,29 @@ end
 ------------------------------------------------------------
 @test
 def damage_floor_is_one()
-  let weak = Stats { hp: 1, mp: 0, atk: 1, def: 100 }
-  let strong = Stats { hp: 100, mp: 0, atk: 10, def: 0 }
+  let weak = Stats { hp: 1, mp: 0, atk: 1, defense: 100 }
+  let strong = Stats { hp: 100, mp: 0, atk: 10, defense: 0 }
   assert(damage(weak, strong, 0) == 1, "raw negative should clamp to 1")
 end
 
 @bench
 def bench_damage_calc()
-  let a = Stats { hp: 100, mp: 0, atk: 50, def: 10 }
-  let t = Stats { hp: 100, mp: 0, atk: 5,  def: 30 }
+  let a = Stats { hp: 100, mp: 0, atk: 50, defense: 10 }
+  let t = Stats { hp: 100, mp: 0, atk: 5, defense: 30 }
   damage(a, t, 100)
 end
 
 @test
 def element_chart_consistent()
   -- Each element beats exactly one other
-  for e in [Element.Fire, Element.Water, Element.Earth, Element.Air] do
-    let count = do                               -- §4.3  do as expression
+  for e in [Element.Fire, Element.Water, Element.Earth, Element.Air]
+    let count = do
+      -- §4.3  do as expression
       let n: i16 = 0
-      for d in [Element.Fire, Element.Water, Element.Earth, Element.Air] do
-        if element_advantage(e, d) > 1.0 then n += 1 end
+      for d in [Element.Fire, Element.Water, Element.Earth, Element.Air]
+        if element_advantage(e, d) > 1.0
+          n += 1
+        end
       end
       n
     end
@@ -331,11 +346,11 @@ def element_chart_consistent()
 end
 
 ------------------------------------------------------------
--- §3.7.7  @asm — last-resort inline asm
+-- §3.7.7  asm — last-resort inline asm
 ------------------------------------------------------------
 @inline
 def fast_swap(a: u16, b: u16)
-  @asm("swap {a}, {b}")
+  asm "swap {a}, {b}"
 end
 
 ------------------------------------------------------------
@@ -344,7 +359,7 @@ end
 let player = Hero("Cecil")
 let slime = Monster("Slime", 30, 6, [0, 1, 0, 2])
 
-if battle(player, slime) then
+if battle(player, slime)
   player.gain_xp(20)
   print "Victory!"
 else

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -40,6 +40,8 @@ const cg_isa = @import("lang/codegen/isa.zig");
 pub const Token = lexer_mod.Token;
 /// Lexer output stream.
 pub const TokenStream = lexer_mod.TokenStream;
+/// A captured line comment (`-- …`); carried through to the formatter.
+pub const Comment = lexer_mod.Comment;
 /// Tokenize `.gr` source.
 pub const tokenize = lexer_mod.tokenize;
 

--- a/src/lang/lexer.zig
+++ b/src/lang/lexer.zig
@@ -210,18 +210,31 @@ pub const Token = struct {
     }
 };
 
+/// A line comment (`-- …`) captured verbatim. `start..end` are byte
+/// offsets covering the `--` through the last byte before the
+/// newline. The parser never sees these — they're kept off the token
+/// stream so they don't perturb grammar rules — but the formatter
+/// re-emits them, so they ride along on `TokenStream` / `ParseTree`.
+pub const Comment = struct {
+    start: u32,
+    end: u32,
+};
+
 /// Output of `tokenize`. `tokens` always ends with `.eof`. Any
 /// `ParseError` raised during lexing is collected in `errors` so
 /// the caller can drain every problem in a single pass.
 pub const TokenStream = struct {
     tokens: []Token,
     errors: []core.ParseError,
+    /// Line comments in source order. Empty for comment-free input.
+    comments: []Comment,
     allocator: std.mem.Allocator,
 
-    /// Release both slices.
+    /// Release the slices.
     pub fn deinit(self: *TokenStream) void {
         self.allocator.free(self.tokens);
         self.allocator.free(self.errors);
+        self.allocator.free(self.comments);
     }
 
     /// `true` when at least one token-level error was recorded.
@@ -361,6 +374,9 @@ const State = struct {
     index: u32,
     tokens: std.ArrayList(Token),
     errors: std.ArrayList(core.ParseError),
+    /// Line comments collected as the scanner skips them. Off the
+    /// token stream; the formatter consumes them.
+    comments: std.ArrayList(Comment),
     /// Most-recent emitted kind, used by `-` disambiguation +
     /// trailing-newline collapsing.
     last_kind: ?Token.Kind,
@@ -655,6 +671,7 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
         .index = 0,
         .tokens = .empty,
         .errors = .empty,
+        .comments = .empty,
         .last_kind = null,
         .str_stack = .empty,
         .allocator = allocator,
@@ -662,6 +679,7 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
     defer state.str_stack.deinit(allocator);
     errdefer state.tokens.deinit(allocator);
     errdefer state.errors.deinit(allocator);
+    errdefer state.comments.deinit(allocator);
 
     while (state.index < source.len) {
         // --- string-body mode ---
@@ -741,7 +759,9 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
                 break :blk prev == ' ' or prev == '\t' or prev == '\n' or prev == '\r';
             };
             if (preceded_by_ws) {
+                const comment_start = state.index;
                 while (state.index < source.len and source[state.index] != '\n') : (state.index += 1) {}
+                try state.comments.append(state.allocator, .{ .start = comment_start, .end = state.index });
                 continue;
             }
             // Directly attached → decrement.
@@ -990,6 +1010,7 @@ pub fn tokenize(allocator: std.mem.Allocator, source: []const u8) !TokenStream {
     return .{
         .tokens = try state.tokens.toOwnedSlice(allocator),
         .errors = try state.errors.toOwnedSlice(allocator),
+        .comments = try state.comments.toOwnedSlice(allocator),
         .allocator = allocator,
     };
 }

--- a/src/lang/parser.zig
+++ b/src/lang/parser.zig
@@ -16,6 +16,10 @@ const Kind = lexer.Token.Kind;
 pub const ParseTree = struct {
     program: ast.Program,
     errors: []core.ParseError,
+    /// Line comments from the lexer, carried through so the formatter
+    /// can re-emit them. Duped into the tree's allocator — the source
+    /// `TokenStream` is freed independently of the tree.
+    comments: []lexer.Comment,
     /// Owned message strings the parser allocPrint'd for richer
     /// diagnostics (e.g. `expect` building `"expected )"`).
     /// String literals don't land here — only heap-allocated bytes
@@ -29,6 +33,7 @@ pub const ParseTree = struct {
         self.allocator.free(self.allocated_messages);
         self.program.deinit();
         self.allocator.free(self.errors);
+        self.allocator.free(self.comments);
     }
 
     /// `true` when at least one diagnostic was recorded.
@@ -112,6 +117,7 @@ pub fn parse(
             .allocator = allocator,
         },
         .errors = try errors.toOwnedSlice(allocator),
+        .comments = try allocator.dupe(lexer.Comment, stream.comments),
         .allocated_messages = try allocated_messages.toOwnedSlice(allocator),
         .allocator = allocator,
     };

--- a/src/lang/print.zig
+++ b/src/lang/print.zig
@@ -1,16 +1,21 @@
 const std = @import("std");
 const ast = @import("ast.zig");
+const lexer = @import("lexer.zig");
 
 /// Emit canonical `.gr` text for `program` into `writer`. `source`
 /// is the original source buffer the AST was parsed from; the
 /// printer slices identifier names, char literals, format specs
-/// and similar atoms from it.
+/// and similar atoms from it. `comments` are the lexer's line
+/// comments in source order — re-emitted as leading/trailing lines so
+/// formatting is lossless. Pass `&.{}` when comment fidelity isn't
+/// needed (e.g. AST round-trip tests).
 pub fn print(
     writer: *std.Io.Writer,
     program: *const ast.Program,
     source: []const u8,
+    comments: []const lexer.Comment,
 ) std.Io.Writer.Error!void {
-    var p: Printer = .{ .writer = writer, .source = source, .indent = 0 };
+    var p: Printer = .{ .writer = writer, .source = source, .indent = 0, .comments = comments, .comment_idx = 0 };
     for (program.statements, 0..) |s, i| {
         if (i > 0) {
             try p.writer.writeByte('\n');
@@ -22,9 +27,13 @@ pub fn print(
                 try p.writer.writeByte('\n');
             }
         }
+        try p.flushLeading(s.span().start);
         try p.writeStatement(s);
+        try p.flushTrailing(s.span().end);
     }
     if (program.statements.len > 0) try p.writer.writeByte('\n');
+    // File-trailing comments after the last statement.
+    try p.flushLeading(@intCast(source.len));
 }
 
 fn isMultiLineStatement(s: ast.Statement) bool {
@@ -48,6 +57,41 @@ const Printer = struct {
     writer: *std.Io.Writer,
     source: []const u8,
     indent: usize,
+    /// Line comments in source order; `comment_idx` is the next one
+    /// not yet emitted. The printer drains this as it walks spanned
+    /// items so every comment lands exactly once.
+    comments: []const lexer.Comment,
+    comment_idx: usize,
+
+    // ---------- comments ----------
+
+    /// Emit every pending comment that starts before `offset`, each on
+    /// its own line at the current indent. Drives leading + standalone
+    /// comments; call it just before printing a spanned item (or the
+    /// closing `end`) so the comment lands above it.
+    fn flushLeading(self: *Printer, offset: u32) std.Io.Writer.Error!void {
+        while (self.comment_idx < self.comments.len and self.comments[self.comment_idx].start < offset) {
+            const c = self.comments[self.comment_idx];
+            try self.writeIndent();
+            try self.writer.writeAll(std.mem.trimEnd(u8, self.source[c.start..c.end], " \t"));
+            try self.writer.writeByte('\n');
+            self.comment_idx += 1;
+        }
+    }
+
+    /// If the next pending comment sits on the same source line as the
+    /// item that just ended at byte `after`, emit it inline as a
+    /// trailing ` -- …`. No-op otherwise (it'll flush as a leading
+    /// comment before the next item).
+    fn flushTrailing(self: *Printer, after: u32) std.Io.Writer.Error!void {
+        if (self.comment_idx >= self.comments.len) return;
+        const c = self.comments[self.comment_idx];
+        if (c.start < after) return;
+        if (std.mem.indexOfScalar(u8, self.source[after..c.start], '\n') != null) return;
+        try self.writer.writeByte(' ');
+        try self.writer.writeAll(std.mem.trimEnd(u8, self.source[c.start..c.end], " \t"));
+        self.comment_idx += 1;
+    }
 
     // ---------- low-level ----------
 
@@ -63,15 +107,24 @@ const Printer = struct {
     /// Bump indent by one and emit each body statement as its own
     /// line. `writeStatement` is responsible for prefixing its own
     /// indent, so this function only sets up indentation depth.
+    /// Interleaves leading/trailing comments per statement; `end_off`
+    /// (the byte offset of the construct's closing keyword) flushes any
+    /// comment between the last statement and `end`. Pass `null` when
+    /// that boundary isn't cleanly known (e.g. `if`/`elif` arms) — such
+    /// comments still emit losslessly, just before the next item.
     fn writeBodyBlock(
         self: *Printer,
         body: []const ast.Statement,
+        end_off: ?u32,
     ) std.Io.Writer.Error!void {
         self.indent += 1;
         for (body) |s| {
+            try self.flushLeading(s.span().start);
             try self.writeStatement(s);
+            try self.flushTrailing(s.span().end);
             try self.writer.writeByte('\n');
         }
+        if (end_off) |off| try self.flushLeading(off);
         self.indent -= 1;
     }
 
@@ -129,7 +182,7 @@ const Printer = struct {
                 try self.writeExpr(d.expr, .lowest);
             },
             .expr_stmt => |es| try self.writeExpr(es.expr, .lowest),
-            .block => |b| try self.writeBlockStmt(b.body),
+            .block => |b| try self.writeBlockStmt(b.body, b.span.end),
             .if_stmt => |is_| try self.writeIfStmt(is_),
             .while_stmt => |ws| try self.writeWhileStmt(ws),
             .for_stmt => |fs| try self.writeForStmt(fs),
@@ -213,32 +266,38 @@ const Printer = struct {
     fn writeBlockStmt(
         self: *Printer,
         body: []const ast.Statement,
+        end_off: u32,
     ) std.Io.Writer.Error!void {
         try self.writer.writeAll("do\n");
-        try self.writeBodyBlock(body);
+        try self.writeBodyBlock(body, end_off);
         try self.writeIndent();
         try self.writer.writeAll("end");
     }
 
     fn writeIfStmt(self: *Printer, s: ast.IfStmt) std.Io.Writer.Error!void {
-        try self.writeIfChain(s.arms, s.else_body);
+        try self.writeIfChain(s.arms, s.else_body, s.span.end);
     }
 
     fn writeIfChain(
         self: *Printer,
         arms: []const ast.IfArm,
         else_body: ?[]const ast.Statement,
+        end_off: u32,
     ) std.Io.Writer.Error!void {
         for (arms, 0..) |arm, i| {
             try self.writer.writeAll(if (i == 0) "if " else "elif ");
             try self.writeIfArmHead(arm);
             try self.writer.writeByte('\n');
-            try self.writeBodyBlock(arm.body);
+            // Arm boundary (next elif/else) isn't a clean offset, so pass
+            // null on non-final arms; the else body (or the final arm
+            // when there's no else) is bounded by the `if`'s `end`.
+            const bound: ?u32 = if (i == arms.len - 1 and else_body == null) end_off else null;
+            try self.writeBodyBlock(arm.body, bound);
         }
         if (else_body) |eb| {
             try self.writeIndent();
             try self.writer.writeAll("else\n");
-            try self.writeBodyBlock(eb);
+            try self.writeBodyBlock(eb, end_off);
         }
         try self.writeIndent();
         try self.writer.writeAll("end");
@@ -278,7 +337,7 @@ const Printer = struct {
             try self.writer.writeAll(self.lexeme(lbl));
         }
         try self.writer.writeByte('\n');
-        try self.writeBodyBlock(s.body);
+        try self.writeBodyBlock(s.body, s.span.end);
         try self.writeIndent();
         try self.writer.writeAll("end");
     }
@@ -297,7 +356,7 @@ const Printer = struct {
             try self.writer.writeAll(self.lexeme(lbl));
         }
         try self.writer.writeByte('\n');
-        try self.writeBodyBlock(s.body);
+        try self.writeBodyBlock(s.body, s.span.end);
         try self.writeIndent();
         try self.writer.writeAll("end");
     }
@@ -309,7 +368,9 @@ const Printer = struct {
             try self.writer.writeAll(self.lexeme(lbl));
         }
         try self.writer.writeByte('\n');
-        try self.writeBodyBlock(s.body);
+        // Body is closed by `until`, which sits just before the cond at
+        // `span.end`; bounding there flushes any pre-`until` comment.
+        try self.writeBodyBlock(s.body, s.span.end);
         try self.writeIndent();
         try self.writer.writeAll("until ");
         try self.writeExpr(s.cond, .lowest);
@@ -321,6 +382,7 @@ const Printer = struct {
         try self.writer.writeByte('\n');
         self.indent += 1;
         for (s.arms) |arm| {
+            try self.flushLeading(arm.pattern.span().start);
             try self.writeIndent();
             try self.writer.writeAll("case ");
             try self.writePattern(arm.pattern);
@@ -332,12 +394,15 @@ const Printer = struct {
             if (arm.body.len == 1 and isSingleLineStatement(arm.body[0])) {
                 try self.writer.writeByte(' ');
                 try self.writeStatementInline(arm.body[0]);
+                try self.flushTrailing(arm.body[0].span().end);
                 try self.writer.writeByte('\n');
             } else {
+                // Arm boundary (next case) isn't a clean offset → null.
                 try self.writer.writeByte('\n');
-                try self.writeBodyBlock(arm.body);
+                try self.writeBodyBlock(arm.body, null);
             }
         }
+        try self.flushLeading(s.span.end);
         self.indent -= 1;
         try self.writeIndent();
         try self.writer.writeAll("end");
@@ -382,11 +447,11 @@ const Printer = struct {
             try self.writer.writeAll(" -> ");
             try self.writeTypeAnn(r);
         }
-        if (d.body.len == 0 and hasAnnotationNamed(d.annotations, "abstract")) {
-            return; // abstract method — no body
+        if (d.body.len == 0 and hasAnnotationNamed(self.source, d.annotations, "abstract")) {
+            return; // abstract method — no body, no `end`
         }
         try self.writer.writeByte('\n');
-        try self.writeBodyBlock(d.body);
+        try self.writeBodyBlock(d.body, d.span.end);
         try self.writeIndent();
         try self.writer.writeAll("end");
     }
@@ -421,6 +486,7 @@ const Printer = struct {
         try self.writer.writeByte('\n');
         self.indent += 1;
         for (d.fields) |f| {
+            try self.flushLeading(f.span.start);
             try self.writeIndent();
             try self.writeAnnotations(f.annotations);
             try self.writer.writeAll("let ");
@@ -433,15 +499,19 @@ const Printer = struct {
                 try self.writer.writeAll(" = ");
                 try self.writeExpr(init_, .lowest);
             }
+            try self.flushTrailing(f.span.end);
             try self.writer.writeByte('\n');
         }
         if (d.fields.len > 0 and d.methods.len > 0) try self.writer.writeByte('\n');
         for (d.methods, 0..) |m, i| {
             if (i > 0) try self.writer.writeByte('\n');
+            try self.flushLeading(m.span.start);
             try self.writeIndent();
             try self.writeDefDecl(m);
+            try self.flushTrailing(m.span.end);
             try self.writer.writeByte('\n');
         }
+        try self.flushLeading(d.span.end);
         self.indent -= 1;
         try self.writeIndent();
         try self.writer.writeAll("end");
@@ -455,12 +525,15 @@ const Printer = struct {
         try self.writer.writeByte('\n');
         self.indent += 1;
         for (d.fields) |f| {
+            try self.flushLeading(f.span.start);
             try self.writeIndent();
             try self.writer.writeAll(self.lexeme(f.name));
             try self.writer.writeAll(": ");
             try self.writeTypeAnn(f.type_ann);
+            try self.flushTrailing(f.span.end);
             try self.writer.writeByte('\n');
         }
+        try self.flushLeading(d.span.end);
         self.indent -= 1;
         try self.writeIndent();
         try self.writer.writeAll("end");
@@ -474,6 +547,7 @@ const Printer = struct {
         try self.writer.writeByte('\n');
         self.indent += 1;
         for (d.variants) |v| {
+            try self.flushLeading(v.span.start);
             try self.writeIndent();
             try self.writer.writeAll("case ");
             try self.writer.writeAll(self.lexeme(v.name));
@@ -492,8 +566,10 @@ const Printer = struct {
                 }
                 try self.writer.writeByte(')');
             }
+            try self.flushTrailing(v.span.end);
             try self.writer.writeByte('\n');
         }
+        try self.flushLeading(d.span.end);
         self.indent -= 1;
         try self.writeIndent();
         try self.writer.writeAll("end");
@@ -762,11 +838,11 @@ const Printer = struct {
             .do_expr => |d| {
                 if (d.is_bake) try self.writer.writeAll("bake ");
                 try self.writer.writeAll("do\n");
-                try self.writeBodyBlock(d.body);
+                try self.writeBodyBlock(d.body, d.span.end);
                 try self.writeIndent();
                 try self.writer.writeAll("end");
             },
-            .if_expr => |ie| try self.writeIfChain(ie.arms, ie.else_body),
+            .if_expr => |ie| try self.writeIfChain(ie.arms, ie.else_body, ie.span.end),
             .lambda => |l| try self.writeLambda(l),
             .list_lit => |ll| {
                 try self.writer.writeByte('[');
@@ -889,7 +965,7 @@ const Printer = struct {
             try self.writeTypeAnn(r);
         }
         try self.writer.writeByte('\n');
-        try self.writeBodyBlock(l.body);
+        try self.writeBodyBlock(l.body, l.span.end);
         try self.writeIndent();
         try self.writer.writeAll("end");
     }
@@ -920,12 +996,14 @@ fn binOpLexeme(op: ast.BinaryOp) []const u8 {
     };
 }
 
-fn hasAnnotationNamed(anns: []const ast.Annotation, _name: []const u8) bool {
-    _ = anns;
-    _ = _name;
-    // The parser already stripped `@abstract` bodies from the AST
-    // (body is empty). We don't need to inspect annotations here —
-    // a body-less def_decl is the signal. Reserved for future use.
+/// `true` when `anns` carries an annotation whose name lexeme equals
+/// `name`. Lets the printer tell an abstract method (body-less +
+/// `@abstract` → no `end`) from an empty-bodied regular def (`def f()
+/// end` → keeps its `end`); both have `body.len == 0`.
+fn hasAnnotationNamed(source: []const u8, anns: []const ast.Annotation, name: []const u8) bool {
+    for (anns) |a| {
+        if (std.mem.eql(u8, source[a.name.start..a.name.end], name)) return true;
+    }
     return false;
 }
 

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -931,7 +931,6 @@ pub const Checker = struct {
         for (arms, 0..) |arm, i| {
             if (arm.cond) |c| _ = try self.inferExpr(c, null);
             if (arm.let_expr) |e| _ = try self.inferExpr(e, null);
-            if (arm.let_guard) |g| _ = try self.inferExpr(g, null);
 
             const arm_gain: ?[]const u8 = if (i == 0 and nil_flow != null and nil_flow.?.is_neq)
                 nil_flow.?.name
@@ -944,6 +943,17 @@ pub const Checker = struct {
                 (if (c.* == .is_test) c.is_test.classBinding() else null)
             else
                 null;
+
+            // `if let PAT = expr [when guard]` binds PAT for the guard
+            // and the arm body. Open a child scope and register the
+            // bindings first — mirrors match-arm scoping — so the guard
+            // and body resolve the names (§4.4.1).
+            const saved = self.current_scope;
+            var child: Scope = .init(self.arena, saved);
+            self.current_scope = &child;
+            defer self.current_scope = saved;
+            if (arm.let_pattern) |pat| try self.registerPatternBindings(pat);
+            if (arm.let_guard) |g| _ = try self.inferExpr(g, null);
             try self.walkArmBodyWithIsBinding(arm.body, is_binding);
             if (added) self.popNonNil(arm_gain.?);
         }
@@ -992,8 +1002,15 @@ pub const Checker = struct {
     fn checkWhile(self: *Checker, ws: ast.WhileStmt) WalkError!void {
         if (ws.cond) |c| _ = try self.inferExpr(c, null);
         if (ws.let_expr) |e| _ = try self.inferExpr(e, null);
+        // `while let PAT = expr [when guard]` binds PAT for the guard
+        // and loop body — same scoping as `if let` / match arms.
+        const saved = self.current_scope;
+        var child: Scope = .init(self.arena, saved);
+        self.current_scope = &child;
+        defer self.current_scope = saved;
+        if (ws.let_pattern) |pat| try self.registerPatternBindings(pat);
         if (ws.let_guard) |g| _ = try self.inferExpr(g, null);
-        try self.walkInScope(ws.body);
+        try self.walkStatementSequence(ws.body);
     }
 
     fn checkFor(self: *Checker, fs: ast.ForStmt) WalkError!void {

--- a/tests/lang/lexer.test.zig
+++ b/tests/lang/lexer.test.zig
@@ -438,3 +438,22 @@ test "lex: char literal compares natural in expressions" {
         .eq_eq, .int_lit,
     });
 }
+
+test "tokenize: line comments captured off the token stream" {
+    var ts = try tokenize("-- header\nlet x = 1  -- trailing\n");
+    defer ts.deinit();
+    // Comments don't perturb the grammar stream — still `let x = 1`.
+    try std.testing.expectEqual(Token.Kind.kw_let, ts.tokens[0].kind);
+    // Both comments are recorded in source order with their spans.
+    const src = "-- header\nlet x = 1  -- trailing\n";
+    try std.testing.expectEqual(@as(usize, 2), ts.comments.len);
+    try std.testing.expectEqualStrings("-- header", src[ts.comments[0].start..ts.comments[0].end]);
+    try std.testing.expectEqualStrings("-- trailing", src[ts.comments[1].start..ts.comments[1].end]);
+}
+
+test "tokenize: `x--` decrement is not captured as a comment" {
+    var ts = try tokenize("x--\n");
+    defer ts.deinit();
+    try std.testing.expectEqual(@as(usize, 0), ts.comments.len);
+    try std.testing.expectEqual(Token.Kind.minus_minus, ts.tokens[1].kind);
+}

--- a/tests/lang/print.test.zig
+++ b/tests/lang/print.test.zig
@@ -38,7 +38,7 @@ fn renderSource(source: []const u8) ![]u8 {
     var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
     defer writer.deinit();
 
-    try gero.lang.print(&writer.writer, &tree.program, source);
+    try gero.lang.print(&writer.writer, &tree.program, source, tree.comments);
     return writer.toOwnedSlice();
 }
 
@@ -518,6 +518,34 @@ test "print: idempotent on nested expressions" {
 
 test "print: idempotent on HOF chains" {
     try expectIdempotent("let r = xs.filter(|x| x > 0).map(|x| x * 2)");
+}
+
+// ---------- comments ----------
+
+test "print: preserves a leading line comment" {
+    try expectPrint("-- a greeting\nlet x = 1", "-- a greeting\nlet x = 1\n");
+}
+
+test "print: preserves a trailing line comment inline" {
+    try expectPrint("let x = 1  -- the answer-ish", "let x = 1 -- the answer-ish\n");
+}
+
+test "print: keeps a comment trailing the last statement in a body" {
+    try expectPrint(
+        "def f()\n  return 0  -- done\nend",
+        "def f()\n  return 0 -- done\nend\n",
+    );
+}
+
+test "print: idempotent with comments throughout a def" {
+    try expectIdempotent(
+        \\-- module header
+        \\def f(x)
+        \\  -- leading
+        \\  let y = x + 1  -- trailing
+        \\  return y
+        \\end
+    );
 }
 
 // ---------- fixture-driven round-trip property ----------

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -248,9 +248,8 @@ test "typecheck: shadowing across scopes is allowed" {
 }
 
 test "typecheck: if let binds the pattern in guard and body" {
-    // Regression: `if let` used to infer the matched expr but never
-    // register the pattern's bindings, so `n` read as undefined in
-    // both the `when` guard and the body (§4.4.1).
+    // The `when` guard and the arm body both resolve the pattern's
+    // bindings — here `n` from `E.A(n)` (§4.4.1).
     try expectClean(
         \\enum E
         \\  case A(x: i16)

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -247,6 +247,42 @@ test "typecheck: shadowing across scopes is allowed" {
     );
 }
 
+test "typecheck: if let binds the pattern in guard and body" {
+    // Regression: `if let` used to infer the matched expr but never
+    // register the pattern's bindings, so `n` read as undefined in
+    // both the `when` guard and the body (§4.4.1).
+    try expectClean(
+        \\enum E
+        \\  case A(x: i16)
+        \\  case B
+        \\end
+        \\
+        \\def f(e: E) -> i16
+        \\  if let E.A(n) = e when n > 0
+        \\    return n
+        \\  end
+        \\  return 0
+        \\end
+    );
+}
+
+test "typecheck: while let binds the pattern in the loop body" {
+    try expectClean(
+        \\enum E
+        \\  case A(x: i16)
+        \\  case B
+        \\end
+        \\
+        \\def f(e: E) -> i16
+        \\  let acc: i16 = 0
+        \\  while let E.A(v) = e
+        \\    return v
+        \\  end
+        \\  return acc
+        \\end
+    );
+}
+
 // ---------- slice 2: function signature registration ----------
 
 test "typecheck: def signature registered in scope" {


### PR DESCRIPTION
## What

Completes `.gr` (gero-lang) coverage for `gero fmt` and `gero check`, and — because validating it against the doc examples surfaced real gaps — makes the `.gr` formatter lossless and fixes two pre-existing bugs it depended on.

> Scope grew during review (each step uncovered the next). Reviewable as five commits, each a self-contained concern.

## Commits

1. **`fix(apps/gero-cli)`** — de-duplicate lexer diagnostics in `gero check .gr`. `parse` already folds lexer errors into `tree.errors`, so the check path double-reported every lexer diagnostic.
2. **`feat(apps/gero-cli)`** — `gero fmt --stdin --lang=<gas|gr>`. Stdin has no filename to dispatch on, so the front-end is explicit (default `gas`). Path mode still dispatches on extension.
3. **`feat(lang)`** — preserve comments through the `.gr` formatter. Lexer captures `-- …` line comments as a side-table (off the token stream), parser carries them on `ParseTree.comments`, printer re-emits leading/standalone/trailing comments at statement/field/case/arm boundaries. Lossless + idempotent. Also fixes a formatter bug where body-less `@abstract` methods got a spurious `end` (`hasAnnotationNamed` was a stub returning `false`).
4. **`fix(lang)`** — `if let` / `while let` now bind their pattern variables into the guard + body scope (mirrors `match`). Previously `if let E.A(n) = e when n > 0` reported `n` undefined.
5. **`docs(examples)`** — modernize `syntax_overview.gr` (66 retired-syntax fixes + type fixes so it actually compiles) and canonicalize `playground.gr`. Both now parse + fmt-clean with every comment intact; `syntax_overview.gr` also typechecks.

## Acceptance criteria (#200)

- [x] `gero fmt --check main.gr` → exit 8 unformatted, 0 formatted
- [x] `gero fmt --stdin --lang=gr` reads stdin, writes canonical form to stdout
- [x] `gero check main.gr` surfaces parse + type errors with carets
- [x] `gero check --format=json` produces jsonl for `.gr`
- [x] `gero fmt` idempotent on every `.gr` fixture (now including comments)
- [x] All four release modes pass (`zig build ci` green)

## Tests

- `cli.zig`: `--lang` parsing + `needsValue` regression. `fmt.zig`: `emitStdin` exit codes. `check.zig`: `collectGrDiagnostics` dedup.
- `lexer.test.zig`: comment capture (off the stream; `x--` not a comment). `print.test.zig`: leading/trailing/body comments + idempotence. `typecheck.test.zig`: `if let` / `while let` binding scope.

## Public API

`gero.lang.print` takes a `comments` slice (`&.{}` for AST round-trip callers). New: `gero.lang.Comment`, `TokenStream.comments`, `ParseTree.comments`.

## Notes

- `playground.gr` is an intentionally-incomplete syntax fragment (references illustrative externals); its contract is fmt round-trip, not typecheck — unchanged.
- The `.gr` doc examples still aren't wired into a CI gate, so they can drift again. A `fmt --check` / `check` gate for `docs/examples/*.gr` would prevent it — flagging as a possible follow-up rather than expanding this PR further.

Closes #200.