### PR TITLE
feat(lang/codegen): structural `==`/`!=` for structs + content `str` equality

### DIFF
--- a/.changeset/lang-codegen-struct-equality.md
+++ b/.changeset/lang-codegen-struct-equality.md
@@ -1,0 +1,27 @@
+---
+bump: minor
+---
+
+`==` / `!=` now work on struct values, and `str` equality is
+content-based.
+
+**Structs** compare structurally per §3.4 ("structurally equal if
+fields equal"): each field compares with the semantics its own `==`
+uses — scalars / `&T` / class / payload-free enum by value or pointer
+identity, `str` by content, nested structs recursively. A struct with
+no `str` field reduces to a fast byte compare over its packed width;
+a struct with a `str` field uses per-field dispatch so those fields
+compare by content. Both operands are materialized as by-value stack
+copies, so two struct-returning calls (which share the sret scratch)
+and struct-literal operands compare correctly. The result is a `0`/`1`
+boolean usable as a value (`let eq = a == b`) and in a fused condition
+(`if a == b`). Ordering operators (`<`, `<=`, `>`, `>=`) remain a
+codegen error on structs — only equality is defined.
+
+**Strings:** `str == other` / `!=` now compare **content**
+(lexicographic, byte-wise) per §3.2.1 instead of pointer identity, so
+two equal strings built at runtime (interpolation, etc.) in distinct
+buffers compare equal. This also fixes scalar `str ==`, not just
+str-typed struct fields.
+
+Closes #322.

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -8,6 +8,7 @@ const assert_builtin = @import("assert.zig");
 const diverge_builtin = @import("diverge.zig");
 const class = @import("class.zig");
 const value_struct = @import("value_struct.zig");
+const strings = @import("strings.zig");
 const lambda = @import("lambda.zig");
 const overflow = @import("overflow.zig");
 
@@ -297,6 +298,12 @@ pub fn emitUnary(self: *Emitter, u: ast.UnaryExpr) !void {
     }
 }
 
+/// `true` when either operand of a comparison is a `str` — its `==` /
+/// `!=` is content-based (§3.2.1) rather than a pointer compare.
+fn isStrComparison(self: *Emitter, b: ast.BinaryExpr) bool {
+    return self.isPrimitiveType(b.lhs, .str) or self.isPrimitiveType(b.rhs, .str);
+}
+
 /// Lower a binary infix expression. Short-circuit operators
 /// (`and`, `or`) take a separate path so the RHS isn't always
 /// evaluated. Comparison ops materialize a `0` / `1` in `acu`.
@@ -310,13 +317,25 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
         else => {},
     }
 
-    // A struct-typed operand would evaluate to its base address, so a
-    // bare `==`/`!=` compares addresses, not fields — never what §3.4's
-    // structural-equality contract means. Reject it rather than emit a
-    // silently-wrong address compare.
-    if (self.structNameOf(b.lhs) != null or self.structNameOf(b.rhs) != null) {
-        try self.unsupported(b.span, "a struct operand in a binary expression — structural equality on structs is not yet implemented");
-        return;
+    // A struct operand evaluates to its base address, so a plain `cmp`
+    // would compare addresses, not fields. `==`/`!=` lower to a
+    // structural (byte-wise) comparison (§3.4); ordering operators are
+    // undefined on structs.
+    if (self.structNameOf(b.lhs) orelse self.structNameOf(b.rhs)) |sname| {
+        switch (b.op) {
+            .eq, .neq => {
+                if (!value_struct.eqSupported(self, sname)) {
+                    try self.unsupported(b.span, "struct `==` not yet supported for a struct with an array, tuple, `Vec`, payload-carrying enum, or nullable field");
+                    return;
+                }
+                try value_struct.emitEquality(self, b.lhs, b.rhs, sname, b.op == .neq);
+                return;
+            },
+            else => {
+                try self.unsupported(b.span, "ordering comparison on structs — only `==` and `!=` are defined");
+                return;
+            },
+        }
     }
 
     const fixed_op = self.isPrimitiveType(b.lhs, .fixed) and
@@ -420,6 +439,13 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
         .shl => try isa.shlRegReg(self, Reg.acu, Reg.r1),
         .shr => try isa.shrRegReg(self, Reg.acu, Reg.r1),
         .eq, .neq, .lt, .lte, .gt, .gte => {
+            // `str` equality is content-based (§3.2.1), not pointer
+            // identity — acu / r1 hold the two string pointers.
+            if ((b.op == .eq or b.op == .neq) and isStrComparison(self, b)) {
+                try isa.movRegToReg(self, Reg.acu, Reg.r2);
+                try strings.emitContentEq(self, Reg.r1, Reg.r2, b.op == .neq);
+                return;
+            }
             try isa.cmpRegReg(self, Reg.acu, Reg.r1);
             try materializeBoolFromFlags(self, b.op);
         },
@@ -437,19 +463,40 @@ pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
         const b = e.binary;
         switch (b.op) {
             .eq, .neq, .lt, .lte, .gt, .gte => {
-                // A struct operand evaluates to its base address, so this
-                // would compare addresses, not fields — reject rather
-                // than emit a silently-wrong compare (§3.4 calls for
-                // structural equality, not yet implemented).
-                if (self.structNameOf(b.lhs) != null or self.structNameOf(b.rhs) != null) {
-                    try self.unsupported(b.span, "a struct operand in a comparison — structural equality on structs is not yet implemented");
-                    return;
+                // A struct operand compares structurally (byte-wise);
+                // the resulting 0/1 in acu is then tested against 0 so
+                // the branch consumes its flags like any scalar cond.
+                // Ordering operators are undefined on structs.
+                if (self.structNameOf(b.lhs) orelse self.structNameOf(b.rhs)) |sname| {
+                    switch (b.op) {
+                        .eq, .neq => {
+                            if (!value_struct.eqSupported(self, sname)) {
+                                try self.unsupported(b.span, "struct `==` not yet supported for a struct with an array, tuple, `Vec`, payload-carrying enum, or nullable field");
+                                return;
+                            }
+                            try value_struct.emitEquality(self, b.lhs, b.rhs, sname, b.op == .neq);
+                            try isa.cmpRegImm(self, Reg.acu, 0);
+                            return;
+                        },
+                        else => {
+                            try self.unsupported(b.span, "ordering comparison on structs — only `==` and `!=` are defined");
+                            return;
+                        },
+                    }
                 }
                 // Eval LHS into acu, eval RHS into r1, cmp acu, r1.
                 try emitExpr(self, b.rhs);
                 try isa.pushReg(self, Reg.acu);
                 try emitExpr(self, b.lhs);
                 try isa.popReg(self, Reg.r1);
+                // `str` equality compares content (§3.2.1); the 0/1 it
+                // leaves in acu is then tested against 0 like any cond.
+                if ((b.op == .eq or b.op == .neq) and isStrComparison(self, b)) {
+                    try isa.movRegToReg(self, Reg.acu, Reg.r2);
+                    try strings.emitContentEq(self, Reg.r1, Reg.r2, b.op == .neq);
+                    try isa.cmpRegImm(self, Reg.acu, 0);
+                    return;
+                }
                 try isa.cmpRegReg(self, Reg.acu, Reg.r1);
                 try materializeBoolFromFlags(self, b.op);
                 try isa.cmpRegImm(self, Reg.acu, 0);

--- a/src/lang/codegen/strings.zig
+++ b/src/lang/codegen/strings.zig
@@ -4,6 +4,7 @@ const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const archive = @import("archive.zig");
+const class = @import("class.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -103,6 +104,37 @@ pub fn emitMovStringAddrToReg(self: *Emitter, string_id: usize, reg: u8) !void {
         .code_offset = slot,
         .string_id = string_id,
     });
+}
+
+/// Compare two null-terminated strings by content (§3.2.1 —
+/// lexicographic, byte-wise equality), leaving `1`/`0` in `acu`
+/// (`negate` selects `!=`). `p1` and `p2` hold the string pointers and
+/// are advanced (consumed); `acu` and `r3` are byte scratch — neither
+/// may be passed as `p1`/`p2`.
+pub fn emitContentEq(self: *Emitter, p1: u8, p2: u8, negate: bool) !void {
+    // Walk both strings in lockstep: a differing byte is not-equal;
+    // reaching the shared null terminator is equal.
+    const loop_start = try self.currentOffset();
+    try class.emitByteLoadAtOffset(self, p1, 0, Reg.acu);
+    try class.emitByteLoadAtOffset(self, p2, 0, Reg.r3);
+    try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+    const ne_patch = try isa.emitJumpPlaceholder(self, Op.jne_addr);
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const eq_patch = try isa.emitJumpPlaceholder(self, Op.jeq_addr);
+    try isa.addImmToReg(self, 1, p1);
+    try isa.addImmToReg(self, 1, p2);
+    try isa.emitJumpBack(self, loop_start);
+
+    // Equal arm.
+    try isa.patchJumpTo(self, eq_patch, try self.currentOffset());
+    try isa.movImmToReg(self, if (negate) 0 else 1, Reg.acu);
+    const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+
+    // Not-equal arm.
+    try isa.patchJumpTo(self, ne_patch, try self.currentOffset());
+    try isa.movImmToReg(self, if (negate) 1 else 0, Reg.acu);
+
+    try isa.patchJumpTo(self, end_patch, try self.currentOffset());
 }
 
 /// Lower a `str_lit` at expression position. Single-literal

--- a/src/lang/codegen/value_struct.zig
+++ b/src/lang/codegen/value_struct.zig
@@ -13,8 +13,10 @@ const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const class = @import("class.zig");
+const strings = @import("strings.zig");
 
 const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
 const Reg = opcodes.Reg;
 
 /// Where a materialized struct lands. `frame` is fp-relative (a local
@@ -154,6 +156,161 @@ pub fn emitFieldStore(self: *Emitter, recv: *const ast.Expr, sname: []const u8, 
     try isa.movRegToReg(self, Reg.acu, Reg.r1);
     try isa.popReg(self, Reg.r2);
     try class_storeAt(self, Reg.r1, info.offset, info.width, Reg.r2);
+}
+
+/// Lower `a == b` / `a != b` on struct operands (`negate` selects
+/// `!=`), leaving a 0/1 boolean in `acu` per §3.4 "structurally equal
+/// if fields equal". Each field compares with the same semantics its
+/// own `==` would use: scalars / `&T` / class / payload-free enum by
+/// value/pointer, `str` by content (§3.2.1), nested structs recursively.
+/// A struct whose fields are all value/pointer-comparable reduces to a
+/// fast byte compare over the packed width (no padding); a struct with
+/// any `str` field uses per-field dispatch so those compare by content.
+pub fn emitEquality(self: *Emitter, lhs: *const ast.Expr, rhs: *const ast.Expr, sname: []const u8, negate: bool) error{OutOfMemory}!void {
+    // Materialize BOTH operands as distinct by-value copies on the
+    // stack. Pushing addresses would alias when both operands share a
+    // buffer (e.g. two struct-returning calls reuse the sret scratch);
+    // copying also lets struct-literal operands (`p == P{ ... }`) work.
+    // The copies stay put (sp stable) so field addresses are `sp + ofs`.
+    const wslot = self.structSlotWidth(sname);
+    try pushArg(self, rhs, sname); // rhs copy at [sp + wslot ..] after the next push
+    try pushArg(self, lhs, sname); // lhs copy at [sp ..]
+
+    // The first field that differs jumps to the not-equal arm; falling
+    // through means every field matched.
+    var mismatch_patches: std.ArrayList(usize) = .empty;
+    defer mismatch_patches.deinit(self.allocator);
+
+    if (structHasContentField(self, sname)) {
+        try emitFieldwiseEq(self, sname, 0, wslot, &mismatch_patches);
+    } else {
+        try emitByteEq(self, wslot, self.structWidth(sname), &mismatch_patches);
+    }
+
+    // All fields equal → `==` yields 1, `!=` yields 0.
+    try isa.movImmToReg(self, if (negate) 0 else 1, Reg.acu);
+    const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+
+    // Not-equal arm: the opposite result.
+    const mismatch_target = try self.currentOffset();
+    for (mismatch_patches.items) |p| try isa.patchJumpTo(self, p, mismatch_target);
+    try isa.movImmToReg(self, if (negate) 1 else 0, Reg.acu);
+
+    try isa.patchJumpTo(self, end_patch, try self.currentOffset());
+
+    // Drop both stack copies. `acu` (the result) survives the sp bump.
+    try isa.addImmToReg(self, 2 * wslot, Reg.sp);
+}
+
+/// Fast path for structs with no content-typed (`str`) field: compare
+/// the two stack copies word-by-word (advancing offset-0 pointers — no
+/// scratch-reg collision), with a trailing byte for an odd width. lhs
+/// copy is at `[sp ..]`, rhs at `[sp + wslot ..]`.
+fn emitByteEq(self: *Emitter, wslot: u16, width: u16, patches: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    try isa.movRegToReg(self, Reg.sp, Reg.r1); // r1 = lhs copy base
+    try isa.movRegToReg(self, Reg.sp, Reg.r2);
+    try isa.addImmToReg(self, wslot, Reg.r2); // r2 = rhs copy base
+    var remaining = width;
+    while (remaining >= 2) : (remaining -= 2) {
+        try isa.movRegOffsetToReg(self, Reg.r1, 0, Reg.acu);
+        try isa.movRegOffsetToReg(self, Reg.r2, 0, Reg.r3);
+        try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+        try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+        try isa.addImmToReg(self, 2, Reg.r1);
+        try isa.addImmToReg(self, 2, Reg.r2);
+    }
+    if (remaining == 1) {
+        try class.emitByteLoadAtOffset(self, Reg.r1, 0, Reg.acu);
+        try class.emitByteLoadAtOffset(self, Reg.r2, 0, Reg.r3);
+        try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+        try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+    }
+}
+
+/// Per-field comparison for structs that contain a `str` field. The lhs
+/// copy is at `[sp + lhs_off ..]` and the rhs at `[sp + rhs_off ..]`;
+/// `sp` is stable, so each field reads at `sp + base_off + field_off`.
+/// `str` fields compare by content; nested structs recurse; every other
+/// field compares its stored word/byte (value or pointer identity).
+fn emitFieldwiseEq(self: *Emitter, sname: []const u8, lhs_off: u16, rhs_off: u16, patches: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    const sd = self.struct_decls.get(sname).?;
+    var fo: u16 = 0;
+    for (sd.fields) |f| {
+        const fw = self.widthOfTypeAnn(f.type_ann.*);
+        if (isStrTypeAnn(self, f.type_ann.*)) {
+            // Content compare (§3.2.1): load both pointers, then streq.
+            // `sp` survives streq's register churn, so the next field
+            // re-addresses from it cleanly. (Checked before the nested-
+            // struct case so the `str` classification matches `eqSupported`
+            // / `structHasContentField`.)
+            try class.emitWordLoadAtOffset(self, Reg.sp, lhs_off + fo, Reg.r1);
+            try class.emitWordLoadAtOffset(self, Reg.sp, rhs_off + fo, Reg.r2);
+            try strings.emitContentEq(self, Reg.r1, Reg.r2, false);
+            try isa.cmpRegImm(self, Reg.acu, 0); // acu == 0 → strings differ
+            try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
+        } else if (self.structNameOfTypeAnn(f.type_ann.*)) |sub| {
+            try emitFieldwiseEq(self, sub, lhs_off + fo, rhs_off + fo, patches);
+        } else if (fw == 1) {
+            try class.emitByteLoadAtOffset(self, Reg.sp, lhs_off + fo, Reg.acu);
+            try class.emitByteLoadAtOffset(self, Reg.sp, rhs_off + fo, Reg.r3);
+            try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+            try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+        } else {
+            try class.emitWordLoadAtOffset(self, Reg.sp, lhs_off + fo, Reg.acu);
+            try class.emitWordLoadAtOffset(self, Reg.sp, rhs_off + fo, Reg.r3);
+            try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+            try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+        }
+        fo += fw;
+    }
+}
+
+/// `true` when `sname` has a `str` field (directly or via a nested
+/// struct) — those must compare by content, forcing the per-field path.
+fn structHasContentField(self: *const Emitter, sname: []const u8) bool {
+    const sd = self.struct_decls.get(sname) orelse return false;
+    for (sd.fields) |f| {
+        if (isStrTypeAnn(self, f.type_ann.*)) return true;
+        if (self.structNameOfTypeAnn(f.type_ann.*)) |sub| {
+            if (structHasContentField(self, sub)) return true;
+        }
+    }
+    return false;
+}
+
+fn isStrTypeAnn(self: *const Emitter, t: ast.TypeAnn) bool {
+    return t == .named and std.mem.eql(u8, self.source[t.named.name.start..t.named.name.end], "str");
+}
+
+/// Whether `==` can be lowered for struct `sname`. Supported field
+/// types compare by value (scalars / bool / char / fixed), pointer
+/// identity (class / `&T` / fn-ptr — correct per §3.4.2 / §3.4.4),
+/// content (`str`, §3.2.1), or recursively (nested struct). Rejected:
+/// array / tuple / `Vec` (element-wise equality not lowered) and
+/// payload-carrying enums (distinct heap slots — no defined content
+/// equality), so those surface a clean diagnostic rather than a
+/// silently-wrong pointer compare.
+pub fn eqSupported(self: *const Emitter, sname: []const u8) bool {
+    const sd = self.struct_decls.get(sname) orelse return false;
+    for (sd.fields) |f| {
+        if (!fieldEqSupported(self, f.type_ann.*)) return false;
+    }
+    return true;
+}
+
+fn fieldEqSupported(self: *const Emitter, t: ast.TypeAnn) bool {
+    switch (t) {
+        .named => |n| {
+            const name = self.source[n.name.start..n.name.end];
+            if (self.struct_decls.contains(name)) return eqSupported(self, name);
+            if (self.enum_decls.get(name)) |ed| return !self.enumHasPayload(ed);
+            // Primitive (incl. `str`) or class name — value / content /
+            // identity compare, all handled.
+            return true;
+        },
+        .reference, .fn_type => return true, // pointer identity
+        .nullable, .array, .vec, .tuple => return false,
+    }
 }
 
 /// Copy `width` bytes from `[src]` to `[dest]` — word strides with a

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -4161,19 +4161,218 @@ fn expectCodegenError(source: []const u8, code: []const u8) !void {
     try std.testing.expect(found);
 }
 
-test "codegen/struct: equality is rejected (no silent address compare)" {
+test "codegen/struct: `==` is field-wise structural equality" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let a = P { x: 3, y: 4 }
+        \\  let b = P { x: 3, y: 4 }
+        \\  let c = P { x: 3, y: 9 }
+        \\  print a == b
+        \\  print a == c
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/struct: `!=` is the negation of `==`" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def main()
+        \\  let a = P { x: 5 }
+        \\  let b = P { x: 5 }
+        \\  let c = P { x: 6 }
+        \\  print a != b
+        \\  print a != c
+        \\end
+    , "0\n1\n");
+}
+
+test "codegen/struct: equality recurses into nested + byte-packed fields" {
+    try runAndExpect(
+        \\struct In
+        \\  a: u8
+        \\  b: u8
+        \\end
+        \\struct Out
+        \\  n: In
+        \\  k: i16
+        \\end
+        \\def main()
+        \\  let p = Out { n: In { a: 1, b: 2 }, k: 300 }
+        \\  let q = Out { n: In { a: 1, b: 2 }, k: 300 }
+        \\  let r = Out { n: In { a: 1, b: 9 }, k: 300 }
+        \\  print p == q
+        \\  print p == r
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/struct: equality of two struct-returning calls (distinct buffers)" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def mk(v: i16) -> P
+        \\  return P { x: v, y: v }
+        \\end
+        \\def main()
+        \\  print mk(5) == mk(5)
+        \\  print mk(5) == mk(6)
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/struct: ordering comparison on structs is rejected" {
     try expectCodegenError(
         \\struct P
         \\  x: i16
         \\end
         \\def main()
         \\  let a = P { x: 1 }
-        \\  let b = P { x: 1 }
-        \\  if a == b
+        \\  let b = P { x: 2 }
+        \\  if a < b
         \\    print 1
         \\  end
         \\end
     , "E_CODEGEN_UNSUPPORTED");
+}
+
+test "codegen/str: `==` compares content, not pointer identity" {
+    // Both strings are built at runtime in distinct interpolation
+    // buffers, so a pointer compare would (wrongly) say not-equal.
+    try runAndExpect(
+        \\def main()
+        \\  let n: i16 = 5
+        \\  let a = "v$(n)"
+        \\  let b = "v$(n)"
+        \\  print a == b
+        \\  print a != b
+        \\  print a == "v9"
+        \\end
+    , "1\n0\n0\n");
+}
+
+test "codegen/str: `==` distinguishes differing length + content" {
+    try runAndExpect(
+        \\def main()
+        \\  print "ab$(1)" == "ab"
+        \\  print "a$(1)" == "b$(1)"
+        \\  print "a$(1)" == "a$(1)"
+        \\end
+    , "0\n0\n1\n");
+}
+
+test "codegen/struct: a `str` field compares by content" {
+    try runAndExpect(
+        \\struct Named
+        \\  id: i16
+        \\  name: str
+        \\end
+        \\def main()
+        \\  let a = Named { id: 1, name: "p$(1)" }
+        \\  let b = Named { id: 1, name: "p$(1)" }
+        \\  let c = Named { id: 1, name: "q$(1)" }
+        \\  let d = Named { id: 2, name: "p$(1)" }
+        \\  print a == b
+        \\  print a == c
+        \\  print a == d
+        \\end
+    , "1\n0\n0\n");
+}
+
+test "codegen/struct: a `str` field inside a nested struct compares by content" {
+    try runAndExpect(
+        \\struct In
+        \\  tag: str
+        \\end
+        \\struct Out
+        \\  n: In
+        \\  k: i16
+        \\end
+        \\def main()
+        \\  let a = Out { n: In { tag: "t$(1)" }, k: 7 }
+        \\  let b = Out { n: In { tag: "t$(1)" }, k: 7 }
+        \\  let c = Out { n: In { tag: "z$(1)" }, k: 7 }
+        \\  print a == b
+        \\  print a == c
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/struct: a `str` field followed by a scalar (sp stable across content compare)" {
+    try runAndExpect(
+        \\struct SI
+        \\  name: str
+        \\  n: i16
+        \\end
+        \\def main()
+        \\  let a = SI { name: "p$(1)", n: 5 }
+        \\  let b = SI { name: "p$(1)", n: 5 }
+        \\  let c = SI { name: "p$(1)", n: 6 }
+        \\  print a == b
+        \\  print a == c
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/struct: a `str`-field struct `==` works in a condition" {
+    try runAndExpect(
+        \\struct N
+        \\  name: str
+        \\end
+        \\def main()
+        \\  let a = N { name: "k$(2)" }
+        \\  let b = N { name: "k$(2)" }
+        \\  if a == b
+        \\    print 1
+        \\  end
+        \\  print 0
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/struct: `==` on a struct with a payload-carrying enum field is rejected" {
+    try expectCodegenError(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\struct Slot
+        \\  qty: i16
+        \\  it: Item
+        \\end
+        \\def main()
+        \\  let a = Slot { qty: 1, it: Item.Potion(20) }
+        \\  let b = Slot { qty: 1, it: Item.Potion(20) }
+        \\  print a == b
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
+}
+
+test "codegen/struct: payload-free enum field compares by tag" {
+    try runAndExpect(
+        \\enum Dir
+        \\  case N
+        \\  case S
+        \\end
+        \\struct Cell
+        \\  d: Dir
+        \\  v: i16
+        \\end
+        \\def main()
+        \\  let a = Cell { d: Dir.N, v: 1 }
+        \\  let b = Cell { d: Dir.N, v: 1 }
+        \\  let c = Cell { d: Dir.S, v: 1 }
+        \\  print a == b
+        \\  print a == c
+        \\end
+    , "1\n0\n");
 }
 
 test "codegen/struct: printing a whole struct is rejected" {


### PR DESCRIPTION
Implements struct equality (#322) and, per the maintainer's call during review, fixes `str` equality to be content-based in the same PR.

## Structs (§3.4 "structurally equal if fields equal")

Each field compares with the semantics its own `==` uses:

| Field type | Comparison |
|---|---|
| scalar / bool / char / fixed | by value |
| class instance | pointer identity (§3.4.2 — classes have identity) |
| `&T` / fn-ptr | pointer identity |
| payload-free enum | by tag |
| `str` | **by content** (§3.2.1) |
| nested struct | recursively |

A struct with **no** `str` field reduces to a fast byte compare over its packed width (no padding); a struct **with** a `str` field uses per-field dispatch so those compare by content. Both operands are materialized as by-value stack copies, so two struct-returning calls (which share the sret scratch) and struct-literal operands (`p == P{…}`) compare correctly. Result is a `0`/`1` boolean — works as a value (`let eq = a == b`) and in a fused condition (`if a == b`). `!=` is the negation.

## Strings

`str == other` / `!=` now walk both null-terminated strings byte-wise (§3.2.1) instead of comparing pointers — two equal strings built at runtime in distinct buffers (interpolation, etc.) now compare equal. This fixes **scalar** `str ==` too, not just str-typed struct fields.

## Rejected (clean `E_CODEGEN_UNSUPPORTED`, never silently miscompiled)

- Ordering operators (`<`, `<=`, `>`, `>=`) on structs — only equality is defined.
- `==` on a struct whose fields include an **array, tuple, `Vec`, payload-carrying enum, or nullable** — element-wise / content equality for those isn't lowered yet, so they error rather than pointer-compare wrongly.

## Verification

Multi-agent adversarial review (3 lenses ×2 rounds) confirmed: the runtime string loop (prefixes, empties, terminator, negate, no offset drift, zero-extension), register/stack discipline (`sp` stable across the string-compare's register churn; both copies released), jump patching, and both lowering paths. 15 new tests cover scalar str content equality, struct equality (value / nested / byte-packed / two-call / `!=`), str-field structs (incl. nested + str-then-scalar + condition position), payload-free-enum fields, and the rejections. `zig build ci` green across all release modes + cross-targets.

## Noted for follow-up (out of scope here)
- **Scalar** payload-carrying enum `==` is pre-existing pointer-compare (e.g. `Item.Potion(20) == Item.Potion(20)` → false). Not introduced by this PR; a separate `enum ==` semantics decision (like `str ==` got here).
- `reserveFrameSlot` panics for frames > 127 bytes (pre-existing i8 fp-offset limit; the `==` path uses `sp`, not frame slots, so it isn't the trigger).

Closes #322.