### PR TITLE
feat(lang/codegen): lower struct literals as inline values

### DIFF
--- a/.changeset/lang-codegen-struct-values.md
+++ b/.changeset/lang-codegen-struct-values.md
@@ -1,0 +1,35 @@
+---
+bump: minor
+---
+
+Struct literals now lower as values — `Foo { ... }` constructs, and
+struct-typed bindings carry full value semantics (§3.4).
+
+A struct value lives inline as contiguous frame bytes; a struct-typed
+expression evaluates to that base address. Construction writes each
+field at its offset (recursing into nested struct fields), and
+assignment copies the bytes, so `let b = a; b.x = 1` leaves `a`
+untouched. Field read/write, nested structs (`o.n.v`), and byte-packed
+layouts (`u8` fields take one byte) all work.
+
+Structs cross call boundaries by value:
+
+- **Pass-by-value** — a struct argument is copied onto the stack at its
+  full (2-aligned) width, so a callee mutating its parameter never
+  affects the caller. Works for free functions, class methods (incl.
+  `super.method` and constructor `init` args), and `@inline` callees.
+- **Return-by-value** — a struct-returning function receives a hidden
+  destination pointer (sret) and copies its result there; the caller
+  reads it from a per-frame scratch buffer. Interrupt-safe (no reliance
+  on a freed callee frame). Covers free functions, methods (via vtable
+  dispatch), and `@inline` callees.
+
+Structs are also usable as inline class fields (`let pos: P` stores the
+struct's bytes inside the instance) with by-value field read/write.
+
+A pre-existing bug surfaced and fixed along the way: `@inline` call
+arguments were evaluated after the caller's locals went out of scope,
+so a local passed to an inlined function failed to resolve. Inline args
+now materialize in the caller's scope before the body splice.
+
+Closes #307.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -434,7 +434,7 @@ features.
 | Inheritance | None | Single inheritance + `extends` |
 | Memory cost | Sum of field bytes | 2-byte vtable pointer + sum of field bytes |
 | Construction | Literal: `Stats { hp: 100, mp: 30, ... }` | Constructor call: `Player("Cecil")` (calls `init`) |
-| Passing semantics | By value (copied at assignment / arg passing) | By reference (vtable pointer copied; instance shared) |
+| Passing semantics | By value (copied at assignment, argument passing, and return) | By reference (vtable pointer copied; instance shared) |
 | Identity | None (structurally equal if fields equal) | Yes (two `Player` instances are distinct even with equal fields) |
 | Use case | "value" — stats, position, range, span, color | "entity" — player, monster, scene, game-state |
 

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -21,6 +21,9 @@ const tc_suggestions = @import("lang/typecheck/suggestions.zig");
 const tc_type_resolve = @import("lang/typecheck/type_resolve.zig");
 const tc_fields = @import("lang/typecheck/fields.zig");
 const tc_operators = @import("lang/typecheck/operators.zig");
+const tc_diagnostics = @import("lang/typecheck/diagnostics.zig");
+const tc_decls = @import("lang/typecheck/decls.zig");
+const tc_class_check = @import("lang/typecheck/class_check.zig");
 const tc_calls = @import("lang/typecheck/calls.zig");
 const bake_mod = @import("lang/bake.zig");
 const cg_opcodes = @import("lang/codegen/opcodes.zig");
@@ -31,7 +34,11 @@ const cg_pattern = @import("lang/codegen/pattern.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 const cg_class = @import("lang/codegen/class.zig");
-const cg_struct = @import("lang/codegen/struct_.zig");
+const cg_value_struct = @import("lang/codegen/value_struct.zig");
+const cg_inline_call = @import("lang/codegen/inline_call.zig");
+const cg_globals = @import("lang/codegen/globals.zig");
+const cg_def = @import("lang/codegen/def.zig");
+const cg_statements = @import("lang/codegen/statements.zig");
 const cg_lambda = @import("lang/codegen/lambda.zig");
 const cg_isa = @import("lang/codegen/isa.zig");
 
@@ -161,6 +168,12 @@ pub const internal = struct {
         pub const operators = tc_operators;
         /// Call type-checking: regular, assert builtins, variadic (§4.6.2), bake (§3.8).
         pub const calls = tc_calls;
+        /// Diagnostic emission + symbol-suggestion helpers.
+        pub const diagnostics = tc_diagnostics;
+        /// Pass-1 top-level name registration.
+        pub const decls = tc_decls;
+        /// `def` / `class` declaration checking + inheritance rules.
+        pub const class_check = tc_class_check;
     };
 
     /// Codegen submodule seams.
@@ -191,9 +204,17 @@ pub const internal = struct {
         pub const class = cg_class;
         /// Inline value-struct lowering (construction, field rw, value-copy,
         /// pass-by-value, return-by-value via sret).
-        pub const struct_ = cg_struct;
+        pub const value_struct = cg_value_struct;
         /// Closure lowering (capture analysis, heap promotion, dispatch).
         pub const lambda = cg_lambda;
+        /// `@inline` call expansion (body splice + size gate).
+        pub const inline_call = cg_inline_call;
+        /// Global placement (`@addr` / `@zero_page` / data) + bake-const eval.
+        pub const globals = cg_globals;
+        /// Per-def emission (prologue + body + epilogue) + call patching.
+        pub const def = cg_def;
+        /// Leaf statement lowering (let / const / assign / return / print).
+        pub const statements = cg_statements;
         /// ISA-instruction emit helpers.
         pub const isa = cg_isa;
     };

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -31,6 +31,7 @@ const cg_pattern = @import("lang/codegen/pattern.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 const cg_class = @import("lang/codegen/class.zig");
+const cg_struct = @import("lang/codegen/struct_.zig");
 const cg_lambda = @import("lang/codegen/lambda.zig");
 const cg_isa = @import("lang/codegen/isa.zig");
 
@@ -188,6 +189,9 @@ pub const internal = struct {
         pub const control_flow = cg_control_flow;
         /// Class lowering (vtable + constructor + field rw + method dispatch).
         pub const class = cg_class;
+        /// Inline value-struct lowering (construction, field rw, value-copy,
+        /// pass-by-value, return-by-value via sret).
+        pub const struct_ = cg_struct;
         /// Closure lowering (capture analysis, heap promotion, dispatch).
         pub const lambda = cg_lambda;
         /// ISA-instruction emit helpers.

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -4,7 +4,10 @@ const types_mod = @import("types.zig");
 const typecheck_mod = @import("typecheck.zig");
 const diag_mod = @import("diagnostic.zig");
 const opcodes = @import("codegen/opcodes.zig");
-const disasm_decoder = @import("../disasm/decoder.zig");
+/// Instruction decoder, re-exported so codegen submodules reach it
+/// without a deep relative import (the `@inline` size gate decodes its
+/// spliced body to count real instructions).
+pub const disasm_decoder = @import("../disasm/decoder.zig");
 const archive = @import("codegen/archive.zig");
 const mem_builtin = @import("codegen/mem_builtin.zig");
 const strings = @import("codegen/strings.zig");
@@ -12,8 +15,11 @@ const pattern = @import("codegen/pattern.zig");
 const expr_emit = @import("codegen/expr.zig");
 const control_flow = @import("codegen/control_flow.zig");
 const class = @import("codegen/class.zig");
-const struct_emit = @import("codegen/struct_.zig");
 const lambda = @import("codegen/lambda.zig");
+const inline_call = @import("codegen/inline_call.zig");
+const globals = @import("codegen/globals.zig");
+const def_emit = @import("codegen/def.zig");
+const statements = @import("codegen/statements.zig");
 const isa = @import("codegen/isa.zig");
 const bake_mod = @import("bake.zig");
 
@@ -246,25 +252,6 @@ fn findEntryDef(source: []const u8, program: *const ast.Program, entry_name: []c
     return null;
 }
 
-/// The binary operator a compound-assignment desugars to —
-/// `+=` → `+`, `<<=` → `<<`, and so on. `.set` has no binary form.
-fn compoundBinaryOp(op: ast.AssignOp) ast.BinaryOp {
-    return switch (op) {
-        // plain `=` never reaches this desugar helper
-        .set => unreachable,
-        .add_set => .add,
-        .sub_set => .sub,
-        .mul_set => .mul,
-        .div_set => .div,
-        .mod_set => .mod,
-        .bit_and_set => .bit_and,
-        .bit_or_set => .bit_or,
-        .bit_xor_set => .bit_xor,
-        .shl_set => .shl,
-        .shr_set => .shr,
-    };
-}
-
 /// `true` when `dd` carries a bare flag annotation named `name`.
 /// Module-level helper so emit-loop branches in `emitProgram` can
 /// route on `@cold` / `@interrupt` / etc. without spinning up a
@@ -376,7 +363,7 @@ pub const LoopFrame = struct {
 /// One top-level `let` / `const` global. Addressed by `@addr`
 /// literal, `@zero_page` (from `zp_cursor`), or the data region
 /// (from `data_cursor`).
-const Global = struct {
+pub const Global = struct {
     /// Resolved absolute address.
     address: u16,
     /// Byte width: 1 for `u8`/`bool`/`char`; 2 for 16-bit
@@ -635,7 +622,7 @@ pub const Emitter = struct {
     /// Reserve `bytes` (2-aligned) of frame space and return the base
     /// offset, without registering a name. For anonymous slots (inline
     /// arg bindings) whose names bind into a scope set up afterward.
-    fn reserveFrameSlot(self: *Emitter, bytes: u16) i8 {
+    pub fn reserveFrameSlot(self: *Emitter, bytes: u16) i8 {
         const slot: u16 = alignUpU16(bytes, 2);
         const new_frame_bytes = self.frame_bytes + slot;
         // @as: i8 covers -128..127; the prologue caps total frame size.
@@ -1061,275 +1048,32 @@ pub const Emitter = struct {
         const tramp_offset: u16 = @intCast(self.code.items.len);
         self.trampoline_addr = code_base + tramp_offset;
 
-        // push mb
+        // Save the caller's bank, switch via r2, call the target in r1,
+        // restore. The byte sequence is the listing in the doc above.
         try self.emitByte(Op.push_reg);
         try self.emitByte(Reg.mb);
-        // mov r2, mb
         try isa.movRegToReg(self, Reg.r2, Reg.mb);
-        // call r1
         try self.emitByte(Op.call_reg);
         try self.emitByte(Reg.r1);
-        // pop mb
         try self.emitByte(Op.pop_reg);
         try self.emitByte(Reg.mb);
-        // ret
         try self.emitByte(Op.ret_op);
     }
 
-    /// Register every top-level `let` / `const` as a `Global`.
-    /// Placement rule:
-    /// 1. `@addr $XXXX` → that literal address.
-    /// 2. `@zero_page` → next `zp_cursor` slot (overflow →
-    ///    `E_CODEGEN_ZP_OVERFLOW`).
-    /// 3. `@align(N)` → pad the cursor to a multiple of `N`.
-    /// 4. No annotation → next `data_cursor` slot.
+    /// Register every top-level `let` / `const` as a `Global` —
+    /// placement + bake-const eval in `codegen/globals.zig`.
     fn registerGlobals(self: *Emitter, program: *const ast.Program) !void {
-        for (program.statements) |*stmt| switch (stmt.*) {
-            .let_decl => |*d| try self.registerGlobalLet(d),
-            .const_decl => |*d| try self.registerGlobalConst(d),
-            else => {},
-        };
+        return globals.registerGlobals(self, program);
     }
 
-    fn registerGlobalLet(self: *Emitter, d: *const ast.LetDecl) !void {
-        if (d.pattern.* != .ident) return; // destructuring at top-level — slice later
-        const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
-        const width = self.widthOfLetDecl(d);
-        try self.placeGlobal(name, width, d.annotations, d.pattern.ident.name);
-    }
-
-    fn registerGlobalConst(self: *Emitter, d: *const ast.ConstDecl) !void {
-        const name = self.source[d.name.start..d.name.end];
-        // Run the bake evaluator first so the resulting value
-        // tells us both the storage width AND the bytes to write
-        // into the data region. Non-bake initializers fall back
-        // to the type-annotation-driven width path.
-        const baked: ?bake_mod.BakeValue = try self.evalConstIfBake(d);
-        const width: u16 = if (baked) |v| @intCast(bake_mod.widthOf(v)) else self.widthOfConstDecl(d);
-        try self.placeGlobal(name, width, d.annotations, d.name);
-
-        if (baked) |v| {
-            const g = self.globals.get(name) orelse return;
-            const bytes = try self.arena.alloc(u8, bake_mod.widthOf(v));
-            _ = bake_mod.serialize(v, bytes);
-            try self.bake_inits.put(self.allocator, g.address, bytes);
-        }
-    }
-
-    /// Evaluate a `const X = …` initializer when the RHS is a
-    /// `bake do` block or a `bake def` call. `null` for
-    /// non-bake initializers.
-    fn evalConstIfBake(self: *Emitter, d: *const ast.ConstDecl) !?bake_mod.BakeValue {
-        switch (d.init.*) {
-            .do_expr => |do| {
-                if (!do.is_bake) return null;
-                return try self.runBake(d.span, .{ .do_expr = &d.init.do_expr });
-            },
-            .call => |c| {
-                if (c.callee.* != .ident) return null;
-                const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
-                const decl = self.bake_defs.get(callee_name) orelse return null;
-                // Top-level entry call: args must be literal /
-                // const-foldable.
-                const args = try self.arena.alloc(bake_mod.BakeValue, c.args.len);
-                for (c.args, 0..) |a, i| {
-                    args[i] = bake_mod.literalAsBakeValue(self.source, a) orelse {
-                        try self.diagFatal(a.span(), "E_BAKE_UNSUPPORTED", "bake-call args at top-level must be literal values");
-                        return null;
-                    };
-                }
-                return try self.runBakeDef(d.span, decl, args);
-            },
-            else => return null,
-        }
-    }
-
-    /// Tagged input to `runBake` — pick the entry shape so a
-    /// single helper handles the diagnostic plumbing.
-    const BakeEntry = union(enum) {
-        do_expr: *const ast.DoExpr,
-    };
-
-    fn runBake(self: *Emitter, span: ast.Span, entry: BakeEntry) !?bake_mod.BakeValue {
-        const opts: bake_mod.Options = .{ .bake_defs = &self.bakeDefsAdapter() };
-        var result = switch (entry) {
-            .do_expr => |de| try bake_mod.evaluateDo(self.allocator, self.source, de, opts),
-        };
-        defer result.deinit(self.allocator);
-        for (result.diagnostics) |diag| {
-            try self.diagnostics.append(self.allocator, .{
-                .severity = diag.severity,
-                .code = diag.code,
-                .message = try self.diag_arena.dupe(u8, diag.message),
-                .span = diag.span,
-            });
-        }
-        if (result.value == null) {
-            try self.diagFatal(span, "E_BAKE_UNSUPPORTED", "bake evaluation failed; see diagnostics above");
-            return null;
-        }
-        return try bake_mod.cloneBakeValue(self.arena, result.value.?);
-    }
-
-    fn runBakeDef(self: *Emitter, span: ast.Span, decl: *const ast.DefDecl, args: []const bake_mod.BakeValue) !?bake_mod.BakeValue {
-        const adapter = self.bakeDefsAdapter();
-        const opts: bake_mod.Options = .{ .bake_defs = &adapter };
-        var result = try bake_mod.evaluateDef(self.allocator, self.source, decl, args, opts);
-        defer result.deinit(self.allocator);
-        for (result.diagnostics) |diag| {
-            try self.diagnostics.append(self.allocator, .{
-                .severity = diag.severity,
-                .code = diag.code,
-                .message = try self.diag_arena.dupe(u8, diag.message),
-                .span = diag.span,
-            });
-        }
-        if (result.value == null) {
-            try self.diagFatal(span, "E_BAKE_UNSUPPORTED", "bake evaluation failed; see diagnostics above");
-            return null;
-        }
-        return try bake_mod.cloneBakeValue(self.arena, result.value.?);
-    }
-
-    /// Snapshot the bake-def index into the std-StringHashMap
-    /// shape the evaluator expects. The evaluator borrows the
-    /// map for the duration of one call; we rebuild the snapshot
-    /// each time so any future bake-def discovery stays visible.
-    fn bakeDefsAdapter(self: *Emitter) std.StringHashMap(*const ast.DefDecl) {
-        var map = std.StringHashMap(*const ast.DefDecl).init(self.arena);
-        var it = self.bake_defs.iterator();
-        while (it.next()) |e| {
-            // allow-strict: copies fit in the same arena that owns `bake_defs`; OOM here would have surfaced upstream.
-            map.put(e.key_ptr.*, e.value_ptr.*) catch unreachable;
-        }
-        return map;
-    }
-
-    fn placeGlobal(
-        self: *Emitter,
-        name: []const u8,
-        width: u16,
-        annotations: []const ast.Annotation,
-        decl_span: ast.Span,
-    ) !void {
-        var pinned_addr: ?u16 = null;
-        var zero_page: bool = false;
-        var align_n: ?u16 = null;
-        for (annotations) |ann| {
-            const ann_name = self.source[ann.name.start..ann.name.end];
-            if (std.mem.eql(u8, ann_name, "addr") and ann.args.len == 1 and ann.args[0].* == .int_lit) {
-                // @as: parser stores int_lit.value as i32; address literals are always non-negative per spec §3.7.1; truncating to u16 preserves bytes.
-                pinned_addr = @intCast(ann.args[0].int_lit.value & 0xFFFF);
-            } else if (std.mem.eql(u8, ann_name, "zero_page")) {
-                zero_page = true;
-            } else if (std.mem.eql(u8, ann_name, "align") and ann.args.len == 1 and ann.args[0].* == .int_lit) {
-                // @as: typechecker verified the value is a power of two; coercing i32 → u16 fits the alignment range.
-                align_n = @intCast(ann.args[0].int_lit.value & 0xFFFF);
-            }
-        }
-        const dup = try self.arena.dupe(u8, name);
-
-        if (pinned_addr) |addr| {
-            try self.globals.put(self.arena, dup, .{
-                .address = addr,
-                .width = width,
-                .placement = .addr,
-            });
-            return;
-        }
-        if (zero_page) {
-            if (align_n) |n| self.zp_cursor = alignUpU16(self.zp_cursor, n);
-            const zp_end: u16 = self.zp_cursor + width;
-            if (zp_end > 0x100) {
-                try self.diagFatal(decl_span, "E_CODEGEN_ZP_OVERFLOW", "zero-page region exhausted — too many `@zero_page` globals");
-                return;
-            }
-            try self.globals.put(self.arena, dup, .{
-                .address = self.zp_cursor,
-                .width = width,
-                .placement = .zero_page,
-            });
-            self.zp_cursor += width;
-            return;
-        }
-        // Dynamic data region.
-        if (align_n) |n| self.data_cursor = alignUpU16(self.data_cursor, n);
-        try self.globals.put(self.arena, dup, .{
-            .address = self.data_cursor,
-            .width = width,
-            .placement = .data,
-        });
-        self.data_cursor += width;
-    }
-
-    /// 1 for `i8` / `u8` / `bool` / `char`, 2 otherwise. Type-name
-    /// resolution is purely lexical against the type annotation;
-    /// the typechecker has already validated that the name refers
-    /// to a primitive or a registered user-type.
-    fn widthOfLetDecl(self: *const Emitter, d: *const ast.LetDecl) u16 {
-        if (d.type_ann) |t| return self.widthOfTypeAnn(t.*);
-        // No annotation — default to the widest primitive (2 bytes).
-        return 2;
-    }
-
-    fn widthOfConstDecl(self: *const Emitter, d: *const ast.ConstDecl) u16 {
-        if (d.type_ann) |t| return self.widthOfTypeAnn(t.*);
-        return 2;
-    }
-
-    /// Emit a load of `g`'s value into `acu`. The instruction
-    /// shape depends on the placement family + byte width.
+    /// Load `g`'s value into `acu` — see `codegen/globals.zig`.
     pub fn emitGlobalLoad(self: *Emitter, g: Global) !void {
-        switch (g.placement) {
-            .addr => {
-                if (g.width == 1) {
-                    try isa.mov8AddrToReg(self, g.address, Reg.acu);
-                } else {
-                    try isa.movAddrToReg(self, g.address, Reg.acu);
-                }
-            },
-            .zero_page => {
-                // @as: zero-page address fits in u8; placement.zero_page guarantees address ≤ 0xFF.
-                const zp: u8 = @intCast(g.address);
-                if (g.width == 1) {
-                    try isa.mov8ZpToReg(self, zp, Reg.acu);
-                } else {
-                    try isa.movZpToReg(self, zp, Reg.acu);
-                }
-            },
-            .data => {
-                if (g.width == 1) {
-                    try isa.mov8AddrToReg(self, g.address, Reg.acu);
-                } else {
-                    try isa.movAddrToReg(self, g.address, Reg.acu);
-                }
-            },
-        }
+        return globals.emitGlobalLoad(self, g);
     }
 
-    /// Emit a store of `src` reg's value into `g`'s slot. Byte-
-    /// width globals use `movl` (low-byte store) so the
-    /// neighboring byte stays untouched — critical for MMIO where
-    /// adjacent addresses are distinct registers.
-    fn emitGlobalStore(self: *Emitter, src: u8, g: Global) !void {
-        switch (g.placement) {
-            .addr, .data => {
-                if (g.width == 1) {
-                    try isa.movlRegToAddr(self, src, g.address);
-                } else {
-                    try isa.movRegToAddr(self, src, g.address);
-                }
-            },
-            .zero_page => {
-                // @as: zero-page address fits in u8; placement.zero_page guarantees address ≤ 0xFF.
-                const zp: u8 = @intCast(g.address);
-                if (g.width == 1) {
-                    try isa.movlRegToZp(self, src, zp);
-                } else {
-                    try isa.movRegToZp(self, src, zp);
-                }
-            },
-        }
+    /// Store `src` into `g`'s slot — see `codegen/globals.zig`.
+    pub fn emitGlobalStore(self: *Emitter, src: u8, g: Global) !void {
+        return globals.emitGlobalStore(self, src, g);
     }
 
     /// Byte width of a type annotation: 1 for `i8`/`u8`/`bool`/
@@ -1378,189 +1122,23 @@ pub const Emitter = struct {
         };
     }
 
-    const DefKind = enum { entry, regular };
+    /// Whether a def is the program entry point (epilogue `hlt`, frame
+    /// starts with `fp == sp`) or a regular fn (`ret` epilogue).
+    pub const DefKind = enum { entry, regular };
 
-    /// Emit one def: prologue + body + epilogue. Resets per-fn
-    /// state for a fresh frame view.
+    /// Emit one def: prologue + body + epilogue — see `codegen/def.zig`.
     fn emitDef(self: *Emitter, def: *const ast.DefDecl, kind: DefKind) !void {
-        const name = self.source[def.name.start..def.name.end];
-        return self.emitDefWithLabel(def, kind, name);
+        return def_emit.emitDef(self, def, kind);
     }
 
-    /// Emit a method as a plain def under a mangled
-    /// `ClassName.methodName` label. Threads
-    /// `current_class_name` so `super` resolves correctly.
+    /// Emit a method as a plain def under a mangled label.
     pub fn emitMethodAsDef(self: *Emitter, def: *const ast.DefDecl, class_name: []const u8, label: []const u8) !void {
-        const saved = self.current_class_name;
-        self.current_class_name = class_name;
-        defer self.current_class_name = saved;
-        return self.emitDefWithLabel(def, .regular, label);
+        return def_emit.emitMethodAsDef(self, def, class_name, label);
     }
 
-    fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, label: []const u8) !void {
-        // Detect `@bank N` annotation — drives bank routing for
-        // this def's body bytes + the fn's resolved address.
-        // `@interrupt N` swaps the body epilogue from `ret` to
-        // `rti` (pop flg/fp/ip in reverse of entry).
-        var bank_target: ?u8 = null;
-        var is_isr: bool = false;
-        for (def.annotations) |ann| {
-            const ann_name = self.source[ann.name.start..ann.name.end];
-            if (std.mem.eql(u8, ann_name, "bank") and ann.args.len == 1 and ann.args[0].* == .int_lit) {
-                // @as: typechecker enforces u8 range on `@bank N`.
-                bank_target = @intCast(ann.args[0].int_lit.value & 0xFF);
-            } else if (std.mem.eql(u8, ann_name, "interrupt")) {
-                is_isr = true;
-            }
-        }
-
-        // Save + restore per-fn state.
-        const saved_locals = self.locals;
-        const saved_params = self.params;
-        const saved_frame = self.frame_bytes;
-        const saved_entry = self.is_entry;
-        const saved_isr = self.is_isr;
-        const saved_bank = self.current_bank;
-        const saved_ret_struct = self.current_ret_struct;
-        const saved_sret_param = self.sret_param_ofs;
-        const saved_sret_scratch = self.sret_scratch_ofs;
-        self.locals = .{};
-        self.params = .{};
-        self.frame_bytes = 0;
-        self.is_entry = (kind == .entry);
-        self.is_isr = is_isr;
-        self.current_bank = bank_target;
-        self.sret_scratch_ofs = null;
-        defer {
-            self.locals = saved_locals;
-            self.params = saved_params;
-            self.frame_bytes = saved_frame;
-            self.is_entry = saved_entry;
-            self.is_isr = saved_isr;
-            self.current_bank = saved_bank;
-            self.current_ret_struct = saved_ret_struct;
-            self.sret_param_ofs = saved_sret_param;
-            self.sret_scratch_ofs = saved_sret_scratch;
-        }
-
-        const dup_name = try self.arena.dupe(u8, label);
-        // @as: narrow usize code offset to u16; per-buffer offset stays ≤ 64 KiB.
-        const code_offset: u16 = @intCast(try self.currentOffset());
-        const addr: u16 = if (bank_target) |_|
-            bank_window_base + code_offset
-        else
-            code_base + code_offset;
-        try self.fn_addresses.put(self.arena, dup_name, addr);
-
-        // Bind params to positive fp-relative offsets. `call` left
-        // the stack as: [low] ret_ip, old_fp, arg_N-1, ..., arg_1,
-        // arg_0 [high] (per right-to-left push order at the call
-        // site). fp points at ret_ip, so param 0 is at fp+4,
-        // param 1 at fp+6, etc.
-        // Each param sits just above the previous one; a struct param
-        // occupies its full width (passed by value), so offsets sum
-        // widths rather than stepping a fixed 2 bytes.
-        var param_ofs: i32 = 4;
-        for (def.params) |p| {
-            const p_name = self.source[p.name.start..p.name.end];
-            const dup_p = try self.arena.dupe(u8, p_name);
-            // @as: i8 fp-offset; the frame-size cap keeps offsets in range.
-            try self.params.put(self.arena, dup_p, @intCast(param_ofs));
-            param_ofs += self.paramWidthAligned(p);
-        }
-
-        // A struct-returning def takes a hidden sret destination pointer
-        // just above its last user param (the caller pushes it first).
-        // `return` copies the result there instead of into `acu`.
-        self.current_ret_struct = if (def.ret_type) |rt| self.structNameOfTypeAnn(rt.*) else null;
-        // @as: sits past the params; the frame-size cap keeps it small.
-        self.sret_param_ofs = @intCast(param_ofs);
-
-        // Reserve local slots up front (cheap fixed reservation —
-        // a real allocator would compute live ranges). The sret scratch
-        // buffer (holds a returned struct until its consumer copies it
-        // out) is carved first so its offset is stable across the body.
-        const scratch_bytes: u16 = self.global_sret_scratch;
-        const frame_bytes = self.countFrameBytes(def.body);
-        // @as: frame size capped well below u16 by the i8 offset cap.
-        const reserve_bytes: u16 = @intCast(frame_bytes + scratch_bytes);
-        if (reserve_bytes > 0) try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
-        if (scratch_bytes > 0) self.sret_scratch_ofs = try self.allocLocalSized("\x00sret", scratch_bytes);
-
-        // Closure-analysis pre-pass — populates fn_closure_info
-        // with the lambda inventory, capture layouts, and the
-        // promotion set. Drives the heap-cell paths in
-        // emitLetDecl / emitIdent / emitAssign + the closure-call
-        // dispatch in emitCall.
-        try lambda.analyzeFn(self, def);
-        defer lambda.resetFnInfo(self);
-
-        // Entry-def prologue: write every `@interrupt N` handler's
-        // address into its IVT slot BEFORE the user body runs.
-        // Boot leaves `flg.I = 0` so an interrupt could otherwise
-        // fire against an uninitialized vector.
-        if (self.is_entry) try self.emitIvtInit();
-
-        // Function body opens the outermost block of the frame —
-        // `defer`s at the top of the body run before the implicit
-        // epilogue's `hlt` / `ret` / `rti`.
-        try self.pushBlock();
-        for (def.body) |stmt| try self.emitStatement(stmt);
-        try self.popBlockWithDefers();
-
-        // Implicit epilogue (no explicit `return`).
-        if (self.is_entry) {
-            try isa.hlt(
-                self,
-            );
-        } else if (is_isr) {
-            // ISR teardown — pop flg/fp/ip in reverse of entry.
-            try self.emitByte(Op.rti_op);
-        } else {
-            // `ret` resets sp = fp then pops ret_ip + old_fp. The
-            // VM handles the whole tear-down; we just need to land
-            // the return value in acu (callers read from there).
-            try self.emitByte(Op.ret_op);
-        }
-
-        // Emit any lambda bodies discovered during analyzeFn —
-        // they emit as plain defs adjacent to the parent so their
-        // call sites + closure-creation patches resolve normally.
-        try lambda.emitLambdaBodies(self, def);
-    }
-
-    /// Rewrite each unresolved call's 2-byte address slot.
-    /// Unknown callees emit `E_CODEGEN_UNDEFINED_FN`.
+    /// Resolve forward-reference call sites — see `codegen/def.zig`.
     fn patchCalls(self: *Emitter) !void {
-        for (self.call_patches.items) |p| {
-            const target_addr: u16 = switch (p.target) {
-                .fn_name => |name| self.fn_addresses.get(name) orelse {
-                    const msg = try std.fmt.allocPrint(
-                        self.diag_arena,
-                        "codegen: call target `{s}` is not a known top-level def",
-                        .{name},
-                    );
-                    try self.diagnostics.append(self.allocator, .{
-                        .severity = .fatal,
-                        .code = "E_CODEGEN_UNDEFINED_FN",
-                        .message = msg,
-                        .span = p.span,
-                    });
-                    continue;
-                },
-                .trampoline => self.trampoline_addr orelse continue,
-            };
-            // Resolve which buffer holds this patch — base or
-            // one of the bank ArrayLists.
-            const buf: []u8 = if (p.bank) |b|
-                if (self.banks.getPtr(b)) |bl| bl.items else continue
-            else
-                self.code.items;
-            // Overwrite the 2-byte LE address slot.
-            // safety: u16 → 2 bytes by definition; both casts are byte-masks.
-            buf[p.code_offset] = @intCast(target_addr & 0xFF);
-            buf[p.code_offset + 1] = @intCast(target_addr >> 8);
-        }
+        return def_emit.patchCalls(self);
     }
 
     // ---------- statement emission ----------
@@ -1758,262 +1336,35 @@ pub const Emitter = struct {
         return 2;
     }
 
-    fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
-        var a = a_in;
-        if (a.op != .set) {
-            // Desugar `target op= value` into `target = (target op value)`
-            // and fall through to the plain-store path — same target
-            // support (ident + class field) as `=`.
-            const rhs = try self.arena.create(ast.Expr);
-            rhs.* = .{ .binary = .{
-                .op = compoundBinaryOp(a.op),
-                .lhs = a.target,
-                .rhs = a.value,
-                .span = a.span,
-            } };
-            a.value = rhs;
-            a.op = .set;
-        }
-        // Field-target assignment — `recv.field = value` on a class
-        // receiver routes to the class field-store path.
-        if (a.target.* == .field) {
-            if (self.classNameOf(a.target.field.receiver)) |cname| {
-                const fname = self.source[a.target.field.field.start..a.target.field.field.end];
-                try class.emitFieldStore(self, a.target.field.receiver, cname, fname, a.value, a.target.field.span);
-                return;
-            }
-            if (self.structNameOf(a.target.field.receiver)) |sname| {
-                const fname = self.source[a.target.field.field.start..a.target.field.field.end];
-                try struct_emit.emitFieldStore(self, a.target.field.receiver, sname, fname, a.value);
-                return;
-            }
-        }
-        if (a.target.* != .ident) {
-            try self.unsupported(a.span, "non-ident assignment targets (field / index)");
-            return;
-        }
-        const name = self.source[a.target.ident.span.start..a.target.ident.span.end];
-        // Struct-typed reassignment (`b = a`) copies the value's bytes
-        // into the binding's slot (§3.4 value semantics).
-        if (self.structNameOf(a.target)) |sname| {
-            if (self.locals.get(name)) |ofs| {
-                try struct_emit.emitInto(self, a.value, sname, ofs);
-                return;
-            }
-        }
-        // Captured-binding write inside a lambda body — store
-        // through the env-relative cell pointer (the parent
-        // promoted the binding so the write is visible everywhere).
-        if (self.captures.get(name)) |slot| {
-            try lambda.emitCaptureStore(self, slot, a.value);
-            return;
-        }
-        // Promoted local in the parent fn — store through the
-        // local-slot cell pointer.
-        if (lambda.isPromoted(self, name)) {
-            if (self.locals.get(name)) |ofs| {
-                try lambda.emitPromotedAssign(self, ofs, a.value);
-                return;
-            }
-        }
-        try self.emitExpr(a.value); // result in acu
-        if (self.locals.get(name)) |ofs| {
-            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
-            return;
-        }
-        if (self.params.get(name)) |ofs| {
-            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
-            return;
-        }
-        if (self.globals.get(name)) |g| {
-            try self.emitGlobalStore(Reg.acu, g);
-            return;
-        }
-        try self.unsupported(a.target.span(), "assignment target not in scope");
+    /// `target = value` (and compound / inc-dec desugarings) — see
+    /// `codegen/statements.zig`.
+    fn emitAssign(self: *Emitter, a: ast.AssignStmt) !void {
+        return statements.emitAssign(self, a);
     }
 
-    /// `target++` / `target--` — desugars to `target = target ± 1` and
-    /// reuses the assignment path.
+    /// `target++` / `target--` — see `codegen/statements.zig`.
     fn emitIncDec(self: *Emitter, id: ast.IncDecStmt) !void {
-        const one = try self.arena.create(ast.Expr);
-        one.* = .{ .int_lit = .{ .value = 1, .span = id.span } };
-        const rhs = try self.arena.create(ast.Expr);
-        rhs.* = .{ .binary = .{
-            .op = if (id.inc) .add else .sub,
-            .lhs = id.target,
-            .rhs = one,
-            .span = id.span,
-        } };
-        try self.emitAssign(.{ .target = id.target, .op = .set, .value = rhs, .span = id.span });
+        return statements.emitIncDec(self, id);
     }
 
+    /// `let` binding lowering — see `codegen/statements.zig`.
     fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
-        if (d.pattern.* != .ident) {
-            try self.unsupported(d.span, "non-ident `let` patterns");
-            return;
-        }
-        const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
-        const dup_name = try self.arena.dupe(u8, name);
-
-        // Struct-typed binding: reserve the full inline slot and
-        // materialize the initializer (literal fields or a value copy)
-        // straight into it (§3.4 value semantics).
-        const struct_name: ?[]const u8 = if (d.type_ann) |t|
-            self.structNameOfTypeAnn(t.*)
-        else if (d.init) |e|
-            self.structNameOf(e)
-        else
-            null;
-        if (struct_name) |sname| {
-            const slot = try self.allocLocalSized(dup_name, self.structWidth(sname));
-            if (d.init) |init_expr| try struct_emit.emitInto(self, init_expr, sname, slot);
-            return;
-        }
-
-        const ofs = try self.allocLocal(dup_name);
-        // Promoted bindings live as heap cells — the slot holds
-        // the cell pointer instead of the value directly.
-        if (lambda.isPromoted(self, name)) {
-            try lambda.emitPromotedLetInit(self, d.init, ofs);
-            return;
-        }
-        if (d.init) |init_expr| {
-            try self.emitExpr(init_expr); // result in acu
-            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
-        }
-        // Uninitialized let leaves the slot at whatever the prologue
-        // memset gave it (sub_imm pads sp downward without zeroing).
+        return statements.emitLetDecl(self, d);
     }
 
+    /// `const` binding lowering — see `codegen/statements.zig`.
     fn emitConstDecl(self: *Emitter, d: ast.ConstDecl) !void {
-        const name = self.source[d.name.start..d.name.end];
-        const dup_name = try self.arena.dupe(u8, name);
-        const ofs = try self.allocLocal(dup_name);
-        try self.emitExpr(d.init);
-        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+        return statements.emitConstDecl(self, d);
     }
 
+    /// `return [value]` lowering — see `codegen/statements.zig`.
     fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
-        if (r.value) |v| {
-            if (self.inline_ret_struct) |sname| {
-                // Inlined struct return: materialize into the caller-
-                // frame result slot, then leave its address in `acu`.
-                try struct_emit.emitInto(self, v, sname, self.inline_ret_slot);
-                try isa.movRegToReg(self, Reg.fp, Reg.acu);
-                const slot = self.inline_ret_slot; // negative — a caller-frame local
-                // @as: widen i8 → i16 so negating the min value is safe; |slot| ≤ frame cap fits u16.
-                if (slot < 0) try isa.subImmFromReg(self, @intCast(-@as(i16, slot)), Reg.acu);
-            } else if (self.current_ret_struct) |sname| {
-                // Struct return: copy the value into the caller's sret
-                // buffer, then leave that buffer's address in `acu` (a
-                // struct value *is* an address).
-                try struct_emit.emitIntoSret(self, v, sname, self.sret_param_ofs);
-                try isa.movRegToReg(self, Reg.fp, Reg.acu);
-                if (self.sret_param_ofs > 0) try isa.addImmToReg(self, @intCast(self.sret_param_ofs), Reg.acu);
-                try isa.movRegOffsetToReg(self, Reg.acu, 0, Reg.acu);
-            } else {
-                try self.emitExpr(v);
-            }
-        }
-        // Defers attached to every still-active block fire before
-        // the frame tears down — innermost first, LIFO within each
-        // block. `acu` carries the return value through the cleanup
-        // (the defer-emitter saves / restores it).
-        try self.unwindAllDefersForReturn();
-        if (self.inline_returns) |*returns| {
-            // Inside an `@inline` body — redirect `return` to a
-            // forward jmp to the after-inlined site. Patch slot
-            // queued for resolution after the body emits.
-            try self.emitByte(Op.jmp_addr);
-            const patch = try self.currentOffset();
-            try self.emitU16Le(0);
-            try returns.append(self.allocator, patch);
-            return;
-        }
-        if (self.is_entry) {
-            try isa.hlt(
-                self,
-            );
-        } else if (self.is_isr) {
-            try self.emitByte(Op.rti_op);
-        } else {
-            try self.emitByte(Op.ret_op);
-        }
+        return statements.emitReturnStmt(self, r);
     }
 
-    /// Emit `mov_imm16_addr <handler>, ivt_base + 2*vec` for every
-    /// `@interrupt N` handler. Handler addresses patch later via
-    /// `call_patches`. Runs at the top of the entry body.
-    fn emitIvtInit(self: *Emitter) !void {
-        for (self.interrupt_defs.items) |handler| {
-            try self.emitByte(Op.mov_imm16_addr);
-            const addr_patch_offset = try self.currentOffset();
-            // 2-byte imm slot — will be patched with the handler's
-            // resolved address.
-            try self.emitU16Le(0);
-            // 2-byte addr slot — IVT slot for this vector (known
-            // at emit time, no patch needed).
-            // @as: widen u8 vector to u16 before doubling so the wrap-add against ivt_base stays in u16.
-            const slot: u16 = ivt_base +% (@as(u16, handler.vector) *% 2);
-            try self.emitU16Le(slot);
-            try self.call_patches.append(self.allocator, .{
-                .bank = self.current_bank,
-                .code_offset = addr_patch_offset,
-                .target = .{ .fn_name = handler.def_name },
-                .span = .{ .start = 0, .end = 0 },
-            });
-        }
-    }
-
+    /// `print a, b, …` lowering — see `codegen/statements.zig`.
     fn emitPrintStmt(self: *Emitter, p: ast.PrintStmt) !void {
-        for (p.args, 0..) |arg, i| {
-            if (i > 0) {
-                // Space separator between args per spec §4.9.
-                try isa.movImmToReg(self, ' ', Reg.acu);
-                try isa.sys(self, Sys.print_char);
-            }
-            try self.emitPrintArg(arg);
-        }
-        // Trailing newline per spec §4.9.
-        try isa.sys(self, Sys.print_newline);
-    }
-
-    /// Emit one `print` argument. Routes to the right syscall by
-    /// the arg's inferred type (spec §4.9):
-    ///
-    /// - `char` → `print_char`.
-    /// - `fixed` → `print_fixed`.
-    /// - String literals: per-part emission for interpolations.
-    /// - `str` non-literal → `print_str`.
-    /// - Otherwise → `print_int`.
-    fn emitPrintArg(self: *Emitter, arg: *const ast.Expr) !void {
-        if (arg.* == .str_lit) {
-            try self.emitPrintStrLit(arg.str_lit);
-            return;
-        }
-        if (self.isPrimitiveType(arg, .char)) {
-            try self.emitExpr(arg);
-            try isa.sys(self, Sys.print_char);
-            return;
-        }
-        if (self.isPrimitiveType(arg, .fixed)) {
-            try self.emitExpr(arg);
-            try isa.sys(self, Sys.print_fixed);
-            return;
-        }
-        if (self.isPrimitiveType(arg, .str)) {
-            try self.emitExpr(arg);
-            try isa.sys(self, Sys.print_str);
-            return;
-        }
-        // A struct has no scalar rendering — `print p` would otherwise
-        // emit `print_int` of its base address. Print fields explicitly.
-        if (self.structNameOf(arg)) |_| {
-            try self.unsupported(arg.span(), "printing a whole struct — print its fields instead");
-            return;
-        }
-        try self.emitExpr(arg);
-        try isa.sys(self, Sys.print_int);
+        return statements.emitPrintStmt(self, p);
     }
 
     /// Delegated to `codegen/strings.zig`.
@@ -2068,148 +1419,10 @@ pub const Emitter = struct {
     /// Max `@inline` nesting depth.
     pub const inline_max_depth: u8 = 8;
 
-    /// Splice an `@inline` callee's body at the current emit
-    /// position. Args land in fresh locals in the caller's frame;
-    /// `return` in the body redirects to a jmp past the splice.
-    /// Body size capped at `inline_body_instruction_cap` (over →
-    /// `E_ANN_INLINE_TOO_LARGE`).
-    pub fn emitInlineCall(
-        self: *Emitter,
-        callee: *const ast.DefDecl,
-        c: ast.CallExpr,
-    ) !void {
-        if (self.inline_depth >= inline_max_depth) {
-            try self.diagFatal(c.span, "E_ANN_INLINE_RECURSIVE", "codegen: `@inline` def expanded past nesting cap — likely recursive inlining");
-            return;
-        }
-        self.inline_depth += 1;
-        defer self.inline_depth -= 1;
-
-        if (c.args.len != callee.params.len) {
-            try self.diagFatal(c.span, "E_ANN_INLINE_ARITY", "codegen: `@inline` call arity mismatch — typechecker should have flagged");
-            return;
-        }
-
-        // Bind args → fresh locals in the caller's frame. Each local
-        // extends `frame_bytes` and stays addressable for the body's
-        // emit (gero pre-reserves the whole frame at the def's
-        // prologue, so a new sub-imm-from-sp is needed for the inline-
-        // only slots). Args are materialized in the CALLER's scope
-        // (locals still live), then their slots bind into the fresh
-        // body scope below.
-        const Binding = struct { name: []const u8, ofs: i8 };
-        const bindings = try self.arena.alloc(Binding, callee.params.len);
-        for (callee.params, c.args, bindings) |p, arg, *b| {
-            const dup = try self.arena.dupe(u8, self.source[p.name.start..p.name.end]);
-            // A struct param binds to a full-width local materialized by
-            // value; a scalar param to a single word.
-            if (self.argStructName(arg)) |sname| {
-                const w = self.structSlotWidth(sname);
-                try isa.subImmFromReg(self, w, Reg.sp);
-                const ofs = self.reserveFrameSlot(w);
-                try struct_emit.emitInto(self, arg, sname, ofs);
-                b.* = .{ .name = dup, .ofs = ofs };
-            } else {
-                try isa.subImmFromReg(self, 2, Reg.sp);
-                try expr_emit.emitExpr(self, arg);
-                const ofs = self.reserveFrameSlot(2);
-                try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
-                b.* = .{ .name = dup, .ofs = ofs };
-            }
-        }
-
-        const saved_locals = self.locals;
-        const saved_params = self.params;
-        self.locals = .{};
-        self.params = .{};
-        defer {
-            self.locals = saved_locals;
-            self.params = saved_params;
-        }
-        for (bindings) |b| try self.locals.put(self.arena, b.name, b.ofs);
-
-        // A struct-returning inline materializes its result into a
-        // caller-frame slot (no callee frame exists to hold it); each
-        // `return` writes there and leaves the slot's address in `acu`.
-        const saved_inline_ret = self.inline_ret_struct;
-        const saved_inline_slot = self.inline_ret_slot;
-        defer {
-            self.inline_ret_struct = saved_inline_ret;
-            self.inline_ret_slot = saved_inline_slot;
-        }
-        if (callee.ret_type) |rt| if (self.structNameOfTypeAnn(rt.*)) |sname| {
-            const w = self.structWidth(sname);
-            try isa.subImmFromReg(self, self.structSlotWidth(sname), Reg.sp);
-            self.inline_ret_struct = sname;
-            self.inline_ret_slot = self.reserveFrameSlot(w);
-        };
-
-        // Body-emit setup: capture starting offset for the
-        // instruction-count gate; install a fresh inline_returns
-        // collector so nested `return` statements rewrite to a
-        // forward jmp instead of `ret`.
-        const start_offset = try self.currentOffset();
-        const saved_returns = self.inline_returns;
-        self.inline_returns = std.ArrayList(usize).empty;
-        defer self.inline_returns = saved_returns;
-
-        // Lambdas inside `@inline` bodies are unsupported
-        // (their mangled labels would collide across call sites).
-        const saved_fn_info = self.fn_closure_info;
-        defer self.fn_closure_info = saved_fn_info;
-        try lambda.analyzeFn(self, callee);
-        if (self.fn_closure_info.lambdas.items.len > 0) {
-            const name = self.source[callee.name.start..callee.name.end];
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "`@inline` def `{s}` declares a lambda in its body — unsupported (lambdas need a host def, but inlined bodies don't emit one)",
-                .{name},
-            );
-            try self.diagFatal(c.span, "E_ANN_INLINE_LAMBDA_BODY", msg);
-            return;
-        }
-
-        try self.pushBlock();
-        for (callee.body) |stmt| try self.emitStatement(stmt);
-        try self.popBlockWithDefers();
-
-        // Patch every `return`-redirected jmp to land HERE (after
-        // the body). The return value is in `acu` and stays there
-        // for the caller — matches the regular-call ABI.
-        const end_offset = try self.currentOffset();
-        const end_addr: u16 = self.codeOffsetToAddress(end_offset);
-        if (self.inline_returns) |*returns| {
-            const buf: []u8 = self.currentBufferMut();
-            for (returns.items) |patch| {
-                buf[patch] = @intCast(end_addr & 0xFF);
-                buf[patch + 1] = @intCast((end_addr >> 8) & 0xFF);
-            }
-            returns.deinit(self.allocator);
-        }
-
-        // Size gate: the body must emit ≤ 32 instructions. Walk
-        // the spliced bytes via the disasm decoder so the count
-        // matches what the ISA considers an instruction (not "Zig
-        // emit calls").
-        const buf: []const u8 = self.currentBufferMut();
-        var inst_count: usize = 0;
-        var cursor: usize = start_offset;
-        while (cursor < end_offset) {
-            const dec = disasm_decoder.decodeOne(self.allocator, buf, cursor) catch break;
-            defer self.allocator.free(dec.instruction.operands);
-            inst_count += 1;
-            if (cursor == dec.next_offset) break;
-            cursor = dec.next_offset;
-        }
-        if (inst_count > inline_body_instruction_cap) {
-            const name = self.source[callee.name.start..callee.name.end];
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "`@inline` body of `{s}` lowers to {d} instructions — over the cap of {d}",
-                .{ name, inst_count, inline_body_instruction_cap },
-            );
-            try self.diagFatal(c.span, "E_ANN_INLINE_TOO_LARGE", msg);
-        }
+    /// Splice an `@inline` callee's body at the call site — see
+    /// `codegen/inline_call.zig`.
+    pub fn emitInlineCall(self: *Emitter, callee: *const ast.DefDecl, c: ast.CallExpr) !void {
+        return inline_call.emitInlineCall(self, callee, c);
     }
 
     /// Emit the debug-symbol section. Includes resolved fn
@@ -2255,7 +1468,7 @@ pub const Emitter = struct {
 
     /// Resolve a code-buffer offset to its run-time address.
     /// Picks `bank_window_base` or `code_base` from `current_bank`.
-    fn codeOffsetToAddress(self: *const Emitter, offset: usize) u16 {
+    pub fn codeOffsetToAddress(self: *const Emitter, offset: usize) u16 {
         // @as: per-buffer offsets stay ≤ 64 KiB by ISA constraint.
         const ofs: u16 = @intCast(offset);
         return if (self.current_bank != null) bank_window_base + ofs else code_base + ofs;
@@ -2263,7 +1476,7 @@ pub const Emitter = struct {
 
     /// Mutable view into the active code buffer. Used for emit-
     /// time slot patches.
-    fn currentBufferMut(self: *Emitter) []u8 {
+    pub fn currentBufferMut(self: *Emitter) []u8 {
         if (self.current_bank) |b| {
             if (self.banks.getPtr(b)) |bl| return bl.items;
         }
@@ -2288,7 +1501,7 @@ pub const Emitter = struct {
     }
 
     /// Delegated to `codegen/control_flow.zig`.
-    fn unwindAllDefersForReturn(self: *Emitter) !void {
+    pub fn unwindAllDefersForReturn(self: *Emitter) !void {
         return control_flow.unwindAllDefersForReturn(self);
     }
 

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -12,6 +12,7 @@ const pattern = @import("codegen/pattern.zig");
 const expr_emit = @import("codegen/expr.zig");
 const control_flow = @import("codegen/control_flow.zig");
 const class = @import("codegen/class.zig");
+const struct_emit = @import("codegen/struct_.zig");
 const lambda = @import("codegen/lambda.zig");
 const isa = @import("codegen/isa.zig");
 const bake_mod = @import("bake.zig");
@@ -128,9 +129,16 @@ pub fn compile(
         .frame_bytes = 0,
         .is_entry = false,
         .is_isr = false,
+        .current_ret_struct = null,
+        .sret_param_ofs = 0,
+        .sret_scratch_ofs = null,
+        .inline_ret_struct = null,
+        .inline_ret_slot = 0,
         .fn_addresses = .{},
         .fn_banks = .{},
         .noreturn_defs = .{},
+        .fn_ret_struct = .{},
+        .global_sret_scratch = 0,
         .inline_defs = .{},
         .interrupt_defs = .empty,
         .inline_returns = null,
@@ -432,6 +440,25 @@ pub const Emitter = struct {
     /// Emitting the body of an `@interrupt N` def. Flips `return`
     /// lowering to `rti`.
     is_isr: bool,
+    /// Struct return-type name of the def currently being emitted, or
+    /// `null` for a scalar-returning def. When set, `return` copies the
+    /// value into the caller-provided sret buffer.
+    current_ret_struct: ?[]const u8,
+    /// fp-offset of the hidden sret destination pointer in the current
+    /// frame (`4 + Σ user-param widths` — it sits just above the last
+    /// user param). Valid only while `current_ret_struct` is set.
+    sret_param_ofs: i16,
+    /// fp-offset of this frame's sret scratch buffer (a returned
+    /// struct's holding space), or `null` when the program returns no
+    /// structs.
+    sret_scratch_ofs: ?i16,
+    /// While splicing a struct-returning `@inline` body: the struct
+    /// name + the caller-frame slot its `return` materializes into
+    /// (`acu` then holds that slot's address). `null` outside such an
+    /// inline. Takes precedence over the sret path — an inlined body
+    /// has no callee frame, so its result lives in a caller local.
+    inline_ret_struct: ?[]const u8,
+    inline_ret_slot: i8,
     /// `def` name → absolute address. Banked defs live in the
     /// bank window; un-banked defs live in the base image.
     fn_addresses: std.StringHashMapUnmanaged(u16),
@@ -442,6 +469,16 @@ pub const Emitter = struct {
     /// `def` names carrying `@noreturn`. `emitCall` skips the
     /// post-call epilogue for these.
     noreturn_defs: std.StringHashMapUnmanaged(void),
+    /// `def` name → struct return-type name, for the ones that return
+    /// a struct by value. Drives the sret calling convention: the
+    /// caller passes a hidden destination pointer and the callee copies
+    /// its result there (§3.4). Absent → returns a scalar in `acu`.
+    fn_ret_struct: std.StringHashMapUnmanaged([]const u8),
+    /// Largest (2-aligned) struct return width across the program — the
+    /// size of the per-frame sret scratch buffer that holds a returned
+    /// struct until its consumer copies it out. 0 when no def returns a
+    /// struct.
+    global_sret_scratch: u16,
     /// `def` names carrying `@inline`. `emitCall` inlines the
     /// body rather than emitting `call addr`.
     inline_defs: std.StringHashMapUnmanaged(*const ast.DefDecl),
@@ -581,77 +618,132 @@ pub const Emitter = struct {
     /// Reserve a 2-byte slot for `name` at the next fp-relative
     /// offset. Returns the offset (negative — locals grow down).
     pub fn allocLocal(self: *Emitter, name: []const u8) !i8 {
-        const new_frame_bytes = self.frame_bytes + 2;
-        // @as: i8 covers -128..127; with 2 bytes per slot we cap at 64 locals per frame, fits.
-        const ofs: i8 = -@as(i8, @intCast(new_frame_bytes));
+        return self.allocLocalSized(name, 2);
+    }
+
+    /// Allocate a frame slot of `bytes` (rounded up to a 2-byte
+    /// boundary so word access stays aligned) and return the offset
+    /// of its base. Multi-byte slots back inline value aggregates —
+    /// a struct local occupies its full width, addressed as
+    /// `[fp + ofs + field_offset]`.
+    pub fn allocLocalSized(self: *Emitter, name: []const u8, bytes: u16) !i8 {
+        const ofs = self.reserveFrameSlot(bytes);
         try self.locals.put(self.arena, name, ofs);
-        self.frame_bytes = new_frame_bytes;
         return ofs;
     }
 
-    /// Conservatively count locals the body could need so the
-    /// prologue can `sub frame_bytes, sp`. Reserves slots for
+    /// Reserve `bytes` (2-aligned) of frame space and return the base
+    /// offset, without registering a name. For anonymous slots (inline
+    /// arg bindings) whose names bind into a scope set up afterward.
+    fn reserveFrameSlot(self: *Emitter, bytes: u16) i8 {
+        const slot: u16 = alignUpU16(bytes, 2);
+        const new_frame_bytes = self.frame_bytes + slot;
+        // @as: i8 covers -128..127; the prologue caps total frame size.
+        const ofs: i8 = -@as(i8, @intCast(new_frame_bytes));
+        self.frame_bytes = @intCast(new_frame_bytes);
+        return ofs;
+    }
+
+    /// Byte width of a checked type. Mirrors `widthOfTypeAnn` but over
+    /// `types.Type` — 1 for `i8`/`u8`/`bool`/`char`, the field sum for
+    /// a named struct, 2 otherwise (16-bit primitives, references,
+    /// class/enum pointers).
+    pub fn widthOfType(self: *const Emitter, ty: *const Type) u16 {
+        switch (ty.*) {
+            .primitive => |p| return switch (p) {
+                .i8, .u8, .bool_, .char => 1,
+                else => 2,
+            },
+            .named => |n| {
+                if (self.struct_decls.get(n.name)) |sd| {
+                    var total: u16 = 0;
+                    for (sd.fields) |f| total +%= self.widthOfTypeAnn(f.type_ann.*);
+                    return total;
+                }
+                return 2;
+            },
+            else => return 2,
+        }
+    }
+
+    /// Bytes of frame space the body could need so the prologue can
+    /// `sub frame_bytes, sp`. A scalar local is 2 bytes; a struct
+    /// local takes its full (2-aligned) width. Reserves space for
     /// every arm of control-flow forms.
-    pub fn countLocalsInBody(self: *const Emitter, body: []const ast.Statement) usize {
+    pub fn countFrameBytes(self: *const Emitter, body: []const ast.Statement) usize {
         var n: usize = 0;
-        for (body) |s| n += self.countLocalsInStmt(s);
+        for (body) |s| n += self.countStmtFrameBytes(s);
         return n;
     }
 
-    fn countLocalsInStmt(self: *const Emitter, stmt: ast.Statement) usize {
+    fn countStmtFrameBytes(self: *const Emitter, stmt: ast.Statement) usize {
         return switch (stmt) {
-            .let_decl, .const_decl => 1,
-            .block => |b| self.countLocalsInBody(b.body),
+            .let_decl => |d| self.letFrameBytes(d),
+            .const_decl => 2,
+            .block => |b| self.countFrameBytes(b.body),
             .if_stmt => |is_| blk: {
                 var n: usize = 0;
                 for (is_.arms) |a| {
-                    if (a.let_pattern) |p| n += countBindingsInPattern(p.*);
+                    if (a.let_pattern) |p| n += countBindingBytes(p.*);
                     // `if expr is Class as h` — `h` parks the
                     // instance pointer in a fresh local slot.
                     if (a.cond) |c| if (c.* == .is_test and c.is_test.classBinding() != null) {
-                        n += 1;
+                        n += 2;
                     };
-                    n += self.countLocalsInBody(a.body);
+                    n += self.countFrameBytes(a.body);
                 }
-                if (is_.else_body) |eb| n += self.countLocalsInBody(eb);
+                if (is_.else_body) |eb| n += self.countFrameBytes(eb);
                 break :blk n;
             },
             .while_stmt => |ws| blk: {
                 var n: usize = 0;
-                if (ws.let_pattern) |p| n += countBindingsInPattern(p.*);
-                n += self.countLocalsInBody(ws.body);
+                if (ws.let_pattern) |p| n += countBindingBytes(p.*);
+                n += self.countFrameBytes(ws.body);
                 break :blk n;
             },
-            // Range-based `for` reserves 1 hidden slot for the
-            // `end` bound (the iteration variable uses its own slot).
-            .for_stmt => |fs| 1 + 1 + self.countLocalsInBody(fs.body),
-            .repeat_stmt => |rs| self.countLocalsInBody(rs.body),
+            // Range-based `for` reserves 1 hidden slot for the `end`
+            // bound (the iteration variable uses its own slot).
+            .for_stmt => |fs| 2 + 2 + self.countFrameBytes(fs.body),
+            .repeat_stmt => |rs| self.countFrameBytes(rs.body),
             .match_stmt => |ms| blk: {
                 // 1 scratch slot to bind the scrutinee when it isn't
                 // already an ident (so subsequent cmps don't re-eval).
-                var n: usize = if (ms.scrutinee.* == .ident) 0 else 1;
+                var n: usize = if (ms.scrutinee.* == .ident) 0 else 2;
                 for (ms.arms) |a| {
-                    n += countBindingsInPattern(a.pattern.*);
-                    n += self.countLocalsInBody(a.body);
+                    n += countBindingBytes(a.pattern.*);
+                    n += self.countFrameBytes(a.body);
                 }
                 break :blk n;
             },
-            .defer_stmt => |ds| self.countLocalsInStmt(ds.body.*),
+            .defer_stmt => |ds| self.countStmtFrameBytes(ds.body.*),
             else => 0,
         };
     }
 
-    /// Count the local-slot bindings a pattern introduces. A bare
-    /// ident binds one; a variant pattern binds one slot per payload
-    /// binder (`E.A(n, m)` → 2). These must be counted so the prologue
-    /// reserves their frame space — an unreserved binder slot would
-    /// overlap the stack-push region used by later binary ops.
-    fn countBindingsInPattern(pat: ast.Pattern) usize {
+    /// Frame bytes a `let` reserves: the 2-aligned width of its type
+    /// (struct fields summed), 2 for scalars. Non-ident patterns
+    /// (destructuring) reserve minimally — lowering them is separate.
+    fn letFrameBytes(self: *const Emitter, d: ast.LetDecl) usize {
+        if (d.pattern.* != .ident) return 2;
+        const w: u16 = if (d.type_ann) |t|
+            self.widthOfTypeAnn(t.*)
+        else if (d.init) |e|
+            (if (self.typeOf(e)) |ty| self.widthOfType(ty) else 2)
+        else
+            2;
+        return alignUpU16(w, 2);
+    }
+
+    /// Frame bytes a pattern's binders introduce. A bare ident binds
+    /// one 2-byte slot; a variant pattern binds one per payload field.
+    /// These must be reserved so a binder slot doesn't overlap the
+    /// stack-push region used by later binary ops.
+    fn countBindingBytes(pat: ast.Pattern) usize {
         return switch (pat) {
-            .ident => 1,
+            .ident => 2,
             .variant_pattern => |vp| blk: {
                 var n: usize = 0;
-                for (vp.args) |arg| n += countBindingsInPattern(arg.*);
+                for (vp.args) |arg| n += countBindingBytes(arg.*);
                 break :blk n;
             },
             else => 0,
@@ -916,6 +1008,11 @@ pub const Emitter = struct {
                     }
                 }
                 try self.fn_banks.put(self.arena, dup, bank);
+                if (dd.ret_type) |rt| if (self.structNameOfTypeAnn(rt.*)) |sname| {
+                    try self.fn_ret_struct.put(self.arena, dup, sname);
+                    const w = self.structSlotWidth(sname);
+                    if (w > self.global_sret_scratch) self.global_sret_scratch = w;
+                };
                 if (noreturn_marked) try self.noreturn_defs.put(self.arena, dup, {});
                 if (inline_marked) try self.inline_defs.put(self.arena, dup, dd);
                 if (interrupt_vec) |vec| {
@@ -1324,12 +1421,16 @@ pub const Emitter = struct {
         const saved_entry = self.is_entry;
         const saved_isr = self.is_isr;
         const saved_bank = self.current_bank;
+        const saved_ret_struct = self.current_ret_struct;
+        const saved_sret_param = self.sret_param_ofs;
+        const saved_sret_scratch = self.sret_scratch_ofs;
         self.locals = .{};
         self.params = .{};
         self.frame_bytes = 0;
         self.is_entry = (kind == .entry);
         self.is_isr = is_isr;
         self.current_bank = bank_target;
+        self.sret_scratch_ofs = null;
         defer {
             self.locals = saved_locals;
             self.params = saved_params;
@@ -1337,6 +1438,9 @@ pub const Emitter = struct {
             self.is_entry = saved_entry;
             self.is_isr = saved_isr;
             self.current_bank = saved_bank;
+            self.current_ret_struct = saved_ret_struct;
+            self.sret_param_ofs = saved_sret_param;
+            self.sret_scratch_ofs = saved_sret_scratch;
         }
 
         const dup_name = try self.arena.dupe(u8, label);
@@ -1353,22 +1457,35 @@ pub const Emitter = struct {
         // arg_0 [high] (per right-to-left push order at the call
         // site). fp points at ret_ip, so param 0 is at fp+4,
         // param 1 at fp+6, etc.
-        for (def.params, 0..) |p, i| {
+        // Each param sits just above the previous one; a struct param
+        // occupies its full width (passed by value), so offsets sum
+        // widths rather than stepping a fixed 2 bytes.
+        var param_ofs: i32 = 4;
+        for (def.params) |p| {
             const p_name = self.source[p.name.start..p.name.end];
             const dup_p = try self.arena.dupe(u8, p_name);
-            // @as: u8 frame index → i8 fp-offset; cap at 62 params → fits.
-            const offset: i8 = @intCast(4 + 2 * @as(i32, @intCast(i)));
-            try self.params.put(self.arena, dup_p, offset);
+            // @as: i8 fp-offset; the frame-size cap keeps offsets in range.
+            try self.params.put(self.arena, dup_p, @intCast(param_ofs));
+            param_ofs += self.paramWidthAligned(p);
         }
 
+        // A struct-returning def takes a hidden sret destination pointer
+        // just above its last user param (the caller pushes it first).
+        // `return` copies the result there instead of into `acu`.
+        self.current_ret_struct = if (def.ret_type) |rt| self.structNameOfTypeAnn(rt.*) else null;
+        // @as: sits past the params; the frame-size cap keeps it small.
+        self.sret_param_ofs = @intCast(param_ofs);
+
         // Reserve local slots up front (cheap fixed reservation —
-        // a real allocator would compute live ranges).
-        const local_count = self.countLocalsInBody(def.body);
-        if (local_count > 0) {
-            // @as: 2 bytes per slot capped well below u16.
-            const reserve_bytes: u16 = @intCast(local_count * 2);
-            try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
-        }
+        // a real allocator would compute live ranges). The sret scratch
+        // buffer (holds a returned struct until its consumer copies it
+        // out) is carved first so its offset is stable across the body.
+        const scratch_bytes: u16 = self.global_sret_scratch;
+        const frame_bytes = self.countFrameBytes(def.body);
+        // @as: frame size capped well below u16 by the i8 offset cap.
+        const reserve_bytes: u16 = @intCast(frame_bytes + scratch_bytes);
+        if (reserve_bytes > 0) try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
+        if (scratch_bytes > 0) self.sret_scratch_ofs = try self.allocLocalSized("\x00sret", scratch_bytes);
 
         // Closure-analysis pre-pass — populates fn_closure_info
         // with the lambda inventory, capture layouts, and the
@@ -1562,6 +1679,85 @@ pub const Emitter = struct {
         return name;
     }
 
+    /// Struct name when `e`'s type is a registered struct (auto-deref
+    /// through a `&T` reference). Structs are inline value aggregates,
+    /// so a struct-typed expression evaluates to its base address.
+    pub fn structNameOf(self: *const Emitter, e: *const ast.Expr) ?[]const u8 {
+        const ty = self.typeOf(e) orelse return null;
+        const inner = if (ty.* == .reference) ty.reference else ty;
+        if (inner.* != .named) return null;
+        const name = inner.named.name;
+        if (!self.struct_decls.contains(name)) return null;
+        return name;
+    }
+
+    /// Layout of one struct field: byte offset, byte width, and — when
+    /// the field is itself a struct — that struct's name (so codegen
+    /// recurses into nested aggregates rather than storing a scalar).
+    pub const FieldInfo = struct { offset: u16, width: u16, struct_name: ?[]const u8 };
+
+    /// `FieldInfo` for `field_name` within `struct_name`, or `null` if
+    /// unknown. Fields are laid out contiguously in declaration order
+    /// (§3.4).
+    pub fn structFieldInfo(self: *const Emitter, struct_name: []const u8, field_name: []const u8) ?FieldInfo {
+        const sd = self.struct_decls.get(struct_name) orelse return null;
+        var ofs: u16 = 0;
+        for (sd.fields) |f| {
+            const w = self.widthOfTypeAnn(f.type_ann.*);
+            if (std.mem.eql(u8, self.source[f.name.start..f.name.end], field_name)) {
+                return .{ .offset = ofs, .width = w, .struct_name = self.structNameOfTypeAnn(f.type_ann.*) };
+            }
+            ofs +%= w;
+        }
+        return null;
+    }
+
+    /// Struct name if `t` names a registered struct, else `null`.
+    pub fn structNameOfTypeAnn(self: *const Emitter, t: ast.TypeAnn) ?[]const u8 {
+        if (t != .named) return null;
+        const name = self.source[t.named.name.start..t.named.name.end];
+        return if (self.struct_decls.contains(name)) name else null;
+    }
+
+    /// Total byte width of struct `struct_name` (its fields summed).
+    pub fn structWidth(self: *const Emitter, struct_name: []const u8) u16 {
+        const sd = self.struct_decls.get(struct_name) orelse return 0;
+        var total: u16 = 0;
+        for (sd.fields) |f| total +%= self.widthOfTypeAnn(f.type_ann.*);
+        return total;
+    }
+
+    /// Struct `struct_name`'s footprint rounded up to a 2-byte slot —
+    /// the word-aligned size used for inline-value frame, param, and
+    /// arg layout.
+    pub fn structSlotWidth(self: *const Emitter, struct_name: []const u8) u16 {
+        return alignUpU16(self.structWidth(struct_name), 2);
+    }
+
+    /// Struct name of a call argument, or `null` for a scalar arg. A
+    /// struct literal carries its name directly; other struct-typed
+    /// expressions resolve through their inferred type. Drives the
+    /// pass-by-value path in free-fn and method calls alike.
+    pub fn argStructName(self: *const Emitter, arg: *const ast.Expr) ?[]const u8 {
+        if (arg.* == .struct_lit) {
+            const name = self.source[arg.struct_lit.type_name.start..arg.struct_lit.type_name.end];
+            return if (self.struct_decls.contains(name)) name else null;
+        }
+        return self.structNameOf(arg);
+    }
+
+    /// Stack footprint of a parameter: a struct param occupies its
+    /// full (2-aligned) width — passed by value as a contiguous copy
+    /// (§3.4) — and a scalar param one word. Drives both the param
+    /// fp-offsets and the caller's arg-push width.
+    pub fn paramWidthAligned(self: *const Emitter, p: ast.Param) u16 {
+        const t = p.type_ann orelse return 2;
+        if (self.structNameOfTypeAnn(t.*)) |sname| {
+            return self.structSlotWidth(sname);
+        }
+        return 2;
+    }
+
     fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
         var a = a_in;
         if (a.op != .set) {
@@ -1586,12 +1782,25 @@ pub const Emitter = struct {
                 try class.emitFieldStore(self, a.target.field.receiver, cname, fname, a.value, a.target.field.span);
                 return;
             }
+            if (self.structNameOf(a.target.field.receiver)) |sname| {
+                const fname = self.source[a.target.field.field.start..a.target.field.field.end];
+                try struct_emit.emitFieldStore(self, a.target.field.receiver, sname, fname, a.value);
+                return;
+            }
         }
         if (a.target.* != .ident) {
             try self.unsupported(a.span, "non-ident assignment targets (field / index)");
             return;
         }
         const name = self.source[a.target.ident.span.start..a.target.ident.span.end];
+        // Struct-typed reassignment (`b = a`) copies the value's bytes
+        // into the binding's slot (§3.4 value semantics).
+        if (self.structNameOf(a.target)) |sname| {
+            if (self.locals.get(name)) |ofs| {
+                try struct_emit.emitInto(self, a.value, sname, ofs);
+                return;
+            }
+        }
         // Captured-binding write inside a lambda body — store
         // through the env-relative cell pointer (the parent
         // promoted the binding so the write is visible everywhere).
@@ -1645,6 +1854,22 @@ pub const Emitter = struct {
         }
         const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
         const dup_name = try self.arena.dupe(u8, name);
+
+        // Struct-typed binding: reserve the full inline slot and
+        // materialize the initializer (literal fields or a value copy)
+        // straight into it (§3.4 value semantics).
+        const struct_name: ?[]const u8 = if (d.type_ann) |t|
+            self.structNameOfTypeAnn(t.*)
+        else if (d.init) |e|
+            self.structNameOf(e)
+        else
+            null;
+        if (struct_name) |sname| {
+            const slot = try self.allocLocalSized(dup_name, self.structWidth(sname));
+            if (d.init) |init_expr| try struct_emit.emitInto(self, init_expr, sname, slot);
+            return;
+        }
+
         const ofs = try self.allocLocal(dup_name);
         // Promoted bindings live as heap cells — the slot holds
         // the cell pointer instead of the value directly.
@@ -1669,7 +1894,27 @@ pub const Emitter = struct {
     }
 
     fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
-        if (r.value) |v| try self.emitExpr(v);
+        if (r.value) |v| {
+            if (self.inline_ret_struct) |sname| {
+                // Inlined struct return: materialize into the caller-
+                // frame result slot, then leave its address in `acu`.
+                try struct_emit.emitInto(self, v, sname, self.inline_ret_slot);
+                try isa.movRegToReg(self, Reg.fp, Reg.acu);
+                const slot = self.inline_ret_slot; // negative — a caller-frame local
+                // @as: widen i8 → i16 so negating the min value is safe; |slot| ≤ frame cap fits u16.
+                if (slot < 0) try isa.subImmFromReg(self, @intCast(-@as(i16, slot)), Reg.acu);
+            } else if (self.current_ret_struct) |sname| {
+                // Struct return: copy the value into the caller's sret
+                // buffer, then leave that buffer's address in `acu` (a
+                // struct value *is* an address).
+                try struct_emit.emitIntoSret(self, v, sname, self.sret_param_ofs);
+                try isa.movRegToReg(self, Reg.fp, Reg.acu);
+                if (self.sret_param_ofs > 0) try isa.addImmToReg(self, @intCast(self.sret_param_ofs), Reg.acu);
+                try isa.movRegOffsetToReg(self, Reg.acu, 0, Reg.acu);
+            } else {
+                try self.emitExpr(v);
+            }
+        }
         // Defers attached to every still-active block fire before
         // the frame tears down — innermost first, LIFO within each
         // block. `acu` carries the return value through the cleanup
@@ -1761,6 +2006,12 @@ pub const Emitter = struct {
             try isa.sys(self, Sys.print_str);
             return;
         }
+        // A struct has no scalar rendering — `print p` would otherwise
+        // emit `print_int` of its base address. Print fields explicitly.
+        if (self.structNameOf(arg)) |_| {
+            try self.unsupported(arg.span(), "printing a whole struct — print its fields instead");
+            return;
+        }
         try self.emitExpr(arg);
         try isa.sys(self, Sys.print_int);
     }
@@ -1839,11 +2090,34 @@ pub const Emitter = struct {
             return;
         }
 
-        // Bind args → fresh locals in the caller's frame. Each
-        // local extends `frame_bytes` and stays addressable for
-        // the body's emit (gero pre-reserves the whole frame at
-        // the def's prologue, so a new sub-imm-from-sp is needed
-        // for the inline-only slots).
+        // Bind args → fresh locals in the caller's frame. Each local
+        // extends `frame_bytes` and stays addressable for the body's
+        // emit (gero pre-reserves the whole frame at the def's
+        // prologue, so a new sub-imm-from-sp is needed for the inline-
+        // only slots). Args are materialized in the CALLER's scope
+        // (locals still live), then their slots bind into the fresh
+        // body scope below.
+        const Binding = struct { name: []const u8, ofs: i8 };
+        const bindings = try self.arena.alloc(Binding, callee.params.len);
+        for (callee.params, c.args, bindings) |p, arg, *b| {
+            const dup = try self.arena.dupe(u8, self.source[p.name.start..p.name.end]);
+            // A struct param binds to a full-width local materialized by
+            // value; a scalar param to a single word.
+            if (self.argStructName(arg)) |sname| {
+                const w = self.structSlotWidth(sname);
+                try isa.subImmFromReg(self, w, Reg.sp);
+                const ofs = self.reserveFrameSlot(w);
+                try struct_emit.emitInto(self, arg, sname, ofs);
+                b.* = .{ .name = dup, .ofs = ofs };
+            } else {
+                try isa.subImmFromReg(self, 2, Reg.sp);
+                try expr_emit.emitExpr(self, arg);
+                const ofs = self.reserveFrameSlot(2);
+                try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+                b.* = .{ .name = dup, .ofs = ofs };
+            }
+        }
+
         const saved_locals = self.locals;
         const saved_params = self.params;
         self.locals = .{};
@@ -1852,14 +2126,23 @@ pub const Emitter = struct {
             self.locals = saved_locals;
             self.params = saved_params;
         }
-        for (callee.params, c.args) |p, arg| {
-            try isa.subImmFromReg(self, 2, Reg.sp);
-            try expr_emit.emitExpr(self, arg);
-            const pname = self.source[p.name.start..p.name.end];
-            const dup = try self.arena.dupe(u8, pname);
-            const ofs = try self.allocLocal(dup);
-            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+        for (bindings) |b| try self.locals.put(self.arena, b.name, b.ofs);
+
+        // A struct-returning inline materializes its result into a
+        // caller-frame slot (no callee frame exists to hold it); each
+        // `return` writes there and leaves the slot's address in `acu`.
+        const saved_inline_ret = self.inline_ret_struct;
+        const saved_inline_slot = self.inline_ret_slot;
+        defer {
+            self.inline_ret_struct = saved_inline_ret;
+            self.inline_ret_slot = saved_inline_slot;
         }
+        if (callee.ret_type) |rt| if (self.structNameOfTypeAnn(rt.*)) |sname| {
+            const w = self.structWidth(sname);
+            try isa.subImmFromReg(self, self.structSlotWidth(sname), Reg.sp);
+            self.inline_ret_struct = sname;
+            self.inline_ret_slot = self.reserveFrameSlot(w);
+        };
 
         // Body-emit setup: capture starting offset for the
         // instruction-count gate; install a fresh inline_returns

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -3,6 +3,7 @@ const ast = @import("../ast.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
+const struct_ = @import("struct_.zig");
 
 const Emitter = codegen_mod.Emitter;
 const Op = opcodes.Op;
@@ -42,6 +43,10 @@ pub const ClassLayout = struct {
 pub const FieldInfo = struct {
     offset: u16,
     width: u8,
+    /// Set when the field is itself a struct value (stored inline in
+    /// the instance) — names that struct so field access recurses into
+    /// it rather than loading a scalar word.
+    struct_name: ?[]const u8 = null,
 };
 
 /// Pre-pass: index every top-level class decl by name. Layouts
@@ -116,11 +121,10 @@ fn computeLayout(self: *Emitter, class_name: []const u8) !void {
     // The parent's slot remains in memory (instance_size already
     // counted it) and stays reachable via `super.X`.
     for (cd.fields) |field| {
-        // Class fields are primitive-width (1) or pointer-width
-        // (2) — aggregates aren't supported as class field types
-        // by the typechecker. Truncate the typecheck-wide u16
-        // back to u8 for the layout entry.
-        // safety: class field widths bounded to 1 or 2 by the typechecker; the truncate is a no-op for that range.
+        // A scalar field is primitive- (1) or pointer-width (2); a
+        // struct field is stored inline at its full width (§3.4).
+        const struct_name: ?[]const u8 = if (field.type_ann) |t| self.structNameOfTypeAnn(t.*) else null;
+        // safety: field widths stay small (structs are POD, <256 bytes); the truncate is lossless in that range.
         const width: u8 = @truncate(if (field.type_ann) |t|
             self.widthOfTypeAnn(t.*)
         else
@@ -130,6 +134,7 @@ fn computeLayout(self: *Emitter, class_name: []const u8) !void {
         try layout.field_offsets.put(self.arena, dup_f, .{
             .offset = layout.instance_size,
             .width = width,
+            .struct_name = struct_name,
         });
         layout.instance_size += width;
     }
@@ -150,6 +155,15 @@ fn computeLayout(self: *Emitter, class_name: []const u8) !void {
             try layout.method_owners.put(self.arena, dup_m, dup_class);
             try layout.method_order.append(self.arena, dup_m);
         }
+    }
+
+    // A struct-returning method needs the same sret scratch buffer as
+    // a free fn — size the per-frame scratch to the widest return.
+    for (cd.methods) |method| {
+        if (method.ret_type) |rt| if (self.structNameOfTypeAnn(rt.*)) |sname| {
+            const w = self.structSlotWidth(sname);
+            if (w > self.global_sret_scratch) self.global_sret_scratch = w;
+        };
     }
 
     try self.class_layouts.put(self.arena, dup_class, layout);
@@ -237,6 +251,58 @@ pub fn patchVtableSlots(self: *Emitter) !void {
     }
 }
 
+/// Struct return-type name of `class_name`.`method_name` (resolving
+/// the owner up the inheritance chain), or `null` when it returns a
+/// scalar. Drives the sret convention at the call site.
+fn methodRetStruct(self: *Emitter, class_name: []const u8, method_name: []const u8) ?[]const u8 {
+    const layout = self.class_layouts.get(class_name) orelse return null;
+    const owner = layout.method_owners.get(method_name) orelse return null;
+    const cd = self.class_decls.get(owner) orelse return null;
+    for (cd.methods) |m| {
+        if (std.mem.eql(u8, self.source[m.name.start..m.name.end], method_name)) {
+            return if (m.ret_type) |rt| self.structNameOfTypeAnn(rt.*) else null;
+        }
+    }
+    return null;
+}
+
+/// Push an optional sret destination pointer (this frame's scratch
+/// buffer) then the method args right-to-left — each struct arg by
+/// value. Returns the bytes pushed (self excluded). Clobbers every
+/// temp, so callers spill anything they still need (e.g. the instance
+/// pointer) above these pushes and reload it afterward.
+fn pushSretAndArgs(self: *Emitter, args: []const *const ast.Expr, sret: bool) !u16 {
+    var total: u16 = 0;
+    if (sret) {
+        const sofs = self.sret_scratch_ofs.?;
+        try isa.movRegToReg(self, Reg.fp, Reg.acu);
+        if (sofs < 0) try isa.subImmFromReg(self, @intCast(-sofs), Reg.acu);
+        try isa.pushReg(self, Reg.acu);
+        total += 2;
+    }
+    var i = args.len;
+    while (i > 0) {
+        i -= 1;
+        if (self.argStructName(args[i])) |sname| {
+            try struct_.pushArg(self, args[i], sname);
+            total += self.structSlotWidth(sname);
+        } else {
+            try self.emitExpr(args[i]);
+            try isa.pushReg(self, Reg.acu);
+            total += 2;
+        }
+    }
+    return total;
+}
+
+/// Load the word at `[sp + ofs]` into `dst` — reload a pointer spilled
+/// just above the freshly pushed args.
+fn loadFromStack(self: *Emitter, ofs: u16, dst: u8) !void {
+    try isa.movRegToReg(self, Reg.sp, dst);
+    if (ofs > 0) try isa.addImmToReg(self, ofs, dst);
+    try emitWordLoadAtOffset(self, dst, 0, dst);
+}
+
 /// Lower `ClassName(args)` — bump-allocate an instance, write the
 /// vtable pointer at offset 0, optionally call `init`, then leave
 /// the instance address in `acu` (so callers can store it in a
@@ -280,16 +346,14 @@ pub fn emitConstructor(
     //    (self=r1, user_args...). The free-fn calling convention
     //    pushes right-to-left.
     if (initOwner(self, class_name)) |owner| {
-        // Push user args right-to-left, preserving r1 across eval.
-        var i: usize = c.args.len;
-        while (i > 0) {
-            i -= 1;
-            try isa.pushReg(self, Reg.r1);
-            try self.emitExpr(c.args[i]);
-            try isa.popReg(self, Reg.r1);
-            try isa.pushReg(self, Reg.acu);
-        }
-        // Push self last so it lands at fp+4 in the callee frame.
+        // Spill the instance pointer above the args; a struct arg's
+        // by-value push moves `sp`, so it can't ride a register across
+        // arg materialization. `init` returns no value, so no sret.
+        try isa.pushReg(self, Reg.r1);
+        const arg_bytes = try pushSretAndArgs(self, c.args, false);
+        // Reload the instance pointer (spilled at `sp + arg_bytes`) and
+        // push it as self so it lands at fp+4 in the callee frame.
+        try loadFromStack(self, arg_bytes, Reg.r1);
         try isa.pushReg(self, Reg.r1);
 
         // Direct-call the inheritance-resolved `init` — may live
@@ -297,13 +361,11 @@ pub fn emitConstructor(
         const init_label = try methodLabel(self, owner, "init");
         try emitDirectCall(self, init_label, c.span);
 
-        // Drop args: 1 (self) + user args, 2 bytes each.
-        // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
-        const drop_bytes: u16 = 2 + @as(u16, @intCast(c.args.len * 2));
-        try isa.addImmToReg(self, drop_bytes, Reg.sp);
-        // init may have clobbered acu — restore the instance ptr
-        // from r1 so the caller's let-bind reads the right value.
-        try isa.movRegToReg(self, Reg.r1, Reg.acu);
+        // Reload the instance pointer from its spill slot (init may
+        // have clobbered every register) so the caller's let-bind reads
+        // the right value, then drop self + args + the spill.
+        try loadFromStack(self, 2 + arg_bytes, Reg.acu);
+        try isa.addImmToReg(self, 2 + arg_bytes + 2, Reg.sp);
     }
     // No-init path leaves acu holding the instance ptr from the
     // `sys alloc` above — none of the intervening ops touched it.
@@ -388,6 +450,12 @@ pub fn emitFieldLoad(
     };
 
     try emitInstancePtr(self, recv);
+    // A struct field is stored inline — its value *is* the address
+    // `instance + offset`; leave that in `acu` rather than loading.
+    if (field.struct_name != null) {
+        if (field.offset != 0) try isa.addImmToReg(self, field.offset, Reg.acu);
+        return;
+    }
     // acu = instance ptr; load at acu + field.offset.
     try isa.movRegToReg(self, Reg.acu, Reg.r1);
     if (field.width == 1) {
@@ -415,6 +483,22 @@ pub fn emitFieldStore(
         try self.diagFatal(recv_span, "E_CODEGEN_UNDEFINED_FIELD", "codegen: unknown class field");
         return;
     };
+
+    // A struct field is stored inline — materialize the value's bytes
+    // on the stack, then copy them into `[instance + offset]` (§3.4
+    // value semantics). The temp rides the stack across the receiver
+    // eval (which is `sp`-balanced) and is released afterward.
+    if (field.struct_name) |sname| {
+        const w = self.structSlotWidth(sname);
+        try struct_.pushArg(self, value, sname); // value bytes at [sp ..]
+        try emitInstancePtr(self, recv); // acu = instance ptr
+        if (field.offset != 0) try isa.addImmToReg(self, field.offset, Reg.acu);
+        try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = dest
+        try isa.movRegToReg(self, Reg.sp, Reg.r1); // r1 = src (stack temp)
+        try struct_.copyBytes(self, Reg.r1, Reg.r2, self.structWidth(sname));
+        try isa.addImmToReg(self, w, Reg.sp); // release the temp
+        return;
+    }
 
     try self.emitExpr(value);
     try isa.pushReg(self, Reg.acu);
@@ -449,42 +533,32 @@ pub fn emitMethodDispatch(
         return;
     };
 
-    // 1. Evaluate receiver (auto-deref if `&T`), stash instance ptr in r1.
+    // 1. Evaluate receiver (auto-deref if `&T`) and spill the instance
+    //    pointer above the args — a struct arg's by-value push moves
+    //    `sp`, so the pointer can't ride a register across arg eval.
     try emitInstancePtr(self, recv);
-    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try isa.pushReg(self, Reg.acu);
 
-    // 2. Load vtable pointer from [r1+0] into r2.
+    // 2. Push the optional sret destination + args (struct-aware).
+    const returns_struct = methodRetStruct(self, class_name, method_name) != null;
+    const arg_bytes = try pushSretAndArgs(self, args, returns_struct);
+
+    // 3. Reload the instance pointer (spilled at `sp + arg_bytes`),
+    //    then resolve the method address through its vtable slot.
+    try loadFromStack(self, arg_bytes, Reg.r1);
     try emitWordLoadAtOffset(self, Reg.r1, 0, Reg.r2);
-
-    // 3. Load method address from [r2 + slot*2] into r3.
     // @as: slot index fits u16; the *2 product fits comfortably.
     const slot_offset: u16 = @as(u16, slot) * 2;
     try emitWordLoadAtOffset(self, Reg.r2, slot_offset, Reg.r3);
 
-    // 4. Push args right-to-left, preserving r1 (instance ptr)
-    //    and r3 (method addr) across arg eval.
-    var i: usize = args.len;
-    while (i > 0) {
-        i -= 1;
-        try isa.pushReg(self, Reg.r1);
-        try isa.pushReg(self, Reg.r3);
-        try self.emitExpr(args[i]);
-        try isa.popReg(self, Reg.r3);
-        try isa.popReg(self, Reg.r1);
-        try isa.pushReg(self, Reg.acu);
-    }
-
-    // 5. Push self last so it lands at fp+4 in the callee frame.
+    // 4. Push self last so it lands at fp+4, then indirect-call.
     try isa.pushReg(self, Reg.r1);
-
-    // 6. call_reg r3 — indirect call to the resolved method.
     try self.emitByte(Op.call_reg);
     try self.emitByte(Reg.r3);
 
-    // 7. Drop args: 1 (self) + user args.
-    // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
-    const drop_bytes: u16 = 2 + @as(u16, @intCast(args.len * 2));
-    try isa.addImmToReg(self, drop_bytes, Reg.sp);
+    // 5. Drop self + args + the spilled instance pointer. The method's
+    //    result (scalar or sret pointer) survives in `acu`.
+    try isa.addImmToReg(self, 2 + arg_bytes + 2, Reg.sp);
 }
 
 /// Lower `super.method(args)` — direct call to the named method
@@ -511,33 +585,25 @@ pub fn emitSuperMethodCall(
         return;
     };
 
-    // self for the super call is the current method's self (fp+4).
-    // Load it into r1 first so arg eval can clobber acu freely.
-    if (self.params.get("self")) |ofs| {
-        try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.r1);
-    } else {
+    // self for the super call is the current method's self — a stable
+    // `fp+4` param, so it reloads cleanly after the args (no spill).
+    const self_ofs = self.params.get("self") orelse {
         try self.diagFatal(span, "E_CODEGEN_NO_SELF", "codegen: `super.method` used outside a method body");
         return;
-    }
+    };
 
-    // Push args right-to-left, preserving r1 across eval.
-    var i: usize = args.len;
-    while (i > 0) {
-        i -= 1;
-        try isa.pushReg(self, Reg.r1);
-        try self.emitExpr(args[i]);
-        try isa.popReg(self, Reg.r1);
-        try isa.pushReg(self, Reg.acu);
-    }
-    // Push self last so it lands at fp+4 in the callee frame.
+    // Push the optional sret destination + args (struct-aware), then
+    // reload self and push it last so it lands at fp+4.
+    const returns_struct = methodRetStruct(self, owner, method_name) != null;
+    const arg_bytes = try pushSretAndArgs(self, args, returns_struct);
+    try isa.movRegOffsetToReg(self, Reg.fp, self_ofs, Reg.r1);
     try isa.pushReg(self, Reg.r1);
 
     const label = try methodLabel(self, owner, method_name);
     try emitDirectCall(self, label, span);
 
-    // @as: widen usize args.len to u16 — practical method arity caps well below 32k.
-    const drop_bytes: u16 = 2 + @as(u16, @intCast(args.len * 2));
-    try isa.addImmToReg(self, drop_bytes, Reg.sp);
+    // Drop self + args. The method's result survives in `acu`.
+    try isa.addImmToReg(self, 2 + arg_bytes, Reg.sp);
 }
 
 /// Lower `super.field` read — load `self`, then read at the

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -3,7 +3,7 @@ const ast = @import("../ast.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
-const struct_ = @import("struct_.zig");
+const value_struct = @import("value_struct.zig");
 
 const Emitter = codegen_mod.Emitter;
 const Op = opcodes.Op;
@@ -284,7 +284,7 @@ fn pushSretAndArgs(self: *Emitter, args: []const *const ast.Expr, sret: bool) !u
     while (i > 0) {
         i -= 1;
         if (self.argStructName(args[i])) |sname| {
-            try struct_.pushArg(self, args[i], sname);
+            try value_struct.pushArg(self, args[i], sname);
             total += self.structSlotWidth(sname);
         } else {
             try self.emitExpr(args[i]);
@@ -330,7 +330,7 @@ pub fn emitConstructor(
     //    `patchVtableSlots` rewrites once `emitVtables` runs.
     try self.emitByte(Op.mov_imm16_reg);
     const vtable_slot = try self.currentOffset();
-    try self.emitU16Le(0); // placeholder, patched in patchVtableSlots
+    try self.emitU16Le(0);
     try self.emitByte(Reg.r2);
     try self.vtable_patches.append(self.allocator, .{
         .bank = self.current_bank,
@@ -490,12 +490,12 @@ pub fn emitFieldStore(
     // eval (which is `sp`-balanced) and is released afterward.
     if (field.struct_name) |sname| {
         const w = self.structSlotWidth(sname);
-        try struct_.pushArg(self, value, sname); // value bytes at [sp ..]
-        try emitInstancePtr(self, recv); // acu = instance ptr
+        try value_struct.pushArg(self, value, sname);
+        try emitInstancePtr(self, recv);
         if (field.offset != 0) try isa.addImmToReg(self, field.offset, Reg.acu);
-        try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = dest
-        try isa.movRegToReg(self, Reg.sp, Reg.r1); // r1 = src (stack temp)
-        try struct_.copyBytes(self, Reg.r1, Reg.r2, self.structWidth(sname));
+        try isa.movRegToReg(self, Reg.acu, Reg.r2); // dest = instance + field offset
+        try isa.movRegToReg(self, Reg.sp, Reg.r1); // src = the stack temp holding the value
+        try value_struct.copyBytes(self, Reg.r1, Reg.r2, self.structWidth(sname));
         try isa.addImmToReg(self, w, Reg.sp); // release the temp
         return;
     }

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -1,0 +1,196 @@
+// Per-def emission: prologue (param binding + frame reservation + sret
+// setup), body, epilogue (`hlt` / `ret` / `rti`). Methods reuse the
+// same path under a mangled label. Forward-reference call sites are
+// resolved here once every def's address is known.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const archive = @import("archive.zig");
+const lambda = @import("lambda.zig");
+
+const Emitter = codegen.Emitter;
+const DefKind = Emitter.DefKind;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const bank_window_base = archive.bank_window_base;
+
+/// Emit one def under its own name: prologue + body + epilogue.
+pub fn emitDef(self: *Emitter, def: *const ast.DefDecl, kind: DefKind) !void {
+    return emitDefWithLabel(self, def, kind, self.source[def.name.start..def.name.end]);
+}
+
+/// Emit a method as a plain def under a mangled `ClassName.methodName`
+/// label, threading `current_class_name` so `super` resolves correctly.
+pub fn emitMethodAsDef(self: *Emitter, def: *const ast.DefDecl, class_name: []const u8, label: []const u8) !void {
+    const saved = self.current_class_name;
+    self.current_class_name = class_name;
+    defer self.current_class_name = saved;
+    return emitDefWithLabel(self, def, .regular, label);
+}
+
+fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, label: []const u8) !void {
+    // `@bank N` routes this def's body bytes + resolved address into a
+    // bank window; `@interrupt N` swaps the epilogue from `ret` to `rti`.
+    var bank_target: ?u8 = null;
+    var is_isr: bool = false;
+    for (def.annotations) |ann| {
+        const ann_name = self.source[ann.name.start..ann.name.end];
+        if (std.mem.eql(u8, ann_name, "bank") and ann.args.len == 1 and ann.args[0].* == .int_lit) {
+            // @as: typechecker enforces u8 range on `@bank N`.
+            bank_target = @intCast(ann.args[0].int_lit.value & 0xFF);
+        } else if (std.mem.eql(u8, ann_name, "interrupt")) {
+            is_isr = true;
+        }
+    }
+
+    // Save + restore per-fn state for a fresh frame view.
+    const saved_locals = self.locals;
+    const saved_params = self.params;
+    const saved_frame = self.frame_bytes;
+    const saved_entry = self.is_entry;
+    const saved_isr = self.is_isr;
+    const saved_bank = self.current_bank;
+    const saved_ret_struct = self.current_ret_struct;
+    const saved_sret_param = self.sret_param_ofs;
+    const saved_sret_scratch = self.sret_scratch_ofs;
+    self.locals = .{};
+    self.params = .{};
+    self.frame_bytes = 0;
+    self.is_entry = (kind == .entry);
+    self.is_isr = is_isr;
+    self.current_bank = bank_target;
+    self.sret_scratch_ofs = null;
+    defer {
+        self.locals = saved_locals;
+        self.params = saved_params;
+        self.frame_bytes = saved_frame;
+        self.is_entry = saved_entry;
+        self.is_isr = saved_isr;
+        self.current_bank = saved_bank;
+        self.current_ret_struct = saved_ret_struct;
+        self.sret_param_ofs = saved_sret_param;
+        self.sret_scratch_ofs = saved_sret_scratch;
+    }
+
+    const dup_name = try self.arena.dupe(u8, label);
+    // @as: per-buffer code offset stays ≤ 64 KiB.
+    const code_offset: u16 = @intCast(try self.currentOffset());
+    const addr: u16 = if (bank_target) |_| bank_window_base + code_offset else codegen.code_base + code_offset;
+    try self.fn_addresses.put(self.arena, dup_name, addr);
+
+    // Bind params to positive fp-relative offsets. `call` leaves the
+    // stack as [low] ret_ip, old_fp, arg_N-1 … arg_0 [high], so param 0
+    // sits at fp+4. Each param sits just above the previous; a struct
+    // param occupies its full width (passed by value), so offsets sum
+    // widths rather than stepping a fixed 2 bytes.
+    var param_ofs: i32 = 4;
+    for (def.params) |p| {
+        const dup_p = try self.arena.dupe(u8, self.source[p.name.start..p.name.end]);
+        // @as: i8 fp-offset; the frame-size cap keeps offsets in range.
+        try self.params.put(self.arena, dup_p, @intCast(param_ofs));
+        param_ofs += self.paramWidthAligned(p);
+    }
+
+    // A struct-returning def takes a hidden sret destination pointer
+    // just above its last user param (the caller pushes it first);
+    // `return` copies the result there instead of into `acu`.
+    self.current_ret_struct = if (def.ret_type) |rt| self.structNameOfTypeAnn(rt.*) else null;
+    // @as: sits past the params; the frame-size cap keeps it small.
+    self.sret_param_ofs = @intCast(param_ofs);
+
+    // Reserve the frame up front (fixed reservation — a real allocator
+    // would compute live ranges). The sret scratch buffer (holds a
+    // returned struct until its consumer copies it out) is carved first
+    // so its offset stays stable across the body.
+    const scratch_bytes: u16 = self.global_sret_scratch;
+    // @as: frame size capped well below u16 by the i8 offset cap.
+    const reserve_bytes: u16 = @intCast(self.countFrameBytes(def.body) + scratch_bytes);
+    if (reserve_bytes > 0) try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
+    if (scratch_bytes > 0) self.sret_scratch_ofs = try self.allocLocalSized("\x00sret", scratch_bytes);
+
+    // Closure-analysis pre-pass — the lambda inventory, capture layouts,
+    // and promotion set drive the heap-cell paths in let / ident / assign
+    // and the closure-call dispatch.
+    try lambda.analyzeFn(self, def);
+    defer lambda.resetFnInfo(self);
+
+    // Entry-def prologue: write every `@interrupt N` handler address into
+    // its IVT slot before the body runs — boot leaves `flg.I = 0`, so an
+    // interrupt could otherwise fire against an uninitialized vector.
+    if (self.is_entry) try emitIvtInit(self);
+
+    // The body opens the outermost block — top-level `defer`s run before
+    // the implicit epilogue.
+    try self.pushBlock();
+    for (def.body) |stmt| try self.emitStatement(stmt);
+    try self.popBlockWithDefers();
+
+    // Implicit epilogue (no explicit `return`). `ret` resets sp = fp then
+    // pops ret_ip + old_fp; the return value rides `acu` for the caller.
+    if (self.is_entry) {
+        try isa.hlt(self);
+    } else if (is_isr) {
+        try self.emitByte(Op.rti_op);
+    } else {
+        try self.emitByte(Op.ret_op);
+    }
+
+    // Lambda bodies discovered during analysis emit as plain defs
+    // adjacent to the parent so their call sites + closure-creation
+    // patches resolve normally.
+    try lambda.emitLambdaBodies(self, def);
+}
+
+/// Write each `@interrupt N` handler's address into its IVT slot. The
+/// handler address is patched later (forward reference); the slot
+/// address is known now.
+fn emitIvtInit(self: *Emitter) !void {
+    for (self.interrupt_defs.items) |handler| {
+        try self.emitByte(Op.mov_imm16_addr);
+        const addr_patch_offset = try self.currentOffset();
+        try self.emitU16Le(0);
+        // @as: widen u8 vector before doubling so the wrap-add stays in u16.
+        try self.emitU16Le(codegen.ivt_base +% (@as(u16, handler.vector) *% 2));
+        try self.call_patches.append(self.allocator, .{
+            .bank = self.current_bank,
+            .code_offset = addr_patch_offset,
+            .target = .{ .fn_name = handler.def_name },
+            .span = .{ .start = 0, .end = 0 },
+        });
+    }
+}
+
+/// Rewrite each unresolved call's 2-byte address slot once every def's
+/// address is known. Unknown callees emit `E_CODEGEN_UNDEFINED_FN`.
+pub fn patchCalls(self: *Emitter) !void {
+    for (self.call_patches.items) |p| {
+        const target_addr: u16 = switch (p.target) {
+            .fn_name => |name| self.fn_addresses.get(name) orelse {
+                const msg = try std.fmt.allocPrint(
+                    self.diag_arena,
+                    "codegen: call target `{s}` is not a known top-level def",
+                    .{name},
+                );
+                try self.diagnostics.append(self.allocator, .{
+                    .severity = .fatal,
+                    .code = "E_CODEGEN_UNDEFINED_FN",
+                    .message = msg,
+                    .span = p.span,
+                });
+                continue;
+            },
+            .trampoline => self.trampoline_addr orelse continue,
+        };
+        // Resolve which buffer holds this patch — base or a bank list.
+        const buf: []u8 = if (p.bank) |b|
+            if (self.banks.getPtr(b)) |bl| bl.items else continue
+        else
+            self.code.items;
+        // safety: u16 → 2 LE bytes; both casts are byte-masks.
+        buf[p.code_offset] = @intCast(target_addr & 0xFF);
+        buf[p.code_offset + 1] = @intCast(target_addr >> 8);
+    }
+}

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -7,6 +7,7 @@ const archive = @import("archive.zig");
 const assert_builtin = @import("assert.zig");
 const diverge_builtin = @import("diverge.zig");
 const class = @import("class.zig");
+const struct_ = @import("struct_.zig");
 const lambda = @import("lambda.zig");
 const overflow = @import("overflow.zig");
 
@@ -47,6 +48,12 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .char_lit => |c| try isa.movImmToReg(self, c.value, Reg.acu),
         .paren => |p| try emitExpr(self, p.inner),
         .ident => |i| {
+            // A struct-typed binding evaluates to its base address —
+            // struct values are addressed inline, not loaded as a word.
+            if (self.structNameOf(e) != null) {
+                try self.emitAddrOf(e);
+                return;
+            }
             const name = self.source[i.span.start..i.span.end];
             // Lookup order: captures (lambda body) → locals → params
             // → globals. Captures take precedence so they shadow any
@@ -180,6 +187,14 @@ pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void
         try class.emitFieldLoad(self, f.receiver, cname, fname, f.span);
         return;
     }
+    // Struct-typed receiver — evaluate the receiver to its base
+    // address, then load the field (or compute the nested address).
+    if (self.structNameOf(f.receiver)) |sname| {
+        const fname = self.source[f.field.start..f.field.end];
+        try emitExpr(self, f.receiver);
+        try struct_.emitFieldLoad(self, sname, fname);
+        return;
+    }
     if (f.receiver.* == .ident) {
         const recv_name = self.source[f.receiver.ident.span.start..f.receiver.ident.span.end];
         if (self.enum_decls.get(recv_name)) |ed| {
@@ -293,6 +308,15 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
             return;
         },
         else => {},
+    }
+
+    // A struct-typed operand would evaluate to its base address, so a
+    // bare `==`/`!=` compares addresses, not fields — never what §3.4's
+    // structural-equality contract means. Reject it rather than emit a
+    // silently-wrong address compare.
+    if (self.structNameOf(b.lhs) != null or self.structNameOf(b.rhs) != null) {
+        try self.unsupported(b.span, "a struct operand in a binary expression — structural equality on structs is not yet implemented");
+        return;
     }
 
     const fixed_op = self.isPrimitiveType(b.lhs, .fixed) and
@@ -413,6 +437,14 @@ pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
         const b = e.binary;
         switch (b.op) {
             .eq, .neq, .lt, .lte, .gt, .gte => {
+                // A struct operand evaluates to its base address, so this
+                // would compare addresses, not fields — reject rather
+                // than emit a silently-wrong compare (§3.4 calls for
+                // structural equality, not yet implemented).
+                if (self.structNameOf(b.lhs) != null or self.structNameOf(b.rhs) != null) {
+                    try self.unsupported(b.span, "a struct operand in a comparison — structural equality on structs is not yet implemented");
+                    return;
+                }
                 // Eval LHS into acu, eval RHS into r1, cmp acu, r1.
                 try emitExpr(self, b.rhs);
                 try isa.pushReg(self, Reg.acu);
@@ -654,12 +686,31 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     const target_bank: ?u8 = self.fn_banks.get(callee_name) orelse null;
     const cross_bank = !archive.banksEqual(self.current_bank, target_bank);
 
-    // Push args right-to-left (caller-cleans-up).
+    // A struct-returning callee takes a hidden sret destination pointer
+    // pushed first (it sits just above the user args). Point it at this
+    // frame's scratch buffer; the callee copies its result there and
+    // returns the pointer in `acu`.
+    const returns_struct = self.fn_ret_struct.contains(callee_name);
+    if (returns_struct) {
+        // Invariant: a struct-returning callee implies the program has a
+        // struct return type, so every frame reserved a scratch slot.
+        const sofs = self.sret_scratch_ofs.?;
+        try isa.movRegToReg(self, Reg.fp, Reg.acu);
+        if (sofs < 0) try isa.subImmFromReg(self, @intCast(-sofs), Reg.acu);
+        try isa.pushReg(self, Reg.acu);
+    }
+
+    // Push args right-to-left (caller-cleans-up). A struct arg is
+    // passed by value — its (2-aligned) width copied onto the stack.
     var i: usize = c.args.len;
     while (i > 0) {
         i -= 1;
-        try emitExpr(self, c.args[i]);
-        try isa.pushReg(self, Reg.acu);
+        if (self.argStructName(c.args[i])) |sname| {
+            try struct_.pushArg(self, c.args[i], sname);
+        } else {
+            try emitExpr(self, c.args[i]);
+            try isa.pushReg(self, Reg.acu);
+        }
     }
 
     if (cross_bank) {
@@ -707,9 +758,15 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     // The args we pushed leak on the stack, which is fine: control
     // never returns to use that space.
     const skip_cleanup = self.noreturn_defs.contains(callee_name);
-    if (c.args.len > 0 and !skip_cleanup) {
-        // @as: each arg is one 16-bit word; arg count capped by parser.
-        const drop_bytes: u16 = @intCast(c.args.len * 2);
-        try isa.addImmToReg(self, drop_bytes, Reg.sp);
+    if (!skip_cleanup) {
+        var drop_bytes: u16 = if (returns_struct) 2 else 0; // hidden sret pointer
+        for (c.args) |a| {
+            if (self.argStructName(a)) |sname| {
+                drop_bytes += self.structSlotWidth(sname);
+            } else {
+                drop_bytes += 2; // one 16-bit word per scalar arg
+            }
+        }
+        if (drop_bytes > 0) try isa.addImmToReg(self, drop_bytes, Reg.sp);
     }
 }

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -7,7 +7,7 @@ const archive = @import("archive.zig");
 const assert_builtin = @import("assert.zig");
 const diverge_builtin = @import("diverge.zig");
 const class = @import("class.zig");
-const struct_ = @import("struct_.zig");
+const value_struct = @import("value_struct.zig");
 const lambda = @import("lambda.zig");
 const overflow = @import("overflow.zig");
 
@@ -192,7 +192,7 @@ pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void
     if (self.structNameOf(f.receiver)) |sname| {
         const fname = self.source[f.field.start..f.field.end];
         try emitExpr(self, f.receiver);
-        try struct_.emitFieldLoad(self, sname, fname);
+        try value_struct.emitFieldLoad(self, sname, fname);
         return;
     }
     if (f.receiver.* == .ident) {
@@ -706,7 +706,7 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     while (i > 0) {
         i -= 1;
         if (self.argStructName(c.args[i])) |sname| {
-            try struct_.pushArg(self, c.args[i], sname);
+            try value_struct.pushArg(self, c.args[i], sname);
         } else {
             try emitExpr(self, c.args[i]);
             try isa.pushReg(self, Reg.acu);

--- a/src/lang/codegen/globals.zig
+++ b/src/lang/codegen/globals.zig
@@ -1,0 +1,234 @@
+// Top-level `let` / `const` placement + access. Globals land in one of
+// three regions — a pinned `@addr`, the zero page, or the dynamic data
+// region — and `const` initializers backed by `bake` are evaluated at
+// compile time so their bytes seed the data region directly.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const archive = @import("archive.zig");
+const bake_mod = @import("../bake.zig");
+const diag_mod = @import("../diagnostic.zig");
+
+const Emitter = codegen.Emitter;
+const Global = codegen.Global;
+const Reg = opcodes.Reg;
+const alignUpU16 = archive.alignUpU16;
+
+/// Register every top-level `let` / `const` as a `Global`. Placement:
+/// `@addr $XXXX` pins the address; `@zero_page` takes the next zero-page
+/// slot; `@align(N)` pads the cursor; otherwise the next data slot.
+pub fn registerGlobals(self: *Emitter, program: *const ast.Program) !void {
+    for (program.statements) |*stmt| switch (stmt.*) {
+        .let_decl => |*d| try registerGlobalLet(self, d),
+        .const_decl => |*d| try registerGlobalConst(self, d),
+        else => {},
+    };
+}
+
+fn registerGlobalLet(self: *Emitter, d: *const ast.LetDecl) !void {
+    if (d.pattern.* != .ident) return; // destructuring at top-level — slice later
+    const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
+    try placeGlobal(self, name, widthOfLetDecl(self, d), d.annotations, d.pattern.ident.name);
+}
+
+fn registerGlobalConst(self: *Emitter, d: *const ast.ConstDecl) !void {
+    const name = self.source[d.name.start..d.name.end];
+    // A `bake`-backed initializer yields both the storage width and the
+    // bytes to seed; other initializers fall back to the annotated width.
+    const baked: ?bake_mod.BakeValue = try evalConstIfBake(self, d);
+    const width: u16 = if (baked) |v| @intCast(bake_mod.widthOf(v)) else widthOfConstDecl(self, d);
+    try placeGlobal(self, name, width, d.annotations, d.name);
+
+    if (baked) |v| {
+        const g = self.globals.get(name) orelse return;
+        const bytes = try self.arena.alloc(u8, bake_mod.widthOf(v));
+        _ = bake_mod.serialize(v, bytes);
+        try self.bake_inits.put(self.allocator, g.address, bytes);
+    }
+}
+
+/// Evaluate a `const X = …` initializer whose RHS is a `bake do` block
+/// or a `bake def` call; `null` for non-bake initializers.
+fn evalConstIfBake(self: *Emitter, d: *const ast.ConstDecl) !?bake_mod.BakeValue {
+    switch (d.init.*) {
+        .do_expr => |do| {
+            if (!do.is_bake) return null;
+            return try runBake(self, d.span, .{ .do_expr = &d.init.do_expr });
+        },
+        .call => |c| {
+            if (c.callee.* != .ident) return null;
+            const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+            const decl = self.bake_defs.get(callee_name) orelse return null;
+            // Top-level entry call — args must be literal / const-foldable.
+            const args = try self.arena.alloc(bake_mod.BakeValue, c.args.len);
+            for (c.args, 0..) |a, i| {
+                args[i] = bake_mod.literalAsBakeValue(self.source, a) orelse {
+                    try self.diagFatal(a.span(), "E_BAKE_UNSUPPORTED", "bake-call args at top-level must be literal values");
+                    return null;
+                };
+            }
+            return try runBakeDef(self, d.span, decl, args);
+        },
+        else => return null,
+    }
+}
+
+/// Tagged input to `runBake` — picks the entry shape so one helper
+/// handles the diagnostic plumbing.
+const BakeEntry = union(enum) {
+    do_expr: *const ast.DoExpr,
+};
+
+fn runBake(self: *Emitter, span: ast.Span, entry: BakeEntry) !?bake_mod.BakeValue {
+    const opts: bake_mod.Options = .{ .bake_defs = &bakeDefsAdapter(self) };
+    var result = switch (entry) {
+        .do_expr => |de| try bake_mod.evaluateDo(self.allocator, self.source, de, opts),
+    };
+    defer result.deinit(self.allocator);
+    try forwardBakeDiagnostics(self, result.diagnostics);
+    if (result.value == null) {
+        try self.diagFatal(span, "E_BAKE_UNSUPPORTED", "bake evaluation failed; see diagnostics above");
+        return null;
+    }
+    return try bake_mod.cloneBakeValue(self.arena, result.value.?);
+}
+
+fn runBakeDef(self: *Emitter, span: ast.Span, decl: *const ast.DefDecl, args: []const bake_mod.BakeValue) !?bake_mod.BakeValue {
+    const adapter = bakeDefsAdapter(self);
+    const opts: bake_mod.Options = .{ .bake_defs = &adapter };
+    var result = try bake_mod.evaluateDef(self.allocator, self.source, decl, args, opts);
+    defer result.deinit(self.allocator);
+    try forwardBakeDiagnostics(self, result.diagnostics);
+    if (result.value == null) {
+        try self.diagFatal(span, "E_BAKE_UNSUPPORTED", "bake evaluation failed; see diagnostics above");
+        return null;
+    }
+    return try bake_mod.cloneBakeValue(self.arena, result.value.?);
+}
+
+fn forwardBakeDiagnostics(self: *Emitter, diags: []const diag_mod.Diagnostic) !void {
+    for (diags) |diag| {
+        try self.diagnostics.append(self.allocator, .{
+            .severity = diag.severity,
+            .code = diag.code,
+            .message = try self.diag_arena.dupe(u8, diag.message),
+            .span = diag.span,
+        });
+    }
+}
+
+/// Snapshot the bake-def index into the std-`StringHashMap` shape the
+/// evaluator expects. Rebuilt per call so later bake-def discovery
+/// stays visible; the evaluator only borrows it for one call.
+fn bakeDefsAdapter(self: *Emitter) std.StringHashMap(*const ast.DefDecl) {
+    var map = std.StringHashMap(*const ast.DefDecl).init(self.arena);
+    var it = self.bake_defs.iterator();
+    while (it.next()) |e| {
+        // allow-strict: copies fit in the arena that owns `bake_defs`; OOM would have surfaced upstream.
+        map.put(e.key_ptr.*, e.value_ptr.*) catch unreachable;
+    }
+    return map;
+}
+
+fn placeGlobal(
+    self: *Emitter,
+    name: []const u8,
+    width: u16,
+    annotations: []const ast.Annotation,
+    decl_span: ast.Span,
+) !void {
+    var pinned_addr: ?u16 = null;
+    var zero_page: bool = false;
+    var align_n: ?u16 = null;
+    for (annotations) |ann| {
+        const ann_name = self.source[ann.name.start..ann.name.end];
+        if (std.mem.eql(u8, ann_name, "addr") and ann.args.len == 1 and ann.args[0].* == .int_lit) {
+            // @as: address literals are non-negative per §3.7.1; truncating i32 → u16 preserves bytes.
+            pinned_addr = @intCast(ann.args[0].int_lit.value & 0xFFFF);
+        } else if (std.mem.eql(u8, ann_name, "zero_page")) {
+            zero_page = true;
+        } else if (std.mem.eql(u8, ann_name, "align") and ann.args.len == 1 and ann.args[0].* == .int_lit) {
+            // @as: typechecker verified a power-of-two; i32 → u16 fits the alignment range.
+            align_n = @intCast(ann.args[0].int_lit.value & 0xFFFF);
+        }
+    }
+    const dup = try self.arena.dupe(u8, name);
+
+    if (pinned_addr) |addr| {
+        try self.globals.put(self.arena, dup, .{ .address = addr, .width = width, .placement = .addr });
+        return;
+    }
+    if (zero_page) {
+        if (align_n) |n| self.zp_cursor = alignUpU16(self.zp_cursor, n);
+        if (self.zp_cursor + width > 0x100) {
+            try self.diagFatal(decl_span, "E_CODEGEN_ZP_OVERFLOW", "zero-page region exhausted — too many `@zero_page` globals");
+            return;
+        }
+        try self.globals.put(self.arena, dup, .{ .address = self.zp_cursor, .width = width, .placement = .zero_page });
+        self.zp_cursor += width;
+        return;
+    }
+    if (align_n) |n| self.data_cursor = alignUpU16(self.data_cursor, n);
+    try self.globals.put(self.arena, dup, .{ .address = self.data_cursor, .width = width, .placement = .data });
+    self.data_cursor += width;
+}
+
+/// Storage width of a `let` / `const` global: its annotated type width,
+/// or the widest primitive (2 bytes) when unannotated.
+fn widthOfLetDecl(self: *const Emitter, d: *const ast.LetDecl) u16 {
+    return if (d.type_ann) |t| self.widthOfTypeAnn(t.*) else 2;
+}
+
+fn widthOfConstDecl(self: *const Emitter, d: *const ast.ConstDecl) u16 {
+    return if (d.type_ann) |t| self.widthOfTypeAnn(t.*) else 2;
+}
+
+/// Load `g`'s value into `acu`. The instruction shape depends on the
+/// placement family + byte width.
+pub fn emitGlobalLoad(self: *Emitter, g: Global) !void {
+    switch (g.placement) {
+        .addr, .data => {
+            if (g.width == 1) {
+                try isa.mov8AddrToReg(self, g.address, Reg.acu);
+            } else {
+                try isa.movAddrToReg(self, g.address, Reg.acu);
+            }
+        },
+        .zero_page => {
+            // @as: placement.zero_page guarantees address ≤ 0xFF.
+            const zp: u8 = @intCast(g.address);
+            if (g.width == 1) {
+                try isa.mov8ZpToReg(self, zp, Reg.acu);
+            } else {
+                try isa.movZpToReg(self, zp, Reg.acu);
+            }
+        },
+    }
+}
+
+/// Store `src`'s value into `g`'s slot. Byte-width globals use `movl`
+/// (low-byte store) so the neighboring byte stays untouched — critical
+/// for MMIO where adjacent addresses are distinct registers.
+pub fn emitGlobalStore(self: *Emitter, src: u8, g: Global) !void {
+    switch (g.placement) {
+        .addr, .data => {
+            if (g.width == 1) {
+                try isa.movlRegToAddr(self, src, g.address);
+            } else {
+                try isa.movRegToAddr(self, src, g.address);
+            }
+        },
+        .zero_page => {
+            // @as: placement.zero_page guarantees address ≤ 0xFF.
+            const zp: u8 = @intCast(g.address);
+            if (g.width == 1) {
+                try isa.movlRegToZp(self, src, zp);
+            } else {
+                try isa.movRegToZp(self, src, zp);
+            }
+        },
+    }
+}

--- a/src/lang/codegen/inline_call.zig
+++ b/src/lang/codegen/inline_call.zig
@@ -1,0 +1,148 @@
+// `@inline` call expansion: splice the callee's body at the call site
+// instead of emitting `call addr`. Args bind to fresh caller-frame
+// locals, `return` redirects to a forward jmp past the splice, and the
+// spliced body is size-capped (decoded through the disassembler so the
+// limit counts real instructions, not Zig emit calls).
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const expr_emit = @import("expr.zig");
+const value_struct = @import("value_struct.zig");
+const lambda = @import("lambda.zig");
+const disasm_decoder = codegen.disasm_decoder;
+
+const Emitter = codegen.Emitter;
+const Reg = opcodes.Reg;
+
+/// Splice an `@inline` callee's body at the current emit position. Args
+/// land in fresh locals in the caller's frame; `return` in the body
+/// redirects to a jmp past the splice. Body size is capped at
+/// `Emitter.inline_body_instruction_cap` (over → `E_ANN_INLINE_TOO_LARGE`).
+pub fn emitInlineCall(self: *Emitter, callee: *const ast.DefDecl, c: ast.CallExpr) !void {
+    if (self.inline_depth >= Emitter.inline_max_depth) {
+        try self.diagFatal(c.span, "E_ANN_INLINE_RECURSIVE", "codegen: `@inline` def expanded past nesting cap — likely recursive inlining");
+        return;
+    }
+    self.inline_depth += 1;
+    defer self.inline_depth -= 1;
+
+    if (c.args.len != callee.params.len) {
+        try self.diagFatal(c.span, "E_ANN_INLINE_ARITY", "codegen: `@inline` call arity mismatch — typechecker should have flagged");
+        return;
+    }
+
+    // Bind args → fresh caller-frame locals. Each slot extends
+    // `frame_bytes` via its own sub-imm (the prologue's bulk reservation
+    // already ran). Args materialize in the CALLER's scope — locals
+    // still live — then bind into the fresh body scope below.
+    const Binding = struct { name: []const u8, ofs: i8 };
+    const bindings = try self.arena.alloc(Binding, callee.params.len);
+    for (callee.params, c.args, bindings) |p, arg, *b| {
+        const dup = try self.arena.dupe(u8, self.source[p.name.start..p.name.end]);
+        // A struct param binds to a full-width local materialized by
+        // value; a scalar param to a single word.
+        if (self.argStructName(arg)) |sname| {
+            try isa.subImmFromReg(self, self.structSlotWidth(sname), Reg.sp);
+            const ofs = self.reserveFrameSlot(self.structSlotWidth(sname));
+            try value_struct.emitInto(self, arg, sname, ofs);
+            b.* = .{ .name = dup, .ofs = ofs };
+        } else {
+            try isa.subImmFromReg(self, 2, Reg.sp);
+            try expr_emit.emitExpr(self, arg);
+            const ofs = self.reserveFrameSlot(2);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+            b.* = .{ .name = dup, .ofs = ofs };
+        }
+    }
+
+    const saved_locals = self.locals;
+    const saved_params = self.params;
+    self.locals = .{};
+    self.params = .{};
+    defer {
+        self.locals = saved_locals;
+        self.params = saved_params;
+    }
+    for (bindings) |b| try self.locals.put(self.arena, b.name, b.ofs);
+
+    // A struct-returning inline writes its result into a caller-frame
+    // slot (there's no callee frame to hold it); each `return` copies
+    // there and leaves the slot's address in `acu`.
+    const saved_inline_ret = self.inline_ret_struct;
+    const saved_inline_slot = self.inline_ret_slot;
+    defer {
+        self.inline_ret_struct = saved_inline_ret;
+        self.inline_ret_slot = saved_inline_slot;
+    }
+    if (callee.ret_type) |rt| if (self.structNameOfTypeAnn(rt.*)) |sname| {
+        try isa.subImmFromReg(self, self.structSlotWidth(sname), Reg.sp);
+        self.inline_ret_struct = sname;
+        self.inline_ret_slot = self.reserveFrameSlot(self.structWidth(sname));
+    };
+
+    // Install a fresh `inline_returns` collector so nested `return`s
+    // rewrite to a forward jmp instead of `ret`.
+    const start_offset = try self.currentOffset();
+    const saved_returns = self.inline_returns;
+    self.inline_returns = std.ArrayList(usize).empty;
+    defer self.inline_returns = saved_returns;
+
+    // Lambdas inside `@inline` bodies are unsupported — their mangled
+    // labels would collide across call sites.
+    const saved_fn_info = self.fn_closure_info;
+    defer self.fn_closure_info = saved_fn_info;
+    try lambda.analyzeFn(self, callee);
+    if (self.fn_closure_info.lambdas.items.len > 0) {
+        const name = self.source[callee.name.start..callee.name.end];
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "`@inline` def `{s}` declares a lambda in its body — unsupported (lambdas need a host def, but inlined bodies don't emit one)",
+            .{name},
+        );
+        try self.diagFatal(c.span, "E_ANN_INLINE_LAMBDA_BODY", msg);
+        return;
+    }
+
+    try self.pushBlock();
+    for (callee.body) |stmt| try self.emitStatement(stmt);
+    try self.popBlockWithDefers();
+
+    // Patch every `return`-redirected jmp to land here, past the body.
+    // The return value rides `acu` for the caller — matches the
+    // regular-call ABI.
+    const end_offset = try self.currentOffset();
+    const end_addr: u16 = self.codeOffsetToAddress(end_offset);
+    if (self.inline_returns) |*returns| {
+        const buf: []u8 = self.currentBufferMut();
+        for (returns.items) |patch| {
+            buf[patch] = @intCast(end_addr & 0xFF);
+            buf[patch + 1] = @intCast((end_addr >> 8) & 0xFF);
+        }
+        returns.deinit(self.allocator);
+    }
+
+    // Size gate: decode the spliced bytes so the count matches what the
+    // ISA considers an instruction, then enforce the cap.
+    const buf: []const u8 = self.currentBufferMut();
+    var inst_count: usize = 0;
+    var cursor: usize = start_offset;
+    while (cursor < end_offset) {
+        const dec = disasm_decoder.decodeOne(self.allocator, buf, cursor) catch break;
+        defer self.allocator.free(dec.instruction.operands);
+        inst_count += 1;
+        if (cursor == dec.next_offset) break;
+        cursor = dec.next_offset;
+    }
+    if (inst_count > Emitter.inline_body_instruction_cap) {
+        const name = self.source[callee.name.start..callee.name.end];
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "`@inline` body of `{s}` lowers to {d} instructions — over the cap of {d}",
+            .{ name, inst_count, Emitter.inline_body_instruction_cap },
+        );
+        try self.diagFatal(c.span, "E_ANN_INLINE_TOO_LARGE", msg);
+    }
+}

--- a/src/lang/codegen/lambda.zig
+++ b/src/lang/codegen/lambda.zig
@@ -340,10 +340,18 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
     const saved_bank = self.current_bank;
     const saved_promoted = self.fn_closure_info.promoted;
     const saved_closure_bindings = self.fn_closure_info.closure_bindings;
+    // A lambda body has its own return contract — don't let the
+    // enclosing fn's sret state leak in. The closure-call path passes
+    // no sret destination, so a struct `return` here surfaces a clean
+    // unsupported error rather than copying through the parent's buffer.
+    const saved_ret_struct = self.current_ret_struct;
+    const saved_inline_ret = self.inline_ret_struct;
     self.locals = .{};
     self.params = .{};
     self.frame_bytes = 0;
     self.is_entry = false;
+    self.current_ret_struct = null;
+    self.inline_ret_struct = null;
     // Swap the scope-dependent analysis fields to this lambda's
     // own — promoted bindings + closure_bindings differ per
     // scope. The lambdas list stays shared across nested levels
@@ -356,6 +364,8 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
         self.frame_bytes = saved_frame;
         self.is_entry = saved_entry;
         self.current_bank = saved_bank;
+        self.current_ret_struct = saved_ret_struct;
+        self.inline_ret_struct = saved_inline_ret;
         self.fn_closure_info.promoted = saved_promoted;
         self.fn_closure_info.closure_bindings = saved_closure_bindings;
     }
@@ -406,10 +416,10 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
 
     // Reserve local slots up front (lambda body uses locals like
     // any other fn).
-    const local_count = self.countLocalsInBody(lambda.body);
-    if (local_count > 0) {
-        // @as: 2 bytes per slot, caps well below u16.
-        const reserve_bytes: u16 = @intCast(local_count * 2);
+    const frame_bytes = self.countFrameBytes(lambda.body);
+    if (frame_bytes > 0) {
+        // @as: frame size caps well below u16 by the i8 offset cap.
+        const reserve_bytes: u16 = @intCast(frame_bytes);
         try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
     }
 

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -1,0 +1,270 @@
+// Leaf statement lowering: `let` / `const` bindings, assignment (and
+// its compound + inc/dec desugarings), `return`, and `print`. The
+// dispatch hub (`emitStatement`) and control-flow forms live elsewhere;
+// these are the terminal statement shapes.
+
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const class = @import("class.zig");
+const value_struct = @import("value_struct.zig");
+const lambda = @import("lambda.zig");
+const strings = @import("strings.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Sys = opcodes.Sys;
+
+/// The binary operator a compound assignment desugars to — `+=` → `+`,
+/// `<<=` → `<<`, and so on. `.set` has no binary form.
+fn compoundBinaryOp(op: ast.AssignOp) ast.BinaryOp {
+    return switch (op) {
+        // plain `=` never reaches this desugar helper
+        .set => unreachable,
+        .add_set => .add,
+        .sub_set => .sub,
+        .mul_set => .mul,
+        .div_set => .div,
+        .mod_set => .mod,
+        .bit_and_set => .bit_and,
+        .bit_or_set => .bit_or,
+        .bit_xor_set => .bit_xor,
+        .shl_set => .shl,
+        .shr_set => .shr,
+    };
+}
+
+/// `target = value`, with `target op= value` and `target++/--`
+/// desugaring to this path. Targets: ident, class field, struct field.
+pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
+    var a = a_in;
+    if (a.op != .set) {
+        // Desugar `target op= value` into `target = (target op value)`
+        // and fall through to the plain-store path.
+        const rhs = try self.arena.create(ast.Expr);
+        rhs.* = .{ .binary = .{
+            .op = compoundBinaryOp(a.op),
+            .lhs = a.target,
+            .rhs = a.value,
+            .span = a.span,
+        } };
+        a.value = rhs;
+        a.op = .set;
+    }
+    // `recv.field = value` routes to the class or struct field-store path.
+    if (a.target.* == .field) {
+        if (self.classNameOf(a.target.field.receiver)) |cname| {
+            const fname = self.source[a.target.field.field.start..a.target.field.field.end];
+            try class.emitFieldStore(self, a.target.field.receiver, cname, fname, a.value, a.target.field.span);
+            return;
+        }
+        if (self.structNameOf(a.target.field.receiver)) |sname| {
+            const fname = self.source[a.target.field.field.start..a.target.field.field.end];
+            try value_struct.emitFieldStore(self, a.target.field.receiver, sname, fname, a.value);
+            return;
+        }
+    }
+    if (a.target.* != .ident) {
+        try self.unsupported(a.span, "non-ident assignment targets (field / index)");
+        return;
+    }
+    const name = self.source[a.target.ident.span.start..a.target.ident.span.end];
+    // Struct-typed reassignment (`b = a`) copies the value's bytes into
+    // the binding's slot (§3.4 value semantics).
+    if (self.structNameOf(a.target)) |sname| {
+        if (self.locals.get(name)) |ofs| {
+            try value_struct.emitInto(self, a.value, sname, ofs);
+            return;
+        }
+    }
+    // Captured-binding write inside a lambda body — store through the
+    // env-relative cell pointer (the parent promoted the binding so the
+    // write is visible everywhere).
+    if (self.captures.get(name)) |slot| {
+        try lambda.emitCaptureStore(self, slot, a.value);
+        return;
+    }
+    // Promoted local in the parent fn — store through the local-slot
+    // cell pointer.
+    if (lambda.isPromoted(self, name)) {
+        if (self.locals.get(name)) |ofs| {
+            try lambda.emitPromotedAssign(self, ofs, a.value);
+            return;
+        }
+    }
+    try self.emitExpr(a.value); // result in acu
+    if (self.locals.get(name)) |ofs| {
+        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+        return;
+    }
+    if (self.params.get(name)) |ofs| {
+        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+        return;
+    }
+    if (self.globals.get(name)) |g| {
+        try self.emitGlobalStore(Reg.acu, g);
+        return;
+    }
+    try self.unsupported(a.target.span(), "assignment target not in scope");
+}
+
+/// `target++` / `target--` — desugars to `target = target ± 1` and
+/// reuses the assignment path.
+pub fn emitIncDec(self: *Emitter, id: ast.IncDecStmt) !void {
+    const one = try self.arena.create(ast.Expr);
+    one.* = .{ .int_lit = .{ .value = 1, .span = id.span } };
+    const rhs = try self.arena.create(ast.Expr);
+    rhs.* = .{ .binary = .{
+        .op = if (id.inc) .add else .sub,
+        .lhs = id.target,
+        .rhs = one,
+        .span = id.span,
+    } };
+    try emitAssign(self, .{ .target = id.target, .op = .set, .value = rhs, .span = id.span });
+}
+
+/// `let name [: T] [= init]` — reserve the binding's slot (full width
+/// for a struct, one word otherwise) and lower its initializer.
+pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
+    if (d.pattern.* != .ident) {
+        try self.unsupported(d.span, "non-ident `let` patterns");
+        return;
+    }
+    const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
+    const dup_name = try self.arena.dupe(u8, name);
+
+    // Struct-typed binding: reserve the full inline slot and materialize
+    // the initializer (literal fields or a value copy) straight into it
+    // (§3.4 value semantics).
+    const struct_name: ?[]const u8 = if (d.type_ann) |t|
+        self.structNameOfTypeAnn(t.*)
+    else if (d.init) |e|
+        self.structNameOf(e)
+    else
+        null;
+    if (struct_name) |sname| {
+        const slot = try self.allocLocalSized(dup_name, self.structWidth(sname));
+        if (d.init) |init_expr| try value_struct.emitInto(self, init_expr, sname, slot);
+        return;
+    }
+
+    const ofs = try self.allocLocal(dup_name);
+    // Promoted bindings live as heap cells — the slot holds the cell
+    // pointer instead of the value directly.
+    if (lambda.isPromoted(self, name)) {
+        try lambda.emitPromotedLetInit(self, d.init, ofs);
+        return;
+    }
+    if (d.init) |init_expr| {
+        try self.emitExpr(init_expr); // result in acu
+        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+    }
+    // An uninitialized `let` leaves the slot at whatever the prologue's
+    // sub-imm gave it (sp padded downward without zeroing).
+}
+
+/// `const name = init` as a local binding — same slot mechanics as a
+/// scalar `let` (top-level consts are handled as globals instead).
+pub fn emitConstDecl(self: *Emitter, d: ast.ConstDecl) !void {
+    const dup_name = try self.arena.dupe(u8, self.source[d.name.start..d.name.end]);
+    const ofs = try self.allocLocal(dup_name);
+    try self.emitExpr(d.init);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+}
+
+/// `return [value]` — places the value (scalar in `acu`, struct via the
+/// sret/inline buffer), runs pending defers, then `ret` / `rti` / `hlt`
+/// (or a forward jmp inside an `@inline` body).
+pub fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
+    if (r.value) |v| {
+        if (self.inline_ret_struct) |sname| {
+            // Inlined struct return: materialize into the caller-frame
+            // result slot, then leave its address in `acu`.
+            try value_struct.emitInto(self, v, sname, self.inline_ret_slot);
+            try isa.movRegToReg(self, Reg.fp, Reg.acu);
+            const slot = self.inline_ret_slot; // negative — a caller-frame local
+            // @as: widen i8 → i16 so negating the min value is safe; |slot| ≤ frame cap fits u16.
+            if (slot < 0) try isa.subImmFromReg(self, @intCast(-@as(i16, slot)), Reg.acu);
+        } else if (self.current_ret_struct) |sname| {
+            // Struct return: copy the value into the caller's sret buffer,
+            // then leave that buffer's address in `acu` (a struct value
+            // *is* an address).
+            try value_struct.emitIntoSret(self, v, sname, self.sret_param_ofs);
+            try isa.movRegToReg(self, Reg.fp, Reg.acu);
+            if (self.sret_param_ofs > 0) try isa.addImmToReg(self, @intCast(self.sret_param_ofs), Reg.acu);
+            try isa.movRegOffsetToReg(self, Reg.acu, 0, Reg.acu);
+        } else {
+            try self.emitExpr(v);
+        }
+    }
+    // Defers on every still-active block fire before the frame tears
+    // down — innermost first, LIFO within each block. `acu` carries the
+    // return value through the cleanup (the defer-emitter saves it).
+    try self.unwindAllDefersForReturn();
+    if (self.inline_returns) |*returns| {
+        // Inside an `@inline` body — redirect `return` to a forward jmp
+        // past the splice; the slot is patched once the body emits.
+        try self.emitByte(Op.jmp_addr);
+        const patch = try self.currentOffset();
+        try self.emitU16Le(0);
+        try returns.append(self.allocator, patch);
+        return;
+    }
+    if (self.is_entry) {
+        try isa.hlt(self);
+    } else if (self.is_isr) {
+        try self.emitByte(Op.rti_op);
+    } else {
+        try self.emitByte(Op.ret_op);
+    }
+}
+
+/// `print a, b, …` — emit each arg by its type, space-separated, with a
+/// trailing newline (§4.9).
+pub fn emitPrintStmt(self: *Emitter, p: ast.PrintStmt) !void {
+    for (p.args, 0..) |arg, i| {
+        // Space separator between args (§4.9).
+        if (i > 0) {
+            try isa.movImmToReg(self, ' ', Reg.acu);
+            try isa.sys(self, Sys.print_char);
+        }
+        try emitPrintArg(self, arg);
+    }
+    try isa.sys(self, Sys.print_newline); // trailing newline (§4.9)
+}
+
+/// Emit one `print` argument, routing to the syscall its inferred type
+/// calls for (§4.9): `char` → `print_char`, `fixed` → `print_fixed`,
+/// `str` → `print_str` (string literals emit per-part for
+/// interpolation), everything else → `print_int`.
+fn emitPrintArg(self: *Emitter, arg: *const ast.Expr) !void {
+    if (arg.* == .str_lit) {
+        try strings.emitPrintStrLit(self, arg.str_lit);
+        return;
+    }
+    if (self.isPrimitiveType(arg, .char)) {
+        try self.emitExpr(arg);
+        try isa.sys(self, Sys.print_char);
+        return;
+    }
+    if (self.isPrimitiveType(arg, .fixed)) {
+        try self.emitExpr(arg);
+        try isa.sys(self, Sys.print_fixed);
+        return;
+    }
+    if (self.isPrimitiveType(arg, .str)) {
+        try self.emitExpr(arg);
+        try isa.sys(self, Sys.print_str);
+        return;
+    }
+    // A struct has no scalar rendering — `print p` would otherwise emit
+    // `print_int` of its base address. Print fields explicitly.
+    if (self.structNameOf(arg)) |_| {
+        try self.unsupported(arg.span(), "printing a whole struct — print its fields instead");
+        return;
+    }
+    try self.emitExpr(arg);
+    try isa.sys(self, Sys.print_int);
+}

--- a/src/lang/codegen/struct_.zig
+++ b/src/lang/codegen/struct_.zig
@@ -1,0 +1,204 @@
+// Codegen for inline value structs (§3.4). A struct value lives in
+// its owner's frame as contiguous bytes; a struct-typed expression
+// evaluates to that base address. Construction writes each field at
+// its offset (recursing into nested struct fields); assignment copies
+// the bytes (value semantics). Nested structs work because they sit
+// inline at a fixed frame offset within the parent. A struct argument
+// is passed by value: the caller reserves its width on the stack and
+// materializes a copy there (`pushArg`).
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const class = @import("class.zig");
+
+const Emitter = codegen.Emitter;
+const Reg = opcodes.Reg;
+
+/// Where a materialized struct lands. `frame` is fp-relative (a local
+/// or param slot — `ofs` negative for locals, positive for params).
+/// `sp` is sp-relative (a freshly reserved stack region for an
+/// outgoing argument — `ofs` ≥ 0 from the current `sp`). `indirect` is
+/// the buffer pointed to by a frame slot holding an address (`ptr_ofs`)
+/// plus a field `delta` — used to write a returned struct into the
+/// caller's sret destination.
+const Dest = union(enum) {
+    frame: i16,
+    sp: i16,
+    indirect: struct { ptr_ofs: i16, delta: i16 },
+
+    /// Shift the destination deeper by `delta` bytes (a nested field).
+    fn at(self: Dest, delta: i16) Dest {
+        return switch (self) {
+            .frame => |o| .{ .frame = o + delta },
+            .sp => |o| .{ .sp = o + delta },
+            .indirect => |ind| .{ .indirect = .{ .ptr_ofs = ind.ptr_ofs, .delta = ind.delta + delta } },
+        };
+    }
+};
+
+/// `reg = base + ofs` for a destination. The `sp` form re-reads `sp`
+/// and `indirect` re-loads its pointer slot — both valid because every
+/// field-value expression restores `sp` and leaves the frame slot
+/// untouched, so the destination base stays stable across fields.
+fn destAddrToReg(self: *Emitter, dest: Dest, reg: u8) !void {
+    switch (dest) {
+        .frame => |ofs| try frameAddrToReg(self, ofs, reg),
+        .sp => |ofs| {
+            try isa.movRegToReg(self, Reg.sp, reg);
+            if (ofs > 0) try isa.addImmToReg(self, @intCast(ofs), reg);
+        },
+        .indirect => |ind| {
+            try isa.movRegToReg(self, Reg.fp, reg);
+            if (ind.ptr_ofs > 0) try isa.addImmToReg(self, @intCast(ind.ptr_ofs), reg);
+            try isa.movRegOffsetToReg(self, reg, 0, reg); // reg = stored pointer
+            if (ind.delta > 0) try isa.addImmToReg(self, @intCast(ind.delta), reg);
+        },
+    }
+}
+
+/// Materialize a value of struct `sname` into the frame slot based at
+/// `dest_ofs` (fp-relative). `src` is a struct literal — write each
+/// field, recursing into nested struct fields — or another struct
+/// value, byte-copied for value semantics.
+pub fn emitInto(self: *Emitter, src: *const ast.Expr, sname: []const u8, dest_ofs: i16) error{OutOfMemory}!void {
+    try emitIntoDest(self, src, sname, .{ .frame = dest_ofs });
+}
+
+/// Pass a struct argument by value: reserve its (2-aligned) width on
+/// the stack and materialize a copy there. Mirrors a `pushReg` for a
+/// scalar arg — leaves the bytes at `[sp ..]` for the callee's param.
+pub fn pushArg(self: *Emitter, arg: *const ast.Expr, sname: []const u8) error{OutOfMemory}!void {
+    const w = self.structSlotWidth(sname);
+    try isa.subImmFromReg(self, w, Reg.sp);
+    try emitIntoDest(self, arg, sname, .{ .sp = 0 });
+}
+
+/// Materialize a returned struct into the caller's sret buffer — the
+/// address held in the frame slot at `ptr_ofs`. Writing through the
+/// stable pointer slot needs no local temp.
+pub fn emitIntoSret(self: *Emitter, src: *const ast.Expr, sname: []const u8, ptr_ofs: i16) error{OutOfMemory}!void {
+    try emitIntoDest(self, src, sname, .{ .indirect = .{ .ptr_ofs = ptr_ofs, .delta = 0 } });
+}
+
+fn emitIntoDest(self: *Emitter, src: *const ast.Expr, sname: []const u8, dest: Dest) error{OutOfMemory}!void {
+    if (src.* == .struct_lit) {
+        try emitLitInto(self, src.struct_lit, sname, dest);
+        return;
+    }
+    // Copy the source struct's bytes into the destination region.
+    try self.emitExpr(src); // acu = source base address
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try destAddrToReg(self, dest, Reg.r2);
+    try copyBytes(self, Reg.r1, Reg.r2, self.structWidth(sname));
+}
+
+fn emitLitInto(self: *Emitter, sl: ast.StructLit, sname: []const u8, dest: Dest) error{OutOfMemory}!void {
+    const sd = self.struct_decls.get(sname).?;
+    for (sd.fields) |df| {
+        const fname = self.source[df.name.start..df.name.end];
+        const info = self.structFieldInfo(sname, fname).?;
+        const value = litFieldValue(self, sl, fname) orelse continue;
+        // The field sits inline at this fixed offset within the region.
+        const field_dest = dest.at(@intCast(info.offset));
+        if (info.struct_name) |sub| {
+            try emitIntoDest(self, value, sub, field_dest);
+        } else {
+            try self.emitExpr(value); // acu = scalar value
+            try isa.movRegToReg(self, Reg.acu, Reg.r2);
+            try destAddrToReg(self, field_dest, Reg.r1);
+            try storeWidth(self, Reg.r1, info.width, Reg.r2);
+        }
+    }
+}
+
+/// Load field `field_name` of struct `sname` given the receiver's base
+/// address in `acu`. A scalar field is loaded into `acu`; a nested
+/// struct field leaves its address in `acu` (a struct value *is* an
+/// address).
+pub fn emitFieldLoad(self: *Emitter, sname: []const u8, field_name: []const u8) !void {
+    const info = self.structFieldInfo(sname, field_name).?;
+    if (info.struct_name != null) {
+        if (info.offset != 0) try isa.addImmToReg(self, info.offset, Reg.acu);
+        return;
+    }
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    if (info.width == 1) {
+        try class.emitByteLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+    } else {
+        try class.emitWordLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+    }
+}
+
+/// Store `value` into field `field_name` of the struct addressed by
+/// `recv`. A nested struct field copies the value's bytes.
+pub fn emitFieldStore(self: *Emitter, recv: *const ast.Expr, sname: []const u8, field_name: []const u8, value: *const ast.Expr) !void {
+    const info = self.structFieldInfo(sname, field_name).?;
+    if (info.struct_name) |sub| {
+        try self.emitExpr(value); // acu = source address
+        try isa.pushReg(self, Reg.acu);
+        try self.emitExpr(recv); // acu = receiver base address
+        if (info.offset != 0) try isa.addImmToReg(self, info.offset, Reg.acu);
+        try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = dest addr
+        try isa.popReg(self, Reg.r1); // r1 = src addr
+        try copyBytes(self, Reg.r1, Reg.r2, self.structWidth(sub));
+        return;
+    }
+    try self.emitExpr(value);
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(recv); // acu = receiver base address
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try isa.popReg(self, Reg.r2);
+    try class_storeAt(self, Reg.r1, info.offset, info.width, Reg.r2);
+}
+
+/// Copy `width` bytes from `[src]` to `[dest]` — word strides with a
+/// trailing byte. Advances both pointers (offset 0 each step) rather
+/// than indexing, so the copy never collides with the at-offset
+/// helpers' scratch registers and works for a struct of any size.
+/// Consumes `src`/`dest` (callers don't reuse them afterward).
+pub fn copyBytes(self: *Emitter, src: u8, dest: u8, width: u16) !void {
+    var remaining = width;
+    while (remaining >= 2) : (remaining -= 2) {
+        try isa.movRegOffsetToReg(self, src, 0, Reg.acu);
+        try isa.movRegToRegOffset(self, Reg.acu, dest, 0);
+        try isa.addImmToReg(self, 2, src);
+        try isa.addImmToReg(self, 2, dest);
+    }
+    if (remaining == 1) {
+        try class.emitByteLoadAtOffset(self, src, 0, Reg.acu);
+        try class.emitByteStoreAtOffset(self, dest, 0, Reg.acu);
+    }
+}
+
+fn storeWidth(self: *Emitter, base: u8, width: u16, src: u8) !void {
+    try class_storeAt(self, base, 0, width, src);
+}
+
+fn class_storeAt(self: *Emitter, base: u8, offset: u16, width: u16, src: u8) !void {
+    if (width == 1) {
+        try class.emitByteStoreAtOffset(self, base, offset, src);
+    } else {
+        try class.emitWordStoreAtOffset(self, base, offset, src);
+    }
+}
+
+/// `reg = fp + ofs` — the address of a frame slot (`ofs` negative for
+/// locals, positive for params).
+fn frameAddrToReg(self: *Emitter, ofs: i16, reg: u8) !void {
+    try isa.movRegToReg(self, Reg.fp, reg);
+    if (ofs < 0) {
+        try isa.subImmFromReg(self, @intCast(-ofs), reg);
+    } else if (ofs > 0) {
+        try isa.addImmToReg(self, @intCast(ofs), reg);
+    }
+}
+
+fn litFieldValue(self: *Emitter, sl: ast.StructLit, field_name: []const u8) ?*const ast.Expr {
+    for (sl.fields) |f| {
+        if (std.mem.eql(u8, self.source[f.name.start..f.name.end], field_name)) return f.value;
+    }
+    return null;
+}

--- a/src/lang/codegen/value_struct.zig
+++ b/src/lang/codegen/value_struct.zig
@@ -106,7 +106,7 @@ fn emitLitInto(self: *Emitter, sl: ast.StructLit, sname: []const u8, dest: Dest)
         if (info.struct_name) |sub| {
             try emitIntoDest(self, value, sub, field_dest);
         } else {
-            try self.emitExpr(value); // acu = scalar value
+            try self.emitExpr(value);
             try isa.movRegToReg(self, Reg.acu, Reg.r2);
             try destAddrToReg(self, field_dest, Reg.r1);
             try storeWidth(self, Reg.r1, info.width, Reg.r2);
@@ -136,19 +136,21 @@ pub fn emitFieldLoad(self: *Emitter, sname: []const u8, field_name: []const u8) 
 /// `recv`. A nested struct field copies the value's bytes.
 pub fn emitFieldStore(self: *Emitter, recv: *const ast.Expr, sname: []const u8, field_name: []const u8, value: *const ast.Expr) !void {
     const info = self.structFieldInfo(sname, field_name).?;
+    // Evaluate the value first and stash it on the stack — computing
+    // the receiver's address reuses acu, so the value can't stay there.
     if (info.struct_name) |sub| {
-        try self.emitExpr(value); // acu = source address
+        try self.emitExpr(value);
         try isa.pushReg(self, Reg.acu);
-        try self.emitExpr(recv); // acu = receiver base address
+        try self.emitExpr(recv);
         if (info.offset != 0) try isa.addImmToReg(self, info.offset, Reg.acu);
-        try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = dest addr
-        try isa.popReg(self, Reg.r1); // r1 = src addr
+        try isa.movRegToReg(self, Reg.acu, Reg.r2);
+        try isa.popReg(self, Reg.r1);
         try copyBytes(self, Reg.r1, Reg.r2, self.structWidth(sub));
         return;
     }
     try self.emitExpr(value);
     try isa.pushReg(self, Reg.acu);
-    try self.emitExpr(recv); // acu = receiver base address
+    try self.emitExpr(recv);
     try isa.movRegToReg(self, Reg.acu, Reg.r1);
     try isa.popReg(self, Reg.r2);
     try class_storeAt(self, Reg.r1, info.offset, info.width, Reg.r2);

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -144,6 +144,9 @@ const suggestions = @import("typecheck/suggestions.zig");
 const type_resolve = @import("typecheck/type_resolve.zig");
 const fields = @import("typecheck/fields.zig");
 const operators = @import("typecheck/operators.zig");
+const diag_check = @import("typecheck/diagnostics.zig");
+const decls = @import("typecheck/decls.zig");
+const class_check = @import("typecheck/class_check.zig");
 const calls = @import("typecheck/calls.zig");
 
 const T = annotations.T;
@@ -245,22 +248,19 @@ pub const Checker = struct {
 
     // ---------- diagnostic helpers ----------
 
-    /// Emit a fatal diagnostic at `span`.
+    // ---------- diagnostic helpers (delegated to typecheck/diagnostics.zig) ----------
+
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn emitSpan(
         self: *Checker,
         code: []const u8,
         span: ast.Span,
         message: []const u8,
     ) WalkError!void {
-        try self.diagnostics.append(self.diag_alloc, .{
-            .severity = .fatal,
-            .code = code,
-            .message = message,
-            .span = span,
-        });
+        return diag_check.emitSpan(self, code, span, message);
     }
 
-    /// Like `emitSpan` plus a `help:` block.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn emitSpanHelp(
         self: *Checker,
         code: []const u8,
@@ -268,35 +268,20 @@ pub const Checker = struct {
         message: []const u8,
         help: []const u8,
     ) WalkError!void {
-        try self.diagnostics.append(self.diag_alloc, .{
-            .severity = .fatal,
-            .code = code,
-            .message = message,
-            .span = span,
-            .help = help,
-        });
+        return diag_check.emitSpanHelp(self, code, span, message, help);
     }
 
-    /// Emit `E_TYPE_MISMATCH` for an expected-vs-actual mismatch
-    /// at a single span.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn emitMismatch(
         self: *Checker,
         span: ast.Span,
         expected_ty: *const types.Type,
         actual_ty: *const types.Type,
     ) WalkError!void {
-        const expected_s = try types.render(self.arena, expected_ty.*);
-        const actual_s = try types.render(self.arena, actual_ty.*);
-        const msg = try std.fmt.allocPrint(
-            self.arena,
-            "type mismatch: expected `{s}`, found `{s}`",
-            .{ expected_s, actual_s },
-        );
-        try self.emitSpan("E_TYPE_MISMATCH", span, msg);
+        return diag_check.emitMismatch(self, span, expected_ty, actual_ty);
     }
 
-    /// Like `emitMismatch` but anchors the expected type to a
-    /// `: T` annotation span via a secondary label.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn emitMismatchAnnotated(
         self: *Checker,
         span: ast.Span,
@@ -304,175 +289,65 @@ pub const Checker = struct {
         actual_ty: *const types.Type,
         annotation_span: ast.Span,
     ) WalkError!void {
-        const expected_s = try types.render(self.arena, expected_ty.*);
-        const actual_s = try types.render(self.arena, actual_ty.*);
-        const msg = try std.fmt.allocPrint(
-            self.arena,
-            "type mismatch: expected `{s}`, found `{s}`",
-            .{ expected_s, actual_s },
-        );
-        const label_msg = try std.fmt.allocPrint(
-            self.arena,
-            "expected `{s}` because of this annotation",
-            .{expected_s},
-        );
-        const sec = try self.singleSecondary(annotation_span, label_msg, .underline);
-        try self.diagnostics.append(self.diag_alloc, .{
-            .severity = .fatal,
-            .code = "E_TYPE_MISMATCH",
-            .message = msg,
-            .span = span,
-            .secondary = sec,
-        });
+        return diag_check.emitMismatchAnnotated(self, span, expected_ty, actual_ty, annotation_span);
     }
 
-    /// Allocate a one-element `SpanLabel` slice on `self.arena`,
-    /// suitable for `Diagnostic.secondary`.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn singleSecondary(
         self: *Checker,
         span: ast.Span,
         message: []const u8,
         decoration: diag_mod.SpanLabel.Decoration,
     ) WalkError![]const diag_mod.SpanLabel {
-        const sec = try self.arena.alloc(diag_mod.SpanLabel, 1);
-        sec[0] = .{ .span = span, .message = message, .decoration = decoration };
-        return sec;
+        return diag_check.singleSecondary(self, span, message, decoration);
     }
 
-    /// Assignability + narrowing check for "store into a typed
-    /// slot" sites (let-init, assignment, call arg, return).
-    /// Routes per spec §3.5.1:
-    /// - Assignable → no diagnostic.
-    /// - Integer narrowing without `as` → `E_CAST_PRECISION_LOSS`
-    ///   (warning).
-    /// - Otherwise → `E_TYPE_MISMATCH` (fatal).
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn checkStoreCompat(
         self: *Checker,
         span: ast.Span,
         expected: *const types.Type,
         actual: *const types.Type,
     ) WalkError!void {
-        if (relations.assignable(actual.*, expected.*)) return;
-        if (self.isClassSubtype(actual.*, expected.*)) return;
-        if (relations.isNarrowingInt(actual.*, expected.*)) {
-            try self.emitNarrowingWarning(span, expected, actual);
-            return;
-        }
-        try self.emitMismatch(span, expected, actual);
+        return diag_check.checkStoreCompat(self, span, expected, actual);
     }
 
-    /// `true` when `actual` is a class derived from `expected`
-    /// (transitively, via `extends`). Also covers `&Sub` → `&Sup`
-    /// reference subtyping by peeling one layer per side.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn isClassSubtype(self: *const Checker, actual: types.Type, expected: types.Type) bool {
-        const a = if (actual == .reference) actual.reference.* else actual;
-        const e = if (expected == .reference) expected.reference.* else expected;
-        if (a != .named or e != .named) return false;
-        const expected_name = e.named.name;
-        var cur = self.class_registry.get(a.named.name) orelse return false;
-        while (cur.extends) |ext| {
-            const parent_name = self.lexeme(ext);
-            if (std.mem.eql(u8, parent_name, expected_name)) return true;
-            cur = self.class_registry.get(parent_name) orelse return false;
-        }
-        return false;
+        return diag_check.isClassSubtype(self, actual, expected);
     }
 
-    fn emitNarrowingWarning(
-        self: *Checker,
-        span: ast.Span,
-        expected_ty: *const types.Type,
-        actual_ty: *const types.Type,
-    ) WalkError!void {
-        const expected_s = try types.render(self.arena, expected_ty.*);
-        const actual_s = try types.render(self.arena, actual_ty.*);
-        const msg = try std.fmt.allocPrint(
-            self.arena,
-            "implicit narrowing from `{s}` to `{s}` may lose precision — use an explicit `as {s}` cast to silence this warning",
-            .{ actual_s, expected_s, expected_s },
-        );
-        try self.diagnostics.append(self.diag_alloc, .{
-            .severity = .warning,
-            .code = "E_CAST_PRECISION_LOSS",
-            .message = msg,
-            .span = span,
-        });
-    }
-
-    /// Return the source-text slice for `span`.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn lexeme(self: *const Checker, span: ast.Span) []const u8 {
-        return self.source[span.start..span.end];
+        return diag_check.lexeme(self, span);
     }
 
-    // ---------- "did you mean…?" suggestions ----------
-
-    /// Closest near-spelling match for an undefined symbol across
-    /// the scope chain + type registries. `null` when nothing is
-    /// within `suggestions.max_distance`.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn suggestSymbol(self: *Checker, name: []const u8) WalkError!?[]const u8 {
-        var pool: std.ArrayList([]const u8) = .empty;
-        defer pool.deinit(self.arena);
-        var scope: ?*const Scope = self.current_scope;
-        while (scope) |s| : (scope = s.parent) {
-            var it = s.entries.keyIterator();
-            while (it.next()) |k| try pool.append(self.arena, k.*);
-        }
-        return suggestions.bestMatch(name, pool.items);
+        return diag_check.suggestSymbol(self, name);
     }
 
-    /// Same pool as `suggestSymbol` plus the primitive type names —
-    /// used by `E_TYPE_UNDEFINED` when an unknown type name shows
-    /// up in an annotation / struct-lit position.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn suggestTypeName(self: *Checker, name: []const u8) WalkError!?[]const u8 {
-        var pool: std.ArrayList([]const u8) = .empty;
-        defer pool.deinit(self.arena);
-        // Primitives matched first so `let x: i8` wins over a stray
-        // `i9` local. Mirrors `types.primitiveFromName`.
-        const primitives = [_][]const u8{ "i8", "u8", "i16", "u16", "int", "uint", "bool", "nil", "str", "fixed", "char" };
-        for (primitives) |p| try pool.append(self.arena, p);
-        var struct_it = self.struct_registry.keyIterator();
-        while (struct_it.next()) |k| try pool.append(self.arena, k.*);
-        var class_it = self.class_registry.keyIterator();
-        while (class_it.next()) |k| try pool.append(self.arena, k.*);
-        var enum_it = self.enum_registry.keyIterator();
-        while (enum_it.next()) |k| try pool.append(self.arena, k.*);
-        return suggestions.bestMatch(name, pool.items);
+        return diag_check.suggestTypeName(self, name);
     }
 
-    /// Best-match field name on a struct.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn suggestStructField(self: *Checker, sd: *const ast.StructDecl, name: []const u8) WalkError!?[]const u8 {
-        var pool: std.ArrayList([]const u8) = .empty;
-        defer pool.deinit(self.arena);
-        for (sd.fields) |f| try pool.append(self.arena, self.lexeme(f.name));
-        return suggestions.bestMatch(name, pool.items);
+        return diag_check.suggestStructField(self, sd, name);
     }
 
-    /// Best-match field name across a class and its parents.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn suggestClassField(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
-        var pool: std.ArrayList([]const u8) = .empty;
-        defer pool.deinit(self.arena);
-        var cur: ?*const ast.ClassDecl = cd;
-        while (cur) |c| {
-            for (c.fields) |f| try pool.append(self.arena, self.lexeme(f.name));
-            cur = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
-        }
-        return suggestions.bestMatch(name, pool.items);
+        return diag_check.suggestClassField(self, cd, name);
     }
 
-    /// Best-match method name across a class and its parents.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn suggestClassMethod(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
-        var pool: std.ArrayList([]const u8) = .empty;
-        defer pool.deinit(self.arena);
-        var cur: ?*const ast.ClassDecl = cd;
-        while (cur) |c| {
-            for (c.methods) |m| try pool.append(self.arena, self.lexeme(m.name));
-            cur = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
-        }
-        return suggestions.bestMatch(name, pool.items);
+        return diag_check.suggestClassMethod(self, cd, name);
     }
 
-    /// Emit a fatal diagnostic; appends `help: did you mean \`X\`?`
-    /// when `candidate` is non-null.
+    /// Delegated to `typecheck/diagnostics.zig`.
     pub fn emitSpanWithSuggestion(
         self: *Checker,
         code: []const u8,
@@ -480,171 +355,30 @@ pub const Checker = struct {
         message: []const u8,
         candidate: ?[]const u8,
     ) WalkError!void {
-        const name = candidate orelse return self.emitSpan(code, span, message);
-        const help = try std.fmt.allocPrint(self.arena, "did you mean `{s}`?", .{name});
-        try self.emitSpanHelp(code, span, message, help);
+        return diag_check.emitSpanWithSuggestion(self, code, span, message, candidate);
     }
-
     // ---------- Pass 1: top-level decl registration ----------
 
-    fn registerTopLevel(self: *Checker, s: ast.Statement) WalkError!void {
-        switch (s) {
-            .let_decl => |d| try self.registerLetPattern(d.pattern, .let_binding, d.type_ann),
-            .const_decl => |d| try self.registerName(
-                self.lexeme(d.name),
-                .{ .kind = .const_binding, .decl_span = d.name, .ty = null },
-            ),
-            .def_decl => |d| {
-                const sig = try self.signatureFromDef(d);
-                try self.registerName(self.lexeme(d.name), .{
-                    .kind = .function,
-                    .decl_span = d.name,
-                    .ty = sig,
-                });
-            },
-            .class_decl => |d| try self.registerName(self.lexeme(d.name), .{
-                .kind = .class,
-                .decl_span = d.name,
-                .ty = null,
-            }),
-            .struct_decl => |d| try self.registerName(self.lexeme(d.name), .{
-                .kind = .struct_,
-                .decl_span = d.name,
-                .ty = null,
-            }),
-            .enum_decl => |d| try self.registerName(self.lexeme(d.name), .{
-                .kind = .enum_,
-                .decl_span = d.name,
-                .ty = null,
-            }),
-            .use_decl => |d| try self.registerUseDecl(d),
-            else => {},
-        }
+    // ---------- Pass 1: top-level decl registration (delegated to typecheck/decls.zig) ----------
+
+    /// Delegated to `typecheck/decls.zig`.
+    pub fn registerTopLevel(self: *Checker, s: ast.Statement) WalkError!void {
+        return decls.registerTopLevel(self, s);
     }
 
-    fn registerLetPattern(
-        self: *Checker,
-        pat: *const ast.Pattern,
-        kind: scope_mod.SymbolKind,
-        type_ann: ?*const ast.TypeAnn,
-    ) WalkError!void {
-        // Only the simple `let name = …` form registers a single
-        // symbol here. Tuple / struct destructuring registers each
-        // bound name in pass 2 (where the rhs type is known).
-        switch (pat.*) {
-            .ident => |i| {
-                const ty: ?*const types.Type = if (type_ann) |t|
-                    try type_resolve.resolveType(self, t)
-                else
-                    null;
-                try self.registerName(self.lexeme(i.name), .{
-                    .kind = kind,
-                    .decl_span = i.name,
-                    .ty = ty,
-                });
-            },
-            else => {
-                // Destructuring patterns will register their inner
-                // names during pass 2 when the type is known.
-            },
-        }
-    }
-
-    fn registerUseDecl(self: *Checker, d: ast.UseDecl) WalkError!void {
-        if (d.items.len > 0) {
-            // `use a [as al], b [as bl] from module` — each item
-            // becomes its own imported symbol.
-            for (d.items) |it| {
-                const name = if (it.alias) |a| self.lexeme(a) else self.lexeme(it.name);
-                try self.registerName(name, .{
-                    .kind = .imported,
-                    .decl_span = it.name,
-                    .ty = null,
-                });
-            }
-        } else {
-            // Whole-module import — register the alias (or the
-            // module lexeme itself if no alias).
-            const name = if (d.alias) |a| self.lexeme(a) else self.lexeme(d.module);
-            try self.registerName(name, .{
-                .kind = .module_alias,
-                .decl_span = d.module,
-                .ty = null,
-            });
-        }
-    }
-
-    fn registerName(
+    /// Delegated to `typecheck/decls.zig`.
+    pub fn registerName(
         self: *Checker,
         name: []const u8,
         info: scope_mod.SymbolInfo,
     ) WalkError!void {
-        if (isReservedBuiltinName(name)) {
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "cannot shadow always-in-scope builtin `{s}`",
-                .{name},
-            );
-            try self.emitSpan("E_BUILTIN_SHADOW", info.decl_span, msg);
-            return;
-        }
-        self.current_scope.define(name, info) catch |err| switch (err) {
-            error.AlreadyDefined => {
-                const existing = self.current_scope.lookupLocal(name).?;
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "`{s}` is already defined in this scope",
-                    .{name},
-                );
-                const sec = try self.singleSecondary(existing.decl_span, "previous definition here", .underline);
-                try self.diagnostics.append(self.diag_alloc, .{
-                    .severity = .fatal,
-                    .code = "E_TYPE_REDEFINED",
-                    .message = msg,
-                    .span = info.decl_span,
-                    .secondary = sec,
-                });
-                return;
-            },
-            error.OutOfMemory => return error.OutOfMemory,
-        };
-        // Track function-body locals for the `return &local`
-        // stack-lifetime check. `null` at module / class scope.
-        if (self.fn_locals) |*set| {
-            _ = try set.put(self.arena, name, {});
-        }
-        // Track lambda-body locals for the `@no_capture`
-        // capture-mutation check. `null` outside a tracked lambda.
-        if (self.lambda_locals) |*set| {
-            _ = try set.put(self.arena, name, {});
-        }
+        return decls.registerName(self, name, info);
     }
 
-    /// Build the function-pointer type for a `def`. Unannotated
-    /// params produce a `nil` placeholder slot (treated as "skip
-    /// arg-type check" by `checkCall`).
-    fn signatureFromDef(self: *Checker, d: ast.DefDecl) WalkError!*const types.Type {
-        var param_types: std.ArrayList(*const types.Type) = .empty;
-        errdefer param_types.deinit(self.arena);
-        for (d.params) |p| {
-            const pt: *const types.Type = if (p.type_ann) |t|
-                try type_resolve.resolveType(self, t)
-            else
-                try self.primitive(.nil_); // unknown until call-site inference
-            try param_types.append(self.arena, pt);
-        }
-        const ret_ty: *const types.Type = if (d.ret_type) |r|
-            try type_resolve.resolveType(self, r)
-        else
-            try self.primitive(.nil_);
-        const sig = try self.arena.create(types.Type);
-        sig.* = .{ .function = .{
-            .params = try param_types.toOwnedSlice(self.arena),
-            .ret = ret_ty,
-        } };
-        return sig;
+    /// Delegated to `typecheck/decls.zig`.
+    pub fn signatureFromDef(self: *Checker, d: ast.DefDecl) WalkError!*const types.Type {
+        return decls.signatureFromDef(self, d);
     }
-
     // ---------- Pass 2: resolution + inference + checking ----------
 
     fn walkStatement(self: *Checker, s: ast.Statement) WalkError!void {
@@ -748,7 +482,7 @@ pub const Checker = struct {
             // annotation as a secondary span so the renderer
             // surfaces "expected `T` because of this annotation"
             // — sole call site that overrides the plain
-            // `checkStoreCompat` path (#254 AC).
+            // `checkStoreCompat` path.
             if (!relations.assignable(init_ty.?.*, ann_ty.?.*) and
                 !self.isClassSubtype(init_ty.?.*, ann_ty.?.*) and
                 !relations.isNarrowingInt(init_ty.?.*, ann_ty.?.*) and
@@ -1097,250 +831,21 @@ pub const Checker = struct {
         try self.emitSpan("E_REF_STACK_LIFETIME", v.span(), msg);
     }
 
-    fn checkDefDecl(self: *Checker, d: ast.DefDecl) WalkError!void {
-        try annotations.validateAnnotations(self, d.annotations, T.DEF);
-        if (d.is_bake) try calls.checkBakeAnnotationConflicts(self, d.annotations);
-        try calls.checkVariadicPosition(self, d);
-        const saved_scope = self.current_scope;
-        var fn_scope: Scope = .init(self.arena, saved_scope);
-        self.current_scope = &fn_scope;
-        defer self.current_scope = saved_scope;
+    // ---------- class + def declaration checking (delegated to typecheck/class_check.zig) ----------
 
-        // Fresh `fn_locals` per fn — params and inner `let`s land
-        // here; nested `def`s push their own frame too so an inner
-        // fn doesn't inherit outer-fn locals.
-        const saved_locals = self.fn_locals;
-        self.fn_locals = .{};
-        defer self.fn_locals = saved_locals;
-
-        // Bake context: `bake def` body satisfies bake rules.
-        // Nested non-bake defs reset the flag for the inner body.
-        const saved_bake = self.in_bake;
-        self.in_bake = d.is_bake;
-        defer self.in_bake = saved_bake;
-
-        // `@no_capture` context: inherited by nested defs.
-        const saved_nc = self.in_no_capture;
-        self.in_no_capture = saved_nc or annotations.defHasNoCapture(self, d);
-        defer self.in_no_capture = saved_nc;
-
-        // Bake fn return type must be bakeable. `Vec(T)` and `&T`
-        // are runtime-only.
-        if (d.is_bake) if (d.ret_type) |r| {
-            const rt = try type_resolve.resolveType(self, r);
-            if (!predicates.isBakeableType(rt.*)) {
-                const ty_s = try types.render(self.arena, rt.*);
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "`bake def` cannot return `{s}` — only types representable as static data are bakeable",
-                    .{ty_s},
-                );
-                try self.emitSpan("E_BAKE_NON_BAKEABLE_VALUE", r.span(), msg);
-            }
-        };
-
-        for (d.params) |p| {
-            const pt: ?*const types.Type = if (p.type_ann) |t|
-                try type_resolve.resolveType(self, t)
-            else
-                null;
-            try self.registerName(self.lexeme(p.name), .{
-                .kind = .param,
-                .decl_span = p.name,
-                .ty = pt,
-            });
-        }
-
-        if (d.ret_type == null and self.bodyMentions(d.body, self.lexeme(d.name))) {
-            const msg = try std.fmt.allocPrint(
-                self.arena,
-                "recursive function `{s}` needs an explicit return type",
-                .{self.lexeme(d.name)},
-            );
-            try self.emitSpan("E_TYPE_RECURSIVE_NO_RET", d.name, msg);
-        }
-
-        // Track ret type for `return expr` checking inside the body.
-        const saved_ret = self.current_ret_ty;
-        self.current_ret_ty = if (d.ret_type) |r| try type_resolve.resolveType(self, r) else null;
-        defer self.current_ret_ty = saved_ret;
-
-        try self.walkStatementSequence(d.body);
+    /// Delegated to `typecheck/class_check.zig`.
+    pub fn checkDefDecl(self: *Checker, d: ast.DefDecl) WalkError!void {
+        return class_check.checkDefDecl(self, d);
     }
 
-    fn checkClassDecl(self: *Checker, d: ast.ClassDecl) WalkError!void {
-        try annotations.validateAnnotations(self, d.annotations, T.CLASS);
-        const saved = self.current_scope;
-        var class_scope: Scope = .init(self.arena, saved);
-        self.current_scope = &class_scope;
-        defer self.current_scope = saved;
-
-        const saved_extends = self.current_class_extends;
-        self.current_class_extends = d.extends;
-        defer self.current_class_extends = saved_extends;
-
-        const saved_name = self.current_class_name;
-        self.current_class_name = self.lexeme(d.name);
-        defer self.current_class_name = saved_name;
-
-        if (d.extends) |ext| if (self.class_registry.get(self.lexeme(ext))) |parent| {
-            if (annotations.hasAnnotation(self, parent.annotations, "final")) {
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "cannot extend `{s}` — parent class is marked `@final`",
-                    .{self.lexeme(ext)},
-                );
-                try self.emitSpan("E_CLASS_FINAL_EXTENDS", ext, msg);
-            }
-        };
-
-        for (d.fields) |f| {
-            try annotations.validateAnnotations(self, f.annotations, T.CLASS_FIELD);
-            const ty: ?*const types.Type = if (f.type_ann) |t|
-                try type_resolve.resolveType(self, t)
-            else
-                null;
-            try self.registerName(self.lexeme(f.name), .{
-                .kind = .let_binding,
-                .decl_span = f.name,
-                .ty = ty,
-            });
-            if (f.init) |init_| _ = try self.inferExpr(init_, ty);
-        }
-        for (d.methods) |m| {
-            try self.checkMethodAnnotations(&d, m);
-            const sig = try self.signatureFromDef(m);
-            try self.registerName(self.lexeme(m.name), .{
-                .kind = .function,
-                .decl_span = m.name,
-                .ty = sig,
-            });
-            try self.checkDefDecl(m);
-        }
-
-        if (!annotations.classIsAbstract(self, &d)) {
-            try self.checkAbstractMethodsImplemented(&d);
-        }
+    /// Delegated to `typecheck/class_check.zig`.
+    pub fn checkClassDecl(self: *Checker, d: ast.ClassDecl) WalkError!void {
+        return class_check.checkClassDecl(self, d);
     }
 
-    /// Validate OOP annotations on a method against its class
-    /// and parent chain.
-    ///
-    /// - `@override` without a parent method → `E_OVERRIDE_NO_PARENT`.
-    /// - Overriding a `@final` method → `E_METHOD_FINAL_OVERRIDE`.
-    /// - `@static` with a `self` first param → `E_STATIC_HAS_SELF`.
-    fn checkMethodAnnotations(
-        self: *Checker,
-        cd: *const ast.ClassDecl,
-        m: ast.DefDecl,
-    ) WalkError!void {
-        const m_name = self.lexeme(m.name);
-        const is_override = annotations.hasAnnotation(self, m.annotations, "override");
-        const is_static = annotations.hasAnnotation(self, m.annotations, "static");
-
-        if (is_static and m.params.len > 0) {
-            const first = self.lexeme(m.params[0].name);
-            if (std.mem.eql(u8, first, "self")) {
-                try self.emitSpan(
-                    "E_STATIC_HAS_SELF",
-                    m.params[0].name,
-                    "`@static` method must not take a `self` parameter — it's called as `ClassName.method(...)`",
-                );
-            }
-        }
-
-        const parent_method = self.lookupParentMethod(cd, m_name);
-        if (is_override) {
-            if (parent_method == null) {
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "`@override` on `{s}` but no parent class declares a method by that name",
-                    .{m_name},
-                );
-                try self.emitSpan("E_OVERRIDE_NO_PARENT", m.name, msg);
-            }
-        }
-        if (parent_method) |pm| {
-            if (annotations.hasAnnotation(self, pm.annotations, "final")) {
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "cannot override `{s}` — parent method is marked `@final`",
-                    .{m_name},
-                );
-                try self.emitSpan("E_METHOD_FINAL_OVERRIDE", m.name, msg);
-            }
-        }
-    }
-
-    /// Walk `cd`'s ancestor chain looking for a method named
-    /// `name`. Returns the closest ancestor's declaration so the
-    /// caller can inspect its annotations (final / abstract /
-    /// private). Returns `null` when no ancestor declares it.
-    fn lookupParentMethod(
-        self: *const Checker,
-        cd: *const ast.ClassDecl,
-        name: []const u8,
-    ) ?*const ast.DefDecl {
-        var cursor = cd;
-        while (cursor.extends) |ext| {
-            const parent = self.class_registry.get(self.lexeme(ext)) orelse return null;
-            for (parent.methods) |*m| {
-                if (std.mem.eql(u8, self.lexeme(m.name), name)) return m;
-            }
-            cursor = parent;
-        }
-        return null;
-    }
-
-    /// Every abstract method inherited by the concrete class `cd`
-    /// must be overridden. Missing impls emit
-    /// `E_ABSTRACT_NOT_IMPLEMENTED`.
-    fn checkAbstractMethodsImplemented(
-        self: *Checker,
-        cd: *const ast.ClassDecl,
-    ) WalkError!void {
-        var cursor: ?*const ast.ClassDecl = cd;
-        while (cursor) |c| : ({
-            cursor = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
-        }) {
-            for (c.methods) |m| {
-                if (!annotations.hasAnnotation(self, m.annotations, "abstract")) continue;
-                if (self.hasConcreteImpl(cd, self.lexeme(m.name), c)) continue;
-                const msg = try std.fmt.allocPrint(
-                    self.arena,
-                    "concrete class `{s}` must override abstract method `{s}` inherited from `{s}`",
-                    .{ self.lexeme(cd.name), self.lexeme(m.name), self.lexeme(c.name) },
-                );
-                try self.emitSpan("E_ABSTRACT_NOT_IMPLEMENTED", cd.name, msg);
-            }
-        }
-    }
-
-    /// Walk from `cd` up through ancestors stopping at (not
-    /// including) `stop_at` — true when some intermediate class
-    /// declares a non-abstract method named `name`.
-    fn hasConcreteImpl(
-        self: *const Checker,
-        cd: *const ast.ClassDecl,
-        name: []const u8,
-        stop_at: *const ast.ClassDecl,
-    ) bool {
-        var cursor: ?*const ast.ClassDecl = cd;
-        while (cursor) |c| {
-            if (c == stop_at) return false;
-            for (c.methods) |m| {
-                if (!std.mem.eql(u8, self.lexeme(m.name), name)) continue;
-                if (annotations.hasAnnotation(self, m.annotations, "abstract")) continue;
-                return true;
-            }
-            cursor = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
-        }
-        return false;
-    }
-
-    /// Register every binder in a pattern (ident binders +
-    /// payload binders inside variant / tuple / struct
-    /// patterns) into the current scope.
+    /// Register every binder a pattern introduces into the current
+    /// scope (untyped — the binding's type resolves later). Recurses
+    /// through tuple / variant / struct / or-pattern alternatives.
     pub fn registerPatternBindings(self: *Checker, p: *const ast.Pattern) WalkError!void {
         switch (p.*) {
             .ident => |i| try self.registerName(self.lexeme(i.name), .{
@@ -1372,7 +877,9 @@ pub const Checker = struct {
         }
     }
 
-    fn bodyMentions(self: *const Checker, body: []const ast.Statement, name: []const u8) bool {
+    /// `true` when `name` appears anywhere in `body` — drives the
+    /// no-capture-mutation check + abstract-method implementation scan.
+    pub fn bodyMentions(self: *const Checker, body: []const ast.Statement, name: []const u8) bool {
         for (body) |s| if (self.stmtMentions(s, name)) return true;
         return false;
     }
@@ -1901,23 +1408,6 @@ fn structLitMentions(c: *const Checker, lit_fields: []const ast.StructLitField, 
 }
 
 // ---------- builtin name reservation ----------
-
-/// `true` when `name` is an always-in-scope builtin per spec §5.3.
-/// User declarations matching these names get `E_BUILTIN_SHADOW`.
-/// `sizeof` is a keyword and rejected by the parser before reaching
-/// here.
-fn isReservedBuiltinName(name: []const u8) bool {
-    const reserved = [_][]const u8{
-        "assert",
-        "debug_assert",
-        "panic",
-        // allow-strict: lang builtin name; the Zig keyword sense doesn't apply on this line.
-        "unreachable",
-        "todo",
-    };
-    for (reserved) |kw| if (std.mem.eql(u8, name, kw)) return true;
-    return false;
-}
 
 // ---------- place expression check ----------
 

--- a/src/lang/typecheck/class_check.zig
+++ b/src/lang/typecheck/class_check.zig
@@ -1,0 +1,263 @@
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const typecheck = @import("../typecheck.zig");
+const annotations = @import("annotations.zig");
+const calls = @import("calls.zig");
+const predicates = @import("predicates.zig");
+const type_resolve = @import("type_resolve.zig");
+const scope_mod = @import("../scope.zig");
+
+const Checker = typecheck.Checker;
+const Scope = scope_mod.Scope;
+const T = annotations.T;
+const WalkError = error{OutOfMemory};
+
+// Declaration-level checking for `def`s and `class`es: signatures,
+// method annotations, inheritance + override rules, and abstract-method
+// implementation enforcement.
+
+/// Type-check a `def`: annotations, variadic position, params +
+/// return type, and the body in a fresh scope.
+pub fn checkDefDecl(self: *Checker, d: ast.DefDecl) WalkError!void {
+    try annotations.validateAnnotations(self, d.annotations, T.DEF);
+    if (d.is_bake) try calls.checkBakeAnnotationConflicts(self, d.annotations);
+    try calls.checkVariadicPosition(self, d);
+    const saved_scope = self.current_scope;
+    var fn_scope: Scope = .init(self.arena, saved_scope);
+    self.current_scope = &fn_scope;
+    defer self.current_scope = saved_scope;
+
+    // Fresh `fn_locals` per fn — params and inner `let`s land
+    // here; nested `def`s push their own frame too so an inner
+    // fn doesn't inherit outer-fn locals.
+    const saved_locals = self.fn_locals;
+    self.fn_locals = .{};
+    defer self.fn_locals = saved_locals;
+
+    // Bake context: `bake def` body satisfies bake rules.
+    // Nested non-bake defs reset the flag for the inner body.
+    const saved_bake = self.in_bake;
+    self.in_bake = d.is_bake;
+    defer self.in_bake = saved_bake;
+
+    // `@no_capture` context: inherited by nested defs.
+    const saved_nc = self.in_no_capture;
+    self.in_no_capture = saved_nc or annotations.defHasNoCapture(self, d);
+    defer self.in_no_capture = saved_nc;
+
+    // Bake fn return type must be bakeable. `Vec(T)` and `&T`
+    // are runtime-only.
+    if (d.is_bake) if (d.ret_type) |r| {
+        const rt = try type_resolve.resolveType(self, r);
+        if (!predicates.isBakeableType(rt.*)) {
+            const ty_s = try types.render(self.arena, rt.*);
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "`bake def` cannot return `{s}` — only types representable as static data are bakeable",
+                .{ty_s},
+            );
+            try self.emitSpan("E_BAKE_NON_BAKEABLE_VALUE", r.span(), msg);
+        }
+    };
+
+    for (d.params) |p| {
+        const pt: ?*const types.Type = if (p.type_ann) |t|
+            try type_resolve.resolveType(self, t)
+        else
+            null;
+        try self.registerName(self.lexeme(p.name), .{
+            .kind = .param,
+            .decl_span = p.name,
+            .ty = pt,
+        });
+    }
+
+    if (d.ret_type == null and self.bodyMentions(d.body, self.lexeme(d.name))) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "recursive function `{s}` needs an explicit return type",
+            .{self.lexeme(d.name)},
+        );
+        try self.emitSpan("E_TYPE_RECURSIVE_NO_RET", d.name, msg);
+    }
+
+    // Track ret type for `return expr` checking inside the body.
+    const saved_ret = self.current_ret_ty;
+    self.current_ret_ty = if (d.ret_type) |r| try type_resolve.resolveType(self, r) else null;
+    defer self.current_ret_ty = saved_ret;
+
+    try self.walkStatementSequence(d.body);
+}
+
+/// Type-check a `class`: annotations, fields, methods, inheritance +
+/// override rules, and that every abstract method is implemented.
+pub fn checkClassDecl(self: *Checker, d: ast.ClassDecl) WalkError!void {
+    try annotations.validateAnnotations(self, d.annotations, T.CLASS);
+    const saved = self.current_scope;
+    var class_scope: Scope = .init(self.arena, saved);
+    self.current_scope = &class_scope;
+    defer self.current_scope = saved;
+
+    const saved_extends = self.current_class_extends;
+    self.current_class_extends = d.extends;
+    defer self.current_class_extends = saved_extends;
+
+    const saved_name = self.current_class_name;
+    self.current_class_name = self.lexeme(d.name);
+    defer self.current_class_name = saved_name;
+
+    if (d.extends) |ext| if (self.class_registry.get(self.lexeme(ext))) |parent| {
+        if (annotations.hasAnnotation(self, parent.annotations, "final")) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "cannot extend `{s}` — parent class is marked `@final`",
+                .{self.lexeme(ext)},
+            );
+            try self.emitSpan("E_CLASS_FINAL_EXTENDS", ext, msg);
+        }
+    };
+
+    for (d.fields) |f| {
+        try annotations.validateAnnotations(self, f.annotations, T.CLASS_FIELD);
+        const ty: ?*const types.Type = if (f.type_ann) |t|
+            try type_resolve.resolveType(self, t)
+        else
+            null;
+        try self.registerName(self.lexeme(f.name), .{
+            .kind = .let_binding,
+            .decl_span = f.name,
+            .ty = ty,
+        });
+        if (f.init) |init_| _ = try self.inferExpr(init_, ty);
+    }
+    for (d.methods) |m| {
+        try checkMethodAnnotations(self, &d, m);
+        const sig = try self.signatureFromDef(m);
+        try self.registerName(self.lexeme(m.name), .{
+            .kind = .function,
+            .decl_span = m.name,
+            .ty = sig,
+        });
+        try checkDefDecl(self, m);
+    }
+
+    if (!annotations.classIsAbstract(self, &d)) {
+        try checkAbstractMethodsImplemented(self, &d);
+    }
+}
+
+/// Validate OOP annotations on a method against its class
+/// and parent chain.
+///
+/// - `@override` without a parent method → `E_OVERRIDE_NO_PARENT`.
+/// - Overriding a `@final` method → `E_METHOD_FINAL_OVERRIDE`.
+/// - `@static` with a `self` first param → `E_STATIC_HAS_SELF`.
+fn checkMethodAnnotations(
+    self: *Checker,
+    cd: *const ast.ClassDecl,
+    m: ast.DefDecl,
+) WalkError!void {
+    const m_name = self.lexeme(m.name);
+    const is_override = annotations.hasAnnotation(self, m.annotations, "override");
+    const is_static = annotations.hasAnnotation(self, m.annotations, "static");
+
+    if (is_static and m.params.len > 0) {
+        const first = self.lexeme(m.params[0].name);
+        if (std.mem.eql(u8, first, "self")) {
+            try self.emitSpan(
+                "E_STATIC_HAS_SELF",
+                m.params[0].name,
+                "`@static` method must not take a `self` parameter — it's called as `ClassName.method(...)`",
+            );
+        }
+    }
+
+    const parent_method = lookupParentMethod(self, cd, m_name);
+    if (is_override) {
+        if (parent_method == null) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "`@override` on `{s}` but no parent class declares a method by that name",
+                .{m_name},
+            );
+            try self.emitSpan("E_OVERRIDE_NO_PARENT", m.name, msg);
+        }
+    }
+    if (parent_method) |pm| {
+        if (annotations.hasAnnotation(self, pm.annotations, "final")) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "cannot override `{s}` — parent method is marked `@final`",
+                .{m_name},
+            );
+            try self.emitSpan("E_METHOD_FINAL_OVERRIDE", m.name, msg);
+        }
+    }
+}
+
+/// Walk `cd`'s ancestor chain looking for a method named
+/// `name`. Returns the closest ancestor's declaration so the
+/// caller can inspect its annotations (final / abstract /
+/// private). Returns `null` when no ancestor declares it.
+fn lookupParentMethod(
+    self: *const Checker,
+    cd: *const ast.ClassDecl,
+    name: []const u8,
+) ?*const ast.DefDecl {
+    var cursor = cd;
+    while (cursor.extends) |ext| {
+        const parent = self.class_registry.get(self.lexeme(ext)) orelse return null;
+        for (parent.methods) |*m| {
+            if (std.mem.eql(u8, self.lexeme(m.name), name)) return m;
+        }
+        cursor = parent;
+    }
+    return null;
+}
+
+/// Every abstract method inherited by the concrete class `cd`
+/// must be overridden. Missing impls emit
+/// `E_ABSTRACT_NOT_IMPLEMENTED`.
+fn checkAbstractMethodsImplemented(
+    self: *Checker,
+    cd: *const ast.ClassDecl,
+) WalkError!void {
+    var cursor: ?*const ast.ClassDecl = cd;
+    while (cursor) |c| : ({
+        cursor = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
+    }) {
+        for (c.methods) |m| {
+            if (!annotations.hasAnnotation(self, m.annotations, "abstract")) continue;
+            if (hasConcreteImpl(self, cd, self.lexeme(m.name), c)) continue;
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "concrete class `{s}` must override abstract method `{s}` inherited from `{s}`",
+                .{ self.lexeme(cd.name), self.lexeme(m.name), self.lexeme(c.name) },
+            );
+            try self.emitSpan("E_ABSTRACT_NOT_IMPLEMENTED", cd.name, msg);
+        }
+    }
+}
+
+/// Walk from `cd` up through ancestors stopping at (not
+/// including) `stop_at` — true when some intermediate class
+/// declares a non-abstract method named `name`.
+fn hasConcreteImpl(
+    self: *const Checker,
+    cd: *const ast.ClassDecl,
+    name: []const u8,
+    stop_at: *const ast.ClassDecl,
+) bool {
+    var cursor: ?*const ast.ClassDecl = cd;
+    while (cursor) |c| {
+        if (c == stop_at) return false;
+        for (c.methods) |m| {
+            if (!std.mem.eql(u8, self.lexeme(m.name), name)) continue;
+            if (annotations.hasAnnotation(self, m.annotations, "abstract")) continue;
+            return true;
+        }
+        cursor = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
+    }
+    return false;
+}

--- a/src/lang/typecheck/decls.zig
+++ b/src/lang/typecheck/decls.zig
@@ -1,0 +1,194 @@
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const scope_mod = @import("../scope.zig");
+const typecheck = @import("../typecheck.zig");
+const type_resolve = @import("type_resolve.zig");
+
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+// Pass 1: register every top-level name (let / const / def / class /
+// struct / enum / use) into the module scope before Pass 2 resolves
+// bodies, so forward references type-check.
+
+/// Register one top-level statement's name(s) into the module
+/// scope (Pass 1), so Pass 2 can resolve forward references.
+pub fn registerTopLevel(self: *Checker, s: ast.Statement) WalkError!void {
+    switch (s) {
+        .let_decl => |d| try registerLetPattern(self, d.pattern, .let_binding, d.type_ann),
+        .const_decl => |d| try registerName(
+            self,
+            self.lexeme(d.name),
+            .{ .kind = .const_binding, .decl_span = d.name, .ty = null },
+        ),
+        .def_decl => |d| {
+            const sig = try signatureFromDef(self, d);
+            try registerName(self, self.lexeme(d.name), .{
+                .kind = .function,
+                .decl_span = d.name,
+                .ty = sig,
+            });
+        },
+        .class_decl => |d| try registerName(self, self.lexeme(d.name), .{
+            .kind = .class,
+            .decl_span = d.name,
+            .ty = null,
+        }),
+        .struct_decl => |d| try registerName(self, self.lexeme(d.name), .{
+            .kind = .struct_,
+            .decl_span = d.name,
+            .ty = null,
+        }),
+        .enum_decl => |d| try registerName(self, self.lexeme(d.name), .{
+            .kind = .enum_,
+            .decl_span = d.name,
+            .ty = null,
+        }),
+        .use_decl => |d| try registerUseDecl(self, d),
+        else => {},
+    }
+}
+
+fn registerLetPattern(
+    self: *Checker,
+    pat: *const ast.Pattern,
+    kind: scope_mod.SymbolKind,
+    type_ann: ?*const ast.TypeAnn,
+) WalkError!void {
+    // Only the simple `let name = …` form registers a single
+    // symbol here. Tuple / struct destructuring registers each
+    // bound name in pass 2 (where the rhs type is known).
+    switch (pat.*) {
+        .ident => |i| {
+            const ty: ?*const types.Type = if (type_ann) |t|
+                try type_resolve.resolveType(self, t)
+            else
+                null;
+            try registerName(self, self.lexeme(i.name), .{
+                .kind = kind,
+                .decl_span = i.name,
+                .ty = ty,
+            });
+        },
+        else => {
+            // Destructuring patterns will register their inner
+            // names during pass 2 when the type is known.
+        },
+    }
+}
+
+fn registerUseDecl(self: *Checker, d: ast.UseDecl) WalkError!void {
+    if (d.items.len > 0) {
+        // `use a [as al], b [as bl] from module` — each item
+        // becomes its own imported symbol.
+        for (d.items) |it| {
+            const name = if (it.alias) |a| self.lexeme(a) else self.lexeme(it.name);
+            try registerName(self, name, .{
+                .kind = .imported,
+                .decl_span = it.name,
+                .ty = null,
+            });
+        }
+    } else {
+        // Whole-module import — register the alias (or the
+        // module lexeme itself if no alias).
+        const name = if (d.alias) |a| self.lexeme(a) else self.lexeme(d.module);
+        try registerName(self, name, .{
+            .kind = .module_alias,
+            .decl_span = d.module,
+            .ty = null,
+        });
+    }
+}
+
+/// Insert `name` into the current scope with its kind + type,
+/// reporting `E_TYPE_REDEFINED` on a clash and rejecting names that
+/// shadow a reserved builtin.
+pub fn registerName(
+    self: *Checker,
+    name: []const u8,
+    info: scope_mod.SymbolInfo,
+) WalkError!void {
+    if (isReservedBuiltinName(name)) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "cannot shadow always-in-scope builtin `{s}`",
+            .{name},
+        );
+        try self.emitSpan("E_BUILTIN_SHADOW", info.decl_span, msg);
+        return;
+    }
+    self.current_scope.define(name, info) catch |err| switch (err) {
+        error.AlreadyDefined => {
+            const existing = self.current_scope.lookupLocal(name).?;
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "`{s}` is already defined in this scope",
+                .{name},
+            );
+            const sec = try self.singleSecondary(existing.decl_span, "previous definition here", .underline);
+            try self.diagnostics.append(self.diag_alloc, .{
+                .severity = .fatal,
+                .code = "E_TYPE_REDEFINED",
+                .message = msg,
+                .span = info.decl_span,
+                .secondary = sec,
+            });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    // Track function-body locals for the `return &local`
+    // stack-lifetime check. `null` at module / class scope.
+    if (self.fn_locals) |*set| {
+        _ = try set.put(self.arena, name, {});
+    }
+    // Track lambda-body locals for the `@no_capture`
+    // capture-mutation check. `null` outside a tracked lambda.
+    if (self.lambda_locals) |*set| {
+        _ = try set.put(self.arena, name, {});
+    }
+}
+
+/// Build the function-pointer type for a `def`. Unannotated
+/// params produce a `nil` placeholder slot (treated as "skip
+/// arg-type check" by `checkCall`).
+pub fn signatureFromDef(self: *Checker, d: ast.DefDecl) WalkError!*const types.Type {
+    var param_types: std.ArrayList(*const types.Type) = .empty;
+    errdefer param_types.deinit(self.arena);
+    for (d.params) |p| {
+        const pt: *const types.Type = if (p.type_ann) |t|
+            try type_resolve.resolveType(self, t)
+        else
+            try self.primitive(.nil_); // unknown until call-site inference
+        try param_types.append(self.arena, pt);
+    }
+    const ret_ty: *const types.Type = if (d.ret_type) |r|
+        try type_resolve.resolveType(self, r)
+    else
+        try self.primitive(.nil_);
+    const sig = try self.arena.create(types.Type);
+    sig.* = .{ .function = .{
+        .params = try param_types.toOwnedSlice(self.arena),
+        .ret = ret_ty,
+    } };
+    return sig;
+}
+
+/// `true` when `name` is an always-in-scope builtin per spec §5.3.
+/// User declarations matching these names get `E_BUILTIN_SHADOW`.
+/// `sizeof` is a keyword and rejected by the parser before reaching
+/// here.
+fn isReservedBuiltinName(name: []const u8) bool {
+    const reserved = [_][]const u8{
+        "assert",
+        "debug_assert",
+        "panic",
+        // allow-strict: lang builtin name; the Zig keyword sense doesn't apply on this line.
+        "unreachable",
+        "todo",
+    };
+    for (reserved) |kw| if (std.mem.eql(u8, name, kw)) return true;
+    return false;
+}

--- a/src/lang/typecheck/diagnostics.zig
+++ b/src/lang/typecheck/diagnostics.zig
@@ -1,0 +1,253 @@
+// Diagnostic emission + symbol-suggestion helpers. The thin layer every
+// checking pass funnels errors and "did you mean" hints through.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const diag_mod = @import("../diagnostic.zig");
+const typecheck = @import("../typecheck.zig");
+const suggestions = @import("suggestions.zig");
+const relations = @import("relations.zig");
+const scope_mod = @import("../scope.zig");
+
+const Checker = typecheck.Checker;
+const Scope = scope_mod.Scope;
+const WalkError = error{OutOfMemory};
+
+/// Emit a fatal diagnostic at `span`.
+pub fn emitSpan(
+    self: *Checker,
+    code: []const u8,
+    span: ast.Span,
+    message: []const u8,
+) WalkError!void {
+    try self.diagnostics.append(self.diag_alloc, .{
+        .severity = .fatal,
+        .code = code,
+        .message = message,
+        .span = span,
+    });
+}
+
+/// Like `emitSpan` plus a `help:` block.
+pub fn emitSpanHelp(
+    self: *Checker,
+    code: []const u8,
+    span: ast.Span,
+    message: []const u8,
+    help: []const u8,
+) WalkError!void {
+    try self.diagnostics.append(self.diag_alloc, .{
+        .severity = .fatal,
+        .code = code,
+        .message = message,
+        .span = span,
+        .help = help,
+    });
+}
+
+/// Emit `E_TYPE_MISMATCH` for an expected-vs-actual mismatch
+/// at a single span.
+pub fn emitMismatch(
+    self: *Checker,
+    span: ast.Span,
+    expected_ty: *const types.Type,
+    actual_ty: *const types.Type,
+) WalkError!void {
+    const expected_s = try types.render(self.arena, expected_ty.*);
+    const actual_s = try types.render(self.arena, actual_ty.*);
+    const msg = try std.fmt.allocPrint(
+        self.arena,
+        "type mismatch: expected `{s}`, found `{s}`",
+        .{ expected_s, actual_s },
+    );
+    try self.emitSpan("E_TYPE_MISMATCH", span, msg);
+}
+
+/// Like `emitMismatch` but anchors the expected type to a
+/// `: T` annotation span via a secondary label.
+pub fn emitMismatchAnnotated(
+    self: *Checker,
+    span: ast.Span,
+    expected_ty: *const types.Type,
+    actual_ty: *const types.Type,
+    annotation_span: ast.Span,
+) WalkError!void {
+    const expected_s = try types.render(self.arena, expected_ty.*);
+    const actual_s = try types.render(self.arena, actual_ty.*);
+    const msg = try std.fmt.allocPrint(
+        self.arena,
+        "type mismatch: expected `{s}`, found `{s}`",
+        .{ expected_s, actual_s },
+    );
+    const label_msg = try std.fmt.allocPrint(
+        self.arena,
+        "expected `{s}` because of this annotation",
+        .{expected_s},
+    );
+    const sec = try self.singleSecondary(annotation_span, label_msg, .underline);
+    try self.diagnostics.append(self.diag_alloc, .{
+        .severity = .fatal,
+        .code = "E_TYPE_MISMATCH",
+        .message = msg,
+        .span = span,
+        .secondary = sec,
+    });
+}
+
+/// Allocate a one-element `SpanLabel` slice on `self.arena`,
+/// suitable for `Diagnostic.secondary`.
+pub fn singleSecondary(
+    self: *Checker,
+    span: ast.Span,
+    message: []const u8,
+    decoration: diag_mod.SpanLabel.Decoration,
+) WalkError![]const diag_mod.SpanLabel {
+    const sec = try self.arena.alloc(diag_mod.SpanLabel, 1);
+    sec[0] = .{ .span = span, .message = message, .decoration = decoration };
+    return sec;
+}
+
+/// Assignability + narrowing check for "store into a typed
+/// slot" sites (let-init, assignment, call arg, return).
+/// Routes per spec §3.5.1:
+/// - Assignable → no diagnostic.
+/// - Integer narrowing without `as` → `E_CAST_PRECISION_LOSS`
+///   (warning).
+/// - Otherwise → `E_TYPE_MISMATCH` (fatal).
+pub fn checkStoreCompat(
+    self: *Checker,
+    span: ast.Span,
+    expected: *const types.Type,
+    actual: *const types.Type,
+) WalkError!void {
+    if (relations.assignable(actual.*, expected.*)) return;
+    if (self.isClassSubtype(actual.*, expected.*)) return;
+    if (relations.isNarrowingInt(actual.*, expected.*)) {
+        try emitNarrowingWarning(self, span, expected, actual);
+        return;
+    }
+    try self.emitMismatch(span, expected, actual);
+}
+
+/// `true` when `actual` is a class derived from `expected`
+/// (transitively, via `extends`). Also covers `&Sub` → `&Sup`
+/// reference subtyping by peeling one layer per side.
+pub fn isClassSubtype(self: *const Checker, actual: types.Type, expected: types.Type) bool {
+    const a = if (actual == .reference) actual.reference.* else actual;
+    const e = if (expected == .reference) expected.reference.* else expected;
+    if (a != .named or e != .named) return false;
+    const expected_name = e.named.name;
+    var cur = self.class_registry.get(a.named.name) orelse return false;
+    while (cur.extends) |ext| {
+        const parent_name = self.lexeme(ext);
+        if (std.mem.eql(u8, parent_name, expected_name)) return true;
+        cur = self.class_registry.get(parent_name) orelse return false;
+    }
+    return false;
+}
+
+fn emitNarrowingWarning(
+    self: *Checker,
+    span: ast.Span,
+    expected_ty: *const types.Type,
+    actual_ty: *const types.Type,
+) WalkError!void {
+    const expected_s = try types.render(self.arena, expected_ty.*);
+    const actual_s = try types.render(self.arena, actual_ty.*);
+    const msg = try std.fmt.allocPrint(
+        self.arena,
+        "implicit narrowing from `{s}` to `{s}` may lose precision — use an explicit `as {s}` cast to silence this warning",
+        .{ actual_s, expected_s, expected_s },
+    );
+    try self.diagnostics.append(self.diag_alloc, .{
+        .severity = .warning,
+        .code = "E_CAST_PRECISION_LOSS",
+        .message = msg,
+        .span = span,
+    });
+}
+
+/// Return the source-text slice for `span`.
+pub fn lexeme(self: *const Checker, span: ast.Span) []const u8 {
+    return self.source[span.start..span.end];
+}
+
+/// Closest near-spelling match for an undefined symbol across
+/// the scope chain + type registries. `null` when nothing is
+/// within `suggestions.max_distance`.
+pub fn suggestSymbol(self: *Checker, name: []const u8) WalkError!?[]const u8 {
+    var pool: std.ArrayList([]const u8) = .empty;
+    defer pool.deinit(self.arena);
+    var scope: ?*const Scope = self.current_scope;
+    while (scope) |s| : (scope = s.parent) {
+        var it = s.entries.keyIterator();
+        while (it.next()) |k| try pool.append(self.arena, k.*);
+    }
+    return suggestions.bestMatch(name, pool.items);
+}
+
+/// Same pool as `suggestSymbol` plus the primitive type names —
+/// used by `E_TYPE_UNDEFINED` when an unknown type name shows
+/// up in an annotation / struct-lit position.
+pub fn suggestTypeName(self: *Checker, name: []const u8) WalkError!?[]const u8 {
+    var pool: std.ArrayList([]const u8) = .empty;
+    defer pool.deinit(self.arena);
+    // Primitives matched first so `let x: i8` wins over a stray
+    // `i9` local. Mirrors `types.primitiveFromName`.
+    const primitives = [_][]const u8{ "i8", "u8", "i16", "u16", "int", "uint", "bool", "nil", "str", "fixed", "char" };
+    for (primitives) |p| try pool.append(self.arena, p);
+    var struct_it = self.struct_registry.keyIterator();
+    while (struct_it.next()) |k| try pool.append(self.arena, k.*);
+    var class_it = self.class_registry.keyIterator();
+    while (class_it.next()) |k| try pool.append(self.arena, k.*);
+    var enum_it = self.enum_registry.keyIterator();
+    while (enum_it.next()) |k| try pool.append(self.arena, k.*);
+    return suggestions.bestMatch(name, pool.items);
+}
+
+/// Best-match field name on a struct.
+pub fn suggestStructField(self: *Checker, sd: *const ast.StructDecl, name: []const u8) WalkError!?[]const u8 {
+    var pool: std.ArrayList([]const u8) = .empty;
+    defer pool.deinit(self.arena);
+    for (sd.fields) |f| try pool.append(self.arena, self.lexeme(f.name));
+    return suggestions.bestMatch(name, pool.items);
+}
+
+/// Best-match field name across a class and its parents.
+pub fn suggestClassField(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
+    var pool: std.ArrayList([]const u8) = .empty;
+    defer pool.deinit(self.arena);
+    var cur: ?*const ast.ClassDecl = cd;
+    while (cur) |c| {
+        for (c.fields) |f| try pool.append(self.arena, self.lexeme(f.name));
+        cur = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
+    }
+    return suggestions.bestMatch(name, pool.items);
+}
+
+/// Best-match method name across a class and its parents.
+pub fn suggestClassMethod(self: *Checker, cd: *const ast.ClassDecl, name: []const u8) WalkError!?[]const u8 {
+    var pool: std.ArrayList([]const u8) = .empty;
+    defer pool.deinit(self.arena);
+    var cur: ?*const ast.ClassDecl = cd;
+    while (cur) |c| {
+        for (c.methods) |m| try pool.append(self.arena, self.lexeme(m.name));
+        cur = if (c.extends) |ext| self.class_registry.get(self.lexeme(ext)) else null;
+    }
+    return suggestions.bestMatch(name, pool.items);
+}
+
+/// Emit a fatal diagnostic; appends `help: did you mean \`X\`?`
+/// when `candidate` is non-null.
+pub fn emitSpanWithSuggestion(
+    self: *Checker,
+    code: []const u8,
+    span: ast.Span,
+    message: []const u8,
+    candidate: ?[]const u8,
+) WalkError!void {
+    const name = candidate orelse return self.emitSpan(code, span, message);
+    const help = try std.fmt.allocPrint(self.arena, "did you mean `{s}`?", .{name});
+    try self.emitSpanHelp(code, span, message, help);
+}

--- a/src/lang/typecheck/suggestions.zig
+++ b/src/lang/typecheck/suggestions.zig
@@ -1,9 +1,8 @@
 const std = @import("std");
 
-/// Maximum edit distance for a suggestion to count. Per spec
-/// (issue #257). Values above this cap return `null` from
-/// `bestMatch` so the diagnostic stays clean — no suggestion is
-/// better than a misleading one.
+/// Maximum edit distance for a suggestion to count. Values above this
+/// cap return `null` from `bestMatch` so the diagnostic stays clean —
+/// no suggestion is better than a misleading one.
 pub const max_distance: usize = 2;
 
 /// Bounded Levenshtein distance — returns the actual distance when

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3907,3 +3907,283 @@ test "codegen: `is` tag test on a payload enum" {
         \\end
     , "1\n3\n");
 }
+
+// ---------- value structs (§3.4) ----------
+
+test "codegen/struct: literal construction + field read" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let p = P { x: 3, y: 4 }
+        \\  print p.x + p.y
+        \\end
+    , "7\n");
+}
+
+test "codegen/struct: field write mutates in place" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def main()
+        \\  let p = P { x: 1 }
+        \\  p.x = 5
+        \\  print p.x
+        \\end
+    , "5\n");
+}
+
+test "codegen/struct: assignment copies by value (a unchanged)" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def main()
+        \\  let a = P { x: 9 }
+        \\  let b = a
+        \\  b.x = 1
+        \\  print a.x
+        \\  print b.x
+        \\end
+    , "9\n1\n");
+}
+
+test "codegen/struct: byte-packed fields (u8 + u8 + i16)" {
+    try runAndExpect(
+        \\struct S
+        \\  a: u8
+        \\  b: u8
+        \\  c: i16
+        \\end
+        \\def main()
+        \\  let s = S { a: 1, b: 2, c: 300 }
+        \\  s.a = 7
+        \\  print s.a
+        \\  print s.c
+        \\end
+    , "7\n300\n");
+}
+
+test "codegen/struct: nested struct field access" {
+    try runAndExpect(
+        \\struct In
+        \\  v: i16
+        \\end
+        \\struct Out
+        \\  n: In
+        \\  k: i16
+        \\end
+        \\def main()
+        \\  let o = Out { n: In { v: 10 }, k: 5 }
+        \\  print o.n.v + o.k
+        \\end
+    , "15\n");
+}
+
+test "codegen/struct: pass-by-value isolates callee mutation" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def bump(p: P) -> i16
+        \\  p.x = 99
+        \\  return p.x
+        \\end
+        \\def main()
+        \\  let q = P { x: 1 }
+        \\  let r = bump(q)
+        \\  print r
+        \\  print q.x
+        \\end
+    , "99\n1\n");
+}
+
+test "codegen/struct: struct arg after scalar param" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def f(p: P, k: i16) -> i16
+        \\  return p.x + p.y + k
+        \\end
+        \\def main()
+        \\  print f(P { x: 1, y: 2 }, 100)
+        \\end
+    , "103\n");
+}
+
+test "codegen/struct: return-by-value via sret" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def mk(a: i16, b: i16) -> P
+        \\  return P { x: a, y: b }
+        \\end
+        \\def main()
+        \\  let p = mk(3, 4)
+        \\  print p.x + p.y
+        \\end
+    , "7\n");
+}
+
+test "codegen/struct: returned struct fed straight into a pass-by-value call" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def mk() -> P
+        \\  return P { x: 3, y: 4 }
+        \\end
+        \\def sum(p: P) -> i16
+        \\  return p.x + p.y
+        \\end
+        \\def main()
+        \\  print sum(mk())
+        \\end
+    , "7\n");
+}
+
+test "codegen/struct: two returned structs hold distinct buffers" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def mk(v: i16) -> P
+        \\  return P { x: v }
+        \\end
+        \\def main()
+        \\  let a = mk(1)
+        \\  let b = mk(2)
+        \\  a.x = 9
+        \\  print a.x
+        \\  print b.x
+        \\end
+    , "9\n2\n");
+}
+
+test "codegen/struct: pass struct by value to a method" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\class C
+        \\  def s(self, p: P) -> i16
+        \\    return p.x + p.y
+        \\  end
+        \\end
+        \\def main()
+        \\  let c = C()
+        \\  print c.s(P { x: 4, y: 5 })
+        \\end
+    , "9\n");
+}
+
+test "codegen/struct: method returns a struct by value" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\class C
+        \\  def make(self, a: i16) -> P
+        \\    return P { x: a, y: a }
+        \\  end
+        \\end
+        \\def main()
+        \\  let c = C()
+        \\  let p = c.make(7)
+        \\  print p.x + p.y
+        \\end
+    , "14\n");
+}
+
+test "codegen/struct: struct stored inline as a class field" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\class E
+        \\  let hp: i16
+        \\  let pos: P
+        \\  def init(self)
+        \\    self.hp = 100
+        \\    self.pos = P { x: 7, y: 0 }
+        \\  end
+        \\  def move_x(self, dx: i16)
+        \\    self.pos.x = self.pos.x + dx
+        \\  end
+        \\end
+        \\def main()
+        \\  let e = E()
+        \\  e.move_x(3)
+        \\  print e.hp + e.pos.x
+        \\end
+    , "110\n");
+}
+
+test "codegen/struct: pass struct by value to an @inline fn" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\@inline
+        \\def s(p: P) -> i16
+        \\  return p.x + p.y
+        \\end
+        \\def main()
+        \\  let q = P { x: 5, y: 6 }
+        \\  print s(q)
+        \\end
+    , "11\n");
+}
+
+/// Compile `source` and assert codegen surfaced a diagnostic with
+/// `code` — for struct operations not yet lowered (rejected rather
+/// than miscompiled).
+fn expectCodegenError(source: []const u8, code: []const u8) !void {
+    var compiled = try compileSource(source);
+    defer compiled.deinit();
+    try std.testing.expect(compiled.hasErrors());
+    var found = false;
+    for (compiled.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, code)) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+test "codegen/struct: equality is rejected (no silent address compare)" {
+    try expectCodegenError(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def main()
+        \\  let a = P { x: 1 }
+        \\  let b = P { x: 1 }
+        \\  if a == b
+        \\    print 1
+        \\  end
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
+}
+
+test "codegen/struct: printing a whole struct is rejected" {
+    try expectCodegenError(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def main()
+        \\  let p = P { x: 5 }
+        \\  print p
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
+}

--- a/tests/lang/codegen/def.test.zig
+++ b/tests/lang/codegen/def.test.zig
@@ -1,0 +1,8 @@
+/// Smoke that the `def` codegen submodule is reachable through the
+/// public barrel. Behavioral coverage lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/def: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.def;
+}

--- a/tests/lang/codegen/globals.test.zig
+++ b/tests/lang/codegen/globals.test.zig
@@ -1,0 +1,8 @@
+/// Smoke that the `globals` codegen submodule is reachable through the
+/// public barrel. Behavioral coverage lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/globals: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.globals;
+}

--- a/tests/lang/codegen/inline_call.test.zig
+++ b/tests/lang/codegen/inline_call.test.zig
@@ -1,0 +1,8 @@
+/// Smoke that the `inline_call` codegen submodule is reachable through the
+/// public barrel. Behavioral coverage lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/inline_call: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.inline_call;
+}

--- a/tests/lang/codegen/statements.test.zig
+++ b/tests/lang/codegen/statements.test.zig
@@ -1,0 +1,8 @@
+/// Smoke that the `statements` codegen submodule is reachable through the
+/// public barrel. Behavioral coverage lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/statements: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.statements;
+}

--- a/tests/lang/codegen/struct_.test.zig
+++ b/tests/lang/codegen/struct_.test.zig
@@ -1,0 +1,11 @@
+/// Smoke that the `struct_` codegen submodule is reachable through
+/// the public barrel. End-to-end coverage of struct construction,
+/// field rw, value-copy, pass-by-value, and return-by-value lives in
+/// `tests/lang/codegen.test.zig` — that's where the VM-side round
+/// trip actually exercises the lowering.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/struct_: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.struct_;
+}

--- a/tests/lang/codegen/value_struct.test.zig
+++ b/tests/lang/codegen/value_struct.test.zig
@@ -1,4 +1,4 @@
-/// Smoke that the `struct_` codegen submodule is reachable through
+/// Smoke that the `value_struct` codegen submodule is reachable through
 /// the public barrel. End-to-end coverage of struct construction,
 /// field rw, value-copy, pass-by-value, and return-by-value lives in
 /// `tests/lang/codegen.test.zig` — that's where the VM-side round
@@ -6,6 +6,6 @@
 const std = @import("std");
 const gero = @import("gero");
 
-test "codegen/struct_: module compiles through the barrel" {
-    _ = gero.lang.internal.codegen.struct_;
+test "codegen/value_struct: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.value_struct;
 }

--- a/tests/lang/typecheck/class_check.test.zig
+++ b/tests/lang/typecheck/class_check.test.zig
@@ -1,0 +1,8 @@
+/// Smoke that the `class_check` typecheck submodule is reachable through the
+/// public barrel. Behavioral coverage lives in `tests/lang/typecheck.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/class_check: module compiles through the barrel" {
+    _ = gero.lang.internal.typechecker.class_check;
+}

--- a/tests/lang/typecheck/decls.test.zig
+++ b/tests/lang/typecheck/decls.test.zig
@@ -1,0 +1,8 @@
+/// Smoke that the `decls` typecheck submodule is reachable through the
+/// public barrel. Behavioral coverage lives in `tests/lang/typecheck.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/decls: module compiles through the barrel" {
+    _ = gero.lang.internal.typechecker.decls;
+}

--- a/tests/lang/typecheck/diagnostics.test.zig
+++ b/tests/lang/typecheck/diagnostics.test.zig
@@ -1,0 +1,8 @@
+/// Smoke that the `diagnostics` typecheck submodule is reachable through the
+/// public barrel. Behavioral coverage lives in `tests/lang/typecheck.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/diagnostics: module compiles through the barrel" {
+    _ = gero.lang.internal.typechecker.diagnostics;
+}


### PR DESCRIPTION
Lowers struct literals as **inline values** with full value semantics (§3.4). A struct value lives inline as contiguous bytes; a struct-typed expression evaluates to that base address.

## What works

| Operation | Free fn | Method | `@inline` | Class field |
|---|:-:|:-:|:-:|:-:|
| Construction `P { … }` (incl. nested) | ✅ | ✅ | ✅ | ✅ |
| Field read/write (`p.x`, `o.n.v`) | ✅ | ✅ | ✅ | ✅ |
| Copy-on-assign (`let b = a`) | ✅ | — | — | — |
| Pass-by-value | ✅ | ✅ | ✅ | — |
| Return-by-value (sret) | ✅ | ✅ | ✅ | — |

- **Frame model** moved from fixed 2-byte slots to byte-summed reservation, so a struct local occupies its full (2-aligned) width and byte-packed fields (`u8`) take one byte.
- **Pass-by-value** copies the argument onto the stack at its full width — a callee mutating its parameter never affects the caller.
- **Return-by-value** uses an sret convention: the caller passes a hidden destination pointer; the callee copies its result there. Interrupt-safe (no reliance on a freed callee frame). Method returns route the hidden pointer through vtable dispatch; methods spill the instance pointer across by-value arg materialization.
- **Inline class fields** (`let pos: P`) store the struct's bytes inside the instance, with by-value field read/write.

## Rejected (no silent-wrong-code)

Now that struct values are constructible, two paths that would otherwise miscompile are rejected with a clear `E_CODEGEN_UNSUPPORTED` diagnostic instead:

- **Struct equality** (`a == b`) — would compare addresses, not fields. §3.4 calls for *structural* equality, which isn't implemented yet.
- **Whole-struct `print`** — would print the base address as an int.

Both are tracked as follow-up work (structural equality + struct formatting). Field-level use (`print p.x`, `if p.x == q.x`) is unaffected.

## Incidental fix

`@inline` arguments were evaluated *after* the caller's locals went out of scope, so a local passed to an inlined function failed to resolve (`E_CODEGEN_UNBOUND_CAPTURE`). Inline args now materialize in the caller's scope before the body splice.

## Tests

13 behavioral tests + 2 negative tests in `tests/lang/codegen.test.zig` covering construction, nested, byte-packing, copy semantics, pass/return-by-value, mutation isolation, methods, class fields, inline, and the two rejections. `zig build ci` green across all release modes + cross-targets.

Closes #307.