### PR TITLE
feat(lang): enum value semantics — print, ==, construction (+ folded fixes)

### DIFF
--- a/.changeset/lang-codegen-struct-print.md
+++ b/.changeset/lang-codegen-struct-print.md
@@ -1,0 +1,64 @@
+---
+bump: minor
+---
+
+`print` now renders structs and enums by value, payload-carrying enums
+compare structurally, and a set of pre-existing lang gaps surfaced
+alongside are closed (§3, §3.2.1, §3.6, §4.9, ISA §syscalls).
+
+**Default rendering.** A struct prints as `Name { field: value, … }` and
+an enum as `Enum.Variant` (or `Enum.Variant(a, b)` with a payload).
+Fields and payloads render recursively, so a struct holding an enum
+prints the variant in place (`Slot { qty: 2, it: Item.Potion(5) }`).
+Types with no default rendering — array / tuple / `Vec` / class /
+reference, a struct enum payload, or a recursive type — are a clean
+compile error rather than a printed address or a compiler crash.
+
+**Enum equality.** `==` / `!=` on a payload-carrying enum compares the
+value, not the pointer: tag first, then the matching variant's payload
+field-by-field (`str` by content per §3.2.1, a nested enum recursively,
+scalars by value). Structs with an enum field compare through it. A
+recursive enum is rejected (no finite structural compare).
+
+**Enum-construction typing.** `Item.Potion(20)` now infers the enum type
+(it parses as a method call), so `let x = Item.Potion(20)` is typed
+`Item` and the payload args are checked — surfacing arity, unknown
+variant, and arg-type errors that were previously accepted silently.
+
+**`str` concatenation + ordering.** `a + b` on `str` allocates a fresh
+buffer and copies both operands (§3.2.1) instead of adding the two
+pointers as integers; the heap now starts above the interned string pool
+so a long concat can't alias its own source. `<` / `<=` / `>` / `>=` on
+`str` compare lexicographically (byte content) rather than the operand
+addresses.
+
+**Guarded match arms.** A `when`-guarded arm no longer marks a later
+unguarded same-variant arm unreachable, nor discharges its variant for
+exhaustiveness — so the guarded-arm-then-fallback idiom (§4.8.4) checks
+correctly.
+
+**Unsigned printing.** A `u16` (bare, struct field, enum payload, or
+interpolated) now prints its unsigned magnitude via the new `print_uint`
+/ `format_uint_to_buf` syscalls, instead of being formatted as a signed
+`i16`. A signed `i8` enum payload is sign-extended on match-bind and
+print so a negative value keeps its sign.
+
+**Module-level initializers.** A top-level `const` / `let` initializer is
+now evaluated and stored into its slot at entry startup (declaration
+order, so a later one can read an earlier one); previously the slot read
+back zero for everything but `bake`-backed consts.
+
+**Boolean conditions.** `if` / `elif` / `while` / `repeat`-`until`
+conditions and `when` guards must be `bool` — there is no implicit
+truthiness (§3). A non-`bool` condition is `E_TYPE_MISMATCH`.
+
+**Recursive structs.** A struct that contains itself by value (directly
+or through a struct / array / tuple field) is rejected with the new
+`E_TYPE_RECURSIVE_STRUCT` — it has infinite size; previously it crashed
+the compiler. Use `Vec(T)` / `&T` for a recursive shape.
+
+**Frame-size diagnostic.** A function frame past the `[fp+imm8]`
+addressing limit reports `E_CODEGEN_FRAME_TOO_LARGE` instead of
+panicking the compiler.
+
+Closes #323.

--- a/docs/examples/syntax_overview.gr
+++ b/docs/examples/syntax_overview.gr
@@ -235,6 +235,7 @@ def battle(hero: Hero, monster: Monster) -> bool
         let dmg = damage(hero.stats, monster.stats, power)
         monster.take_damage(dmg)
         print "$(hero.name) hits for $(dmg:3d)" -- format spec
+      case Action.Attack(_, _) => print "$(hero.name)'s attack fizzles" -- guard fall-through
       case Action.Defend => print "$(hero.name) defends"
       case Action.Heal(amount) => hero.stats.hp = clamp(hero.stats.hp + amount, 0, MAX_HP)
       case Action.Flee =>

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -1183,26 +1183,31 @@ codegen and have no meaning for compile-time evaluation.
 ```
 let name = expr               -- mutable, inferred type
 let name: T = expr            -- mutable, explicit type
-const name = expr             -- immutable binding (compile-time inlined when possible)
+const name = expr             -- immutable binding (read-only; reassignment is an error)
 ```
 
 **`let`** is a mutable binding. Reassign freely.
 
 **`const`** is an **immutable binding**. Reassignment is a compile
-error. Two flavors handled by the compiler:
-
-- If the RHS is **comptime-evaluable** (literals + `const`-only
-  arithmetic), the value is inlined at use sites with no runtime
-  storage. This is the canonical case (`const MAX_HP = 100`).
-- If the RHS depends on runtime values (`const player_name =
-  read_input()`), the binding gets a stack/static slot but is
-  read-only — you can't `player_name = "x"` later.
+error; otherwise it stores like a `let`. A `bake`-backed `const`
+(`const X = bake do … end`) is evaluated at compile time and its bytes
+seed the slot directly; every other initializer is evaluated at run
+time into the binding's slot.
 
 Same model as JavaScript / TypeScript `const`.
 
+**Module-level initialization order.** A top-level `const` / `let`
+initializer runs at program start, in **declaration order**, before
+`main`'s body — so an initializer may reference bindings declared above
+it (`const A = 3` then `const B = A + 4`). A reference to a binding
+declared *below* reads its not-yet-initialized slot. An `@addr`-pinned
+binding is the exception: its initializer is **not** written at boot —
+the pinned location (typically MMIO, §3.7.1) already holds the live
+value, and a read picks that up.
+
 ```
-const PI_FIXED = $0324       -- comptime, inlined
-const player_name = read_input()  -- runtime, but read-only
+const PI_FIXED = $0324       -- seeded at startup, read-only
+const player_name = read_input()  -- runtime value, read-only
 player_name = "x"             -- compile error: cannot reassign const
 ```
 
@@ -2071,6 +2076,28 @@ Compiles to a host-provided syscall (`int $10`). The host's printer
 implementation defines the output channel (gtx-16 prints to a debug
 console; CLI tools print to stdout).
 
+**Default rendering.** Each argument renders by its type:
+
+| Type | Rendering | Example |
+|---|---|---|
+| integer (`i8`/`u8`/`i16`/`u16`), `bool` | decimal | `42`, `1` |
+| `char` | the glyph | `'A'` → `A` |
+| `fixed` | fixed-point decimal | `1.5` → `1.500` |
+| `str` | the bytes | `"hi"` → `hi` |
+| `struct` | `Name { field: value, … }` (each field by its type, recursively) | `P { x: 1, y: 2 }` |
+| `enum` | `Enum.Variant`, or `Enum.Variant(a, b)` with a payload (each payload field by its type, recursively) | `Item.Potion(5)`, `Dir.N` |
+
+Struct fields and enum payloads render recursively, so a struct that
+holds an enum prints the variant in place (`Slot { qty: 2, it:
+Item.Potion(5) }`). Enum payload fields are stored as single
+register-width slot values, so a payload may be a scalar / `char` /
+`fixed` / `str` / enum — **not** a struct.
+
+Types with no default rendering — array, tuple, `Vec`, `class`,
+reference, function pointer, nullable, and (as an enum payload) struct
+— are a compile error (`E_CODEGEN_UNSUPPORTED`) rather than a
+silently-meaningless address.
+
 ### 4.10 Defer
 
 `defer <stmt>` schedules a statement to run when the enclosing block
@@ -2475,8 +2502,8 @@ Old-school enough — same model NES games used for actor systems.
 
 | Source construct | Bytecode shape |
 |------------------|----------------|
-| `let x: i16 = 0` | Stack slot or register allocation |
-| `const X = 5` | Inlined at use sites |
+| `let x: i16 = 0` | Stack slot (local) or static slot (module-level) |
+| `const X = 5` | Static slot, seeded at startup (or compile-time bytes for a `bake` const) |
 | Function | `addr_of_label`; calls become `call addr` |
 | Lambda | Synthesized hidden function + closure-capture struct |
 | Class | Vtable in static data + per-instance memory layout |

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -561,11 +561,13 @@ silent no-ops. Unknown syscall numbers raise the
 | `0x03`| `print_char`           | low byte of `acu` written directly. |
 | `0x04`| `print_newline`        | writes a single `\n` byte. |
 | `0x05`| `print_fixed`          | `acu` = Q8.8 fixed-point value. Formats as `<int>.<3-digit-frac>` decimal — e.g. value `384` (1.5 in Q8.8) prints `1.500`. Negative values get a leading `-`. |
+| `0x06`| `print_uint`           | `acu` = unsigned 16-bit value. Written as decimal to `Host.out`. (Unsigned counterpart of `print_int`.) |
 | `0x10`| `format_str_to_buf`    | `acu` = source str address (null-terminated). `r1` = dst cursor. Copies the bytes (excluding the trailing null) from `[acu]` to `[r1]`, then advances `r1` past the copy. |
 | `0x11`| `format_int_to_buf`    | `acu` = i16 value. `r1` = dst cursor. Appends the signed-decimal representation of `acu` at `[r1]`, then advances `r1`. |
 | `0x12`| `format_char_to_buf`   | `acu` = char value (low byte). `r1` = dst cursor. Writes the low byte to `[r1]`, advances `r1` by 1. |
 | `0x13`| `format_fixed_to_buf`  | `acu` = Q8.8 value. `r1` = dst cursor. Appends the same `<int>.<3-digit-frac>` formatting as `print_fixed` at `[r1]`, then advances `r1`. |
 | `0x14`| `format_terminate_buf` | `r1` = dst cursor. Writes a single null byte at `[r1]` and advances `r1` by 1 (so chained terminators don't stomp the same slot). |
+| `0x15`| `format_uint_to_buf`   | `acu` = u16 value. `r1` = dst cursor. Appends the unsigned-decimal representation of `acu` at `[r1]`, then advances `r1`. (Unsigned counterpart of `format_int_to_buf`.) |
 | `0x20`| `alloc`                | bump-allocate `acu` bytes on the heap. On success, sets `acu` to the address of the freshly-allocated block and advances the VM's heap cursor by the requested size. On exhaustion (cursor + size would collide with the stack or fall outside the program's heap region), raises the **heap-exhausted** fault (vector `0x04`). Faults if `heap_base = 0` (program declared no heap). |
 
 Writer failures (host stdout closed, OOM in the writer's buffer)

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -711,6 +711,33 @@ note: defers run after the enclosing block's control flow is
       already decided (spec §4.10)
 ```
 
+### 5.15 Codegen (E_CODEGEN_*)
+
+Emitted by the lowering pass when a construct can't be turned into
+valid bytecode. Most indicate a not-yet-lowered feature or a resource
+the target can't satisfy; a few are internal invariants the front-end
+should have already enforced.
+
+| Code | Meaning |
+|------|---------|
+| `E_CODEGEN_UNSUPPORTED` | A syntactically + type-valid construct the codegen doesn't lower yet (the catch-all — e.g. printing a whole struct, an ordering comparison on structs, a struct `==` with an array / tuple / `Vec` / payload-enum / nullable field). |
+| `E_CODEGEN_FRAME_TOO_LARGE` | A function's locals or parameters exceed the 127-byte limit on `[fp + imm8]` fp-relative addressing (the ISA's only frame-offset mode). Reduce locals/params. |
+| `E_CODEGEN_UNDEFINED_FN` | A call's target isn't a known top-level `def` (an unresolved forward reference at patch time). |
+| `E_CODEGEN_UNKNOWN_CLASS` | A constructor / field / method targets a class with no computed layout. |
+| `E_CODEGEN_UNDEFINED_FIELD` | A `recv.field` names a field the class doesn't declare. |
+| `E_CODEGEN_UNDEFINED_METHOD` | A `recv.method(…)` / `super.method(…)` resolves to no method on the class or its ancestors. |
+| `E_CODEGEN_UNDEFINED_VARIANT` | An `Enum.Variant` names a variant the enum doesn't declare. |
+| `E_CODEGEN_BAD_VARIANT_PATH` | A variant constructor path isn't the expected `Enum.Variant` shape. |
+| `E_CODEGEN_NO_PARENT` | `super` used in a class with no `extends` parent. |
+| `E_CODEGEN_NO_SELF` | `super.method` / `self` used outside a method body. |
+| `E_CODEGEN_ZP_OVERFLOW` | The zero-page region is exhausted — too many `@zero_page` globals. |
+| `E_CODEGEN_DATA_OVERFLOW` | The static data region is exhausted (globals + string pool + vtables). |
+| `E_CODEGEN_DEFER_NO_BLOCK` | A `defer` was emitted with no enclosing block frame (internal invariant). |
+| `E_CODEGEN_LOOP_JUMP_NO_LOOP` | `break` / `continue` reached codegen outside any loop (internal — the typechecker normally catches this). |
+| `E_CODEGEN_LAMBDA_NOT_ANALYZED` | Internal: a lambda body was missing from the closure-analysis pass. |
+| `E_CODEGEN_UNBOUND_CAPTURE` | A captured binding has no env slot — e.g. calling a free `def` from inside a lambda body, which closure analysis doesn't support. |
+| `E_CODEGEN_NONPROMOTED_CAPTURE_WRITE` | A write targets a captured binding the analysis didn't promote to a heap cell. |
+
 ---
 
 ## 6. Error code registry
@@ -783,6 +810,23 @@ Codes are stable. New ones append; old ones never change meaning.
 | `W_DEAD_TEST` | `is` runtime type test | v0.3 |
 | `E_BUILTIN_SHADOW` | Builtin shadowing | v0.3 |
 | `E_UNDEFINED_SYMBOL` | Name resolution | v0.3 |
+| `E_CODEGEN_UNSUPPORTED` | Codegen | v0.3 |
+| `E_CODEGEN_FRAME_TOO_LARGE` | Codegen | v0.3 |
+| `E_CODEGEN_UNDEFINED_FN` | Codegen | v0.3 |
+| `E_CODEGEN_UNKNOWN_CLASS` | Codegen | v0.3 |
+| `E_CODEGEN_UNDEFINED_FIELD` | Codegen | v0.3 |
+| `E_CODEGEN_UNDEFINED_METHOD` | Codegen | v0.3 |
+| `E_CODEGEN_UNDEFINED_VARIANT` | Codegen | v0.3 |
+| `E_CODEGEN_BAD_VARIANT_PATH` | Codegen | v0.3 |
+| `E_CODEGEN_NO_PARENT` | Codegen | v0.3 |
+| `E_CODEGEN_NO_SELF` | Codegen | v0.3 |
+| `E_CODEGEN_ZP_OVERFLOW` | Codegen | v0.3 |
+| `E_CODEGEN_DATA_OVERFLOW` | Codegen | v0.3 |
+| `E_CODEGEN_DEFER_NO_BLOCK` | Codegen | v0.3 |
+| `E_CODEGEN_LOOP_JUMP_NO_LOOP` | Codegen | v0.3 |
+| `E_CODEGEN_LAMBDA_NOT_ANALYZED` | Codegen | v0.3 |
+| `E_CODEGEN_UNBOUND_CAPTURE` | Codegen | v0.3 |
+| `E_CODEGEN_NONPROMOTED_CAPTURE_WRITE` | Codegen | v0.3 |
 
 ---
 

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -232,6 +232,7 @@ Raised by the typechecker after parsing succeeds.
 | `E_TYPE_UNDEFINED_FIELD` | Field name doesn't exist on the receiver's type. |
 | `E_TYPE_UNDEFINED_METHOD` | Method name doesn't exist on the receiver's class (or any parent). |
 | `E_TYPE_MISSING_FIELD` | Struct literal omits a field declared by the type. |
+| `E_TYPE_RECURSIVE_STRUCT` | A struct contains itself by value (directly or transitively, through a struct / array / tuple field) — infinite size, no layout. Use `Vec(T)` or `&T` for a recursive shape. |
 | `E_TYPE_TUPLE_ARITY` | Tuple-destructuring pattern's element count doesn't match the init's tuple arity. |
 | `E_TYPE_REDEFINED` | A name is declared twice in the same scope. |
 | `E_TYPE_ARG_COUNT` | Wrong number of args at a call site. |
@@ -720,7 +721,7 @@ should have already enforced.
 
 | Code | Meaning |
 |------|---------|
-| `E_CODEGEN_UNSUPPORTED` | A syntactically + type-valid construct the codegen doesn't lower yet (the catch-all — e.g. printing a whole struct, an ordering comparison on structs, a struct `==` with an array / tuple / `Vec` / payload-enum / nullable field). |
+| `E_CODEGEN_UNSUPPORTED` | A syntactically + type-valid construct the codegen doesn't lower yet (the catch-all — e.g. an ordering comparison on structs, a `==` over an array / tuple / `Vec` / nullable field or a recursive enum, printing a value with no default rendering (array / tuple / `Vec` / class / reference) or a recursive type). |
 | `E_CODEGEN_FRAME_TOO_LARGE` | A function's locals or parameters exceed the 127-byte limit on `[fp + imm8]` fp-relative addressing (the ISA's only frame-offset mode). Reduce locals/params. |
 | `E_CODEGEN_UNDEFINED_FN` | A call's target isn't a known top-level `def` (an unresolved forward reference at patch time). |
 | `E_CODEGEN_UNKNOWN_CLASS` | A constructor / field / method targets a class with no computed layout. |
@@ -757,6 +758,7 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_TYPE_UNDEFINED_FIELD` | Typechecker | v0.3 |
 | `E_TYPE_UNDEFINED_METHOD` | Typechecker | v0.3 |
 | `E_TYPE_MISSING_FIELD` | Typechecker | v0.3 |
+| `E_TYPE_RECURSIVE_STRUCT` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_ARITY` | Typechecker | v0.3 |
 | `E_TYPE_REDEFINED` | Typechecker | v0.3 |
 | `E_TYPE_ARG_COUNT` | Typechecker | v0.3 |

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -133,6 +133,7 @@ pub fn compile(
         .locals = .{},
         .params = .{},
         .frame_bytes = 0,
+        .frame_overflow = false,
         .is_entry = false,
         .is_isr = false,
         .current_ret_struct = null,
@@ -419,6 +420,10 @@ pub const Emitter = struct {
     /// Total bytes reserved for this fn's locals — the prologue
     /// emits `sub frame_bytes, sp`.
     frame_bytes: u8,
+    /// Set when a frame slot or param offset exceeds the i8 fp-relative
+    /// addressing range (±127); `emitDefWithLabel` reports it as
+    /// `E_CODEGEN_FRAME_TOO_LARGE`. Reset per def.
+    frame_overflow: bool,
     /// `true` while emitting the entry def's body. Drives the
     /// `return` lowering (`hlt` vs `ret`) and skips the
     /// `push fp` / `mov sp, fp` parts of the prologue (the VM
@@ -624,8 +629,18 @@ pub const Emitter = struct {
     /// arg bindings) whose names bind into a scope set up afterward.
     pub fn reserveFrameSlot(self: *Emitter, bytes: u16) i8 {
         const slot: u16 = alignUpU16(bytes, 2);
-        const new_frame_bytes = self.frame_bytes + slot;
-        // @as: i8 covers -128..127; the prologue caps total frame size.
+        // @as: widen the u8 cursor so the sum can exceed 255 + be range-checked below instead of wrapping.
+        const new_frame_bytes = @as(u16, self.frame_bytes) + slot;
+        // The ISA's only fp-relative addressing is `[fp + imm8]` (±127),
+        // so a frame past 127 bytes can't be addressed. Flag it and
+        // return a placeholder; `emitDefWithLabel` turns the flag into a
+        // clean `E_CODEGEN_FRAME_TOO_LARGE` rather than panicking on the
+        // i8 cast (the compile fails, so the placeholder is never run).
+        if (new_frame_bytes > 127) {
+            self.frame_overflow = true;
+            return -1;
+        }
+        // @as: bounded ≤127 by the check above.
         const ofs: i8 = -@as(i8, @intCast(new_frame_bytes));
         self.frame_bytes = @intCast(new_frame_bytes);
         return ofs;

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -179,11 +179,13 @@ pub fn compile(
         .diagnostics = &diagnostics,
         .optimize = opts.optimize,
         .bake_inits = .{},
+        .global_inits = .empty,
         .bake_defs = .{},
     };
     defer emitter.code.deinit(allocator);
     defer emitter.call_patches.deinit(allocator);
     defer emitter.bake_inits.deinit(allocator);
+    defer emitter.global_inits.deinit(allocator);
     defer emitter.bake_defs.deinit(allocator);
     defer emitter.vtable_patches.deinit(allocator);
     defer emitter.lambda_patches.deinit(allocator);
@@ -229,7 +231,14 @@ pub fn compile(
     else
         null;
     defer if (debug_blob) |s| allocator.free(s);
-    const image = try buildArchive(allocator, base_image, code_base, emitter.data_cursor, &emitter.banks, debug_blob);
+    // Heap starts above the whole image — past the code + interned
+    // string pool (which grows the code buffer, so `code_end` can exceed
+    // `data_cursor`) AND past the data-global region. Pinning it at
+    // `data_cursor` alone let `alloc` hand out addresses inside the live
+    // string literals, so a concat's copy aliased its own source.
+    // @as: code_end / data_cursor are both ≤ 64 KiB by ISA; the max fits u16.
+    const heap_base: u16 = @intCast(@max(code_end, @as(usize, emitter.data_cursor)));
+    const image = try buildArchive(allocator, base_image, code_base, heap_base, &emitter.banks, debug_blob);
     allocator.free(base_image);
 
     return .{
@@ -373,6 +382,18 @@ pub const Global = struct {
     /// Placement family. Drives the addressing mode used for
     /// loads / stores against this global.
     placement: enum { addr, zero_page, data },
+    /// `true` for an `i8` global — a byte load sign-extends rather than
+    /// zero-extends, so a negative value keeps its sign.
+    signed_byte: bool = false,
+};
+
+/// A top-level `let` / `const` whose initializer isn't `bake`-seeded —
+/// its value is evaluated and stored into the global's slot at entry-def
+/// startup. Recorded in declaration order so a later init can read an
+/// earlier one.
+pub const GlobalInit = struct {
+    name: []const u8,
+    init: *const ast.Expr,
 };
 
 /// Unresolved vtable-address site. Patched by `patchVtableSlots`
@@ -554,6 +575,9 @@ pub const Emitter = struct {
     /// data-region address. Written into the base image at
     /// `compile()` so the runtime sees baked values at boot.
     bake_inits: std.AutoHashMapUnmanaged(u16, []const u8),
+    /// Non-`bake` top-level initializers, emitted as stores at entry
+    /// startup (declaration order). See `GlobalInit`.
+    global_inits: std.ArrayListUnmanaged(GlobalInit),
     /// `bake def`s by name. Populated pre-emission so
     /// `const X = bake_def_name()` initializers can find the
     /// callee.
@@ -855,6 +879,21 @@ pub const Emitter = struct {
     pub fn isPrimitiveType(self: *const Emitter, e: *const ast.Expr, p: types_mod.Primitive) bool {
         const t = self.typeOf(e) orelse return false;
         return t.* == .primitive and t.primitive == p;
+    }
+
+    /// `true` when the type annotation is the named primitive `name`
+    /// (e.g. `"i8"`). Used to pick signed vs unsigned narrow-load
+    /// handling where only the declared type — not an inferred type —
+    /// is in hand.
+    pub fn isPrimitiveTypeAnn(self: *const Emitter, t: ast.TypeAnn, name: []const u8) bool {
+        return t == .named and std.mem.eql(u8, self.source[t.named.name.start..t.named.name.end], name);
+    }
+
+    /// `true` when the expression's inferred type is an unsigned integer
+    /// (`u8` / `u16`) — picks `print_uint` over the signed `print_int`
+    /// so a high-bit value renders as its unsigned magnitude.
+    pub fn isUnsignedInt(self: *const Emitter, e: *const ast.Expr) bool {
+        return self.isPrimitiveType(e, .u8) or self.isPrimitiveType(e, .u16);
     }
 
     /// Pre-pass: index every top-level `enum` decl by name so the
@@ -1287,7 +1326,7 @@ pub const Emitter = struct {
     /// Layout of one struct field: byte offset, byte width, and — when
     /// the field is itself a struct — that struct's name (so codegen
     /// recurses into nested aggregates rather than storing a scalar).
-    pub const FieldInfo = struct { offset: u16, width: u16, struct_name: ?[]const u8 };
+    pub const FieldInfo = struct { offset: u16, width: u16, struct_name: ?[]const u8, signed_byte: bool = false };
 
     /// `FieldInfo` for `field_name` within `struct_name`, or `null` if
     /// unknown. Fields are laid out contiguously in declaration order
@@ -1298,7 +1337,12 @@ pub const Emitter = struct {
         for (sd.fields) |f| {
             const w = self.widthOfTypeAnn(f.type_ann.*);
             if (std.mem.eql(u8, self.source[f.name.start..f.name.end], field_name)) {
-                return .{ .offset = ofs, .width = w, .struct_name = self.structNameOfTypeAnn(f.type_ann.*) };
+                return .{
+                    .offset = ofs,
+                    .width = w,
+                    .struct_name = self.structNameOfTypeAnn(f.type_ann.*),
+                    .signed_byte = self.isPrimitiveTypeAnn(f.type_ann.*, "i8"),
+                };
             }
             ofs +%= w;
         }

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -47,8 +47,13 @@ fn emitPayloadBinders(
         for (vp.args, 0..) |arg, i| {
             if (arg.* != .ident or i >= v.payload.len) continue;
             const ofs = self.variantFieldOffset(v, i);
-            if (self.widthOfTypeAnn(v.payload[i].type_ann.*) == 1) {
+            const fty = v.payload[i].type_ann.*;
+            if (self.widthOfTypeAnn(fty) == 1) {
                 try class.emitByteLoadAtOffset(self, Reg.r1, ofs, Reg.acu);
+                // `i8` is the only signed byte type — sign-extend so a
+                // negative payload keeps its sign through the binder
+                // (`u8` / `bool` / `char` stay zero-extended).
+                if (self.isPrimitiveTypeAnn(fty, "i8")) try isa.signExtendByte(self, Reg.acu);
             } else {
                 try class.emitWordLoadAtOffset(self, Reg.r1, ofs, Reg.acu);
             }

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -10,6 +10,7 @@ const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const archive = @import("archive.zig");
 const lambda = @import("lambda.zig");
+const globals = @import("globals.zig");
 
 const Emitter = codegen.Emitter;
 const DefKind = Emitter.DefKind;
@@ -130,6 +131,10 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     // its IVT slot before the body runs — boot leaves `flg.I = 0`, so an
     // interrupt could otherwise fire against an uninitialized vector.
     if (self.is_entry) try emitIvtInit(self);
+
+    // Entry-def prologue: seed every non-`bake` top-level `let` / `const`
+    // slot with its initializer before the body can read it.
+    if (self.is_entry) try globals.emitGlobalInits(self);
 
     // The body opens the outermost block — top-level `defer`s run before
     // the implicit epilogue.

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -50,6 +50,7 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     const saved_locals = self.locals;
     const saved_params = self.params;
     const saved_frame = self.frame_bytes;
+    const saved_overflow = self.frame_overflow;
     const saved_entry = self.is_entry;
     const saved_isr = self.is_isr;
     const saved_bank = self.current_bank;
@@ -59,6 +60,7 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     self.locals = .{};
     self.params = .{};
     self.frame_bytes = 0;
+    self.frame_overflow = false;
     self.is_entry = (kind == .entry);
     self.is_isr = is_isr;
     self.current_bank = bank_target;
@@ -67,6 +69,7 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
         self.locals = saved_locals;
         self.params = saved_params;
         self.frame_bytes = saved_frame;
+        self.frame_overflow = saved_overflow;
         self.is_entry = saved_entry;
         self.is_isr = saved_isr;
         self.current_bank = saved_bank;
@@ -89,8 +92,14 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     var param_ofs: i32 = 4;
     for (def.params) |p| {
         const dup_p = try self.arena.dupe(u8, self.source[p.name.start..p.name.end]);
-        // @as: i8 fp-offset; the frame-size cap keeps offsets in range.
-        try self.params.put(self.arena, dup_p, @intCast(param_ofs));
+        // Params sit at positive fp-offsets, addressed via `[fp + imm8]`
+        // (±127). Past that, flag it (reported below) and bind a
+        // placeholder so we don't panic on the i8 cast.
+        const ofs: i8 = if (param_ofs > 127) blk: {
+            self.frame_overflow = true;
+            break :blk 4;
+        } else @intCast(param_ofs);
+        try self.params.put(self.arena, dup_p, ofs);
         param_ofs += self.paramWidthAligned(p);
     }
 
@@ -136,6 +145,13 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
         try self.emitByte(Op.rti_op);
     } else {
         try self.emitByte(Op.ret_op);
+    }
+
+    // A frame slot or param that overran the i8 fp-offset range during
+    // body emission can't be addressed — fail cleanly rather than ship
+    // the placeholder offsets reserveFrameSlot / the param loop emitted.
+    if (self.frame_overflow) {
+        try self.diagFatal(def.span, "E_CODEGEN_FRAME_TOO_LARGE", "function frame exceeds the 127-byte limit on fp-relative addressing — reduce its locals or parameters");
     }
 
     // Lambda bodies discovered during analysis emit as plain defs

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -304,6 +304,24 @@ fn isStrComparison(self: *Emitter, b: ast.BinaryExpr) bool {
     return self.isPrimitiveType(b.lhs, .str) or self.isPrimitiveType(b.rhs, .str);
 }
 
+/// `true` for a `str` ordering comparison (`< <= > >=`) — lexicographic
+/// per §3.2.1, distinct from the `==` / `!=` content path.
+fn isStrOrdering(self: *Emitter, b: ast.BinaryExpr) bool {
+    return switch (b.op) {
+        .lt, .lte, .gt, .gte => isStrComparison(self, b),
+        else => false,
+    };
+}
+
+/// The enum decl when a comparison's operands are a payload-carrying
+/// enum, else `null`. Such a value is a `[tag|payload]` slot pointer, so
+/// `==` must compare the slots, not the pointers. Payload-free enums are
+/// bare tags and compare correctly via the plain register `cmp`.
+fn payloadEnumComparison(self: *Emitter, b: ast.BinaryExpr) ?*const ast.EnumDecl {
+    const ed = self.enumDeclForExpr(b.lhs) orelse self.enumDeclForExpr(b.rhs) orelse return null;
+    return if (self.enumHasPayload(ed)) ed else null;
+}
+
 /// Lower a binary infix expression. Short-circuit operators
 /// (`and`, `or`) take a separate path so the RHS isn't always
 /// evaluated. Comparison ops materialize a `0` / `1` in `acu`.
@@ -361,6 +379,13 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
     try isa.popReg(self, Reg.r1);
     switch (b.op) {
         .add => {
+            // `str + str` allocates a fresh buffer and concatenates
+            // (§3.2.1) — acu / r1 hold the lhs / rhs pointers. (Typecheck
+            // guarantees both sides are `str` when either is.)
+            if (self.isPrimitiveType(b.lhs, .str)) {
+                try strings.emitStrConcat(self, Reg.acu, Reg.r1);
+                return;
+            }
             try isa.addRegToAcu(self, Reg.r1);
             if (integer_arith) try overflow.emitOverflowTrap(self, signedness);
         },
@@ -446,6 +471,28 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
                 try strings.emitContentEq(self, Reg.r1, Reg.r2, b.op == .neq);
                 return;
             }
+            // `str` ordering is lexicographic (§3.2.1): strcmp the bytes,
+            // then map the sign to the relation. acu / r1 = lhs / rhs ptrs.
+            if (isStrOrdering(self, b)) {
+                try isa.movRegToReg(self, Reg.acu, Reg.r2);
+                try strings.emitStrCmp(self, Reg.r2, Reg.r1);
+                try isa.cmpRegImm(self, Reg.acu, 0);
+                try materializeBoolFromFlags(self, b.op);
+                return;
+            }
+            // Payload-carrying enum: compare the two slots by value (tag,
+            // then per-variant payload), not the pointers — acu / r1 hold
+            // the lhs / rhs slot addresses.
+            if (b.op == .eq or b.op == .neq) {
+                if (payloadEnumComparison(self, b)) |ed| {
+                    if (!value_struct.enumEqSupported(self, ed)) {
+                        try self.unsupported(b.span, "`==` on an enum with a recursive or non-comparable payload");
+                        return;
+                    }
+                    try value_struct.emitEnumEqual(self, ed, Reg.acu, Reg.r1, b.op == .neq);
+                    return;
+                }
+            }
             try isa.cmpRegReg(self, Reg.acu, Reg.r1);
             try materializeBoolFromFlags(self, b.op);
         },
@@ -496,6 +543,29 @@ pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
                     try strings.emitContentEq(self, Reg.r1, Reg.r2, b.op == .neq);
                     try isa.cmpRegImm(self, Reg.acu, 0);
                     return;
+                }
+                // `str` ordering (§3.2.1): strcmp, then the 0/1 it
+                // materializes is tested against 0 like any cond.
+                if (isStrOrdering(self, b)) {
+                    try isa.movRegToReg(self, Reg.acu, Reg.r2);
+                    try strings.emitStrCmp(self, Reg.r2, Reg.r1);
+                    try isa.cmpRegImm(self, Reg.acu, 0);
+                    try materializeBoolFromFlags(self, b.op);
+                    try isa.cmpRegImm(self, Reg.acu, 0);
+                    return;
+                }
+                // Payload-carrying enum: slot compare by value, then test
+                // the 0/1 against 0 so the branch consumes its flags.
+                if (b.op == .eq or b.op == .neq) {
+                    if (payloadEnumComparison(self, b)) |ed| {
+                        if (!value_struct.enumEqSupported(self, ed)) {
+                            try self.unsupported(b.span, "`==` on an enum with a recursive or non-comparable payload");
+                            return;
+                        }
+                        try value_struct.emitEnumEqual(self, ed, Reg.acu, Reg.r1, b.op == .neq);
+                        try isa.cmpRegImm(self, Reg.acu, 0);
+                        return;
+                    }
                 }
                 try isa.cmpRegReg(self, Reg.acu, Reg.r1);
                 try materializeBoolFromFlags(self, b.op);

--- a/src/lang/codegen/globals.zig
+++ b/src/lang/codegen/globals.zig
@@ -31,7 +31,11 @@ pub fn registerGlobals(self: *Emitter, program: *const ast.Program) !void {
 fn registerGlobalLet(self: *Emitter, d: *const ast.LetDecl) !void {
     if (d.pattern.* != .ident) return; // destructuring at top-level — slice later
     const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
-    try placeGlobal(self, name, widthOfLetDecl(self, d), d.annotations, d.pattern.ident.name);
+    try placeGlobal(self, name, widthOfLetDecl(self, d), isI8Decl(self, d.type_ann), d.annotations, d.pattern.ident.name);
+    // A top-level `let` with an initializer needs a runtime store at
+    // startup — the slot is otherwise zero-filled. (`let name: T` with no
+    // init stays zero, the declared-but-unset default.)
+    if (d.init) |init| try self.global_inits.append(self.allocator, .{ .name = name, .init = init });
 }
 
 fn registerGlobalConst(self: *Emitter, d: *const ast.ConstDecl) !void {
@@ -40,13 +44,39 @@ fn registerGlobalConst(self: *Emitter, d: *const ast.ConstDecl) !void {
     // bytes to seed; other initializers fall back to the annotated width.
     const baked: ?bake_mod.BakeValue = try evalConstIfBake(self, d);
     const width: u16 = if (baked) |v| @intCast(bake_mod.widthOf(v)) else widthOfConstDecl(self, d);
-    try placeGlobal(self, name, width, d.annotations, d.name);
+    try placeGlobal(self, name, width, isI8Decl(self, d.type_ann), d.annotations, d.name);
 
     if (baked) |v| {
         const g = self.globals.get(name) orelse return;
         const bytes = try self.arena.alloc(u8, bake_mod.widthOf(v));
         _ = bake_mod.serialize(v, bytes);
         try self.bake_inits.put(self.allocator, g.address, bytes);
+        return;
+    }
+    // A non-`bake` initializer is evaluated + stored at startup, like a
+    // top-level `let` — without this the slot reads back zero.
+    try self.global_inits.append(self.allocator, .{ .name = name, .init = d.init });
+}
+
+/// Whether a binding's declared type is `i8` — the one signed byte type,
+/// so a byte load must sign-extend. `null` (unannotated) widens to a word
+/// slot, which carries the sign already.
+fn isI8Decl(self: *const Emitter, type_ann: ?*ast.TypeAnn) bool {
+    const t = type_ann orelse return false;
+    return self.isPrimitiveTypeAnn(t.*, "i8");
+}
+
+/// Emit the entry-startup stores that seed every non-`bake` top-level
+/// `let` / `const` slot with its initializer's value (declaration order,
+/// so a later init can read an earlier one). An `@addr`-pinned global is
+/// skipped — it names a fixed location (typically MMIO) that already
+/// holds the live value, so its initializer must not stomp it at boot.
+pub fn emitGlobalInits(self: *Emitter) !void {
+    for (self.global_inits.items) |gi| {
+        const g = self.globals.get(gi.name) orelse continue;
+        if (g.placement == .addr) continue;
+        try self.emitExpr(gi.init);
+        try emitGlobalStore(self, Reg.acu, g);
     }
 }
 
@@ -137,6 +167,7 @@ fn placeGlobal(
     self: *Emitter,
     name: []const u8,
     width: u16,
+    signed_byte: bool,
     annotations: []const ast.Annotation,
     decl_span: ast.Span,
 ) !void {
@@ -158,7 +189,7 @@ fn placeGlobal(
     const dup = try self.arena.dupe(u8, name);
 
     if (pinned_addr) |addr| {
-        try self.globals.put(self.arena, dup, .{ .address = addr, .width = width, .placement = .addr });
+        try self.globals.put(self.arena, dup, .{ .address = addr, .width = width, .placement = .addr, .signed_byte = signed_byte });
         return;
     }
     if (zero_page) {
@@ -167,12 +198,12 @@ fn placeGlobal(
             try self.diagFatal(decl_span, "E_CODEGEN_ZP_OVERFLOW", "zero-page region exhausted — too many `@zero_page` globals");
             return;
         }
-        try self.globals.put(self.arena, dup, .{ .address = self.zp_cursor, .width = width, .placement = .zero_page });
+        try self.globals.put(self.arena, dup, .{ .address = self.zp_cursor, .width = width, .placement = .zero_page, .signed_byte = signed_byte });
         self.zp_cursor += width;
         return;
     }
     if (align_n) |n| self.data_cursor = alignUpU16(self.data_cursor, n);
-    try self.globals.put(self.arena, dup, .{ .address = self.data_cursor, .width = width, .placement = .data });
+    try self.globals.put(self.arena, dup, .{ .address = self.data_cursor, .width = width, .placement = .data, .signed_byte = signed_byte });
     self.data_cursor += width;
 }
 
@@ -207,6 +238,9 @@ pub fn emitGlobalLoad(self: *Emitter, g: Global) !void {
             }
         },
     }
+    // A byte-wide `i8` global loads zero-extended; sign-extend so a
+    // negative value keeps its sign in expression context.
+    if (g.width == 1 and g.signed_byte) try isa.signExtendByte(self, Reg.acu);
 }
 
 /// Store `src`'s value into `g`'s slot. Byte-width globals use `movl`

--- a/src/lang/codegen/isa.zig
+++ b/src/lang/codegen/isa.zig
@@ -243,6 +243,14 @@ pub fn asrRegImm(self: *Emitter, reg: u8, imm: u8) !void {
     try self.emitByte(imm);
 }
 
+/// Sign-extend the low byte of `reg` into its high byte: `shl 8 ; asr 8`.
+/// The byte sits in `reg.lo`; shifting it into the top half and back via
+/// an arithmetic shift propagates the sign bit through the high byte.
+pub fn signExtendByte(self: *Emitter, reg: u8) !void {
+    try shlRegImm(self, reg, 8);
+    try asrRegImm(self, reg, 8);
+}
+
 /// Emit a forward jump with a placeholder address slot. Returns
 /// the offset of the 2-byte slot inside the current code buffer —
 /// pass it to `patchJumpTo` once the target offset is known.

--- a/src/lang/codegen/lambda.zig
+++ b/src/lang/codegen/lambda.zig
@@ -346,9 +346,11 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
     // unsupported error rather than copying through the parent's buffer.
     const saved_ret_struct = self.current_ret_struct;
     const saved_inline_ret = self.inline_ret_struct;
+    const saved_overflow = self.frame_overflow;
     self.locals = .{};
     self.params = .{};
     self.frame_bytes = 0;
+    self.frame_overflow = false;
     self.is_entry = false;
     self.current_ret_struct = null;
     self.inline_ret_struct = null;
@@ -362,6 +364,7 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
         self.locals = saved_locals;
         self.params = saved_params;
         self.frame_bytes = saved_frame;
+        self.frame_overflow = saved_overflow;
         self.is_entry = saved_entry;
         self.current_bank = saved_bank;
         self.current_ret_struct = saved_ret_struct;
@@ -428,6 +431,10 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
     try self.popBlockWithDefers();
 
     try self.emitByte(Op.ret_op);
+
+    if (self.frame_overflow) {
+        try self.diagFatal(lambda.span, "E_CODEGEN_FRAME_TOO_LARGE", "lambda frame exceeds the 127-byte limit on fp-relative addressing");
+    }
 }
 
 /// One captured binding inside a lambda body — drives the

--- a/src/lang/codegen/mem_builtin.zig
+++ b/src/lang/codegen/mem_builtin.zig
@@ -67,12 +67,7 @@ fn emitMemRead1Arg(self: *Emitter, c: ast.CallExpr, kind: MemReadKind) !void {
             try self.emitByte(Op.mov8_ptr_to_reg);
             try self.emitByte(Reg.r1);
             try self.emitByte(Reg.acu);
-            // Sign-extend 8 → 16: `shl 8 ; asr 8`. The byte sits
-            // in `acu.lo`; shifting it into the top byte and back
-            // arithmetic-shift-right preserves the sign bit
-            // through the high half.
-            try isa.shlRegImm(self, Reg.acu, 8);
-            try isa.asrRegImm(self, Reg.acu, 8);
+            try isa.signExtendByte(self, Reg.acu);
         },
     }
 }

--- a/src/lang/codegen/opcodes.zig
+++ b/src/lang/codegen/opcodes.zig
@@ -162,7 +162,7 @@ pub const Reg = struct {
 pub const Sys = struct {
     /// `print_str` — write a null-terminated string from `[acu]`.
     pub const print_str: u8 = 0x01;
-    /// `print_int` — write `acu` as decimal.
+    /// `print_int` — write `acu` as signed decimal.
     pub const print_int: u8 = 0x02;
     /// `print_char` — write `acu.lo` as a single byte.
     pub const print_char: u8 = 0x03;
@@ -170,6 +170,8 @@ pub const Sys = struct {
     pub const print_newline: u8 = 0x04;
     /// `print_fixed` — write `acu` as Q-format fixed-point.
     pub const print_fixed: u8 = 0x05;
+    /// `print_uint` — write `acu` as unsigned decimal.
+    pub const print_uint: u8 = 0x06;
 
     /// `format_str_to_buf` — append `[acu]` (null-terminated str)
     /// to the buffer pointed to by `r1`.
@@ -186,6 +188,9 @@ pub const Sys = struct {
     /// `format_terminate_buf` — write a trailing null byte at the
     /// current cursor of the buffer pointed to by `r1`.
     pub const format_terminate_buf: u8 = 0x14;
+    /// `format_uint_to_buf` — append `acu` as unsigned decimal to the
+    /// buffer pointed to by `r1`.
+    pub const format_uint_to_buf: u8 = 0x15;
 
     /// `alloc` — bump-allocate `acu` bytes on the heap. Returns
     /// the freshly-allocated address in `acu`; faults

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -264,7 +264,7 @@ fn emitPrintArg(self: *Emitter, arg: *const ast.Expr) !void {
     // address is in `acu` after evaluation.
     if (self.structNameOf(arg)) |sname| {
         if (!printSupported(self, sname)) {
-            try self.unsupported(arg.span(), "printing a struct with a field type that has no default rendering (array / tuple / Vec / payload-carrying enum / class / reference)");
+            try self.unsupported(arg.span(), "printing a struct with a field type that has no default rendering (array / tuple / Vec / class / reference)");
             return;
         }
         // A struct literal has no standalone address — materialize it as
@@ -281,8 +281,67 @@ fn emitPrintArg(self: *Emitter, arg: *const ast.Expr) !void {
         }
         return;
     }
+    // An enum renders as `Enum.Variant` (`Enum.Variant(a, b)` with a
+    // payload) — `acu` holds the tag (payload-free) or slot pointer.
+    if (self.enumDeclForExpr(arg)) |ed| {
+        if (!enumPrintSupported(self, ed)) {
+            try self.unsupported(arg.span(), "printing an enum with a payload field type that has no default rendering (array / tuple / Vec / class / reference)");
+            return;
+        }
+        try self.emitExpr(arg);
+        try emitPrintEnum(self, ed);
+        return;
+    }
     try self.emitExpr(arg);
-    try isa.sys(self, Sys.print_int);
+    try isa.sys(self, if (self.isUnsignedInt(arg)) Sys.print_uint else Sys.print_int);
+}
+
+/// Render an enum value (tag or slot pointer in `acu`) as
+/// `Enum.Variant` / `Enum.Variant(a, b)`. The value is parked at `[sp]`
+/// across the tag dispatch, then dropped.
+fn emitPrintEnum(self: *Emitter, ed: *const ast.EnumDecl) error{OutOfMemory}!void {
+    try isa.pushReg(self, Reg.acu);
+    try emitEnumDispatchAtSp(self, ed);
+    try isa.addImmToReg(self, 2, Reg.sp);
+}
+
+/// Tag-dispatch + render the enum value parked at `[sp]` (a tag word for
+/// payload-free enums, a `[tag|payload]` slot pointer otherwise). Each
+/// arm compares the tag, prints `Enum.Variant`, then walks the variant's
+/// payload fields off the slot base; a final jump skips the other arms.
+fn emitEnumDispatchAtSp(self: *Emitter, ed: *const ast.EnumDecl) error{OutOfMemory}!void {
+    const enum_name = self.source[ed.name.start..ed.name.end];
+    const payload = self.enumHasPayload(ed);
+    var end_patches: std.ArrayList(usize) = .empty;
+    defer end_patches.deinit(self.allocator);
+    for (ed.variants, 0..) |v, ti| {
+        // @as: variant count is bounded by the u8 tag (§3.6).
+        const tag: u16 = @intCast(ti);
+        if (payload) {
+            try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r2); // r2 = slot ptr
+            try class.emitByteLoadAtOffset(self, Reg.r2, 0, Reg.r1); // r1 = tag
+        } else {
+            try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = tag word
+        }
+        try isa.cmpRegImm(self, Reg.r1, tag);
+        const next = try isa.emitJumpPlaceholder(self, Op.jne_addr);
+        const variant_name = self.source[v.name.start..v.name.end];
+        try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s}.{s}", .{ enum_name, variant_name }));
+        if (v.payload.len > 0) {
+            try printLiteral(self, "(");
+            for (v.payload, 0..) |pf, j| {
+                if (j > 0) try printLiteral(self, ", ");
+                // Payload fields read off the slot base parked at `[sp]`,
+                // at the variant's per-field offset (past the tag byte).
+                try emitPrintField(self, pf.type_ann.*, self.variantFieldOffset(v, j));
+            }
+            try printLiteral(self, ")");
+        }
+        try end_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
+        try isa.patchJumpTo(self, next, try self.currentOffset());
+    }
+    const end = try self.currentOffset();
+    for (end_patches.items) |p| try isa.patchJumpTo(self, p, end);
 }
 
 /// Render struct `sname` (base address in `acu`) as
@@ -319,6 +378,20 @@ fn emitPrintField(self: *Emitter, t: ast.TypeAnn, fo: u16) error{OutOfMemory}!vo
         try emitPrintStruct(self, sub);
         return;
     }
+    if (enumDeclOfTypeAnn(self, t)) |ed| {
+        // Load the field's stored value — a slot pointer (payload-
+        // carrying) or the bare tag byte — then dispatch off a fresh
+        // park so payload fields re-address from the slot base.
+        if (self.enumHasPayload(ed)) {
+            try class.emitWordLoadAtOffset(self, Reg.r1, fo, Reg.acu);
+        } else {
+            try class.emitByteLoadAtOffset(self, Reg.r1, fo, Reg.acu);
+        }
+        try isa.pushReg(self, Reg.acu);
+        try emitEnumDispatchAtSp(self, ed);
+        try isa.addImmToReg(self, 2, Reg.sp);
+        return;
+    }
     if (isPrimNamed(self, t, "char")) {
         try class.emitByteLoadAtOffset(self, Reg.r1, fo, Reg.acu);
         try isa.sys(self, Sys.print_char);
@@ -330,10 +403,14 @@ fn emitPrintField(self: *Emitter, t: ast.TypeAnn, fo: u16) error{OutOfMemory}!vo
         try isa.sys(self, Sys.print_str);
     } else if (self.widthOfTypeAnn(t) == 1) {
         try class.emitByteLoadAtOffset(self, Reg.r1, fo, Reg.acu);
-        try isa.sys(self, Sys.print_int);
+        // `i8` is the only signed byte type — sign-extend so `print_int`
+        // (which formats a signed word) shows a negative value. `u8`
+        // routes to the unsigned printer like any unsigned int.
+        if (self.isPrimitiveTypeAnn(t, "i8")) try isa.signExtendByte(self, Reg.acu);
+        try isa.sys(self, if (self.isPrimitiveTypeAnn(t, "u8")) Sys.print_uint else Sys.print_int);
     } else {
         try class.emitWordLoadAtOffset(self, Reg.r1, fo, Reg.acu);
-        try isa.sys(self, Sys.print_int);
+        try isa.sys(self, if (self.isPrimitiveTypeAnn(t, "u16")) Sys.print_uint else Sys.print_int);
     }
 }
 
@@ -346,25 +423,69 @@ fn printLiteral(self: *Emitter, text: []const u8) error{OutOfMemory}!void {
 }
 
 /// Whether `print` can render every field of `sname`. Supported:
-/// scalars / bool / char / fixed (decimal/char/fixed), `str`,
-/// payload-free enum (tag as int), and nested supported structs.
-/// Rejected: array / tuple / `Vec` / payload-carrying enum / class /
-/// reference / fn-ptr / nullable — no default rendering yet.
+/// scalars / bool / char / fixed (decimal/char/fixed), `str`, enums
+/// (`Enum.Variant` + printable payload), and nested supported structs.
+/// Rejected: array / tuple / `Vec` / class / reference / fn-ptr /
+/// nullable — no default rendering yet. A type cycle (a struct / enum
+/// reachable from itself) is rejected too — it has no finite rendering.
 fn printSupported(self: *const Emitter, sname: []const u8) bool {
+    var visited: std.ArrayList([]const u8) = .empty;
+    defer visited.deinit(self.allocator);
+    return printSupportedRec(self, sname, &visited) catch false;
+}
+
+/// Whether `print` can render every variant of `ed` (entry point — see
+/// `enumPrintSupportedRec`).
+fn enumPrintSupported(self: *const Emitter, ed: *const ast.EnumDecl) bool {
+    var visited: std.ArrayList([]const u8) = .empty;
+    defer visited.deinit(self.allocator);
+    return enumPrintSupportedRec(self, ed, &visited) catch false;
+}
+
+// `visited` is the current type path (push on descent, pop on return), so
+// a name reappearing on the path is a cycle — distinct from a diamond
+// (the same type used by two sibling fields), which is fine.
+fn printSupportedRec(self: *const Emitter, sname: []const u8, visited: *std.ArrayList([]const u8)) error{OutOfMemory}!bool {
     const sd = self.struct_decls.get(sname) orelse return false;
+    for (visited.items) |seen| if (std.mem.eql(u8, seen, sname)) return false;
+    try visited.append(self.allocator, sname);
+    defer _ = visited.pop();
     for (sd.fields) |f| {
-        if (!fieldPrintSupported(self, f.type_ann.*)) return false;
+        if (!try fieldPrintSupportedRec(self, f.type_ann.*, visited)) return false;
     }
     return true;
 }
 
-fn fieldPrintSupported(self: *const Emitter, t: ast.TypeAnn) bool {
+/// A payload field is stored as a single register-width slot value (a
+/// scalar, or a `str` / enum pointer), so a struct payload — which has
+/// no inline slot representation — is rejected here, matching what
+/// construction emits.
+fn enumPrintSupportedRec(self: *const Emitter, ed: *const ast.EnumDecl, visited: *std.ArrayList([]const u8)) error{OutOfMemory}!bool {
+    const name = self.source[ed.name.start..ed.name.end];
+    for (visited.items) |seen| if (std.mem.eql(u8, seen, name)) return false;
+    try visited.append(self.allocator, name);
+    defer _ = visited.pop();
+    for (ed.variants) |v| {
+        for (v.payload) |pf| {
+            if (self.structNameOfTypeAnn(pf.type_ann.*) != null) return false;
+            if (!try fieldPrintSupportedRec(self, pf.type_ann.*, visited)) return false;
+        }
+    }
+    return true;
+}
+
+fn fieldPrintSupportedRec(self: *const Emitter, t: ast.TypeAnn, visited: *std.ArrayList([]const u8)) error{OutOfMemory}!bool {
     if (t != .named) return false; // array / tuple / vec / reference / fn / nullable
     const name = self.source[t.named.name.start..t.named.name.end];
-    if (self.struct_decls.contains(name)) return printSupported(self, name);
-    if (self.enum_decls.get(name)) |ed| return !self.enumHasPayload(ed);
+    if (self.struct_decls.contains(name)) return printSupportedRec(self, name, visited);
+    if (self.enum_decls.get(name)) |ed| return enumPrintSupportedRec(self, ed, visited);
     if (self.class_decls.contains(name)) return false;
     return true; // a primitive (i8/u8/i16/u16/bool/char/fixed/str)
+}
+
+fn enumDeclOfTypeAnn(self: *const Emitter, t: ast.TypeAnn) ?*const ast.EnumDecl {
+    if (t != .named) return null;
+    return self.enum_decls.get(self.source[t.named.name.start..t.named.name.end]);
 }
 
 fn isPrimNamed(self: *const Emitter, t: ast.TypeAnn, name: []const u8) bool {

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -3,6 +3,7 @@
 // dispatch hub (`emitStatement`) and control-flow forms live elsewhere;
 // these are the terminal statement shapes.
 
+const std = @import("std");
 const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
@@ -259,12 +260,113 @@ fn emitPrintArg(self: *Emitter, arg: *const ast.Expr) !void {
         try isa.sys(self, Sys.print_str);
         return;
     }
-    // A struct has no scalar rendering — `print p` would otherwise emit
-    // `print_int` of its base address. Print fields explicitly.
-    if (self.structNameOf(arg)) |_| {
-        try self.unsupported(arg.span(), "printing a whole struct — print its fields instead");
+    // A struct renders as `Name { field: value, ... }` — its base
+    // address is in `acu` after evaluation.
+    if (self.structNameOf(arg)) |sname| {
+        if (!printSupported(self, sname)) {
+            try self.unsupported(arg.span(), "printing a struct with a field type that has no default rendering (array / tuple / Vec / payload-carrying enum / class / reference)");
+            return;
+        }
+        // A struct literal has no standalone address — materialize it as
+        // a by-value stack copy first; struct *values* already evaluate
+        // to a base address.
+        if (arg.* == .struct_lit) {
+            try value_struct.pushArg(self, arg, sname);
+            try isa.movRegToReg(self, Reg.sp, Reg.acu);
+            try emitPrintStruct(self, sname);
+            try isa.addImmToReg(self, self.structSlotWidth(sname), Reg.sp);
+        } else {
+            try self.emitExpr(arg);
+            try emitPrintStruct(self, sname);
+        }
         return;
     }
     try self.emitExpr(arg);
     try isa.sys(self, Sys.print_int);
+}
+
+/// Render struct `sname` (base address in `acu`) as
+/// `Name { f1: v1, f2: v2 }`. Each field prints per its type; nested
+/// structs recurse. The base is parked on the stack across the field
+/// prints (the `print_*` syscalls + recursion churn registers but
+/// leave `sp` alone), and reloaded per field.
+fn emitPrintStruct(self: *Emitter, sname: []const u8) error{OutOfMemory}!void {
+    const sd = self.struct_decls.get(sname).?;
+    try isa.pushReg(self, Reg.acu); // park base at [sp]
+
+    try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s} {{ ", .{sname}));
+
+    var fo: u16 = 0;
+    for (sd.fields, 0..) |f, i| {
+        if (i > 0) try printLiteral(self, ", ");
+        const fname = self.source[f.name.start..f.name.end];
+        try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s}: ", .{fname}));
+        try emitPrintField(self, f.type_ann.*, fo);
+        fo += self.widthOfTypeAnn(f.type_ann.*);
+    }
+
+    try printLiteral(self, " }");
+    try isa.addImmToReg(self, 2, Reg.sp); // drop the parked base
+}
+
+/// Print the field at `fo` of the struct whose base is parked at `[sp]`.
+/// Dispatches per type; a nested struct recurses (its base = base + fo).
+fn emitPrintField(self: *Emitter, t: ast.TypeAnn, fo: u16) error{OutOfMemory}!void {
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = parked base
+    if (self.structNameOfTypeAnn(t)) |sub| {
+        try isa.movRegToReg(self, Reg.r1, Reg.acu);
+        if (fo != 0) try isa.addImmToReg(self, fo, Reg.acu); // acu = nested base
+        try emitPrintStruct(self, sub);
+        return;
+    }
+    if (isPrimNamed(self, t, "char")) {
+        try class.emitByteLoadAtOffset(self, Reg.r1, fo, Reg.acu);
+        try isa.sys(self, Sys.print_char);
+    } else if (isPrimNamed(self, t, "fixed")) {
+        try class.emitWordLoadAtOffset(self, Reg.r1, fo, Reg.acu);
+        try isa.sys(self, Sys.print_fixed);
+    } else if (isPrimNamed(self, t, "str")) {
+        try class.emitWordLoadAtOffset(self, Reg.r1, fo, Reg.acu);
+        try isa.sys(self, Sys.print_str);
+    } else if (self.widthOfTypeAnn(t) == 1) {
+        try class.emitByteLoadAtOffset(self, Reg.r1, fo, Reg.acu);
+        try isa.sys(self, Sys.print_int);
+    } else {
+        try class.emitWordLoadAtOffset(self, Reg.r1, fo, Reg.acu);
+        try isa.sys(self, Sys.print_int);
+    }
+}
+
+/// Intern `text` and emit a `print_str` of it (the constant separators
+/// + field labels in a struct rendering).
+fn printLiteral(self: *Emitter, text: []const u8) error{OutOfMemory}!void {
+    const id = try strings.internString(self, text);
+    try strings.emitMovStringAddrToReg(self, id, Reg.acu);
+    try isa.sys(self, Sys.print_str);
+}
+
+/// Whether `print` can render every field of `sname`. Supported:
+/// scalars / bool / char / fixed (decimal/char/fixed), `str`,
+/// payload-free enum (tag as int), and nested supported structs.
+/// Rejected: array / tuple / `Vec` / payload-carrying enum / class /
+/// reference / fn-ptr / nullable — no default rendering yet.
+fn printSupported(self: *const Emitter, sname: []const u8) bool {
+    const sd = self.struct_decls.get(sname) orelse return false;
+    for (sd.fields) |f| {
+        if (!fieldPrintSupported(self, f.type_ann.*)) return false;
+    }
+    return true;
+}
+
+fn fieldPrintSupported(self: *const Emitter, t: ast.TypeAnn) bool {
+    if (t != .named) return false; // array / tuple / vec / reference / fn / nullable
+    const name = self.source[t.named.name.start..t.named.name.end];
+    if (self.struct_decls.contains(name)) return printSupported(self, name);
+    if (self.enum_decls.get(name)) |ed| return !self.enumHasPayload(ed);
+    if (self.class_decls.contains(name)) return false;
+    return true; // a primitive (i8/u8/i16/u16/bool/char/fixed/str)
+}
+
+fn isPrimNamed(self: *const Emitter, t: ast.TypeAnn, name: []const u8) bool {
+    return t == .named and std.mem.eql(u8, self.source[t.named.name.start..t.named.name.end], name);
 }

--- a/src/lang/codegen/strings.zig
+++ b/src/lang/codegen/strings.zig
@@ -137,6 +137,94 @@ pub fn emitContentEq(self: *Emitter, p1: u8, p2: u8, negate: bool) !void {
     try isa.patchJumpTo(self, end_patch, try self.currentOffset());
 }
 
+/// Lexicographic byte compare of two `str` values (§3.2.1): walks `p1` /
+/// `p2` in lockstep and leaves a strcmp-style result in `acu` — negative
+/// when `p1 < p2`, `0` when equal, positive when `p1 > p2`. The caller
+/// turns that into the `< / <= / > / >=` boolean via `cmp acu, 0` +
+/// `materializeBoolFromFlags`. Bytes are zero-extended (always `0..255`,
+/// non-negative), so the signed subtraction orders them as unsigned and
+/// the shared null terminator (`0`) sorts before any byte — a prefix is
+/// less than its extension. `p1` / `p2` / `r3` are scratch.
+pub fn emitStrCmp(self: *Emitter, p1: u8, p2: u8) error{OutOfMemory}!void {
+    const loop = try self.currentOffset();
+    try class.emitByteLoadAtOffset(self, p1, 0, Reg.acu); // a
+    try class.emitByteLoadAtOffset(self, p2, 0, Reg.r3); // b
+    try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+    const differ = try isa.emitJumpPlaceholder(self, Op.jne_addr);
+    try isa.cmpRegImm(self, Reg.acu, 0); // equal bytes — at the shared null?
+    const end = try isa.emitJumpPlaceholder(self, Op.jeq_addr); // → acu already 0
+    try isa.addImmToReg(self, 1, p1);
+    try isa.addImmToReg(self, 1, p2);
+    try isa.emitJumpBack(self, loop);
+    // First differing byte: acu = a - b carries the ordering.
+    try isa.patchJumpTo(self, differ, try self.currentOffset());
+    try isa.subRegFromAcu(self, Reg.r3);
+    try isa.patchJumpTo(self, end, try self.currentOffset());
+}
+
+/// Concatenate two `str` values into a fresh heap buffer (§3.2.1): `a` /
+/// `b` hold the operand pointers. Computes `len(a) + len(b) + 1`,
+/// `alloc`s it, copies `a` then `b`, null-terminates, and leaves the new
+/// buffer's address in `acu`. The pointers are parked on the stack and
+/// reloaded, since the strlen / copy loops + `alloc` churn the scratch
+/// registers. (Needs a heap — `alloc` faults `heap_exhausted` otherwise,
+/// like every allocating construct.)
+pub fn emitStrConcat(self: *Emitter, a: u8, b: u8) error{OutOfMemory}!void {
+    try isa.pushReg(self, a); // lhs ptr at [sp + 2]
+    try isa.pushReg(self, b); // rhs ptr at [sp + 0]
+
+    // total = len(lhs) + len(rhs) + 1 (terminator), accumulated in r2.
+    try isa.movImmToReg(self, 0, Reg.r2);
+    try emitStrlenAdd(self, 2, Reg.r2);
+    try emitStrlenAdd(self, 0, Reg.r2);
+    try isa.addImmToReg(self, 1, Reg.r2);
+
+    // alloc(total) → acu = dst; park it above the two operand pointers.
+    try isa.movRegToReg(self, Reg.r2, Reg.acu);
+    try isa.sys(self, Sys.alloc);
+    try isa.pushReg(self, Reg.acu); // dst [sp+0]; rhs [sp+2]; lhs [sp+4]
+
+    // Copy lhs then rhs into the buffer; r1 is the running dst cursor.
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1);
+    try emitStrCopy(self, 4, Reg.r1); // lhs
+    try emitStrCopy(self, 2, Reg.r1); // rhs
+    try isa.movImmToReg(self, 0, Reg.acu); // null-terminate at the cursor
+    try class.emitByteStoreAtOffset(self, Reg.r1, 0, Reg.acu);
+
+    // Result = the buffer base; drop the three parked pointers.
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.acu);
+    try isa.addImmToReg(self, 6, Reg.sp);
+}
+
+/// Walk the null-terminated string parked at `[sp + ofs]`, adding its
+/// length (excluding the terminator) to `counter`. `acu` + `r3` scratch.
+fn emitStrlenAdd(self: *Emitter, ofs: i8, counter: u8) error{OutOfMemory}!void {
+    try isa.movRegOffsetToReg(self, Reg.sp, ofs, Reg.r3);
+    const loop = try self.currentOffset();
+    try class.emitByteLoadAtOffset(self, Reg.r3, 0, Reg.acu);
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const done = try isa.emitJumpPlaceholder(self, Op.jeq_addr);
+    try isa.addImmToReg(self, 1, counter);
+    try isa.addImmToReg(self, 1, Reg.r3);
+    try isa.emitJumpBack(self, loop);
+    try isa.patchJumpTo(self, done, try self.currentOffset());
+}
+
+/// Copy the null-terminated string parked at `[sp + ofs]` to `[dst]`
+/// (excluding the terminator), advancing `dst`. `acu` + `r3` scratch.
+fn emitStrCopy(self: *Emitter, ofs: i8, dst: u8) error{OutOfMemory}!void {
+    try isa.movRegOffsetToReg(self, Reg.sp, ofs, Reg.r3);
+    const loop = try self.currentOffset();
+    try class.emitByteLoadAtOffset(self, Reg.r3, 0, Reg.acu);
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const done = try isa.emitJumpPlaceholder(self, Op.jeq_addr);
+    try class.emitByteStoreAtOffset(self, dst, 0, Reg.acu);
+    try isa.addImmToReg(self, 1, dst);
+    try isa.addImmToReg(self, 1, Reg.r3);
+    try isa.emitJumpBack(self, loop);
+    try isa.patchJumpTo(self, done, try self.currentOffset());
+}
+
 /// Lower a `str_lit` at expression position. Single-literal
 /// strings load the pooled address directly into `acu`.
 /// Interpolated strings allocate a fixed-size buffer in the
@@ -218,7 +306,7 @@ pub fn emitInterpFill(self: *Emitter, sl: ast.StrLitExpr) !void {
             } else if (self.isPrimitiveType(ip.expr, .str)) {
                 try isa.sys(self, Sys.format_str_to_buf);
             } else {
-                try isa.sys(self, Sys.format_int_to_buf);
+                try isa.sys(self, if (self.isUnsignedInt(ip.expr)) Sys.format_uint_to_buf else Sys.format_int_to_buf);
             }
         },
     };
@@ -255,7 +343,7 @@ pub fn emitPrintStrLit(self: *Emitter, sl: ast.StrLitExpr) !void {
                 try isa.sys(self, Sys.print_str);
             } else {
                 try self.emitExpr(ip.expr);
-                try isa.sys(self, Sys.print_int);
+                try isa.sys(self, if (self.isUnsignedInt(ip.expr)) Sys.print_uint else Sys.print_int);
             }
         },
     };

--- a/src/lang/codegen/value_struct.zig
+++ b/src/lang/codegen/value_struct.zig
@@ -129,6 +129,9 @@ pub fn emitFieldLoad(self: *Emitter, sname: []const u8, field_name: []const u8) 
     try isa.movRegToReg(self, Reg.acu, Reg.r1);
     if (info.width == 1) {
         try class.emitByteLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+        // A signed byte field (`i8`) sign-extends; `u8` / `bool` / `char`
+        // stay zero-extended.
+        if (info.signed_byte) try isa.signExtendByte(self, Reg.acu);
     } else {
         try class.emitWordLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
     }
@@ -174,64 +177,213 @@ pub fn emitEquality(self: *Emitter, lhs: *const ast.Expr, rhs: *const ast.Expr, 
     // The copies stay put (sp stable) so field addresses are `sp + ofs`.
     const wslot = self.structSlotWidth(sname);
     try pushArg(self, rhs, sname); // rhs copy at [sp + wslot ..] after the next push
-    try pushArg(self, lhs, sname); // lhs copy at [sp ..]
+    try pushArg(self, lhs, sname); // lhs copy at [sp ..]; sp stays put
 
-    // The first field that differs jumps to the not-equal arm; falling
-    // through means every field matched.
-    var mismatch_patches: std.ArrayList(usize) = .empty;
-    defer mismatch_patches.deinit(self.allocator);
-
-    if (structHasContentField(self, sname)) {
+    if (needsFieldwise(self, sname)) {
+        // Per-field dispatch — `str` by content, payload-enum by its
+        // dereferenced slot, nested structs recursively. The first
+        // mismatch jumps to the not-equal arm; falling through is equal.
+        var mismatch_patches: std.ArrayList(usize) = .empty;
+        defer mismatch_patches.deinit(self.allocator);
         try emitFieldwiseEq(self, sname, 0, wslot, &mismatch_patches);
+        try isa.movImmToReg(self, if (negate) 0 else 1, Reg.acu);
+        const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+        const mismatch_target = try self.currentOffset();
+        for (mismatch_patches.items) |p| try isa.patchJumpTo(self, p, mismatch_target);
+        try isa.movImmToReg(self, if (negate) 1 else 0, Reg.acu);
+        try isa.patchJumpTo(self, end_patch, try self.currentOffset());
     } else {
-        try emitByteEq(self, wslot, self.structWidth(sname), &mismatch_patches);
+        // Every field is value/pointer-comparable — one byte compare
+        // over the packed width.
+        try isa.movRegToReg(self, Reg.sp, Reg.r1); // lhs copy base
+        try isa.movRegToReg(self, Reg.sp, Reg.r2);
+        try isa.addImmToReg(self, wslot, Reg.r2); // rhs copy base
+        try emitBytesEqual(self, Reg.r1, Reg.r2, self.structWidth(sname), negate);
     }
-
-    // All fields equal → `==` yields 1, `!=` yields 0.
-    try isa.movImmToReg(self, if (negate) 0 else 1, Reg.acu);
-    const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
-
-    // Not-equal arm: the opposite result.
-    const mismatch_target = try self.currentOffset();
-    for (mismatch_patches.items) |p| try isa.patchJumpTo(self, p, mismatch_target);
-    try isa.movImmToReg(self, if (negate) 1 else 0, Reg.acu);
-
-    try isa.patchJumpTo(self, end_patch, try self.currentOffset());
 
     // Drop both stack copies. `acu` (the result) survives the sp bump.
     try isa.addImmToReg(self, 2 * wslot, Reg.sp);
 }
 
-/// Fast path for structs with no content-typed (`str`) field: compare
-/// the two stack copies word-by-word (advancing offset-0 pointers — no
-/// scratch-reg collision), with a trailing byte for an odd width. lhs
-/// copy is at `[sp ..]`, rhs at `[sp + wslot ..]`.
-fn emitByteEq(self: *Emitter, wslot: u16, width: u16, patches: *std.ArrayList(usize)) error{OutOfMemory}!void {
-    try isa.movRegToReg(self, Reg.sp, Reg.r1); // r1 = lhs copy base
-    try isa.movRegToReg(self, Reg.sp, Reg.r2);
-    try isa.addImmToReg(self, wslot, Reg.r2); // r2 = rhs copy base
+/// Compare `width` bytes at `[p1]` vs `[p2]` (both pointers, advanced as
+/// it walks), leaving `1`/`0` in `acu` (`negate` selects `!=`). Word
+/// strides + a trailing byte; `acu` and `r3` are scratch — neither may
+/// be passed as `p1`/`p2`. Used for the all-scalar struct byte path.
+pub fn emitBytesEqual(self: *Emitter, p1: u8, p2: u8, width: u16, negate: bool) error{OutOfMemory}!void {
+    var mismatch_patches: std.ArrayList(usize) = .empty;
+    defer mismatch_patches.deinit(self.allocator);
     var remaining = width;
     while (remaining >= 2) : (remaining -= 2) {
-        try isa.movRegOffsetToReg(self, Reg.r1, 0, Reg.acu);
-        try isa.movRegOffsetToReg(self, Reg.r2, 0, Reg.r3);
+        try isa.movRegOffsetToReg(self, p1, 0, Reg.acu);
+        try isa.movRegOffsetToReg(self, p2, 0, Reg.r3);
         try isa.cmpRegReg(self, Reg.acu, Reg.r3);
-        try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
-        try isa.addImmToReg(self, 2, Reg.r1);
-        try isa.addImmToReg(self, 2, Reg.r2);
+        try mismatch_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+        try isa.addImmToReg(self, 2, p1);
+        try isa.addImmToReg(self, 2, p2);
     }
     if (remaining == 1) {
-        try class.emitByteLoadAtOffset(self, Reg.r1, 0, Reg.acu);
-        try class.emitByteLoadAtOffset(self, Reg.r2, 0, Reg.r3);
+        try class.emitByteLoadAtOffset(self, p1, 0, Reg.acu);
+        try class.emitByteLoadAtOffset(self, p2, 0, Reg.r3);
         try isa.cmpRegReg(self, Reg.acu, Reg.r3);
-        try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+        try mismatch_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+    }
+    try isa.movImmToReg(self, if (negate) 0 else 1, Reg.acu);
+    const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    const mismatch_target = try self.currentOffset();
+    for (mismatch_patches.items) |p| try isa.patchJumpTo(self, p, mismatch_target);
+    try isa.movImmToReg(self, if (negate) 1 else 0, Reg.acu);
+    try isa.patchJumpTo(self, end_patch, try self.currentOffset());
+}
+
+// ---- payload-carrying enum equality ----
+
+/// Lower equality of two payload-carrying enum values (`p1` / `p2` hold
+/// the `[tag | payload]` slot pointers), leaving `1`/`0` in `acu`
+/// (`negate` selects `!=`). Compares the tag, then — for the matching
+/// variant — each payload field by its own semantics: `str` by content
+/// (§3.2.1), a nested payload enum recursively, every other field by its
+/// stored word/byte (value, or pointer identity for `&T` / class). The
+/// slot pointers are parked on the stack and reloaded per field, since
+/// content compare + recursion churn registers. Caller must have checked
+/// `enumEqSupported` (which rejects recursive enums, so this terminates).
+pub fn emitEnumEqual(self: *Emitter, ed: *const ast.EnumDecl, p1: u8, p2: u8, negate: bool) error{OutOfMemory}!void {
+    try isa.pushReg(self, p1); // lhs slot ptr at [sp + 2]
+    try isa.pushReg(self, p2); // rhs slot ptr at [sp + 0]
+    const lhs_at: i8 = 2;
+    const rhs_at: i8 = 0;
+
+    var ne_patches: std.ArrayList(usize) = .empty; // → not-equal arm
+    defer ne_patches.deinit(self.allocator);
+    var eq_patches: std.ArrayList(usize) = .empty; // → equal arm
+    defer eq_patches.deinit(self.allocator);
+
+    // A differing tag is unequal outright.
+    try loadSlotTag(self, lhs_at, Reg.acu);
+    try loadSlotTag(self, rhs_at, Reg.r3);
+    try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+    try ne_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+
+    // Tags match: dispatch on the tag and compare that variant's payload.
+    // A nullary variant carries no payload, so a tag match already
+    // settles it — those fall through to the equal arm.
+    for (ed.variants, 0..) |v, ti| {
+        if (v.payload.len == 0) continue;
+        // @as: variant index fits the u8 tag (§3.6).
+        const tag: u16 = @intCast(ti);
+        try loadSlotTag(self, lhs_at, Reg.acu);
+        try isa.cmpRegImm(self, Reg.acu, tag);
+        const skip = try isa.emitJumpPlaceholder(self, Op.jne_addr);
+        for (v.payload, 0..) |pf, j| {
+            try emitEnumFieldEq(self, pf.type_ann.*, lhs_at, rhs_at, self.variantFieldOffset(v, j), &ne_patches);
+        }
+        try eq_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
+        try isa.patchJumpTo(self, skip, try self.currentOffset());
+    }
+
+    const eq_target = try self.currentOffset();
+    for (eq_patches.items) |p| try isa.patchJumpTo(self, p, eq_target);
+    try isa.movImmToReg(self, if (negate) 0 else 1, Reg.acu);
+    const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    const ne_target = try self.currentOffset();
+    for (ne_patches.items) |p| try isa.patchJumpTo(self, p, ne_target);
+    try isa.movImmToReg(self, if (negate) 1 else 0, Reg.acu);
+    try isa.patchJumpTo(self, end_patch, try self.currentOffset());
+
+    try isa.addImmToReg(self, 4, Reg.sp); // drop both parked pointers
+}
+
+/// Reload the slot pointer parked at `[sp + sp_off]` and load its tag
+/// byte (offset 0) into `dst`.
+fn loadSlotTag(self: *Emitter, sp_off: i8, dst: u8) error{OutOfMemory}!void {
+    try isa.movRegOffsetToReg(self, Reg.sp, sp_off, dst);
+    try class.emitByteLoadAtOffset(self, dst, 0, dst);
+}
+
+/// Compare one payload field (at `field_off` within the slot) of the two
+/// enum values whose slot pointers are parked at `[sp + lhs_at]` /
+/// `[sp + rhs_at]`. A mismatch jumps to the not-equal arm via `patches`.
+fn emitEnumFieldEq(self: *Emitter, t: ast.TypeAnn, lhs_at: i8, rhs_at: i8, field_off: u16, patches: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    if (isStrTypeAnn(self, t)) {
+        try loadSlotField(self, lhs_at, field_off, Reg.r1); // lhs str ptr
+        try loadSlotField(self, rhs_at, field_off, Reg.r2); // rhs str ptr
+        try strings.emitContentEq(self, Reg.r1, Reg.r2, false);
+        try isa.cmpRegImm(self, Reg.acu, 0); // acu == 0 → strings differ
+        try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
+        return;
+    }
+    if (payloadEnumDecl(self, t)) |inner| {
+        try loadSlotField(self, lhs_at, field_off, Reg.r1); // lhs inner slot ptr
+        try loadSlotField(self, rhs_at, field_off, Reg.r2); // rhs inner slot ptr
+        try emitEnumEqual(self, inner, Reg.r1, Reg.r2, false);
+        try isa.cmpRegImm(self, Reg.acu, 0); // acu == 0 → slots differ
+        try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
+        return;
+    }
+    // Scalar / `char` / `fixed` / `bool` / payload-free enum tag / `&T` /
+    // class — compare the stored word or byte (value or pointer identity).
+    const fw = self.widthOfTypeAnn(t);
+    try isa.movRegOffsetToReg(self, Reg.sp, lhs_at, Reg.r1);
+    if (fw == 1) try class.emitByteLoadAtOffset(self, Reg.r1, field_off, Reg.acu) else try class.emitWordLoadAtOffset(self, Reg.r1, field_off, Reg.acu);
+    try isa.movRegOffsetToReg(self, Reg.sp, rhs_at, Reg.r1);
+    if (fw == 1) try class.emitByteLoadAtOffset(self, Reg.r1, field_off, Reg.r3) else try class.emitWordLoadAtOffset(self, Reg.r1, field_off, Reg.r3);
+    try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+    try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+}
+
+/// Reload the slot pointer parked at `[sp + sp_off]` and load the word at
+/// `field_off` within it into `dst`.
+fn loadSlotField(self: *Emitter, sp_off: i8, field_off: u16, dst: u8) error{OutOfMemory}!void {
+    try isa.movRegOffsetToReg(self, Reg.sp, sp_off, dst);
+    try class.emitWordLoadAtOffset(self, dst, field_off, dst);
+}
+
+/// Whether `==` can be lowered for payload-carrying enum `ed`. Every
+/// payload field must be comparable — a scalar / `char` / `fixed` /
+/// `bool` / `str` / `&T` / class, or a nested payload enum. Rejected:
+/// a struct payload (not a valid slot value) and a recursive enum
+/// (`visited` breaks the cycle — structural compare would unroll without
+/// bound), plus array / tuple / `Vec` / nullable payloads.
+pub fn enumEqSupported(self: *const Emitter, ed: *const ast.EnumDecl) bool {
+    var visited: std.ArrayList([]const u8) = .empty;
+    defer visited.deinit(self.allocator);
+    return enumEqSupportedRec(self, ed, &visited) catch false;
+}
+
+fn enumEqSupportedRec(self: *const Emitter, ed: *const ast.EnumDecl, visited: *std.ArrayList([]const u8)) error{OutOfMemory}!bool {
+    const name = self.source[ed.name.start..ed.name.end];
+    for (visited.items) |seen| if (std.mem.eql(u8, seen, name)) return false; // cycle
+    try visited.append(self.allocator, name);
+    defer _ = visited.pop();
+    for (ed.variants) |v| {
+        for (v.payload) |pf| {
+            if (!try enumFieldEqSupported(self, pf.type_ann.*, visited)) return false;
+        }
+    }
+    return true;
+}
+
+fn enumFieldEqSupported(self: *const Emitter, t: ast.TypeAnn, visited: *std.ArrayList([]const u8)) error{OutOfMemory}!bool {
+    switch (t) {
+        .named => |n| {
+            const name = self.source[n.name.start..n.name.end];
+            if (self.struct_decls.contains(name)) return false; // not a valid enum-payload slot value
+            if (self.enum_decls.get(name)) |inner| {
+                if (!self.enumHasPayload(inner)) return true; // bare tag byte
+                return enumEqSupportedRec(self, inner, visited);
+            }
+            return true; // primitive (incl. `str`) or class — value / content / identity
+        },
+        .reference, .fn_type => return true, // pointer identity
+        .nullable, .array, .vec, .tuple => return false,
     }
 }
 
-/// Per-field comparison for structs that contain a `str` field. The lhs
-/// copy is at `[sp + lhs_off ..]` and the rhs at `[sp + rhs_off ..]`;
-/// `sp` is stable, so each field reads at `sp + base_off + field_off`.
-/// `str` fields compare by content; nested structs recurse; every other
-/// field compares its stored word/byte (value or pointer identity).
+/// Per-field comparison for structs that need it (a `str` or payload-
+/// enum field). The lhs copy is at `[sp + lhs_off ..]` and the rhs at
+/// `[sp + rhs_off ..]`; `sp` is stable, so each field reads at
+/// `sp + base_off + field_off`. `str` compares by content, a payload
+/// enum by its dereferenced slot, nested structs recurse, and every
+/// other field by its stored word/byte (value or pointer identity).
 fn emitFieldwiseEq(self: *Emitter, sname: []const u8, lhs_off: u16, rhs_off: u16, patches: *std.ArrayList(usize)) error{OutOfMemory}!void {
     const sd = self.struct_decls.get(sname).?;
     var fo: u16 = 0;
@@ -242,11 +394,19 @@ fn emitFieldwiseEq(self: *Emitter, sname: []const u8, lhs_off: u16, rhs_off: u16
             // `sp` survives streq's register churn, so the next field
             // re-addresses from it cleanly. (Checked before the nested-
             // struct case so the `str` classification matches `eqSupported`
-            // / `structHasContentField`.)
+            // / `needsFieldwise`.)
             try class.emitWordLoadAtOffset(self, Reg.sp, lhs_off + fo, Reg.r1);
             try class.emitWordLoadAtOffset(self, Reg.sp, rhs_off + fo, Reg.r2);
             try strings.emitContentEq(self, Reg.r1, Reg.r2, false);
             try isa.cmpRegImm(self, Reg.acu, 0); // acu == 0 → strings differ
+            try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
+        } else if (payloadEnumDecl(self, f.type_ann.*)) |ed| {
+            // Payload-carrying enum field stores a slot pointer; compare
+            // the two slots by value (tag, then per-variant payload).
+            try class.emitWordLoadAtOffset(self, Reg.sp, lhs_off + fo, Reg.r1);
+            try class.emitWordLoadAtOffset(self, Reg.sp, rhs_off + fo, Reg.r2);
+            try emitEnumEqual(self, ed, Reg.r1, Reg.r2, false);
+            try isa.cmpRegImm(self, Reg.acu, 0); // acu == 0 → slots differ
             try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
         } else if (self.structNameOfTypeAnn(f.type_ann.*)) |sub| {
             try emitFieldwiseEq(self, sub, lhs_off + fo, rhs_off + fo, patches);
@@ -265,14 +425,17 @@ fn emitFieldwiseEq(self: *Emitter, sname: []const u8, lhs_off: u16, rhs_off: u16
     }
 }
 
-/// `true` when `sname` has a `str` field (directly or via a nested
-/// struct) — those must compare by content, forcing the per-field path.
-fn structHasContentField(self: *const Emitter, sname: []const u8) bool {
+/// `true` when `sname` has a field that can't be compared by a flat
+/// byte sweep — a `str` (content) or a payload-carrying enum (deref the
+/// slot pointer), directly or via a nested struct — forcing the
+/// per-field path.
+fn needsFieldwise(self: *const Emitter, sname: []const u8) bool {
     const sd = self.struct_decls.get(sname) orelse return false;
     for (sd.fields) |f| {
         if (isStrTypeAnn(self, f.type_ann.*)) return true;
+        if (payloadEnumDecl(self, f.type_ann.*) != null) return true;
         if (self.structNameOfTypeAnn(f.type_ann.*)) |sub| {
-            if (structHasContentField(self, sub)) return true;
+            if (needsFieldwise(self, sub)) return true;
         }
     }
     return false;
@@ -282,14 +445,21 @@ fn isStrTypeAnn(self: *const Emitter, t: ast.TypeAnn) bool {
     return t == .named and std.mem.eql(u8, self.source[t.named.name.start..t.named.name.end], "str");
 }
 
+/// The enum declaration for a payload-carrying enum type annotation,
+/// else `null`. Payload-free enums (a bare tag) compare like any scalar.
+fn payloadEnumDecl(self: *const Emitter, t: ast.TypeAnn) ?*const ast.EnumDecl {
+    if (t != .named) return null;
+    const ed = self.enum_decls.get(self.source[t.named.name.start..t.named.name.end]) orelse return null;
+    return if (self.enumHasPayload(ed)) ed else null;
+}
+
 /// Whether `==` can be lowered for struct `sname`. Supported field
 /// types compare by value (scalars / bool / char / fixed), pointer
 /// identity (class / `&T` / fn-ptr — correct per §3.4.2 / §3.4.4),
-/// content (`str`, §3.2.1), or recursively (nested struct). Rejected:
-/// array / tuple / `Vec` (element-wise equality not lowered) and
-/// payload-carrying enums (distinct heap slots — no defined content
-/// equality), so those surface a clean diagnostic rather than a
-/// silently-wrong pointer compare.
+/// content (`str`, §3.2.1), enum (tag, or `[tag|payload]` slot), or
+/// recursively (nested struct). Rejected: array / tuple / `Vec`
+/// (element-wise equality not lowered yet) and nullable — those surface
+/// a clean diagnostic rather than a silently-wrong compare.
 pub fn eqSupported(self: *const Emitter, sname: []const u8) bool {
     const sd = self.struct_decls.get(sname) orelse return false;
     for (sd.fields) |f| {
@@ -303,9 +473,14 @@ fn fieldEqSupported(self: *const Emitter, t: ast.TypeAnn) bool {
         .named => |n| {
             const name = self.source[n.name.start..n.name.end];
             if (self.struct_decls.contains(name)) return eqSupported(self, name);
-            if (self.enum_decls.get(name)) |ed| return !self.enumHasPayload(ed);
-            // Primitive (incl. `str`) or class name — value / content /
-            // identity compare, all handled.
+            if (self.enum_decls.get(name)) |ed| {
+                // Payload-free enums compare by tag; payload-carrying ones
+                // by slot value — which `enumEqSupported` gates (rejecting
+                // recursive / struct-payload enums).
+                return !self.enumHasPayload(ed) or enumEqSupported(self, ed);
+            }
+            // Primitive (incl. `str`) or class — value / content /
+            // pointer-identity compare, all handled.
             return true;
         },
         .reference, .fn_type => return true, // pointer identity

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -402,7 +402,10 @@ pub const Checker = struct {
             },
             .def_decl => |d| try self.checkDefDecl(d),
             .class_decl => |c| try self.checkClassDecl(c),
-            .struct_decl => |sd| try annotations.validateAnnotations(self, sd.annotations, T.STRUCT),
+            .struct_decl => |sd| {
+                try annotations.validateAnnotations(self, sd.annotations, T.STRUCT);
+                try self.checkStructFinite(sd);
+            },
             .enum_decl => |ed| try annotations.validateAnnotations(self, ed.annotations, T.ENUM),
             .use_decl, .local_decl => {},
             .asm_stmt => |as_| if (self.in_bake) {
@@ -663,7 +666,7 @@ pub const Checker = struct {
             null;
 
         for (arms, 0..) |arm, i| {
-            if (arm.cond) |c| _ = try self.inferExpr(c, null);
+            if (arm.cond) |c| try self.requireBool(c);
             if (arm.let_expr) |e| _ = try self.inferExpr(e, null);
 
             const arm_gain: ?[]const u8 = if (i == 0 and nil_flow != null and nil_flow.?.is_neq)
@@ -687,7 +690,7 @@ pub const Checker = struct {
             self.current_scope = &child;
             defer self.current_scope = saved;
             if (arm.let_pattern) |pat| try self.registerPatternBindings(pat);
-            if (arm.let_guard) |g| _ = try self.inferExpr(g, null);
+            if (arm.let_guard) |g| try self.requireBool(g);
             try self.walkArmBodyWithIsBinding(arm.body, is_binding);
             if (added) self.popNonNil(arm_gain.?);
         }
@@ -734,7 +737,7 @@ pub const Checker = struct {
     }
 
     fn checkWhile(self: *Checker, ws: ast.WhileStmt) WalkError!void {
-        if (ws.cond) |c| _ = try self.inferExpr(c, null);
+        if (ws.cond) |c| try self.requireBool(c);
         if (ws.let_expr) |e| _ = try self.inferExpr(e, null);
         // `while let PAT = expr [when guard]` binds PAT for the guard
         // and loop body — same scoping as `if let` / match arms.
@@ -743,7 +746,7 @@ pub const Checker = struct {
         self.current_scope = &child;
         defer self.current_scope = saved;
         if (ws.let_pattern) |pat| try self.registerPatternBindings(pat);
-        if (ws.let_guard) |g| _ = try self.inferExpr(g, null);
+        if (ws.let_guard) |g| try self.requireBool(g);
         try self.walkStatementSequence(ws.body);
     }
 
@@ -764,7 +767,66 @@ pub const Checker = struct {
 
     fn checkRepeat(self: *Checker, rs: ast.RepeatStmt) WalkError!void {
         try self.walkInScope(rs.body);
-        _ = try self.inferExpr(rs.cond, null);
+        try self.requireBool(rs.cond);
+    }
+
+    /// Reject a struct that contains itself by value (directly or
+    /// transitively, through a struct / array / tuple field) — such a
+    /// type has infinite size and no layout. `Vec` / `&T` / nullable /
+    /// fn fields are pointer-width, so they break the cycle legally
+    /// (the linked-list / tree idiom).
+    fn checkStructFinite(self: *Checker, sd: ast.StructDecl) WalkError!void {
+        var visited: std.ArrayList([]const u8) = .empty;
+        defer visited.deinit(self.arena);
+        const name = self.lexeme(sd.name);
+        if (try self.structSizeFinite(name, &visited)) return;
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "struct `{s}` is infinitely recursive — it contains itself by value (use `Vec({s})` or `&{s}` for a recursive shape)",
+            .{ name, name, name },
+        );
+        try self.emitSpan("E_TYPE_RECURSIVE_STRUCT", sd.name, msg);
+    }
+
+    // `visited` is the current containment path (push on descent, pop on
+    // return), so a name reappearing is a by-value cycle — a diamond
+    // (the same struct in two sibling fields) is finite and allowed.
+    fn structSizeFinite(self: *Checker, sname: []const u8, visited: *std.ArrayList([]const u8)) WalkError!bool {
+        for (visited.items) |seen| if (std.mem.eql(u8, seen, sname)) return false;
+        const sd = self.struct_registry.get(sname) orelse return true;
+        try visited.append(self.arena, sname);
+        defer _ = visited.pop();
+        for (sd.fields) |f| {
+            if (!try self.typeAnnSizeFinite(f.type_ann.*, visited)) return false;
+        }
+        return true;
+    }
+
+    fn typeAnnSizeFinite(self: *Checker, t: ast.TypeAnn, visited: *std.ArrayList([]const u8)) WalkError!bool {
+        return switch (t) {
+            .named => |n| if (self.struct_registry.contains(self.lexeme(n.name)))
+                try self.structSizeFinite(self.lexeme(n.name), visited)
+            else
+                true, // primitive / enum / class — value or pointer, finite
+            .array => |a| try self.typeAnnSizeFinite(a.elem.*, visited),
+            .tuple => |xs| blk: {
+                for (xs.elems) |e| if (!try self.typeAnnSizeFinite(e.*, visited)) break :blk false;
+                break :blk true;
+            },
+            else => true, // vec / reference / nullable / fn — pointer-width
+        };
+    }
+
+    /// Type-check an expression in boolean-condition position (an `if` /
+    /// `elif` / `while` / `repeat`-`until` condition, or a `when` guard).
+    /// The spec has no implicit truthiness (§3) — a non-`bool` condition
+    /// is `E_TYPE_MISMATCH`, mirroring how `assert` checks its arg.
+    pub fn requireBool(self: *Checker, cond: *const ast.Expr) WalkError!void {
+        const bool_ty = try self.primitive(.bool_);
+        const ty = try self.inferExpr(cond, bool_ty);
+        if (ty != null and !relations.assignable(ty.?.*, bool_ty.*)) {
+            try self.emitMismatch(cond.span(), bool_ty, ty.?);
+        }
     }
 
     /// Delegated to `typecheck/match.zig`.
@@ -1025,6 +1087,12 @@ pub const Checker = struct {
                     const recv_name = self.lexeme(m.receiver.ident.span);
                     if (std.mem.eql(u8, recv_name, "mem")) {
                         return try fields.checkMemMethodCall(self, m);
+                    }
+                    // `Enum.Variant(args)` is indistinguishable from a
+                    // method call at parse time — resolve it as a
+                    // payload-variant constructor.
+                    if (self.enum_registry.get(recv_name)) |ed| {
+                        return try fields.checkEnumVariantConstruct(self, m, ed, recv_name);
                     }
                 }
                 const recv_ty = try self.inferExpr(m.receiver, null);

--- a/src/lang/typecheck/fields.zig
+++ b/src/lang/typecheck/fields.zig
@@ -60,6 +60,52 @@ pub fn resolveEnumVariant(
     return fn_ty;
 }
 
+/// Type-check a payload-variant constructor written as a method
+/// call — `Item.Potion(20)` parses as `Item`.`Potion`(20), since the
+/// surface syntax is indistinguishable from a method call. Resolves
+/// the variant, checks the payload args against its field types, and
+/// infers the enum's `Named` type (so `let x = Item.Potion(20)` binds
+/// `x: Item` rather than leaving it untyped).
+pub fn checkEnumVariantConstruct(
+    self: *Checker,
+    m: ast.MethodCallExpr,
+    ed: *const ast.EnumDecl,
+    enum_name: []const u8,
+) WalkError!?*const types.Type {
+    const variant_name = self.lexeme(m.method);
+    const variant: *const ast.EnumVariant = blk: {
+        for (ed.variants) |*v| {
+            if (std.mem.eql(u8, self.lexeme(v.name), variant_name)) break :blk v;
+        }
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "enum `{s}` has no variant `{s}`",
+            .{ enum_name, variant_name },
+        );
+        try self.emitSpan("E_TYPE_UNDEFINED_VARIANT", m.method, msg);
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    };
+    const enum_ty = try types.mkNamed(self.arena, enum_name, m.receiver.span());
+    if (m.args.len != variant.payload.len) {
+        const suffix: []const u8 = if (variant.payload.len == 1) "" else "s";
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "variant `{s}.{s}` takes {d} argument{s}, called with {d}",
+            .{ enum_name, variant_name, variant.payload.len, suffix, m.args.len },
+        );
+        try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return enum_ty;
+    }
+    for (m.args, variant.payload) |arg, pf| {
+        const field_ty = try type_resolve.resolveType(self, pf.type_ann);
+        const arg_ty = try self.inferExpr(arg, field_ty);
+        if (arg_ty) |at| try self.checkStoreCompat(arg.span(), field_ty, at);
+    }
+    return enum_ty;
+}
+
 /// Type-check `mem.X(args)` as a method-call expression
 /// (delegates to `typecheck/mem_builtin.zig`).
 pub fn checkMemMethodCall(self: *Checker, m: ast.MethodCallExpr) WalkError!?*const types.Type {

--- a/src/lang/typecheck/match.zig
+++ b/src/lang/typecheck/match.zig
@@ -44,7 +44,7 @@ pub fn checkMatch(self: *Checker, ms: ast.MatchStmt) WalkError!void {
         self.current_scope = &child;
         defer self.current_scope = saved;
         try registerArmBindings(self, arm.pattern, enum_decl);
-        if (arm.guard) |g| _ = try self.inferExpr(g, null);
+        if (arm.guard) |g| try self.requireBool(g);
         try self.walkStatementSequence(arm.body);
     }
 
@@ -89,7 +89,11 @@ fn recordArmCoverage(
     if (has_wildcard.*) {
         try self.emitSpan("E_MATCH_UNREACHABLE_ARM", arm.span, "this arm cannot be reached — a wildcard `_` arm above already handles every remaining variant");
     }
-    try walkArmPattern(self, arm.pattern, ed, covered, has_wildcard);
+    // A `when`-guarded arm only conditionally matches, so it doesn't
+    // cover its variant — a later unguarded same-variant arm is the
+    // legitimate fallback. The arm is still flagged unreachable if a
+    // prior *unguarded* arm already fully covered it.
+    try walkArmPattern(self, arm.pattern, ed, covered, has_wildcard, arm.guard == null);
 }
 
 fn walkArmPattern(
@@ -98,12 +102,13 @@ fn walkArmPattern(
     ed: *const ast.EnumDecl,
     covered: *std.StringHashMapUnmanaged(void),
     has_wildcard: *bool,
+    adds_coverage: bool,
 ) WalkError!void {
     switch (pat.*) {
         .wildcard, .ident => {
             // Bare ident in match-arm position binds the value
             // — equivalent to `_` from the exhaustiveness POV.
-            has_wildcard.* = true;
+            if (adds_coverage) has_wildcard.* = true;
         },
         .variant_pattern => |vp| {
             const split = splitPath(self.lexeme(vp.path));
@@ -112,18 +117,19 @@ fn walkArmPattern(
             if (split.head.len > 0 and !std.mem.eql(u8, split.head, self.lexeme(ed.name))) return;
             // Verify variant exists on this enum.
             if (!variantExists(self, ed, split.tail)) return;
-            const gop = try covered.getOrPut(self.arena, split.tail);
-            if (gop.found_existing) {
+            if (covered.contains(split.tail)) {
                 const msg = try std.fmt.allocPrint(
                     self.arena,
                     "variant `{s}.{s}` is already handled by an earlier arm",
                     .{ self.lexeme(ed.name), split.tail },
                 );
                 try self.emitSpan("E_MATCH_UNREACHABLE_ARM", pat.span(), msg);
+            } else if (adds_coverage) {
+                try covered.put(self.arena, split.tail, {});
             }
         },
         .or_pattern => |op| {
-            for (op.alts) |alt| try walkArmPattern(self, alt, ed, covered, has_wildcard);
+            for (op.alts) |alt| try walkArmPattern(self, alt, ed, covered, has_wildcard, adds_coverage);
         },
         else => {
             // Literal / range / tuple / struct patterns don't
@@ -150,7 +156,10 @@ fn recordBoolArmCoverage(
     } else if (has_true.* and has_false.*) {
         try self.emitSpan("E_MATCH_UNREACHABLE_ARM", arm.span, "this arm cannot be reached — both `true` and `false` are already handled");
     }
-    try walkBoolArmPattern(self, arm.pattern, has_true, has_false, has_wildcard);
+    // A guarded arm only conditionally matches — it doesn't cover its
+    // value (a later unguarded arm is the fallback), but is still flagged
+    // unreachable if an earlier unguarded arm already covered it.
+    try walkBoolArmPattern(self, arm.pattern, has_true, has_false, has_wildcard, arm.guard == null);
 }
 
 fn walkBoolArmPattern(
@@ -159,24 +168,25 @@ fn walkBoolArmPattern(
     has_true: *bool,
     has_false: *bool,
     has_wildcard: *bool,
+    adds_coverage: bool,
 ) WalkError!void {
     switch (pat.*) {
         .wildcard, .ident => {
             // Bare ident in match-arm position binds the value —
             // equivalent to `_` from the exhaustiveness POV.
-            has_wildcard.* = true;
+            if (adds_coverage) has_wildcard.* = true;
         },
         .bool_lit => |bl| {
             const slot = if (bl.value) has_true else has_false;
             if (slot.*) {
                 const msg = if (bl.value) "`true` is already handled by an earlier arm" else "`false` is already handled by an earlier arm";
                 try self.emitSpan("E_MATCH_UNREACHABLE_ARM", pat.span(), msg);
-            } else {
+            } else if (adds_coverage) {
                 slot.* = true;
             }
         },
         .or_pattern => |op| {
-            for (op.alts) |alt| try walkBoolArmPattern(self, alt, has_true, has_false, has_wildcard);
+            for (op.alts) |alt| try walkBoolArmPattern(self, alt, has_true, has_false, has_wildcard, adds_coverage);
         },
         else => {
             // Non-bool patterns (literal int, range, variant, …)

--- a/src/vm/handlers/system.zig
+++ b/src/vm/handlers/system.zig
@@ -126,6 +126,9 @@ pub const SyscallId = enum(u8) {
     /// (1.5 in Q8.8) prints `1.500`. Negative values get a
     /// leading `-`.
     print_fixed = 0x05,
+    /// `acu` = unsigned 16-bit value, formatted as decimal into
+    /// `host.out`. (`print_int` is the signed counterpart.)
+    print_uint = 0x06,
 
     // ---------- format-to-buffer family ----------
     //
@@ -153,6 +156,10 @@ pub const SyscallId = enum(u8) {
     /// and advances `r1` by 1 (so chained terminators don't
     /// stomp the same slot).
     format_terminate_buf = 0x14,
+    /// `acu` = u16 value. `r1` = dst cursor. Appends the unsigned
+    /// decimal representation of `acu` at `[r1]`, advances `r1`.
+    /// (`format_int_to_buf` is the signed counterpart.)
+    format_uint_to_buf = 0x15,
 
     /// `acu` = requested size in bytes. On success: `acu` ← the
     /// address of the freshly-allocated block, and the VM's bump
@@ -182,12 +189,13 @@ pub fn sys(vm: *VM) StepResult {
     // unrecognized ones via the `else` arm below.
     const id: SyscallId = @enumFromInt(id_byte);
     switch (id) {
-        .print_str, .print_int, .print_char, .print_newline, .print_fixed => {
+        .print_str, .print_int, .print_uint, .print_char, .print_newline, .print_fixed => {
             const writer = vm.host.out orelse return ok;
             return dispatchPrint(vm, id, writer);
         },
         .format_str_to_buf => formatStrToBuf(vm),
         .format_int_to_buf => formatIntToBuf(vm) catch return fault(vm, .invalid_opcode),
+        .format_uint_to_buf => formatUintToBuf(vm) catch return fault(vm, .invalid_opcode),
         .format_char_to_buf => formatCharToBuf(vm),
         .format_fixed_to_buf => formatFixedToBuf(vm) catch return fault(vm, .invalid_opcode),
         .format_terminate_buf => formatTerminateBuf(vm),
@@ -224,6 +232,10 @@ fn dispatchPrint(vm: *VM, id: SyscallId, writer: *@import("std").Io.Writer) Step
         .print_int => {
             // safety: acu is u16; bit-cast to i16 for signed-decimal output.
             const v: i16 = @bitCast(vm.regs.read(.acu));
+            writer.print("{d}", .{v}) catch return fault(vm, .invalid_opcode);
+        },
+        .print_uint => {
+            const v: u16 = vm.regs.read(.acu);
             writer.print("{d}", .{v}) catch return fault(vm, .invalid_opcode);
         },
         .print_char => {
@@ -273,6 +285,14 @@ fn formatStrToBuf(vm: *VM) void {
 fn formatIntToBuf(vm: *VM) !void {
     // safety: acu is u16; bit-cast to i16 for signed-decimal output.
     const v: i16 = @bitCast(vm.regs.read(.acu));
+    var stack_buf: [8]u8 = undefined;
+    var local: @import("std").Io.Writer = .fixed(&stack_buf);
+    try local.print("{d}", .{v});
+    for (local.buffered()) |b| writeBufByte(vm, b);
+}
+
+fn formatUintToBuf(vm: *VM) !void {
+    const v: u16 = vm.regs.read(.acu);
     var stack_buf: [8]u8 = undefined;
     var local: @import("std").Io.Writer = .fixed(&stack_buf);
     try local.print("{d}", .{v});

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -4386,14 +4386,55 @@ test "codegen: a frame past the 127-byte fp-offset limit is a clean error (not a
     , "E_CODEGEN_FRAME_TOO_LARGE");
 }
 
-test "codegen/struct: printing a whole struct is rejected" {
-    try expectCodegenError(
+test "codegen/struct: `print` renders `Name { field: value, ... }`" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let p = P { x: 1, y: 2 }
+        \\  print p
+        \\end
+    , "P { x: 1, y: 2 }\n");
+}
+
+test "codegen/struct: `print` recurses into nested structs + str/char fields" {
+    try runAndExpect(
+        \\struct In
+        \\  v: i16
+        \\end
+        \\struct Out
+        \\  n: In
+        \\  tag: str
+        \\  c: char
+        \\end
+        \\def main()
+        \\  let o = Out { n: In { v: 9 }, tag: "hi", c: 'A' }
+        \\  print o
+        \\end
+    , "Out { n: In { v: 9 }, tag: hi, c: A }\n");
+}
+
+test "codegen/struct: `print` works on a literal + amid other args" {
+    try runAndExpect(
         \\struct P
         \\  x: i16
         \\end
         \\def main()
-        \\  let p = P { x: 5 }
-        \\  print p
+        \\  print "pt = ", P { x: 7 }, "!"
+        \\end
+    , "pt =  P { x: 7 } !\n");
+}
+
+test "codegen/struct: `print` of a struct with an array field is rejected" {
+    try expectCodegenError(
+        \\struct B
+        \\  d: [u8; 3]
+        \\end
+        \\def main()
+        \\  let b = B { d: [1, 2, 3] }
+        \\  print b
         \\end
     , "E_CODEGEN_UNSUPPORTED");
 }

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -549,6 +549,43 @@ test "codegen: globals in data region land at data_base upward" {
     try std.testing.expectEqual(@as(u16, 200), vm.mmap.readWord(0x2002));
 }
 
+test "codegen: a module-level `const` / `let` initializer is stored at startup" {
+    // The slot is otherwise zero-filled; the entry prologue seeds it.
+    try runAndExpect(
+        \\const MAX_HP = 100
+        \\const NAME = "hero"
+        \\let counter = 7
+        \\def main()
+        \\  print MAX_HP
+        \\  print NAME
+        \\  print counter + 1
+        \\end
+    , "100\nhero\n8\n");
+}
+
+test "codegen: a module-level `const` can read an earlier `const` (declaration order)" {
+    try runAndExpect(
+        \\const A = 3
+        \\const B = A + 4
+        \\def main()
+        \\  print A, B
+        \\end
+    , "3 7\n");
+}
+
+test "codegen: a module-level `const` enum value initializes its slot" {
+    try runAndExpect(
+        \\enum E
+        \\  case Nil
+        \\  case V(n: i16)
+        \\end
+        \\const C = E.V(9)
+        \\def main()
+        \\  print C
+        \\end
+    , "E.V(9)\n");
+}
+
 test "codegen: @align(16) pads global placement to a 16-byte boundary" {
     var compiled = try compileSource(
         \\let pad: i16 = 0
@@ -1321,7 +1358,7 @@ test "codegen: zero-page overflow emits E_CODEGEN_ZP_OVERFLOW" {
 
 // ---------- enum codegen (nullary variants) ----------
 
-test "codegen: nullary enum constructor loads tag byte into acu" {
+test "codegen: a nullary enum value renders as `Enum.Variant`" {
     try runAndExpect(
         \\enum Color
         \\  case Red
@@ -1332,9 +1369,7 @@ test "codegen: nullary enum constructor loads tag byte into acu" {
         \\  let c: Color = Color.Green
         \\  print c
         \\end
-    ,
-        // Green is the second declared variant → tag = 1.
-        "1\n");
+    , "Color.Green\n");
 }
 
 test "codegen: `is` test on enum returns true on the right variant" {
@@ -4243,6 +4278,63 @@ test "codegen/struct: ordering comparison on structs is rejected" {
     , "E_CODEGEN_UNSUPPORTED");
 }
 
+test "codegen/str: `+` concatenates into a fresh buffer (§3.2.1)" {
+    // Pointer-adding the two string addresses (the old miscompile) would
+    // print garbage; concat allocates and copies both operands' bytes.
+    try runAndExpect(
+        \\def main()
+        \\  let c = "foo" + "bar"
+        \\  print c
+        \\  print c == "foobar"
+        \\  print "a" + "b" + "c"
+        \\  print "" + "hi"
+        \\end
+    , "foobar\n1\nabc\nhi\n");
+}
+
+test "codegen/str: `+` concatenates runtime-built (distinct-buffer) operands" {
+    try runAndExpect(
+        \\def main()
+        \\  let n = 1
+        \\  let c = "x$(n)" + "y$(n)"
+        \\  print c
+        \\  print c == "x1y1"
+        \\end
+    , "x1y1\n1\n");
+}
+
+test "codegen/str: `<` `<=` `>` `>=` are lexicographic, not pointer compares (§3.2.1)" {
+    // A prefix sorts before its extension; results must be deterministic
+    // (a pointer compare was layout-dependent garbage).
+    try runAndExpect(
+        \\def main()
+        \\  print "a" < "b"
+        \\  print "b" > "a"
+        \\  print "abc" < "abd"
+        \\  print "ab" < "abc"
+        \\  print "abc" <= "abc"
+        \\  print "abc" > "abc"
+        \\  print "abd" >= "abc"
+        \\  if "apple" < "banana"
+        \\    print 1
+        \\  else
+        \\    print 2
+        \\  end
+        \\end
+    , "1\n1\n1\n1\n1\n0\n1\n1\n");
+}
+
+test "codegen/str: ordering of runtime-built operands compares by content" {
+    try runAndExpect(
+        \\def main()
+        \\  let n = 1
+        \\  print "a$(n)" < "a$(n)9"
+        \\  print "a$(n)9" < "a$(n)"
+        \\  print "a$(n)" >= "a$(n)"
+        \\end
+    , "1\n0\n1\n");
+}
+
 test "codegen/str: `==` compares content, not pointer identity" {
     // Both strings are built at runtime in distinct interpolation
     // buffers, so a pointer compare would (wrongly) say not-equal.
@@ -4337,8 +4429,8 @@ test "codegen/struct: a `str`-field struct `==` works in a condition" {
     , "1\n0\n");
 }
 
-test "codegen/struct: `==` on a struct with a payload-carrying enum field is rejected" {
-    try expectCodegenError(
+test "codegen/struct: `==` on a struct with a payload-carrying enum field compares slots" {
+    try runAndExpect(
         \\enum Item
         \\  case Sword
         \\  case Potion(amount: i16)
@@ -4350,9 +4442,31 @@ test "codegen/struct: `==` on a struct with a payload-carrying enum field is rej
         \\def main()
         \\  let a = Slot { qty: 1, it: Item.Potion(20) }
         \\  let b = Slot { qty: 1, it: Item.Potion(20) }
+        \\  let c = Slot { qty: 1, it: Item.Potion(99) }
+        \\  let d = Slot { qty: 2, it: Item.Potion(20) }
         \\  print a == b
+        \\  print a == c
+        \\  print a == d
         \\end
-    , "E_CODEGEN_UNSUPPORTED");
+    , "1\n0\n0\n");
+}
+
+test "codegen/struct: a payload enum field with a `str` payload compares by content" {
+    // The enum field's `str` payload must compare by content through the
+    // struct's per-field path, not by the slot's stored pointer.
+    try runAndExpect(
+        \\enum K
+        \\  case Key(name: str)
+        \\end
+        \\struct Box
+        \\  k: K
+        \\end
+        \\def main()
+        \\  let n = 1
+        \\  print Box { k: K.Key("x$(n)") } == Box { k: K.Key("x$(n)") }
+        \\  print Box { k: K.Key("x$(n)") } == Box { k: K.Key("y$(n)") }
+        \\end
+    , "1\n0\n");
 }
 
 test "codegen/struct: payload-free enum field compares by tag" {
@@ -4373,6 +4487,325 @@ test "codegen/struct: payload-free enum field compares by tag" {
         \\  print a == c
         \\end
     , "1\n0\n");
+}
+
+test "codegen/enum: payload-carrying `==` compares slot value, not pointer identity" {
+    // Distinct constructor calls allocate distinct slots, so a
+    // pointer compare would (wrongly) say not-equal.
+    try runAndExpect(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\def main()
+        \\  let a = Item.Potion(20)
+        \\  let b = Item.Potion(20)
+        \\  let c = Item.Potion(30)
+        \\  let d = Item.Sword
+        \\  print a == b
+        \\  print a != b
+        \\  print a == c
+        \\  print a == d
+        \\end
+    , "1\n0\n0\n0\n");
+}
+
+test "codegen/enum: payload-carrying `==` resolves in a control-flow condition" {
+    try runAndExpect(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\def main()
+        \\  let a = Item.Potion(5)
+        \\  if a == Item.Potion(5)
+        \\    print 1
+        \\  end
+        \\  if a != Item.Potion(9)
+        \\    print 2
+        \\  end
+        \\end
+    , "1\n2\n");
+}
+
+test "codegen/enum: a `str` payload compares by content, not pointer (§3.2.1)" {
+    // The names are built in distinct interpolation buffers, so a slot
+    // byte compare (pointer) would wrongly say not-equal.
+    try runAndExpect(
+        \\enum K
+        \\  case Key(name: str, count: u8)
+        \\end
+        \\def main()
+        \\  let n = 1
+        \\  print K.Key("brass$(n)", 1) == K.Key("brass$(n)", 1)
+        \\  print K.Key("brass$(n)", 1) == K.Key("brass$(n)", 2)
+        \\  print K.Key("gold$(n)", 1) == K.Key("brass$(n)", 1)
+        \\end
+    , "1\n0\n0\n");
+}
+
+test "codegen/enum: a nested payload enum compares recursively" {
+    try runAndExpect(
+        \\enum Inner
+        \\  case A
+        \\  case Num(v: i16)
+        \\end
+        \\enum Outer
+        \\  case None
+        \\  case Wrap(i: Inner)
+        \\end
+        \\def main()
+        \\  print Outer.Wrap(Inner.Num(7)) == Outer.Wrap(Inner.Num(7))
+        \\  print Outer.Wrap(Inner.Num(7)) == Outer.Wrap(Inner.Num(8))
+        \\  print Outer.Wrap(Inner.A) == Outer.Wrap(Inner.Num(7))
+        \\  print Outer.None == Outer.Wrap(Inner.A)
+        \\end
+    , "1\n0\n0\n0\n");
+}
+
+test "codegen/enum: `==` on a recursive enum is a clean error" {
+    // Structural equality of a self-referential enum would unroll the
+    // comparison without bound; reject rather than hang the compiler.
+    try expectCodegenError(
+        \\enum List
+        \\  case Nil
+        \\  case Cons(head: i16, tail: List)
+        \\end
+        \\def main()
+        \\  print List.Cons(1, List.Nil) == List.Cons(1, List.Nil)
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
+}
+
+test "codegen/enum: `print` of a recursive enum is a clean error (not a stack overflow)" {
+    // A self-referential payload has no finite rendering; the support
+    // walk must terminate on the cycle and reject, not recurse forever.
+    try expectCodegenError(
+        \\enum Tree
+        \\  case Leaf
+        \\  case Node(child: Tree)
+        \\end
+        \\def main()
+        \\  print Tree.Leaf
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
+}
+
+test "codegen/struct: `print` of a diamond (a type reused by sibling fields) is not a false cycle" {
+    try runAndExpect(
+        \\struct Pt
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\struct Line
+        \\  a: Pt
+        \\  b: Pt
+        \\end
+        \\def main()
+        \\  print Line { a: Pt { x: 1, y: 2 }, b: Pt { x: 3, y: 4 } }
+        \\end
+    , "Line { a: Pt { x: 1, y: 2 }, b: Pt { x: 3, y: 4 } }\n");
+}
+
+test "codegen/enum: a signed `i8` payload keeps its sign on match-bind" {
+    // Byte-loading a narrow payload zero-extends; an `i8` must be
+    // sign-extended so a negative value survives the binder.
+    try runAndExpect(
+        \\enum E
+        \\  case V(n: i8)
+        \\end
+        \\def main()
+        \\  match E.V(-5)
+        \\    case E.V(v) =>
+        \\      print v
+        \\      if v < 0
+        \\        print 1
+        \\      end
+        \\    case _ => print 0
+        \\  end
+        \\end
+    , "-5\n1\n");
+}
+
+test "codegen: a `u16` prints as unsigned (bare, field, payload, interpolation)" {
+    // The signed `print_int` would show a high-bit `u16` as negative;
+    // unsigned values route to `print_uint` / `format_uint_to_buf`.
+    try runAndExpect(
+        \\struct S
+        \\  a: u16
+        \\end
+        \\enum E
+        \\  case V(n: u16)
+        \\end
+        \\def main()
+        \\  let x: u16 = 50000
+        \\  print x
+        \\  print S { a: 65535 }
+        \\  print E.V(40000)
+        \\  print "v=$(x)"
+        \\end
+    , "50000\nS { a: 65535 }\nE.V(40000)\nv=50000\n");
+}
+
+test "codegen: an `i16` still prints signed" {
+    try runAndExpect(
+        \\def main()
+        \\  let x: i16 = -1
+        \\  print x
+        \\end
+    , "-1\n");
+}
+
+test "codegen: a signed `i8` field / payload prints with its sign" {
+    try runAndExpect(
+        \\enum E
+        \\  case V(n: i8)
+        \\end
+        \\struct S
+        \\  a: i8
+        \\  b: u8
+        \\end
+        \\def main()
+        \\  print E.V(-5)
+        \\  print S { a: -5, b: 200 }
+        \\end
+    , "E.V(-5)\nS { a: -5, b: 200 }\n");
+}
+
+test "codegen: a signed `i8` struct-field read sign-extends in expression context" {
+    // `s.d` byte-loads the field; an `i8` must sign-extend (not just in
+    // the auto-render path) so a negative field reads as negative.
+    try runAndExpect(
+        \\struct S
+        \\  d: i8
+        \\end
+        \\def main()
+        \\  let s = S { d: -100 }
+        \\  print s.d
+        \\  let x: i16 = s.d
+        \\  print x
+        \\  if s.d < 0
+        \\    print 1
+        \\  end
+        \\end
+    , "-100\n-100\n1\n");
+}
+
+test "codegen: a signed `i8` global read sign-extends" {
+    try runAndExpect(
+        \\let g: i8 = -100
+        \\def main()
+        \\  print g
+        \\  if g < 0
+        \\    print 1
+        \\  end
+        \\end
+    , "-100\n1\n");
+}
+
+test "codegen: the heap starts above the code + interned string pool" {
+    // A large string literal grows the code buffer past the data base.
+    // The heap must still begin at/after the whole image — otherwise
+    // `alloc` (e.g. a `str` concat) would hand out addresses inside the
+    // live string pool and corrupt it.
+    const big = "z" ** 4000;
+    var compiled = try compileSource("let s = \"" ++ big ++ "\"\ndef main()\n  print s\nend");
+    defer compiled.deinit();
+    const loaded = try gero.vm.parseGx(compiled.image);
+    try std.testing.expect(loaded.header.heap_base >= loaded.header.image_size);
+}
+
+test "codegen/enum: payload-free `==` compares the bare tag" {
+    try runAndExpect(
+        \\enum Dir
+        \\  case N
+        \\  case S
+        \\end
+        \\def main()
+        \\  let a = Dir.N
+        \\  print a == Dir.N
+        \\  print a == Dir.S
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/enum: `print` renders a payload-carrying value as `Enum.Variant(...)`" {
+    try runAndExpect(
+        \\enum Tok
+        \\  case Eof
+        \\  case Num(v: i16)
+        \\  case Pair(a: i16, b: i16)
+        \\end
+        \\def main()
+        \\  print Tok.Eof
+        \\  print Tok.Num(42)
+        \\  print Tok.Pair(3, 7)
+        \\end
+    , "Tok.Eof\nTok.Num(42)\nTok.Pair(3, 7)\n");
+}
+
+test "codegen/enum: `print` renders char / fixed / str payloads" {
+    try runAndExpect(
+        \\enum V
+        \\  case C(c: char)
+        \\  case F(f: fixed)
+        \\  case S(s: str)
+        \\end
+        \\def main()
+        \\  print V.C('A')
+        \\  print V.F(1.5)
+        \\  print V.S("hi")
+        \\end
+    , "V.C(A)\nV.F(1.500)\nV.S(hi)\n");
+}
+
+test "codegen/enum: `print` recurses into a nested enum payload" {
+    try runAndExpect(
+        \\enum Inner
+        \\  case A
+        \\  case Num(v: i16)
+        \\end
+        \\enum Outer
+        \\  case None
+        \\  case Wrap(i: Inner)
+        \\end
+        \\def main()
+        \\  print Outer.Wrap(Inner.Num(7))
+        \\  print Outer.Wrap(Inner.A)
+        \\  print Outer.None
+        \\end
+    , "Outer.Wrap(Inner.Num(7))\nOuter.Wrap(Inner.A)\nOuter.None\n");
+}
+
+test "codegen/struct: `print` renders an enum field as `Enum.Variant(...)`" {
+    try runAndExpect(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\struct Slot
+        \\  qty: i16
+        \\  it: Item
+        \\end
+        \\def main()
+        \\  print Slot { qty: 2, it: Item.Potion(5) }
+        \\  print Slot { qty: 1, it: Item.Sword }
+        \\end
+    , "Slot { qty: 2, it: Item.Potion(5) }\nSlot { qty: 1, it: Item.Sword }\n");
+}
+
+test "codegen/enum: `print` of a struct-payload variant is a clean error" {
+    try expectCodegenError(
+        \\struct Pt
+        \\  x: i16
+        \\end
+        \\enum Shape
+        \\  case At(p: Pt)
+        \\end
+        \\def main()
+        \\  print Shape.At(Pt { x: 1 })
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
 }
 
 test "codegen: a frame past the 127-byte fp-offset limit is a clean error (not a panic)" {

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -4375,6 +4375,17 @@ test "codegen/struct: payload-free enum field compares by tag" {
     , "1\n0\n");
 }
 
+test "codegen: a frame past the 127-byte fp-offset limit is a clean error (not a panic)" {
+    try expectCodegenError(
+        \\struct Big
+        \\  a: [i16; 70]
+        \\end
+        \\def main()
+        \\  let b: Big
+        \\end
+    , "E_CODEGEN_FRAME_TOO_LARGE");
+}
+
 test "codegen/struct: printing a whole struct is rejected" {
     try expectCodegenError(
         \\struct P

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -300,8 +300,8 @@ test "typecheck: match payload binder carries the variant's field type" {
 }
 
 test "typecheck: payload binder typed for an inline-constructor scrutinee" {
-    // The scrutinee `E.A(1)` surfaces no inferred type, so the enum is
-    // recovered from the arm path — `n` is still typed `i16`.
+    // The scrutinee `E.A(1)` infers as `E`, so the match resolves the
+    // enum and `n` binds the variant's `i16` payload.
     try expectCode(
         \\enum E
         \\  case A(x: i16)
@@ -313,6 +313,142 @@ test "typecheck: payload binder typed for an inline-constructor scrutinee" {
         \\      let bad: str = n
         \\      print bad
         \\    case E.B => print 0
+        \\  end
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: payload-variant constructor infers the enum type" {
+    try expectClean(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\def main()
+        \\  let x: Item = Item.Potion(20)
+        \\  print x
+        \\end
+    );
+}
+
+test "typecheck: payload-variant binding is typed, not left untyped" {
+    // A wrong-type annotation must clash — an untyped binding would
+    // have silently accepted the `i16` slot.
+    try expectCode(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\def main()
+        \\  let x: i16 = Item.Potion(20)
+        \\  print x
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: payload-variant constructor checks payload arg type" {
+    try expectCode(
+        \\enum Item
+        \\  case Potion(amount: i16)
+        \\end
+        \\def main()
+        \\  let x = Item.Potion("nope")
+        \\  print 0
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: payload-variant constructor checks arity" {
+    try expectCode(
+        \\enum Item
+        \\  case Potion(amount: i16)
+        \\end
+        \\def main()
+        \\  let x = Item.Potion(1, 2)
+        \\  print 0
+        \\end
+    , "E_TYPE_ARG_COUNT");
+}
+
+test "typecheck: constructor for an unknown variant is rejected" {
+    try expectCode(
+        \\enum Item
+        \\  case Potion(amount: i16)
+        \\end
+        \\def main()
+        \\  let x = Item.Nope(1)
+        \\  print 0
+        \\end
+    , "E_TYPE_UNDEFINED_VARIANT");
+}
+
+test "typecheck: a self-referential struct is rejected (infinite size)" {
+    try expectCode(
+        \\struct N
+        \\  v: i16
+        \\  next: N
+        \\end
+        \\def main()
+        \\  print 0
+        \\end
+    , "E_TYPE_RECURSIVE_STRUCT");
+}
+
+test "typecheck: mutually-recursive structs are rejected" {
+    try expectCode(
+        \\struct A
+        \\  b: B
+        \\end
+        \\struct B
+        \\  a: A
+        \\end
+        \\def main()
+        \\  print 0
+        \\end
+    , "E_TYPE_RECURSIVE_STRUCT");
+}
+
+test "typecheck: a `Vec`/reference of the same struct is finite (not rejected)" {
+    try expectClean(
+        \\struct Node
+        \\  v: i16
+        \\  kids: Vec(Node)
+        \\end
+        \\def main()
+        \\  print 0
+        \\end
+    );
+}
+
+test "typecheck: an `if` condition must be `bool`" {
+    try expectCode(
+        \\def main()
+        \\  let x: i16 = 5
+        \\  if x
+        \\    print 1
+        \\  end
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: a `while` condition must be `bool`" {
+    try expectCode(
+        \\def main()
+        \\  let x: i16 = 3
+        \\  while x
+        \\    print 1
+        \\  end
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: a `match` `when` guard must be `bool`" {
+    try expectCode(
+        \\def main()
+        \\  let n: i16 = 5
+        \\  match n
+        \\    case _ when "x" => print 1
+        \\    case _ => print 0
         \\  end
         \\end
     , "E_TYPE_MISMATCH");
@@ -931,6 +1067,39 @@ test "typecheck: non-exhaustive match errors with E_MATCH_NON_EXHAUSTIVE" {
         \\let it: Item = Item.Sword
         \\match it
         \\  case Item.Sword => let x = 0
+        \\end
+    , "E_MATCH_NON_EXHAUSTIVE");
+}
+
+test "typecheck: a guarded arm doesn't make a later unguarded same-variant arm unreachable" {
+    // `case X(n) when g => / case X(n) =>` — the guarded arm only
+    // conditionally matches, so the unguarded fallback is reachable.
+    try expectClean(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\
+        \\let it: Item = Item.Potion(5)
+        \\match it
+        \\  case Item.Potion(n) when n > 0 => let a = 1
+        \\  case Item.Potion(n) => let a = 2
+        \\  case Item.Sword => let a = 0
+        \\end
+    );
+}
+
+test "typecheck: a guarded arm does not discharge its variant for exhaustiveness" {
+    try expectCode(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(amount: i16)
+        \\end
+        \\
+        \\let it: Item = Item.Potion(5)
+        \\match it
+        \\  case Item.Potion(n) when n > 0 => let a = 1
+        \\  case Item.Sword => let a = 0
         \\end
     , "E_MATCH_NON_EXHAUSTIVE");
 }


### PR DESCRIPTION
Default whole-struct `print` (#323) grew into full enum value semantics, plus a batch of pre-existing lang correctness gaps that surfaced while building it — folded in per maintainer direction.

## #323 scope
- **Whole-struct `print`** — `P { x: 1, y: 2 }`, recursing into nested structs / `str` / `char` / enum fields.
- **Scalar payload-enum `==`** (folded from #322) — value equality, not pointer identity.
- **`reserveFrameSlot` >127-byte frame** — clean `E_CODEGEN_FRAME_TOO_LARGE` instead of a compiler panic.

## Absorbed (maintainer-approved)
**Enum value semantics**
- Enum `==` / `!=` compares the `[tag|payload]` slot by value: tag, then the matching variant's payload field-by-field (`str` by content §3.2.1, nested enum recursively, scalars by value). Structs compare through an enum field. Recursive enums are rejected.
- Enum-value `print` → `Enum.Variant` / `Enum.Variant(a, b)`, recursing into payloads. Unrenderable / cyclic types are a clean `E_CODEGEN_UNSUPPORTED` (no stack overflow).
- `Item.Potion(20)` (parses as a method call) now infers the enum type — `let x = Item.Potion(20)` is typed and its args are checked (arity / unknown-variant / arg-type).

**Pre-existing fixes**
- `str + str` allocates + concatenates (§3.2.1); the heap now starts above the interned string pool so a long concat can't alias its source.
- `str` `< <= > >=` compare lexicographically, not by pointer address.
- `u16` prints unsigned (new `print_uint` / `format_uint_to_buf` syscalls, ISA §syscalls); `i8` sign-extends on every load (enum payload, struct field, global).
- Module-level `const` / `let` initializers are stored at startup in declaration order (previously read back zero); `@addr` bindings keep their pinned-location value.
- `if` / `while` / `repeat` conditions and `when` guards must be `bool` (no implicit truthiness, §3).
- A struct containing itself by value → new `E_TYPE_RECURSIVE_STRUCT` instead of a compiler crash.
- A `when`-guarded match arm no longer marks a later unguarded same-variant arm unreachable nor discharges its variant for exhaustiveness (fixes the §4.8.4 idiom).

## Verification
- `zig build ci` green (all release modes + cross-targets + examples).
- Spec updated in lockstep: gero-lang.md (§3.2.1, §3.6, §4.1, §4.9, §7.1), isa.md (syscalls), lang-diagnostics.md (`E_TYPE_RECURSIVE_STRUCT` + pruned stale `E_CODEGEN_UNSUPPORTED` examples).
- Two adversarial review passes; every confirmed finding fixed or (for false positives like `@addr` init / `&T`-enum `==`) justified.

Closes #323.