### PR TITLE
feat(lang/codegen): tuple values — literal + .N access (#305)

### DIFF
--- a/.changeset/lang-codegen-tuples.md
+++ b/.changeset/lang-codegen-tuples.md
@@ -1,0 +1,34 @@
+---
+bump: minor
+---
+
+Tuple values now construct, lower, and support `.N` element access
+(§3.4).
+
+A tuple is an anonymous positional aggregate stored inline as
+contiguous, byte-packed slots — the same value model as a struct. `t.0`
+/ `t.1` element access parses (the selector is an ordinal, not an
+ident) and type-checks to the element's type, and codegen lowers:
+
+- **Construction** — `(1, "x")` writes each element at its slot offset.
+- **`.N` access** — loads the element (an `i8` sign-extends).
+- **Value semantics** — `let b = a` / `b = a` copy the bytes;
+  pass-by-value (a tuple param is copied onto the stack) and
+  return-by-value (the multi-return `def f() -> (i16, i16)` shape, via
+  the same sret convention as struct returns), including through an
+  `@inline` parameter.
+
+Tuple elements are register-width (scalar / `char` / `fixed` / `str` /
+enum / class / reference). Combinations not yet lowered are a clean
+`E_CODEGEN_UNSUPPORTED` rather than a wrong result: tuple `==` / `!=`,
+whole-tuple `print`, a nested struct/tuple element, tuple element store
+(`t.0 = x`), and a tuple return from an `@inline` function.
+
+A tuple's max of 4 elements (§3.4) is now enforced — a 5+-element tuple
+literal or type annotation is rejected (previously accepted silently).
+
+New diagnostics: `E_TYPE_NOT_A_TUPLE` (`.N` on a non-tuple),
+`E_TYPE_TUPLE_INDEX_OOR` (index past the arity), and
+`E_TYPE_TUPLE_TOO_MANY` (more than 4 elements).
+
+Closes #305.

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -233,6 +233,9 @@ Raised by the typechecker after parsing succeeds.
 | `E_TYPE_UNDEFINED_METHOD` | Method name doesn't exist on the receiver's class (or any parent). |
 | `E_TYPE_MISSING_FIELD` | Struct literal omits a field declared by the type. |
 | `E_TYPE_RECURSIVE_STRUCT` | A struct contains itself by value (directly or transitively, through a struct / array / tuple field) — infinite size, no layout. Use `Vec(T)` or `&T` for a recursive shape. |
+| `E_TYPE_NOT_A_TUPLE` | `.N` element access on a non-tuple value. |
+| `E_TYPE_TUPLE_INDEX_OOR` | Tuple element index `.N` is past the tuple's arity. |
+| `E_TYPE_TUPLE_TOO_MANY` | A tuple has more than 4 elements (§3.4) — use a struct instead. |
 | `E_TYPE_TUPLE_ARITY` | Tuple-destructuring pattern's element count doesn't match the init's tuple arity. |
 | `E_TYPE_REDEFINED` | A name is declared twice in the same scope. |
 | `E_TYPE_ARG_COUNT` | Wrong number of args at a call site. |
@@ -759,6 +762,9 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_TYPE_UNDEFINED_METHOD` | Typechecker | v0.3 |
 | `E_TYPE_MISSING_FIELD` | Typechecker | v0.3 |
 | `E_TYPE_RECURSIVE_STRUCT` | Typechecker | v0.3 |
+| `E_TYPE_NOT_A_TUPLE` | Typechecker | v0.3 |
+| `E_TYPE_TUPLE_INDEX_OOR` | Typechecker | v0.3 |
+| `E_TYPE_TUPLE_TOO_MANY` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_ARITY` | Typechecker | v0.3 |
 | `E_TYPE_REDEFINED` | Typechecker | v0.3 |
 | `E_TYPE_ARG_COUNT` | Typechecker | v0.3 |

--- a/src/lang/ast.zig
+++ b/src/lang/ast.zig
@@ -333,6 +333,8 @@ pub const Expr = union(enum) {
     method_call: MethodCallExpr,
     /// `obj.field` — direct field access, no parentheses.
     field: FieldExpr,
+    /// `tuple.0` / `tuple.1` — positional tuple element access (§3.4).
+    tuple_index: TupleIndexExpr,
     /// `obj[index]` — bracket-index access. For `Vec(T)` and arrays
     /// codegen emits the `at`/`get` opcode; for strings it's byte
     /// access.
@@ -392,6 +394,7 @@ pub const Expr = union(enum) {
             .call => |e| e.span,
             .method_call => |e| e.span,
             .field => |e| e.span,
+            .tuple_index => |e| e.span,
             .index => |e| e.span,
             .do_expr => |e| e.span,
             .if_expr => |e| e.span,
@@ -577,6 +580,15 @@ pub const FieldExpr = struct {
     receiver: *Expr,
     /// Field name span.
     field: Span,
+    span: Span,
+};
+
+/// `tuple.N` — positional access of element `index` (§3.4). Distinct
+/// from `FieldExpr` because the selector is an ordinal, not an ident.
+pub const TupleIndexExpr = struct {
+    receiver: *Expr,
+    /// Element ordinal (`0`-based). Bounds-checked in typecheck.
+    index: u8,
     span: Span,
 };
 
@@ -1365,6 +1377,7 @@ pub fn freeExpr(allocator: std.mem.Allocator, e: *Expr) void {
             allocator.free(m.args);
         },
         .field => |f| freeExpr(allocator, f.receiver),
+        .tuple_index => |t| freeExpr(allocator, t.receiver),
         .index => |i| {
             freeExpr(allocator, i.receiver);
             freeExpr(allocator, i.index);

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -137,6 +137,7 @@ pub fn compile(
         .is_entry = false,
         .is_isr = false,
         .current_ret_struct = null,
+        .current_ret_is_tuple = false,
         .sret_param_ofs = 0,
         .sret_scratch_ofs = null,
         .inline_ret_struct = null,
@@ -145,6 +146,7 @@ pub fn compile(
         .fn_banks = .{},
         .noreturn_defs = .{},
         .fn_ret_struct = .{},
+        .fn_ret_tuple = .{},
         .global_sret_scratch = 0,
         .inline_defs = .{},
         .interrupt_defs = .empty,
@@ -457,9 +459,15 @@ pub const Emitter = struct {
     /// `null` for a scalar-returning def. When set, `return` copies the
     /// value into the caller-provided sret buffer.
     current_ret_struct: ?[]const u8,
+    /// `true` while emitting a tuple-returning def — `return` copies the
+    /// tuple into the caller's sret buffer (same convention as
+    /// `current_ret_struct`; the element layout comes from the return
+    /// expression's inferred type).
+    current_ret_is_tuple: bool,
     /// fp-offset of the hidden sret destination pointer in the current
     /// frame (`4 + Σ user-param widths` — it sits just above the last
-    /// user param). Valid only while `current_ret_struct` is set.
+    /// user param). Valid while `current_ret_struct` is set or
+    /// `current_ret_is_tuple` is true.
     sret_param_ofs: i16,
     /// fp-offset of this frame's sret scratch buffer (a returned
     /// struct's holding space), or `null` when the program returns no
@@ -487,6 +495,10 @@ pub const Emitter = struct {
     /// caller passes a hidden destination pointer and the callee copies
     /// its result there (§3.4). Absent → returns a scalar in `acu`.
     fn_ret_struct: std.StringHashMapUnmanaged([]const u8),
+    /// `def` names that return a tuple by value — drives the same sret
+    /// convention as `fn_ret_struct` (a set: the element layout is read
+    /// from the call/return expression's inferred type).
+    fn_ret_tuple: std.StringHashMapUnmanaged(void),
     /// Largest (2-aligned) struct return width across the program — the
     /// size of the per-frame sret scratch buffer that holds a returned
     /// struct until its consumer copies it out. 0 when no def returns a
@@ -671,9 +683,9 @@ pub const Emitter = struct {
     }
 
     /// Byte width of a checked type. Mirrors `widthOfTypeAnn` but over
-    /// `types.Type` — 1 for `i8`/`u8`/`bool`/`char`, the field sum for
-    /// a named struct, 2 otherwise (16-bit primitives, references,
-    /// class/enum pointers).
+    /// `types.Type` — 1 for `i8`/`u8`/`bool`/`char`, the element sum for
+    /// a named struct or tuple, 2 otherwise (16-bit primitives,
+    /// references, class/enum pointers).
     pub fn widthOfType(self: *const Emitter, ty: *const Type) u16 {
         switch (ty.*) {
             .primitive => |p| return switch (p) {
@@ -687,6 +699,11 @@ pub const Emitter = struct {
                     return total;
                 }
                 return 2;
+            },
+            .tuple => |elems| {
+                var total: u16 = 0;
+                for (elems) |elem| total +%= self.widthOfType(elem);
+                return total;
             },
             else => return 2,
         }
@@ -1054,6 +1071,12 @@ pub const Emitter = struct {
                     const w = self.structSlotWidth(sname);
                     if (w > self.global_sret_scratch) self.global_sret_scratch = w;
                 };
+                // A tuple-returning def uses the same sret scratch buffer.
+                if (dd.ret_type) |rt| if (rt.* == .tuple) {
+                    try self.fn_ret_tuple.put(self.arena, dup, {});
+                    const w = alignUpU16(self.widthOfTypeAnn(rt.*), 2);
+                    if (w > self.global_sret_scratch) self.global_sret_scratch = w;
+                };
                 if (noreturn_marked) try self.noreturn_defs.put(self.arena, dup, {});
                 if (inline_marked) try self.inline_defs.put(self.arena, dup, dd);
                 if (interrupt_vec) |vec| {
@@ -1383,8 +1406,8 @@ pub const Emitter = struct {
         return self.structNameOf(arg);
     }
 
-    /// Stack footprint of a parameter: a struct param occupies its
-    /// full (2-aligned) width — passed by value as a contiguous copy
+    /// Stack footprint of a parameter: a struct or tuple param occupies
+    /// its full (2-aligned) width — passed by value as a contiguous copy
     /// (§3.4) — and a scalar param one word. Drives both the param
     /// fp-offsets and the caller's arg-push width.
     pub fn paramWidthAligned(self: *const Emitter, p: ast.Param) u16 {
@@ -1392,7 +1415,58 @@ pub const Emitter = struct {
         if (self.structNameOfTypeAnn(t.*)) |sname| {
             return self.structSlotWidth(sname);
         }
+        if (t.* == .tuple) return alignUpU16(self.widthOfTypeAnn(t.*), 2);
         return 2;
+    }
+
+    /// Element list of a tuple-typed expression, or `null` for a
+    /// non-tuple. The tuple analog of `structNameOf`: a tuple value is
+    /// its base address (inline contiguous slots, §3.4).
+    pub fn tupleElemsOf(self: *const Emitter, e: *const ast.Expr) ?[]const *const Type {
+        const ty = self.typeOf(e) orelse return null;
+        const inner = if (ty.* == .reference) ty.reference else ty;
+        return if (inner.* == .tuple) inner.tuple else null;
+    }
+
+    /// Total byte width of a tuple (elements summed).
+    pub fn tupleWidth(self: *const Emitter, elems: []const *const Type) u16 {
+        var total: u16 = 0;
+        for (elems) |e| total +%= self.widthOfType(e);
+        return total;
+    }
+
+    /// A tuple's footprint rounded up to a 2-byte slot — the aligned
+    /// size for inline-value frame, param, and arg layout.
+    pub fn tupleSlotWidth(self: *const Emitter, elems: []const *const Type) u16 {
+        return alignUpU16(self.tupleWidth(elems), 2);
+    }
+
+    /// Layout of one tuple element: byte offset (sum of prior element
+    /// widths, byte-packed) + width, and whether it is a signed byte
+    /// (`i8`, sign-extended on load).
+    pub const TupleElemInfo = struct { offset: u16, width: u16, signed_byte: bool };
+
+    /// Layout of tuple element `index` within its inline slots.
+    pub fn tupleElemInfo(self: *const Emitter, elems: []const *const Type, index: u8) TupleElemInfo {
+        var ofs: u16 = 0;
+        for (elems[0..index]) |e| ofs +%= self.widthOfType(e);
+        const et = elems[index];
+        return .{
+            .offset = ofs,
+            .width = self.widthOfType(et),
+            .signed_byte = et.* == .primitive and et.primitive == .i8,
+        };
+    }
+
+    /// `true` if any element is itself an inline aggregate (a tuple or a
+    /// named struct). #305 lowers register-width elements (scalar / `str`
+    /// / enum / class / reference); nested inline aggregates are deferred.
+    pub fn tupleHasAggregateElem(self: *const Emitter, elems: []const *const Type) bool {
+        for (elems) |e| {
+            if (e.* == .tuple) return true;
+            if (e.* == .named and self.struct_decls.contains(e.named.name)) return true;
+        }
+        return false;
     }
 
     /// `target = value` (and compound / inc-dec desugarings) — see

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -108,6 +108,7 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     // just above its last user param (the caller pushes it first);
     // `return` copies the result there instead of into `acu`.
     self.current_ret_struct = if (def.ret_type) |rt| self.structNameOfTypeAnn(rt.*) else null;
+    self.current_ret_is_tuple = if (def.ret_type) |rt| rt.* == .tuple else false;
     // @as: sits past the params; the frame-size cap keeps it small.
     self.sret_param_ofs = @intCast(param_ofs);
 

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -49,9 +49,10 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .char_lit => |c| try isa.movImmToReg(self, c.value, Reg.acu),
         .paren => |p| try emitExpr(self, p.inner),
         .ident => |i| {
-            // A struct-typed binding evaluates to its base address —
-            // struct values are addressed inline, not loaded as a word.
-            if (self.structNameOf(e) != null) {
+            // A struct- or tuple-typed binding evaluates to its base
+            // address — aggregate values are addressed inline, not
+            // loaded as a word.
+            if (self.structNameOf(e) != null or self.tupleElemsOf(e) != null) {
                 try self.emitAddrOf(e);
                 return;
             }
@@ -88,6 +89,7 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .call => |c| try emitCall(self, c),
         .method_call => |m| try emitMethodCall(self, m, e),
         .field => |f| try emitFieldExpr(self, f, e),
+        .tuple_index => |ti| try emitTupleIndexExpr(self, ti),
         .self_expr => |se| {
             // `self` inside a method body lives at fp+4 (the first
             // implicit param). Outside a method it's a typecheck
@@ -230,6 +232,22 @@ pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void
     try self.unsupported(e.span(), "non-enum field access");
 }
 
+/// Lower a `tuple.N` element access — evaluate the receiver to its base
+/// address, then load element `N`. Tuples with a nested struct/tuple
+/// element aren't lowered yet (deferred from #305).
+fn emitTupleIndexExpr(self: *Emitter, ti: ast.TupleIndexExpr) !void {
+    const elems = self.tupleElemsOf(ti.receiver) orelse {
+        try self.unsupported(ti.span, "tuple element access on a non-tuple value");
+        return;
+    };
+    if (self.tupleHasAggregateElem(elems)) {
+        try self.unsupported(ti.span, "a tuple with a nested struct/tuple element");
+        return;
+    }
+    try emitExpr(self, ti.receiver); // acu = tuple base address
+    try value_struct.emitTupleElemLoad(self, elems, ti.index);
+}
+
 /// Lower an `is` test. Two shapes:
 /// - `expr is Enum.Variant` — compares the tag in `acu` against
 ///   the variant's compile-time tag.
@@ -354,6 +372,13 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
                 return;
             },
         }
+    }
+
+    // Tuple `==` / `!=` (element-wise) isn't lowered yet — reject rather
+    // than compare the operand addresses (deferred from #305).
+    if (self.tupleElemsOf(b.lhs) != null or self.tupleElemsOf(b.rhs) != null) {
+        try self.unsupported(b.span, "`==` / `!=` on tuples");
+        return;
     }
 
     const fixed_op = self.isPrimitiveType(b.lhs, .fixed) and
@@ -530,6 +555,11 @@ pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
                             return;
                         },
                     }
+                }
+                // Tuple comparison isn't lowered yet (deferred from #305).
+                if (self.tupleElemsOf(b.lhs) != null or self.tupleElemsOf(b.rhs) != null) {
+                    try self.unsupported(b.span, "`==` / `!=` on tuples");
+                    return;
                 }
                 // Eval LHS into acu, eval RHS into r1, cmp acu, r1.
                 try emitExpr(self, b.rhs);
@@ -808,22 +838,26 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     // frame's scratch buffer; the callee copies its result there and
     // returns the pointer in `acu`.
     const returns_struct = self.fn_ret_struct.contains(callee_name);
-    if (returns_struct) {
-        // Invariant: a struct-returning callee implies the program has a
-        // struct return type, so every frame reserved a scratch slot.
+    const returns_tuple = self.fn_ret_tuple.contains(callee_name);
+    if (returns_struct or returns_tuple) {
+        // Invariant: an aggregate-returning callee implies the program
+        // reserved an sret scratch slot in every frame (struct + tuple
+        // returns share it).
         const sofs = self.sret_scratch_ofs.?;
         try isa.movRegToReg(self, Reg.fp, Reg.acu);
         if (sofs < 0) try isa.subImmFromReg(self, @intCast(-sofs), Reg.acu);
         try isa.pushReg(self, Reg.acu);
     }
 
-    // Push args right-to-left (caller-cleans-up). A struct arg is
-    // passed by value — its (2-aligned) width copied onto the stack.
+    // Push args right-to-left (caller-cleans-up). A struct or tuple arg
+    // is passed by value — its (2-aligned) width copied onto the stack.
     var i: usize = c.args.len;
     while (i > 0) {
         i -= 1;
         if (self.argStructName(c.args[i])) |sname| {
             try value_struct.pushArg(self, c.args[i], sname);
+        } else if (self.tupleElemsOf(c.args[i])) |elems| {
+            try value_struct.pushTupleArg(self, c.args[i], elems);
         } else {
             try emitExpr(self, c.args[i]);
             try isa.pushReg(self, Reg.acu);
@@ -876,10 +910,12 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     // never returns to use that space.
     const skip_cleanup = self.noreturn_defs.contains(callee_name);
     if (!skip_cleanup) {
-        var drop_bytes: u16 = if (returns_struct) 2 else 0; // hidden sret pointer
+        var drop_bytes: u16 = if (returns_struct or returns_tuple) 2 else 0; // hidden sret pointer
         for (c.args) |a| {
             if (self.argStructName(a)) |sname| {
                 drop_bytes += self.structSlotWidth(sname);
+            } else if (self.tupleElemsOf(a)) |elems| {
+                drop_bytes += self.tupleSlotWidth(elems);
             } else {
                 drop_bytes += 2; // one 16-bit word per scalar arg
             }

--- a/src/lang/codegen/inline_call.zig
+++ b/src/lang/codegen/inline_call.zig
@@ -34,6 +34,14 @@ pub fn emitInlineCall(self: *Emitter, callee: *const ast.DefDecl, c: ast.CallExp
         return;
     }
 
+    // A tuple-returning `@inline` body would need the inline-return
+    // buffer plumbing the struct path has; not lowered yet (deferred
+    // from #305). Reject before any frame mutation.
+    if (callee.ret_type) |rt| if (rt.* == .tuple) {
+        try self.unsupported(c.span, "a tuple return from an `@inline` function");
+        return;
+    };
+
     // Bind args → fresh caller-frame locals. Each slot extends
     // `frame_bytes` via its own sub-imm (the prologue's bulk reservation
     // already ran). Args materialize in the CALLER's scope — locals
@@ -48,6 +56,11 @@ pub fn emitInlineCall(self: *Emitter, callee: *const ast.DefDecl, c: ast.CallExp
             try isa.subImmFromReg(self, self.structSlotWidth(sname), Reg.sp);
             const ofs = self.reserveFrameSlot(self.structSlotWidth(sname));
             try value_struct.emitInto(self, arg, sname, ofs);
+            b.* = .{ .name = dup, .ofs = ofs };
+        } else if (self.tupleElemsOf(arg)) |elems| {
+            try isa.subImmFromReg(self, self.tupleSlotWidth(elems), Reg.sp);
+            const ofs = self.reserveFrameSlot(self.tupleSlotWidth(elems));
+            try value_struct.emitTupleInto(self, arg, elems, ofs);
             b.* = .{ .name = dup, .ofs = ofs };
         } else {
             try isa.subImmFromReg(self, 2, Reg.sp);

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -80,6 +80,13 @@ pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
             return;
         }
     }
+    // Tuple-typed reassignment — same inline value copy.
+    if (self.tupleElemsOf(a.target)) |elems| {
+        if (self.locals.get(name)) |ofs| {
+            try value_struct.emitTupleInto(self, a.value, elems, ofs);
+            return;
+        }
+    }
     // Captured-binding write inside a lambda body — store through the
     // env-relative cell pointer (the parent promoted the binding so the
     // write is visible everywhere).
@@ -151,6 +158,21 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
         return;
     }
 
+    // Tuple-typed binding — inline value semantics like a struct, sized
+    // by the tuple width (annotated width, or the initializer's).
+    const tuple_elems = if (d.init) |e| self.tupleElemsOf(e) else null;
+    const ann_tuple = if (d.type_ann) |t| t.* == .tuple else false;
+    if (tuple_elems != null or ann_tuple) {
+        const width = if (d.type_ann) |t| self.widthOfTypeAnn(t.*) else self.tupleWidth(tuple_elems.?);
+        const slot = try self.allocLocalSized(dup_name, width);
+        if (d.init) |init_expr| {
+            if (tuple_elems) |elems| {
+                try value_struct.emitTupleInto(self, init_expr, elems, slot);
+            } else try self.unsupported(d.span, "tuple binding initialized from a non-tuple value");
+        }
+        return;
+    }
+
     const ofs = try self.allocLocal(dup_name);
     // Promoted bindings live as heap cells — the slot holds the cell
     // pointer instead of the value directly.
@@ -196,6 +218,15 @@ pub fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
             try isa.movRegToReg(self, Reg.fp, Reg.acu);
             if (self.sret_param_ofs > 0) try isa.addImmToReg(self, @intCast(self.sret_param_ofs), Reg.acu);
             try isa.movRegOffsetToReg(self, Reg.acu, 0, Reg.acu);
+        } else if (self.current_ret_is_tuple) {
+            // Tuple return: same sret convention as a struct. The element
+            // layout comes from the return expression's inferred type.
+            if (self.tupleElemsOf(v)) |elems| {
+                try value_struct.emitTupleIntoSret(self, v, elems, self.sret_param_ofs);
+                try isa.movRegToReg(self, Reg.fp, Reg.acu);
+                if (self.sret_param_ofs > 0) try isa.addImmToReg(self, @intCast(self.sret_param_ofs), Reg.acu);
+                try isa.movRegOffsetToReg(self, Reg.acu, 0, Reg.acu);
+            } else try self.unsupported(r.span, "tuple return from a non-tuple value");
         } else {
             try self.emitExpr(v);
         }
@@ -290,6 +321,12 @@ fn emitPrintArg(self: *Emitter, arg: *const ast.Expr) !void {
         }
         try self.emitExpr(arg);
         try emitPrintEnum(self, ed);
+        return;
+    }
+    // A whole-tuple default rendering isn't lowered yet (deferred from
+    // #305) — reject rather than print the base address as an int.
+    if (self.tupleElemsOf(arg) != null) {
+        try self.unsupported(arg.span(), "printing a whole tuple — print its elements (`t.0`, `t.1`, …)");
         return;
     }
     try self.emitExpr(arg);

--- a/src/lang/codegen/value_struct.zig
+++ b/src/lang/codegen/value_struct.zig
@@ -1,14 +1,16 @@
-// Codegen for inline value structs (§3.4). A struct value lives in
-// its owner's frame as contiguous bytes; a struct-typed expression
-// evaluates to that base address. Construction writes each field at
-// its offset (recursing into nested struct fields); assignment copies
-// the bytes (value semantics). Nested structs work because they sit
-// inline at a fixed frame offset within the parent. A struct argument
-// is passed by value: the caller reserves its width on the stack and
-// materializes a copy there (`pushArg`).
+// Codegen for inline value aggregates (§3.4) — structs and tuples. An
+// aggregate value lives in its owner's frame as contiguous bytes; an
+// aggregate-typed expression evaluates to that base address.
+// Construction writes each field/element at its offset (recursing into
+// nested struct fields); assignment copies the bytes (value semantics).
+// An aggregate argument is passed by value: the caller reserves its
+// width on the stack and materializes a copy there (`pushArg` /
+// `pushTupleArg`). Tuples reuse the same `Dest` / `copyBytes` plumbing
+// but key on the element type list rather than a struct name.
 
 const std = @import("std");
 const ast = @import("../ast.zig");
+const types = @import("../types.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
@@ -95,6 +97,66 @@ fn emitIntoDest(self: *Emitter, src: *const ast.Expr, sname: []const u8, dest: D
     try isa.movRegToReg(self, Reg.acu, Reg.r1);
     try destAddrToReg(self, dest, Reg.r2);
     try copyBytes(self, Reg.r1, Reg.r2, self.structWidth(sname));
+}
+
+// ---- tuple values (§3.4) ----
+// A tuple is an anonymous positional aggregate stored inline like a
+// struct (contiguous, byte-packed slots). #305 lowers register-width
+// elements (scalar / `str` / enum / class / reference); nested inline
+// aggregates are rejected at the dispatch sites (deferred).
+
+/// Materialize a tuple value into the frame slot based at `dest_ofs`
+/// (fp-relative).
+pub fn emitTupleInto(self: *Emitter, src: *const ast.Expr, elems: []const *const types.Type, dest_ofs: i16) error{OutOfMemory}!void {
+    try emitTupleIntoDest(self, src, elems, .{ .frame = dest_ofs });
+}
+
+/// Pass a tuple argument by value: reserve its (2-aligned) width on the
+/// stack and materialize a copy there.
+pub fn pushTupleArg(self: *Emitter, arg: *const ast.Expr, elems: []const *const types.Type) error{OutOfMemory}!void {
+    try isa.subImmFromReg(self, self.tupleSlotWidth(elems), Reg.sp);
+    try emitTupleIntoDest(self, arg, elems, .{ .sp = 0 });
+}
+
+/// Materialize a returned tuple into the caller's sret buffer.
+pub fn emitTupleIntoSret(self: *Emitter, src: *const ast.Expr, elems: []const *const types.Type, ptr_ofs: i16) error{OutOfMemory}!void {
+    try emitTupleIntoDest(self, src, elems, .{ .indirect = .{ .ptr_ofs = ptr_ofs, .delta = 0 } });
+}
+
+fn emitTupleIntoDest(self: *Emitter, src: *const ast.Expr, elems: []const *const types.Type, dest: Dest) error{OutOfMemory}!void {
+    if (self.tupleHasAggregateElem(elems)) {
+        try self.unsupported(src.span(), "a tuple with a nested struct/tuple element");
+        return;
+    }
+    if (src.* == .tuple_lit) {
+        for (src.tuple_lit.elems, 0..) |elem, i| {
+            // safety: tuple arity ≤ 4 (§3.4) fits u8.
+            const info = self.tupleElemInfo(elems, @intCast(i));
+            try self.emitExpr(elem);
+            try isa.movRegToReg(self, Reg.acu, Reg.r2);
+            try destAddrToReg(self, dest.at(@intCast(info.offset)), Reg.r1);
+            try storeWidth(self, Reg.r1, info.width, Reg.r2);
+        }
+        return;
+    }
+    // A tuple value — byte-copy its contiguous slots into the dest.
+    try self.emitExpr(src); // acu = source base address
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try destAddrToReg(self, dest, Reg.r2);
+    try copyBytes(self, Reg.r1, Reg.r2, self.tupleWidth(elems));
+}
+
+/// Load element `index` of the tuple whose base address is in `acu`,
+/// leaving the element value in `acu` (`i8` sign-extends).
+pub fn emitTupleElemLoad(self: *Emitter, elems: []const *const types.Type, index: u8) error{OutOfMemory}!void {
+    const info = self.tupleElemInfo(elems, index);
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    if (info.width == 1) {
+        try class.emitByteLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+        if (info.signed_byte) try isa.signExtendByte(self, Reg.acu);
+    } else {
+        try class.emitWordLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+    }
 }
 
 fn emitLitInto(self: *Emitter, sl: ast.StructLit, sname: []const u8, dest: Dest) error{OutOfMemory}!void {

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -286,6 +286,27 @@ fn parseIndexAccess(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
 
 fn parseFieldOrMethod(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
     p.pos += 1;
+    // `tuple.N` — a positional element access. The selector is an int
+    // literal (`t.0`); a char literal (`t.'a'`) also lexes as `int_lit`,
+    // so exclude it. The index's range vs the tuple's arity is checked
+    // in typecheck.
+    if (p.check(.int_lit)) {
+        const idx_tok = p.peek();
+        const is_char = idx_tok.start < p.source.len and p.source[idx_tok.start] == '\'';
+        if (is_char or idx_tok.value < 0 or idx_tok.value > 255) {
+            try p.recordError("expected a tuple element index (`.0`, `.1`, …)", "E_SYNTAX_MISSING_TOKEN");
+            return error.ParseFailed;
+        }
+        p.pos += 1;
+        return try p.allocExpr(.{
+            .tuple_index = .{
+                .receiver = receiver,
+                // safety: bounded to 0..255 just above.
+                .index = @intCast(idx_tok.value),
+                .span = .{ .start = receiver.span().start, .end = idx_tok.end },
+            },
+        });
+    }
     const name_tok = try p.expect(.ident, "field or method name");
     if (p.check(.lparen)) {
         p.pos += 1;

--- a/src/lang/print.zig
+++ b/src/lang/print.zig
@@ -832,6 +832,10 @@ const Printer = struct {
                 try self.writer.writeByte('.');
                 try self.writer.writeAll(self.lexeme(f.field));
             },
+            .tuple_index => |ti| {
+                try self.writeExpr(ti.receiver, .call);
+                try self.writer.print(".{d}", .{ti.index});
+            },
             .index => |ix| {
                 try self.writeExpr(ix.receiver, .call);
                 try self.writer.writeByte('[');

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -978,6 +978,7 @@ pub const Checker = struct {
             .call => |c| self.exprMentions(c.callee, name) or anyExprMentions(self, c.args, name),
             .method_call => |m| self.exprMentions(m.receiver, name) or anyExprMentions(self, m.args, name),
             .field => |f| self.exprMentions(f.receiver, name),
+            .tuple_index => |ti| self.exprMentions(ti.receiver, name),
             .index => |ix| self.exprMentions(ix.receiver, name) or self.exprMentions(ix.index, name),
             .do_expr => |d| self.bodyMentions(d.body, name),
             .if_expr => |ie| ifChainMentions(self, ie.arms, ie.else_body, name),
@@ -1118,6 +1119,25 @@ pub const Checker = struct {
                 try self.checkNotNullableDeref(f.receiver, recv_ty, f.span);
                 return try fields.resolveFieldAccess(self, f, peelReference(recv_ty));
             },
+            .tuple_index => |ti| {
+                const recv_ty = try self.inferExpr(ti.receiver, null);
+                try self.checkNotNullableDeref(ti.receiver, recv_ty, ti.span);
+                const peeled = peelReference(recv_ty) orelse return null;
+                if (peeled.* != .tuple) {
+                    const ty_s = try types.render(self.arena, peeled.*);
+                    const msg = try std.fmt.allocPrint(self.arena, "`.{d}` element access requires a tuple, found `{s}`", .{ ti.index, ty_s });
+                    try self.emitSpan("E_TYPE_NOT_A_TUPLE", ti.span, msg);
+                    return null;
+                }
+                const elems = peeled.tuple;
+                if (ti.index >= elems.len) {
+                    const suffix: []const u8 = if (elems.len == 1) "" else "s";
+                    const msg = try std.fmt.allocPrint(self.arena, "tuple index {d} out of range — tuple has {d} element{s}", .{ ti.index, elems.len, suffix });
+                    try self.emitSpan("E_TYPE_TUPLE_INDEX_OOR", ti.span, msg);
+                    return null;
+                }
+                return elems[ti.index];
+            },
             .index => |ix| {
                 _ = try self.inferExpr(ix.receiver, null);
                 _ = try self.inferExpr(ix.index, null);
@@ -1195,6 +1215,10 @@ pub const Checker = struct {
             .list_repeat => |lr| return try self.inferListRepeat(lr, hint),
             .struct_lit => |sl| return try fields.checkStructLit(self, sl),
             .tuple_lit => |tl| {
+                if (tl.elems.len > 4) {
+                    const msg = try std.fmt.allocPrint(self.arena, "a tuple has at most 4 elements (§3.4) — found {d}; use a struct for more", .{tl.elems.len});
+                    try self.emitSpan("E_TYPE_TUPLE_TOO_MANY", tl.span, msg);
+                }
                 // Bidirectional: when the hint is a same-arity
                 // tuple, each element pins to its slot's expected
                 // type so `(0, nil)` against `(i16, str?)` works.

--- a/src/lang/typecheck/type_resolve.zig
+++ b/src/lang/typecheck/type_resolve.zig
@@ -56,6 +56,10 @@ pub fn resolveType(self: *Checker, t: *const ast.TypeAnn) WalkError!*const types
             return try types.mkVec(self.arena, elem);
         },
         .tuple => |tu| {
+            if (tu.elems.len > 4) {
+                const msg = try std.fmt.allocPrint(self.arena, "a tuple has at most 4 elements (§3.4) — found {d}; use a struct for more", .{tu.elems.len});
+                try self.emitSpan("E_TYPE_TUPLE_TOO_MANY", tu.span, msg);
+            }
             var elems: std.ArrayList(*const types.Type) = .empty;
             errdefer elems.deinit(self.arena);
             for (tu.elems) |e| try elems.append(self.arena, try resolveType(self, e));

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3943,6 +3943,144 @@ test "codegen: `is` tag test on a payload enum" {
     , "1\n3\n");
 }
 
+// ---------- value tuples (§3.4) ----------
+
+test "codegen/tuple: literal construction + `.N` element read" {
+    try runAndExpect(
+        \\def main()
+        \\  let t = (3, 4)
+        \\  print t.0
+        \\  print t.1
+        \\  print t.0 + t.1
+        \\end
+    , "3\n4\n7\n");
+}
+
+test "codegen/tuple: mixed-width elements pack contiguously" {
+    try runAndExpect(
+        \\def main()
+        \\  let t = (1 as u8, 300, 2 as u8)
+        \\  print t.0
+        \\  print t.1
+        \\  print t.2
+        \\end
+    , "1\n300\n2\n");
+}
+
+test "codegen/tuple: a `str` element reads back by pointer" {
+    try runAndExpect(
+        \\def main()
+        \\  let t = (5, "hi")
+        \\  print t.0
+        \\  print t.1
+        \\end
+    , "5\nhi\n");
+}
+
+test "codegen/tuple: a signed `i8` element sign-extends on read" {
+    try runAndExpect(
+        \\def main()
+        \\  let t = (-5 as i8, 1)
+        \\  print t.0
+        \\end
+    , "-5\n");
+}
+
+test "codegen/tuple: value copy on `let` + reassignment leaves the source intact" {
+    try runAndExpect(
+        \\def main()
+        \\  let a = (1, 2)
+        \\  let b = a
+        \\  let c = (0, 0)
+        \\  c = a
+        \\  print b.0
+        \\  print c.1
+        \\  print a.0
+        \\  print a.1
+        \\end
+    , "1\n2\n1\n2\n");
+}
+
+test "codegen/tuple: return-by-value (multi-return) + element read" {
+    try runAndExpect(
+        \\def pair() -> (i16, i16)
+        \\  return (1, 2)
+        \\end
+        \\def main()
+        \\  let t = pair()
+        \\  print t.0
+        \\  print t.1
+        \\end
+    , "1\n2\n");
+}
+
+test "codegen/tuple: pass-by-value param (mutation-isolated) after a scalar arg" {
+    try runAndExpect(
+        \\def snd(n: i16, t: (i16, i16)) -> i16
+        \\  return n + t.1
+        \\end
+        \\def main()
+        \\  let a = (5, 6)
+        \\  print snd(100, a)
+        \\  print a.0
+        \\end
+    , "106\n5\n");
+}
+
+test "codegen/tuple: a returned tuple feeds straight into a by-value param" {
+    try runAndExpect(
+        \\def mk() -> (i16, i16)
+        \\  return (10, 20)
+        \\end
+        \\def snd(t: (i16, i16)) -> i16
+        \\  return t.1
+        \\end
+        \\def main()
+        \\  print snd(mk())
+        \\end
+    , "20\n");
+}
+
+test "codegen/tuple: passed by value through an `@inline` fn" {
+    try runAndExpect(
+        \\@inline
+        \\def fst(t: (i16, i16)) -> i16
+        \\  return t.0
+        \\end
+        \\def main()
+        \\  print fst((7, 8))
+        \\end
+    , "7\n");
+}
+
+test "codegen/tuple: `==` is not lowered yet (clean error, not address compare)" {
+    try expectCodegenError(
+        \\def main()
+        \\  let a = (1, 2)
+        \\  let b = (1, 2)
+        \\  print a == b
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
+}
+
+test "codegen/tuple: whole-tuple `print` is a clean error" {
+    try expectCodegenError(
+        \\def main()
+        \\  let t = (1, 2)
+        \\  print t
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
+}
+
+test "codegen/tuple: a nested-aggregate element is a clean error" {
+    try expectCodegenError(
+        \\def main()
+        \\  let t = ((1, 2), 3)
+        \\  print t.1
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
+}
+
 // ---------- value structs (§3.4) ----------
 
 test "codegen/struct: literal construction + field read" {

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -248,6 +248,28 @@ test "parse: field access" {
     try std.testing.expect(init.* == .field);
 }
 
+test "parse: tuple index access `t.0`" {
+    var tree = try parseClean("let r = t.0");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .tuple_index);
+    try std.testing.expectEqual(@as(u8, 0), init.tuple_index.index);
+}
+
+test "parse: `2.0` still lexes as a fixed literal, not a tuple index" {
+    var tree = try parseClean("let r = 2.0");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .fixed_lit);
+}
+
+test "parse: `n.foo()` is a method call, not a tuple index" {
+    var tree = try parseClean("let r = n.foo()");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .method_call);
+}
+
 test "parse: index access" {
     var tree = try parseClean("let r = arr[i]");
     defer tree.deinit();

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -1485,6 +1485,64 @@ test "typecheck: class with extends — inherited field resolves" {
     );
 }
 
+// ---------- tuple `.N` element access (§3.4) ----------
+
+test "typecheck: `.N` element access infers the element type" {
+    try expectClean(
+        \\def main()
+        \\  let t = (1, "x")
+        \\  let a: i16 = t.0
+        \\  let b: str = t.1
+        \\  print a, b
+        \\end
+    );
+}
+
+test "typecheck: `.N` element-type mismatch is caught" {
+    try expectCode(
+        \\def main()
+        \\  let t = (1, "x")
+        \\  let bad: str = t.0
+        \\  print bad
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: a tuple index past the arity errors" {
+    try expectCode(
+        \\def main()
+        \\  let t = (1, 2)
+        \\  print t.5
+        \\end
+    , "E_TYPE_TUPLE_INDEX_OOR");
+}
+
+test "typecheck: `.N` on a non-tuple errors" {
+    try expectCode(
+        \\def main()
+        \\  let x = 5
+        \\  print x.0
+        \\end
+    , "E_TYPE_NOT_A_TUPLE");
+}
+
+test "typecheck: a tuple literal with more than 4 elements is rejected (§3.4)" {
+    try expectCode(
+        \\def main()
+        \\  let t = (1, 2, 3, 4, 5)
+        \\  print t.0
+        \\end
+    , "E_TYPE_TUPLE_TOO_MANY");
+}
+
+test "typecheck: an oversize tuple type annotation is rejected" {
+    try expectCode(
+        \\def five() -> (i16, i16, i16, i16, i16)
+        \\  return (1, 2, 3, 4, 5)
+        \\end
+    , "E_TYPE_TUPLE_TOO_MANY");
+}
+
 // ---------- slice 6: multi-return tuple destructuring + flow ----------
 
 test "typecheck: tuple destructure types each binding from init slots" {


### PR DESCRIPTION
Tuples (§3.4) now construct, lower, and support positional `.N` element access. A tuple is an anonymous aggregate stored inline as contiguous, byte-packed slots — the same value model as a struct (#307).

## Scope (#305)
- **Parser** — `t.0` / `t.1` element access (new `tuple_index` AST node; the selector is an int token after `.`, distinct from a field ident).
- **Typecheck** — `.N` infers the element's type; bounds-checked (`E_TYPE_TUPLE_INDEX_OOR`), non-tuple receivers rejected (`E_TYPE_NOT_A_TUPLE`), and the §3.4 **max-4-elements** limit enforced on literals + annotations (`E_TYPE_TUPLE_TOO_MANY` — previously oversize tuples were silently accepted).
- **Codegen** — literal construction, `.N` load (`i8` sign-extends), and full value semantics: let-copy, reassignment, pass-by-value, and **return-by-value** (the `def f() -> (i16, i16)` multi-return shape, via the struct sret convention), including through an `@inline` parameter. Tuple-aware helpers reuse the struct value plumbing keyed on the element type list (no synthesized struct decls — the source-span design rules that out).

## Deferred (clean `E_CODEGEN_UNSUPPORTED`, never a wrong value/crash)
Mirroring how #307 deferred struct `==`/`print` to #322/#323:
- tuple `==` / `!=` (element-wise) — parallels #322
- whole-tuple `print` (`(v0, v1, …)`) — parallels #323
- a nested struct/tuple element (`((1,2),3)`, `(P{…},5)`) — also blocks chained `t.0.1` (the `0.1` lexes as a fixed literal)
- tuple element store `t.0 = x`
- a tuple return from an `@inline` function

These want follow-up issues (happy to file on your nod).

## Verification
- `zig build ci` green (all release modes + cross-targets + examples).
- Tests across parser / typecheck / codegen, incl. mixed-width packing, `i8` sign, value-copy isolation, multi-return, `@inline` param, and the deferral rejections.
- Adversarial review pass; its one confirmed finding (oversize tuples silently accepted) is fixed in this PR. Spec: lang-diagnostics.md updated with the three new `E_TYPE_TUPLE_*` codes; gero-lang.md §3.4 already documents `.N`.

Closes #305.