### PR TITLE
docs(lang): state the strong-typing guarantee

### DIFF
--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -175,6 +175,14 @@ See §3.7 for the canonical list.
 
 ## 3. Type system
 
+gero-lang is **strongly, statically typed**. Every binding and every
+expression has a concrete type known at compile time — there is no
+`any`, no dynamic value, and no implicit escape hatch. Where a type
+can't be resolved (an unbound payload, an unannotated empty
+collection, a missing inference), that's a **type error**, not a
+silent fallback. Conversions across types are always explicit (`as`,
+§3.5.1).
+
 ### 3.1 Primitive types
 
 | Type | Width | Range |


### PR DESCRIPTION
Opens §3 (Type system) with the guarantee the language makes: gero-lang is **strongly, statically typed** — every binding and expression has a concrete compile-time type, there is no `any` / dynamic value, and an unresolvable type is a **type error**, not a silent fallback.

This records the principle directing the codegen + typecheck backlog (#303–#316): the typechecker's current accept-and-bind-untyped spots (pattern payloads, loop vars, array elements, stdlib returns) are bugs against this guarantee, and each affected issue is annotated to assign the concrete type rather than fall through to unknown.

Docs-only.