### PR TITLE
feat(lang/codegen): complete tuple support — ==, print, nested, store, @inline return

### DIFF
--- a/.changeset/lang-codegen-tuple-deferrals.md
+++ b/.changeset/lang-codegen-tuple-deferrals.md
@@ -1,0 +1,51 @@
+---
+bump: minor
+---
+
+Tuple support is now complete (§3.4) — the five combinations deferred
+from the initial tuple PR are lowered.
+
+- **Structural `==` / `!=`** — element-wise, mirroring struct equality:
+  an all-scalar tuple byte-compares; a `str` element compares by content
+  (§3.2.1); a nested struct / tuple / payload-enum element recurses.
+  Ordering operators stay rejected.
+- **Whole-tuple `print`** — renders `(v0, v1, …)`, each element by its
+  type (recursing into nested structs / tuples / enums). A struct with a
+  tuple field renders it inline too.
+- **Nested aggregate elements** — a tuple element may itself be a struct
+  (`(P, i16)`) or a tuple (`((1, 2), 3)`), and a struct may have a tuple
+  field (`S { p: (i16, str) }`); they lay out inline and `.N` / `.field`
+  access addresses them. Chained `t.0.1` now parses (the parser splits
+  the `0.1` the lexer folds into a fixed literal).
+- **Element store** — `t.N = x` (and `t.N += …` / `t.N++`) assigns into
+  a tuple element; `.N` is a place expression. Storing into an aggregate
+  element is a clean `E_CODEGEN_UNSUPPORTED`.
+- **Return from `@inline`** — a tuple-returning `@inline` function
+  materializes its result into the caller frame, like the struct path.
+
+Folded in while completing the above:
+
+- **`@inline` expansion frames are caller-prologue-backed** — every
+  inline call-site's args, return slot, and body inner locals are now
+  reserved up front by the caller's prologue (`countFrameBytes` walks the
+  inline call graph) instead of self-backing with `sub sp` at expansion
+  time. Inline slots therefore sit above the entry `sp`, where pushed
+  operands never reach, so a mid-expression inline call no longer aliases
+  live stack. Fixes a family of silent miscompiles: `sq(3) + sq(4)` (two
+  inline calls in one expression), `mk(a, b).x` where the body has inner
+  `let`s feeding a returned aggregate, and `==` / `!=` on `@inline`-returned
+  structs / tuples — all of which previously read clobbered bytes.
+- **Interpolated strings allocate per evaluation** (§3.2.2) — a fresh
+  heap buffer each time, so two evaluations of the same `"…$(x)…"` (e.g.
+  a value returned from a function called twice) no longer alias; the
+  earlier binding kept its own bytes. Replaces the static per-site buffer.
+- **`E_CODEGEN_DATA_OVERFLOW`** now guards the data-global region itself
+  (a global past the region ceiling is flagged), matching its documented
+  scope instead of riding on the removed interpolation buffer.
+- **Interpolating a non-scalar value renders it** — `"$(s)"` where `s` is
+  a struct / tuple / enum now formats the value's default rendering
+  (§4.9) into the string, instead of formatting its address as an
+  integer. The same renderer drives `print` and `$(…)`.
+- **`$$` collapses to a literal `$`** (§3.2.2) — the escape was passing
+  through verbatim; the string decoder now folds it (a lone `$`, e.g.
+  `$5`, is untouched).

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -243,8 +243,10 @@ let p = "$(percent:>3d)% complete"        -- right-aligned in 3 chars
 ```
 
 **Substitution syntax:**
-- `$(expr)` — embed `expr`'s value, formatted with the type's default
-- `$(expr:fmt)` — embed with explicit format spec
+- `$(expr)` — embed `expr`'s value, formatted with the type's default. A
+  scalar uses its formatter; a struct / tuple / enum embeds its §4.9
+  default rendering (the same one `print` produces).
+- `$(expr:fmt)` — embed with explicit format spec (scalar types only)
 - `$$` — literal `$` (escape)
 
 **Format spec grammar** (subset of Python's spec):
@@ -274,8 +276,11 @@ Common idioms for old-school output:
 **Compilation:**
 - The compiler parses interpolation strings at compile time.
 - Static parts compile to literal byte runs.
-- `$(expr)` calls a stdlib formatter for the type, writing into an
-  output buffer.
+- `$(expr)` formats into an output buffer: a scalar via its
+  `format_*_to_buf` syscall, an aggregate by rendering its §4.9 default
+  form into the buffer (the same renderer `print` uses). A value whose
+  type has no rendering (array / `Vec` / class / reference) is a compile
+  error.
 - The whole interpolated string allocates **once** in
   `state.allocator` (vs the chain of allocs `+` would produce).
 - For `print "$(x) is $(y)"` — no string allocation; the runtime
@@ -321,7 +326,7 @@ PICO-8, Sonic, early Doom used.
 |------|---------|-------|
 | Array (fixed-size) | `[u8; 64]` | N is comptime. Stack-allocated if local. Literals: `[a, b, c]` for explicit elements or `[value; count]` to repeat a single value. |
 | Dynamic array | `Vec(i16)` | Growable buffer with `push` / `pop` / `len` / `at`. See §3.4.3. |
-| Tuple | `(i16, str)` | Anonymous heterogeneous pair / triple / etc. Max 4 elements (5+ → use a struct). Destructurable in `let` and `match`. Field access via `.0`, `.1`, …. |
+| Tuple | `(i16, str)` | Anonymous heterogeneous pair / triple / etc. Max 4 elements (5+ → use a struct). Destructurable in `let` and `match`. Element access `.0` / `.1` / …, element store `t.N = x`, value-copy + pass / return by value, structural `==` / `!=`, and `(v0, v1, …)` print. |
 | Optional | `T?` | Nullable pointer type — see §3.4.1. |
 | Reference | `&T` | Borrowed reference, no arithmetic. See §3.4.4. |
 | Function | `fn(i16, i16) -> i16` | First-class — assignable, passable. |
@@ -2086,16 +2091,18 @@ console; CLI tools print to stdout).
 | `str` | the bytes | `"hi"` → `hi` |
 | `struct` | `Name { field: value, … }` (each field by its type, recursively) | `P { x: 1, y: 2 }` |
 | `enum` | `Enum.Variant`, or `Enum.Variant(a, b)` with a payload (each payload field by its type, recursively) | `Item.Potion(5)`, `Dir.N` |
+| `tuple` | `(v0, v1, …)` (each element by its type, recursively) | `(1, hi, -3)` |
 
-Struct fields and enum payloads render recursively, so a struct that
-holds an enum prints the variant in place (`Slot { qty: 2, it:
-Item.Potion(5) }`). Enum payload fields are stored as single
+Struct fields, enum payloads, and tuple elements render recursively, so
+a struct that holds an enum prints the variant in place (`Slot { qty: 2,
+it: Item.Potion(5) }`) and a tuple of a struct prints it nested
+(`(P { x: 1 }, 5)`). Enum payload fields are stored as single
 register-width slot values, so a payload may be a scalar / `char` /
 `fixed` / `str` / enum — **not** a struct.
 
-Types with no default rendering — array, tuple, `Vec`, `class`,
-reference, function pointer, nullable, and (as an enum payload) struct
-— are a compile error (`E_CODEGEN_UNSUPPORTED`) rather than a
+Types with no default rendering — array, `Vec`, `class`, reference,
+function pointer, nullable, and (as an enum payload) struct — are a
+compile error (`E_CODEGEN_UNSUPPORTED`) rather than a
 silently-meaningless address.
 
 ### 4.10 Defer

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -724,7 +724,7 @@ should have already enforced.
 
 | Code | Meaning |
 |------|---------|
-| `E_CODEGEN_UNSUPPORTED` | A syntactically + type-valid construct the codegen doesn't lower yet (the catch-all — e.g. an ordering comparison on structs, a `==` over an array / tuple / `Vec` / nullable field or a recursive enum, printing a value with no default rendering (array / tuple / `Vec` / class / reference) or a recursive type). |
+| `E_CODEGEN_UNSUPPORTED` | A syntactically + type-valid construct the codegen doesn't lower yet (the catch-all — e.g. an ordering comparison on a struct or tuple, a `==` over an array / `Vec` / nullable field or a recursive enum, printing a value with no default rendering (array / `Vec` / class / reference) or a recursive type, storing into a tuple's aggregate element). |
 | `E_CODEGEN_FRAME_TOO_LARGE` | A function's locals or parameters exceed the 127-byte limit on `[fp + imm8]` fp-relative addressing (the ISA's only frame-offset mode). Reduce locals/params. |
 | `E_CODEGEN_UNDEFINED_FN` | A call's target isn't a known top-level `def` (an unresolved forward reference at patch time). |
 | `E_CODEGEN_UNKNOWN_CLASS` | A constructor / field / method targets a class with no computed layout. |
@@ -735,7 +735,7 @@ should have already enforced.
 | `E_CODEGEN_NO_PARENT` | `super` used in a class with no `extends` parent. |
 | `E_CODEGEN_NO_SELF` | `super.method` / `self` used outside a method body. |
 | `E_CODEGEN_ZP_OVERFLOW` | The zero-page region is exhausted — too many `@zero_page` globals. |
-| `E_CODEGEN_DATA_OVERFLOW` | The static data region is exhausted (globals + string pool + vtables). |
+| `E_CODEGEN_DATA_OVERFLOW` | The static data region is exhausted — too many data globals. |
 | `E_CODEGEN_DEFER_NO_BLOCK` | A `defer` was emitted with no enclosing block frame (internal invariant). |
 | `E_CODEGEN_LOOP_JUMP_NO_LOOP` | `break` / `continue` reached codegen outside any loop (internal — the typechecker normally catches this). |
 | `E_CODEGEN_LAMBDA_NOT_ANALYZED` | Internal: a lambda body was missing from the closure-analysis pass. |

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -38,6 +38,11 @@ pub const ivt_base: u16 = 0x1000;
 pub const code_base: u16 = 0x1100;
 /// First byte of static-data emission.
 pub const data_base: u16 = 0x2000;
+/// Upper bound (exclusive) of the static-data region. Data globals grow
+/// up from `data_base` and must stay below the host IO / command surface
+/// just above (gtx-16 maps its command surface at `0xFE50`); past this a
+/// global can't be addressed safely.
+pub const data_region_end: u16 = 0xFE40;
 
 // ---------- .gx file constants (re-exported from archive) ----------
 
@@ -142,6 +147,8 @@ pub fn compile(
         .sret_scratch_ofs = null,
         .inline_ret_struct = null,
         .inline_ret_slot = 0,
+        .inline_ret_is_tuple = false,
+        .inline_ret_tuple_slot = 0,
         .fn_addresses = .{},
         .fn_banks = .{},
         .noreturn_defs = .{},
@@ -480,6 +487,12 @@ pub const Emitter = struct {
     /// has no callee frame, so its result lives in a caller local.
     inline_ret_struct: ?[]const u8,
     inline_ret_slot: i8,
+    /// While splicing a tuple-returning `@inline` body: `true` + the
+    /// caller-frame result slot its `return` materializes into (element
+    /// layout comes from the return expression's type). Mirrors
+    /// `inline_ret_struct`.
+    inline_ret_is_tuple: bool,
+    inline_ret_tuple_slot: i8,
     /// `def` name → absolute address. Banked defs live in the
     /// bank window; un-banked defs live in the base image.
     fn_addresses: std.StringHashMapUnmanaged(u16),
@@ -714,16 +727,28 @@ pub const Emitter = struct {
     /// local takes its full (2-aligned) width. Reserves space for
     /// every arm of control-flow forms.
     pub fn countFrameBytes(self: *const Emitter, body: []const ast.Statement) usize {
+        return self.countFrameBytesDepth(body, 0);
+    }
+
+    /// Frame bytes the prologue must reserve for `body`: the def's own
+    /// locals plus the frame every `@inline` call-site splices in. Inline
+    /// expansions reserve fp-relative slots but emit no `sub sp` of their
+    /// own — the prologue backs them here, so a slot always sits above the
+    /// entry `sp` and a mid-expression inline call can't alias a value the
+    /// surrounding expression already pushed. `depth` bounds the recursion
+    /// at the same cap the expander uses for recursive inlines.
+    fn countFrameBytesDepth(self: *const Emitter, body: []const ast.Statement, depth: u8) usize {
         var n: usize = 0;
-        for (body) |s| n += self.countStmtFrameBytes(s);
+        for (body) |s| n += self.countStmtFrameBytes(s, depth);
         return n;
     }
 
-    fn countStmtFrameBytes(self: *const Emitter, stmt: ast.Statement) usize {
-        return switch (stmt) {
+    fn countStmtFrameBytes(self: *const Emitter, stmt: ast.Statement, depth: u8) usize {
+        // Locals + nested-body bytes the statement reserves directly...
+        const own: usize = switch (stmt) {
             .let_decl => |d| self.letFrameBytes(d),
             .const_decl => 2,
-            .block => |b| self.countFrameBytes(b.body),
+            .block => |b| self.countFrameBytesDepth(b.body, depth),
             .if_stmt => |is_| blk: {
                 var n: usize = 0;
                 for (is_.arms) |a| {
@@ -733,34 +758,180 @@ pub const Emitter = struct {
                     if (a.cond) |c| if (c.* == .is_test and c.is_test.classBinding() != null) {
                         n += 2;
                     };
-                    n += self.countFrameBytes(a.body);
+                    n += self.countFrameBytesDepth(a.body, depth);
                 }
-                if (is_.else_body) |eb| n += self.countFrameBytes(eb);
+                if (is_.else_body) |eb| n += self.countFrameBytesDepth(eb, depth);
                 break :blk n;
             },
             .while_stmt => |ws| blk: {
                 var n: usize = 0;
                 if (ws.let_pattern) |p| n += countBindingBytes(p.*);
-                n += self.countFrameBytes(ws.body);
+                n += self.countFrameBytesDepth(ws.body, depth);
                 break :blk n;
             },
             // Range-based `for` reserves 1 hidden slot for the `end`
             // bound (the iteration variable uses its own slot).
-            .for_stmt => |fs| 2 + 2 + self.countFrameBytes(fs.body),
-            .repeat_stmt => |rs| self.countFrameBytes(rs.body),
+            .for_stmt => |fs| 2 + 2 + self.countFrameBytesDepth(fs.body, depth),
+            .repeat_stmt => |rs| self.countFrameBytesDepth(rs.body, depth),
             .match_stmt => |ms| blk: {
                 // 1 scratch slot to bind the scrutinee when it isn't
                 // already an ident (so subsequent cmps don't re-eval).
                 var n: usize = if (ms.scrutinee.* == .ident) 0 else 2;
                 for (ms.arms) |a| {
                     n += countBindingBytes(a.pattern.*);
-                    n += self.countFrameBytes(a.body);
+                    n += self.countFrameBytesDepth(a.body, depth);
                 }
                 break :blk n;
             },
-            .defer_stmt => |ds| self.countStmtFrameBytes(ds.body.*),
+            .defer_stmt => |ds| self.countStmtFrameBytes(ds.body.*, depth),
             else => 0,
         };
+        // ...plus the inline frames in the statement's own expressions
+        // (sub-bodies are covered by the recursion above).
+        return own + self.stmtInlineFrameBytes(stmt, depth);
+    }
+
+    /// Inline-expansion bytes reachable from a statement's own
+    /// expressions (conditions / initializers / arguments / values),
+    /// mirroring `freeStatement`'s expression walk. Sub-statement bodies
+    /// are not visited here — `countStmtFrameBytes` recurses into those.
+    fn stmtInlineFrameBytes(self: *const Emitter, stmt: ast.Statement, depth: u8) usize {
+        return switch (stmt) {
+            .let_decl => |d| if (d.init) |e| self.countExprInlineBytes(e, depth) else 0,
+            .const_decl => |d| self.countExprInlineBytes(d.init, depth),
+            .assign => |a| self.countExprInlineBytes(a.target, depth) + self.countExprInlineBytes(a.value, depth),
+            .inc_dec => |id| self.countExprInlineBytes(id.target, depth),
+            .discard => |d| self.countExprInlineBytes(d.expr, depth),
+            .expr_stmt => |es| self.countExprInlineBytes(es.expr, depth),
+            .if_stmt => |is_| blk: {
+                var n: usize = 0;
+                for (is_.arms) |a| {
+                    if (a.cond) |c| n += self.countExprInlineBytes(c, depth);
+                    if (a.let_expr) |e| n += self.countExprInlineBytes(e, depth);
+                    if (a.let_guard) |g| n += self.countExprInlineBytes(g, depth);
+                }
+                break :blk n;
+            },
+            .while_stmt => |ws| blk: {
+                var n: usize = 0;
+                if (ws.cond) |c| n += self.countExprInlineBytes(c, depth);
+                if (ws.let_expr) |e| n += self.countExprInlineBytes(e, depth);
+                if (ws.let_guard) |g| n += self.countExprInlineBytes(g, depth);
+                break :blk n;
+            },
+            .for_stmt => |fs| blk: {
+                var n: usize = self.countExprInlineBytes(fs.iter, depth);
+                if (fs.step) |s| n += self.countExprInlineBytes(s, depth);
+                break :blk n;
+            },
+            .repeat_stmt => |rs| self.countExprInlineBytes(rs.cond, depth),
+            .match_stmt => |ms| blk: {
+                var n: usize = self.countExprInlineBytes(ms.scrutinee, depth);
+                for (ms.arms) |a| if (a.guard) |g| {
+                    n += self.countExprInlineBytes(g, depth);
+                };
+                break :blk n;
+            },
+            .return_stmt => |rs| if (rs.value) |v| self.countExprInlineBytes(v, depth) else 0,
+            .print_stmt => |ps| blk: {
+                var n: usize = 0;
+                for (ps.args) |a| n += self.countExprInlineBytes(a, depth);
+                break :blk n;
+            },
+            else => 0,
+        };
+    }
+
+    /// Sum of every `@inline` expansion frame reachable from `e`,
+    /// recursing into sub-expressions exactly like `freeExpr`.
+    fn countExprInlineBytes(self: *const Emitter, e: *const ast.Expr, depth: u8) usize {
+        return switch (e.*) {
+            .int_lit, .fixed_lit, .bool_lit, .nil_lit, .char_lit, .ident, .self_expr, .super_expr, .sizeof => 0,
+            // `if` / `do` expressions and lambda bodies don't splice an
+            // inline frame into THIS frame (unsupported at value position
+            // / compile-time-only / a separate def with its own prologue).
+            .if_expr, .do_expr, .lambda => 0,
+            .str_lit => |s| blk: {
+                var n: usize = 0;
+                var has_aggregate = false;
+                for (s.parts) |p| switch (p) {
+                    .lit => {},
+                    .interp => |ip| {
+                        n += self.countExprInlineBytes(ip.expr, depth);
+                        // A non-scalar interpolation buffers its render
+                        // through a cursor slot (see `emitInterpFill`).
+                        if (!self.interpFormattable(ip.expr)) has_aggregate = true;
+                    },
+                };
+                if (has_aggregate) n += 2;
+                break :blk n;
+            },
+            .paren => |p| self.countExprInlineBytes(p.inner, depth),
+            .unary => |u| self.countExprInlineBytes(u.operand, depth),
+            .binary => |b| self.countExprInlineBytes(b.lhs, depth) + self.countExprInlineBytes(b.rhs, depth),
+            .range => |r| self.countExprInlineBytes(r.start, depth) + self.countExprInlineBytes(r.end, depth),
+            .call => |c| blk: {
+                var n: usize = 0;
+                for (c.args) |a| n += self.countExprInlineBytes(a, depth);
+                if (c.callee.* == .ident) {
+                    const name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+                    if (self.inline_defs.get(name)) |callee| n += self.inlineExpansionBytes(callee, c.args, depth);
+                } else n += self.countExprInlineBytes(c.callee, depth);
+                break :blk n;
+            },
+            .method_call => |m| blk: {
+                var n: usize = self.countExprInlineBytes(m.receiver, depth);
+                for (m.args) |a| n += self.countExprInlineBytes(a, depth);
+                break :blk n;
+            },
+            .field => |f| self.countExprInlineBytes(f.receiver, depth),
+            .tuple_index => |t| self.countExprInlineBytes(t.receiver, depth),
+            .index => |i| self.countExprInlineBytes(i.receiver, depth) + self.countExprInlineBytes(i.index, depth),
+            .list_lit => |ll| blk: {
+                var n: usize = 0;
+                for (ll.elems) |x| n += self.countExprInlineBytes(x, depth);
+                break :blk n;
+            },
+            .list_repeat => |lr| self.countExprInlineBytes(lr.value, depth) + self.countExprInlineBytes(lr.count, depth),
+            .struct_lit => |sl| blk: {
+                var n: usize = 0;
+                for (sl.fields) |f| n += self.countExprInlineBytes(f.value, depth);
+                break :blk n;
+            },
+            .tuple_lit => |tl| blk: {
+                var n: usize = 0;
+                for (tl.elems) |x| n += self.countExprInlineBytes(x, depth);
+                break :blk n;
+            },
+            .is_test => |it| self.countExprInlineBytes(it.lhs, depth),
+            .cast => |c| self.countExprInlineBytes(c.inner, depth),
+            .ref_of => |r| self.countExprInlineBytes(r.inner, depth),
+        };
+    }
+
+    /// Frame an `@inline` call-site reserves when it splices: an arg slot
+    /// per argument (by the argument's shape), the return slot for an
+    /// aggregate return, and the callee body's own frame (recursively).
+    /// Mirrors the reservations `emitInlineCall` makes. Past the inline
+    /// nesting cap it returns 0 — the expander rejects that as recursive.
+    fn inlineExpansionBytes(self: *const Emitter, callee: *const ast.DefDecl, args: []const *ast.Expr, depth: u8) usize {
+        if (depth >= inline_max_depth) return 0;
+        var n: usize = 0;
+        for (args) |arg| {
+            if (self.argStructName(arg)) |sname|
+                n += self.structSlotWidth(sname)
+            else if (self.tupleElemsOf(arg)) |elems|
+                n += self.tupleSlotWidth(elems)
+            else
+                n += 2;
+        }
+        if (callee.ret_type) |rt| {
+            if (self.structNameOfTypeAnn(rt.*)) |sname|
+                n += self.structSlotWidth(sname)
+            else if (rt.* == .tuple)
+                n += alignUpU16(self.widthOfTypeAnn(rt.*), 2);
+        }
+        return n + self.countFrameBytesDepth(callee.body, depth + 1);
     }
 
     /// Frame bytes a `let` reserves: the 2-aligned width of its type
@@ -896,6 +1067,17 @@ pub const Emitter = struct {
     pub fn isPrimitiveType(self: *const Emitter, e: *const ast.Expr, p: types_mod.Primitive) bool {
         const t = self.typeOf(e) orelse return false;
         return t.* == .primitive and t.primitive == p;
+    }
+
+    /// `true` when `e` has a direct scalar `$(…)` formatter (a primitive).
+    /// A non-primitive interpolation — struct / tuple / enum — renders via
+    /// the shared `emitRenderValue` machinery into the buffer instead; this
+    /// distinguishes the fast scalar path from that aggregate path. A
+    /// missing type falls through as scalar (the dispatch then formats it
+    /// as an integer).
+    pub fn interpFormattable(self: *const Emitter, e: *const ast.Expr) bool {
+        const t = self.typeOf(e) orelse return true;
+        return t.* == .primitive;
     }
 
     /// `true` when the type annotation is the named primitive `name`
@@ -1349,7 +1531,7 @@ pub const Emitter = struct {
     /// Layout of one struct field: byte offset, byte width, and — when
     /// the field is itself a struct — that struct's name (so codegen
     /// recurses into nested aggregates rather than storing a scalar).
-    pub const FieldInfo = struct { offset: u16, width: u16, struct_name: ?[]const u8, signed_byte: bool = false };
+    pub const FieldInfo = struct { offset: u16, width: u16, struct_name: ?[]const u8, signed_byte: bool = false, is_tuple: bool = false };
 
     /// `FieldInfo` for `field_name` within `struct_name`, or `null` if
     /// unknown. Fields are laid out contiguously in declaration order
@@ -1365,6 +1547,7 @@ pub const Emitter = struct {
                     .width = w,
                     .struct_name = self.structNameOfTypeAnn(f.type_ann.*),
                     .signed_byte = self.isPrimitiveTypeAnn(f.type_ann.*, "i8"),
+                    .is_tuple = f.type_ann.* == .tuple,
                 };
             }
             ofs +%= w;
@@ -1458,15 +1641,18 @@ pub const Emitter = struct {
         };
     }
 
-    /// `true` if any element is itself an inline aggregate (a tuple or a
-    /// named struct). #305 lowers register-width elements (scalar / `str`
-    /// / enum / class / reference); nested inline aggregates are deferred.
-    pub fn tupleHasAggregateElem(self: *const Emitter, elems: []const *const Type) bool {
-        for (elems) |e| {
-            if (e.* == .tuple) return true;
-            if (e.* == .named and self.struct_decls.contains(e.named.name)) return true;
-        }
-        return false;
+    /// Classifies a tuple element as a register-width scalar, an inline
+    /// named struct, or a nested tuple — so construction / `.N` access /
+    /// `==` / `print` can recurse into aggregate elements.
+    pub const TupleElemKind = union(enum) { scalar, structure: []const u8, tuple: []const *const Type };
+
+    /// Classify tuple element `index` — a register-width scalar, an
+    /// inline named struct, or a nested tuple.
+    pub fn tupleElemAggregate(self: *const Emitter, elems: []const *const Type, index: u8) TupleElemKind {
+        const et = elems[index];
+        if (et.* == .tuple) return .{ .tuple = et.tuple };
+        if (et.* == .named and self.struct_decls.contains(et.named.name)) return .{ .structure = et.named.name };
+        return .scalar;
     }
 
     /// `target = value` (and compound / inc-dec desugarings) — see

--- a/src/lang/codegen/archive.zig
+++ b/src/lang/codegen/archive.zig
@@ -106,11 +106,11 @@ pub fn writeU16Le(dst: *[2]u8, value: u16) void {
 }
 
 /// Decode the standard backslash escapes (`\n`, `\r`, `\t`, `\\`,
-/// `\"`, `\0`) into raw bytes. The source slice is the part
-/// between the surrounding `"` delimiters with escapes still
-/// encoded; the returned slice owns its bytes (caller's
-/// allocator). Unknown escape sequences pass through as the
-/// bare character following the backslash.
+/// `\"`, `\0`) plus the interpolation escape `$$` → `$` (§3.2.2) into
+/// raw bytes. The source slice is the part between the surrounding `"`
+/// delimiters with escapes still encoded; the returned slice owns its
+/// bytes (caller's allocator). Unknown escape sequences pass through as
+/// the bare character following the backslash.
 pub fn decodeStringEscapes(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
@@ -129,6 +129,13 @@ pub fn decodeStringEscapes(allocator: std.mem.Allocator, raw: []const u8) ![]u8 
                 else => next,
             };
             try out.append(allocator, decoded);
+            i += 2;
+            continue;
+        }
+        // `$$` is the escape for a literal `$` (the lexer leaves it in the
+        // literal run; a lone `$` — e.g. `$5` — passes through unchanged).
+        if (c == '$' and i + 1 < raw.len and raw[i + 1] == '$') {
+            try out.append(allocator, '$');
             i += 2;
             continue;
         }

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -233,17 +233,13 @@ pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void
 }
 
 /// Lower a `tuple.N` element access — evaluate the receiver to its base
-/// address, then load element `N`. Tuples with a nested struct/tuple
-/// element aren't lowered yet (deferred from #305).
+/// address, then load element `N` (an aggregate element leaves its
+/// inline address in `acu`, a scalar its value).
 fn emitTupleIndexExpr(self: *Emitter, ti: ast.TupleIndexExpr) !void {
     const elems = self.tupleElemsOf(ti.receiver) orelse {
         try self.unsupported(ti.span, "tuple element access on a non-tuple value");
         return;
     };
-    if (self.tupleHasAggregateElem(elems)) {
-        try self.unsupported(ti.span, "a tuple with a nested struct/tuple element");
-        return;
-    }
     try emitExpr(self, ti.receiver); // acu = tuple base address
     try value_struct.emitTupleElemLoad(self, elems, ti.index);
 }
@@ -374,11 +370,22 @@ pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
         }
     }
 
-    // Tuple `==` / `!=` (element-wise) isn't lowered yet — reject rather
-    // than compare the operand addresses (deferred from #305).
-    if (self.tupleElemsOf(b.lhs) != null or self.tupleElemsOf(b.rhs) != null) {
-        try self.unsupported(b.span, "`==` / `!=` on tuples");
-        return;
+    // A tuple operand compares element-wise (§3.4); ordering is undefined.
+    if (self.tupleElemsOf(b.lhs) orelse self.tupleElemsOf(b.rhs)) |elems| {
+        switch (b.op) {
+            .eq, .neq => {
+                if (!value_struct.tupleEqSupported(self, elems)) {
+                    try self.unsupported(b.span, "tuple `==` with a nullable / array / `Vec` element");
+                    return;
+                }
+                try value_struct.emitTupleEquality(self, b.lhs, b.rhs, elems, b.op == .neq);
+                return;
+            },
+            else => {
+                try self.unsupported(b.span, "ordering comparison on tuples — only `==` and `!=` are defined");
+                return;
+            },
+        }
     }
 
     const fixed_op = self.isPrimitiveType(b.lhs, .fixed) and
@@ -556,10 +563,24 @@ pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
                         },
                     }
                 }
-                // Tuple comparison isn't lowered yet (deferred from #305).
-                if (self.tupleElemsOf(b.lhs) != null or self.tupleElemsOf(b.rhs) != null) {
-                    try self.unsupported(b.span, "`==` / `!=` on tuples");
-                    return;
+                // Tuple compare element-wise; the 0/1 it leaves in acu is
+                // tested against 0 so the branch consumes its flags.
+                if (self.tupleElemsOf(b.lhs) orelse self.tupleElemsOf(b.rhs)) |elems| {
+                    switch (b.op) {
+                        .eq, .neq => {
+                            if (!value_struct.tupleEqSupported(self, elems)) {
+                                try self.unsupported(b.span, "tuple `==` with a nullable / array / `Vec` element");
+                                return;
+                            }
+                            try value_struct.emitTupleEquality(self, b.lhs, b.rhs, elems, b.op == .neq);
+                            try isa.cmpRegImm(self, Reg.acu, 0);
+                            return;
+                        },
+                        else => {
+                            try self.unsupported(b.span, "ordering comparison on tuples — only `==` and `!=` are defined");
+                            return;
+                        },
+                    }
                 }
                 // Eval LHS into acu, eval RHS into r1, cmp acu, r1.
                 try emitExpr(self, b.rhs);

--- a/src/lang/codegen/globals.zig
+++ b/src/lang/codegen/globals.zig
@@ -203,6 +203,11 @@ fn placeGlobal(
         return;
     }
     if (align_n) |n| self.data_cursor = alignUpU16(self.data_cursor, n);
+    // @as: widen to u32 so a wide global (e.g. a large baked array) can't wrap the bound check itself.
+    if (@as(u32, self.data_cursor) + width > codegen.data_region_end) {
+        try self.diagFatal(decl_span, "E_CODEGEN_DATA_OVERFLOW", "static-data region exhausted — too many data globals");
+        return;
+    }
     try self.globals.put(self.arena, dup, .{ .address = self.data_cursor, .width = width, .placement = .data, .signed_byte = signed_byte });
     self.data_cursor += width;
 }

--- a/src/lang/codegen/inline_call.zig
+++ b/src/lang/codegen/inline_call.zig
@@ -34,18 +34,12 @@ pub fn emitInlineCall(self: *Emitter, callee: *const ast.DefDecl, c: ast.CallExp
         return;
     }
 
-    // A tuple-returning `@inline` body would need the inline-return
-    // buffer plumbing the struct path has; not lowered yet (deferred
-    // from #305). Reject before any frame mutation.
-    if (callee.ret_type) |rt| if (rt.* == .tuple) {
-        try self.unsupported(c.span, "a tuple return from an `@inline` function");
-        return;
-    };
-
-    // Bind args → fresh caller-frame locals. Each slot extends
-    // `frame_bytes` via its own sub-imm (the prologue's bulk reservation
-    // already ran). Args materialize in the CALLER's scope — locals
-    // still live — then bind into the fresh body scope below.
+    // Bind args → fresh caller-frame locals. The slots are fp-relative
+    // and backed up front by the caller's prologue (`countFrameBytes`
+    // counts every inline expansion), so no `sub sp` here — keeping `sp`
+    // put is what lets an inline call sit mid-expression without aliasing
+    // already-pushed operands. Args materialize in the CALLER's scope —
+    // locals still live — then bind into the fresh body scope below.
     const Binding = struct { name: []const u8, ofs: i8 };
     const bindings = try self.arena.alloc(Binding, callee.params.len);
     for (callee.params, c.args, bindings) |p, arg, *b| {
@@ -53,17 +47,14 @@ pub fn emitInlineCall(self: *Emitter, callee: *const ast.DefDecl, c: ast.CallExp
         // A struct param binds to a full-width local materialized by
         // value; a scalar param to a single word.
         if (self.argStructName(arg)) |sname| {
-            try isa.subImmFromReg(self, self.structSlotWidth(sname), Reg.sp);
             const ofs = self.reserveFrameSlot(self.structSlotWidth(sname));
             try value_struct.emitInto(self, arg, sname, ofs);
             b.* = .{ .name = dup, .ofs = ofs };
         } else if (self.tupleElemsOf(arg)) |elems| {
-            try isa.subImmFromReg(self, self.tupleSlotWidth(elems), Reg.sp);
             const ofs = self.reserveFrameSlot(self.tupleSlotWidth(elems));
             try value_struct.emitTupleInto(self, arg, elems, ofs);
             b.* = .{ .name = dup, .ofs = ofs };
         } else {
-            try isa.subImmFromReg(self, 2, Reg.sp);
             try expr_emit.emitExpr(self, arg);
             const ofs = self.reserveFrameSlot(2);
             try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
@@ -91,9 +82,20 @@ pub fn emitInlineCall(self: *Emitter, callee: *const ast.DefDecl, c: ast.CallExp
         self.inline_ret_slot = saved_inline_slot;
     }
     if (callee.ret_type) |rt| if (self.structNameOfTypeAnn(rt.*)) |sname| {
-        try isa.subImmFromReg(self, self.structSlotWidth(sname), Reg.sp);
         self.inline_ret_struct = sname;
         self.inline_ret_slot = self.reserveFrameSlot(self.structWidth(sname));
+    };
+    // A tuple-returning inline mirrors the struct path; the element
+    // layout is read from each `return` expression's inferred type.
+    const saved_inline_tuple = self.inline_ret_is_tuple;
+    const saved_inline_tuple_slot = self.inline_ret_tuple_slot;
+    defer {
+        self.inline_ret_is_tuple = saved_inline_tuple;
+        self.inline_ret_tuple_slot = saved_inline_tuple_slot;
+    }
+    if (callee.ret_type) |rt| if (rt.* == .tuple) {
+        self.inline_ret_is_tuple = true;
+        self.inline_ret_tuple_slot = self.reserveFrameSlot(self.widthOfTypeAnn(rt.*));
     };
 
     // Install a fresh `inline_returns` collector so nested `return`s

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const ast = @import("../ast.zig");
+const types = @import("../types.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
@@ -17,6 +18,48 @@ const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
 const Reg = opcodes.Reg;
 const Sys = opcodes.Sys;
+
+/// Where a default value rendering goes. `host` writes each piece to the
+/// host output (`print_*`, §4.9). `buffer` appends to the heap string
+/// being built for an interpolation (§3.2.2) via `format_*_to_buf`; the
+/// running write cursor lives in the fp-relative slot `cursor_ofs` (the
+/// renderers need `r1` for the value base, so the cursor is parked there
+/// and reloaded around each append). The same renderers drive both.
+pub const Sink = union(enum) {
+    host,
+    buffer: i8,
+};
+
+/// The scalar shapes a leaf value takes — picks `print_*` vs the matching
+/// `format_*_to_buf` syscall.
+const Leaf = enum { str, int, uint, char, fixed };
+
+/// Emit the value in `acu` (a string address for `.str`) to `sink`. For
+/// the buffer sink the cursor is reloaded into `r1`, advanced by the
+/// `format_*_to_buf` syscall, and stored back — the renderer's base in
+/// `r1` is already consumed by the time a leaf is emitted.
+fn sinkEmit(self: *Emitter, sink: Sink, leaf: Leaf) error{OutOfMemory}!void {
+    switch (sink) {
+        .host => try isa.sys(self, switch (leaf) {
+            .str => Sys.print_str,
+            .int => Sys.print_int,
+            .uint => Sys.print_uint,
+            .char => Sys.print_char,
+            .fixed => Sys.print_fixed,
+        }),
+        .buffer => |ofs| {
+            try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.r1); // r1 = cursor
+            try isa.sys(self, switch (leaf) {
+                .str => Sys.format_str_to_buf,
+                .int => Sys.format_int_to_buf,
+                .uint => Sys.format_uint_to_buf,
+                .char => Sys.format_char_to_buf,
+                .fixed => Sys.format_fixed_to_buf,
+            });
+            try isa.movRegToRegOffset(self, Reg.r1, Reg.fp, ofs); // store advanced cursor
+        },
+    }
+}
 
 /// The binary operator a compound assignment desugars to — `+=` → `+`,
 /// `<<=` → `<<`, and so on. `.set` has no binary form.
@@ -66,6 +109,30 @@ pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
             try value_struct.emitFieldStore(self, a.target.field.receiver, sname, fname, a.value);
             return;
         }
+    }
+    // `t.N = value` — store into a tuple element at its inline offset.
+    if (a.target.* == .tuple_index) {
+        const ti = a.target.tuple_index;
+        const elems = self.tupleElemsOf(ti.receiver) orelse {
+            try self.unsupported(a.span, "tuple element store on a non-tuple value");
+            return;
+        };
+        if (self.tupleElemAggregate(elems, ti.index) != .scalar) {
+            try self.unsupported(a.span, "storing into a tuple's nested struct/tuple element");
+            return;
+        }
+        const info = self.tupleElemInfo(elems, ti.index);
+        try self.emitExpr(a.value); // value → stash on stack
+        try isa.pushReg(self, Reg.acu);
+        try self.emitExpr(ti.receiver); // acu = tuple base address
+        try isa.movRegToReg(self, Reg.acu, Reg.r1);
+        try isa.popReg(self, Reg.r2);
+        if (info.width == 1) {
+            try class.emitByteStoreAtOffset(self, Reg.r1, info.offset, Reg.r2);
+        } else {
+            try class.emitWordStoreAtOffset(self, Reg.r1, info.offset, Reg.r2);
+        }
+        return;
     }
     if (a.target.* != .ident) {
         try self.unsupported(a.span, "non-ident assignment targets (field / index)");
@@ -202,7 +269,19 @@ pub fn emitConstDecl(self: *Emitter, d: ast.ConstDecl) !void {
 /// (or a forward jmp inside an `@inline` body).
 pub fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
     if (r.value) |v| {
-        if (self.inline_ret_struct) |sname| {
+        if (self.inline_ret_is_tuple) {
+            // Inlined tuple return: materialize into the caller-frame
+            // result slot, then leave its address in `acu`.
+            const elems = self.tupleElemsOf(v) orelse {
+                try self.unsupported(r.span, "tuple return from a non-tuple value");
+                return;
+            };
+            try value_struct.emitTupleInto(self, v, elems, self.inline_ret_tuple_slot);
+            try isa.movRegToReg(self, Reg.fp, Reg.acu);
+            const slot = self.inline_ret_tuple_slot; // negative — a caller-frame local
+            // @as: widen i8 → i16 so negating the min value is safe.
+            if (slot < 0) try isa.subImmFromReg(self, @intCast(-@as(i16, slot)), Reg.acu);
+        } else if (self.inline_ret_struct) |sname| {
             // Inlined struct return: materialize into the caller-frame
             // result slot, then leave its address in `acu`.
             try value_struct.emitInto(self, v, sname, self.inline_ret_slot);
@@ -272,73 +351,179 @@ pub fn emitPrintStmt(self: *Emitter, p: ast.PrintStmt) !void {
 /// `str` → `print_str` (string literals emit per-part for
 /// interpolation), everything else → `print_int`.
 fn emitPrintArg(self: *Emitter, arg: *const ast.Expr) !void {
+    // A string literal emits its parts (interpolation, §3.2.2) straight
+    // to the host; everything else renders its value (§4.9).
     if (arg.* == .str_lit) {
         try strings.emitPrintStrLit(self, arg.str_lit);
         return;
     }
-    if (self.isPrimitiveType(arg, .char)) {
-        try self.emitExpr(arg);
-        try isa.sys(self, Sys.print_char);
+    try emitRenderValue(self, arg, .host);
+}
+
+/// Emit `expr`'s default value rendering to `sink` (§4.9): a scalar by
+/// its formatter, a struct as `Name { f: v, … }`, an enum as
+/// `Enum.Variant`, a tuple as `(v0, v1, …)`. Drives both `print` (the
+/// host sink) and `$(…)` interpolation (the buffer sink). A value whose
+/// type — or a reachable field / element — has no rendering is rejected.
+pub fn emitRenderValue(self: *Emitter, expr: *const ast.Expr, sink: Sink) error{OutOfMemory}!void {
+    if (self.isPrimitiveType(expr, .char)) {
+        try self.emitExpr(expr);
+        try sinkEmit(self, sink, .char);
         return;
     }
-    if (self.isPrimitiveType(arg, .fixed)) {
-        try self.emitExpr(arg);
-        try isa.sys(self, Sys.print_fixed);
+    if (self.isPrimitiveType(expr, .fixed)) {
+        try self.emitExpr(expr);
+        try sinkEmit(self, sink, .fixed);
         return;
     }
-    if (self.isPrimitiveType(arg, .str)) {
-        try self.emitExpr(arg);
-        try isa.sys(self, Sys.print_str);
+    if (self.isPrimitiveType(expr, .str)) {
+        try self.emitExpr(expr);
+        try sinkEmit(self, sink, .str);
         return;
     }
-    // A struct renders as `Name { field: value, ... }` — its base
-    // address is in `acu` after evaluation.
-    if (self.structNameOf(arg)) |sname| {
+    // A struct's base address is in `acu` after evaluation; a literal has
+    // no standalone address, so materialize it as a stack copy first.
+    if (self.structNameOf(expr)) |sname| {
         if (!printSupported(self, sname)) {
-            try self.unsupported(arg.span(), "printing a struct with a field type that has no default rendering (array / tuple / Vec / class / reference)");
+            try self.unsupported(expr.span(), "a struct with a field type that has no default rendering (array / Vec / class / reference)");
             return;
         }
-        // A struct literal has no standalone address — materialize it as
-        // a by-value stack copy first; struct *values* already evaluate
-        // to a base address.
-        if (arg.* == .struct_lit) {
-            try value_struct.pushArg(self, arg, sname);
+        if (expr.* == .struct_lit) {
+            try value_struct.pushArg(self, expr, sname);
             try isa.movRegToReg(self, Reg.sp, Reg.acu);
-            try emitPrintStruct(self, sname);
+            try emitPrintStruct(self, sname, sink);
             try isa.addImmToReg(self, self.structSlotWidth(sname), Reg.sp);
         } else {
-            try self.emitExpr(arg);
-            try emitPrintStruct(self, sname);
+            try self.emitExpr(expr);
+            try emitPrintStruct(self, sname, sink);
         }
         return;
     }
-    // An enum renders as `Enum.Variant` (`Enum.Variant(a, b)` with a
-    // payload) — `acu` holds the tag (payload-free) or slot pointer.
-    if (self.enumDeclForExpr(arg)) |ed| {
+    // An enum value in `acu` is the tag (payload-free) or slot pointer.
+    if (self.enumDeclForExpr(expr)) |ed| {
         if (!enumPrintSupported(self, ed)) {
-            try self.unsupported(arg.span(), "printing an enum with a payload field type that has no default rendering (array / tuple / Vec / class / reference)");
+            try self.unsupported(expr.span(), "an enum with a payload field type that has no default rendering (array / tuple / Vec / class / reference)");
             return;
         }
-        try self.emitExpr(arg);
-        try emitPrintEnum(self, ed);
+        try self.emitExpr(expr);
+        try emitPrintEnum(self, ed, sink);
         return;
     }
-    // A whole-tuple default rendering isn't lowered yet (deferred from
-    // #305) — reject rather than print the base address as an int.
-    if (self.tupleElemsOf(arg) != null) {
-        try self.unsupported(arg.span(), "printing a whole tuple — print its elements (`t.0`, `t.1`, …)");
+    if (self.tupleElemsOf(expr)) |elems| {
+        if (!tuplePrintSupported(self, elems)) {
+            try self.unsupported(expr.span(), "a tuple with an element that has no default rendering (array / Vec / class / reference)");
+            return;
+        }
+        if (expr.* == .tuple_lit) {
+            try value_struct.pushTupleArg(self, expr, elems);
+            try isa.movRegToReg(self, Reg.sp, Reg.acu);
+            try emitPrintTuple(self, elems, sink);
+            try isa.addImmToReg(self, self.tupleSlotWidth(elems), Reg.sp);
+        } else {
+            try self.emitExpr(expr);
+            try emitPrintTuple(self, elems, sink);
+        }
         return;
     }
-    try self.emitExpr(arg);
-    try isa.sys(self, if (self.isUnsignedInt(arg)) Sys.print_uint else Sys.print_int);
+    try self.emitExpr(expr);
+    try sinkEmit(self, sink, if (self.isUnsignedInt(expr)) .uint else .int);
+}
+
+/// Render a tuple (base address in `acu`) as `(v0, v1, …)`. Parks the
+/// base across the per-element prints (the `print_*` syscalls + recursion
+/// churn registers but leave `sp` alone), reloaded per element.
+fn emitPrintTuple(self: *Emitter, elems: []const *const types.Type, sink: Sink) error{OutOfMemory}!void {
+    try isa.pushReg(self, Reg.acu); // park base at [sp]
+    try printLiteral(self, "(", sink);
+    for (elems, 0..) |_, i| {
+        if (i > 0) try printLiteral(self, ", ", sink);
+        // safety: tuple arity ≤ 4 (§3.4) fits u8.
+        try emitPrintTupleElem(self, elems, @intCast(i), sink);
+    }
+    try printLiteral(self, ")", sink);
+    try isa.addImmToReg(self, 2, Reg.sp); // drop the parked base
+}
+
+/// Print element `index` of the tuple whose base is parked at `[sp]`.
+fn emitPrintTupleElem(self: *Emitter, elems: []const *const types.Type, index: u8, sink: Sink) error{OutOfMemory}!void {
+    const info = self.tupleElemInfo(elems, index);
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = parked base
+    switch (self.tupleElemAggregate(elems, index)) {
+        .structure => |sub| {
+            try isa.movRegToReg(self, Reg.r1, Reg.acu);
+            if (info.offset != 0) try isa.addImmToReg(self, info.offset, Reg.acu);
+            try emitPrintStruct(self, sub, sink);
+            return;
+        },
+        .tuple => |nested| {
+            try isa.movRegToReg(self, Reg.r1, Reg.acu);
+            if (info.offset != 0) try isa.addImmToReg(self, info.offset, Reg.acu);
+            try emitPrintTuple(self, nested, sink);
+            return;
+        },
+        .scalar => {},
+    }
+    const et = elems[index];
+    if (et.* == .named) {
+        if (self.enum_decls.get(et.named.name)) |ed| {
+            if (self.enumHasPayload(ed)) {
+                try class.emitWordLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+            } else {
+                try class.emitByteLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+            }
+            try isa.pushReg(self, Reg.acu);
+            try emitEnumDispatchAtSp(self, ed, sink);
+            try isa.addImmToReg(self, 2, Reg.sp);
+            return;
+        }
+    }
+    const prim: ?types.Primitive = if (et.* == .primitive) et.primitive else null;
+    if (prim == .char) {
+        try class.emitByteLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+        try sinkEmit(self, sink, .char);
+    } else if (prim == .fixed) {
+        try class.emitWordLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+        try sinkEmit(self, sink, .fixed);
+    } else if (prim == .str) {
+        try class.emitWordLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+        try sinkEmit(self, sink, .str);
+    } else if (info.width == 1) {
+        try class.emitByteLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+        if (info.signed_byte) try isa.signExtendByte(self, Reg.acu);
+        try sinkEmit(self, sink, if (prim == .u8) .uint else .int);
+    } else {
+        try class.emitWordLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
+        try sinkEmit(self, sink, if (prim == .u16) .uint else .int);
+    }
+}
+
+/// Whether `print` can render every element of a tuple — scalars / `str`
+/// / enum, and nested supported structs / tuples. Rejects array / `Vec`
+/// / class / reference / nullable / fn-ptr elements.
+fn tuplePrintSupported(self: *const Emitter, elems: []const *const types.Type) bool {
+    for (elems) |e| {
+        switch (e.*) {
+            .tuple => |nested| if (!tuplePrintSupported(self, nested)) return false,
+            .primitive => {},
+            .named => |n| {
+                if (self.struct_decls.contains(n.name)) {
+                    if (!printSupported(self, n.name)) return false;
+                } else if (self.enum_decls.get(n.name)) |ed| {
+                    if (!enumPrintSupported(self, ed)) return false;
+                } else if (self.class_decls.contains(n.name)) return false;
+            },
+            else => return false, // array / vec / reference / optional / function
+        }
+    }
+    return true;
 }
 
 /// Render an enum value (tag or slot pointer in `acu`) as
 /// `Enum.Variant` / `Enum.Variant(a, b)`. The value is parked at `[sp]`
 /// across the tag dispatch, then dropped.
-fn emitPrintEnum(self: *Emitter, ed: *const ast.EnumDecl) error{OutOfMemory}!void {
+fn emitPrintEnum(self: *Emitter, ed: *const ast.EnumDecl, sink: Sink) error{OutOfMemory}!void {
     try isa.pushReg(self, Reg.acu);
-    try emitEnumDispatchAtSp(self, ed);
+    try emitEnumDispatchAtSp(self, ed, sink);
     try isa.addImmToReg(self, 2, Reg.sp);
 }
 
@@ -346,7 +531,7 @@ fn emitPrintEnum(self: *Emitter, ed: *const ast.EnumDecl) error{OutOfMemory}!voi
 /// payload-free enums, a `[tag|payload]` slot pointer otherwise). Each
 /// arm compares the tag, prints `Enum.Variant`, then walks the variant's
 /// payload fields off the slot base; a final jump skips the other arms.
-fn emitEnumDispatchAtSp(self: *Emitter, ed: *const ast.EnumDecl) error{OutOfMemory}!void {
+fn emitEnumDispatchAtSp(self: *Emitter, ed: *const ast.EnumDecl, sink: Sink) error{OutOfMemory}!void {
     const enum_name = self.source[ed.name.start..ed.name.end];
     const payload = self.enumHasPayload(ed);
     var end_patches: std.ArrayList(usize) = .empty;
@@ -363,16 +548,16 @@ fn emitEnumDispatchAtSp(self: *Emitter, ed: *const ast.EnumDecl) error{OutOfMemo
         try isa.cmpRegImm(self, Reg.r1, tag);
         const next = try isa.emitJumpPlaceholder(self, Op.jne_addr);
         const variant_name = self.source[v.name.start..v.name.end];
-        try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s}.{s}", .{ enum_name, variant_name }));
+        try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s}.{s}", .{ enum_name, variant_name }), sink);
         if (v.payload.len > 0) {
-            try printLiteral(self, "(");
+            try printLiteral(self, "(", sink);
             for (v.payload, 0..) |pf, j| {
-                if (j > 0) try printLiteral(self, ", ");
+                if (j > 0) try printLiteral(self, ", ", sink);
                 // Payload fields read off the slot base parked at `[sp]`,
                 // at the variant's per-field offset (past the tag byte).
-                try emitPrintField(self, pf.type_ann.*, self.variantFieldOffset(v, j));
+                try emitPrintField(self, pf.type_ann.*, self.variantFieldOffset(v, j), sink);
             }
-            try printLiteral(self, ")");
+            try printLiteral(self, ")", sink);
         }
         try end_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
         try isa.patchJumpTo(self, next, try self.currentOffset());
@@ -386,33 +571,39 @@ fn emitEnumDispatchAtSp(self: *Emitter, ed: *const ast.EnumDecl) error{OutOfMemo
 /// structs recurse. The base is parked on the stack across the field
 /// prints (the `print_*` syscalls + recursion churn registers but
 /// leave `sp` alone), and reloaded per field.
-fn emitPrintStruct(self: *Emitter, sname: []const u8) error{OutOfMemory}!void {
+fn emitPrintStruct(self: *Emitter, sname: []const u8, sink: Sink) error{OutOfMemory}!void {
     const sd = self.struct_decls.get(sname).?;
     try isa.pushReg(self, Reg.acu); // park base at [sp]
 
-    try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s} {{ ", .{sname}));
+    try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s} {{ ", .{sname}), sink);
 
     var fo: u16 = 0;
     for (sd.fields, 0..) |f, i| {
-        if (i > 0) try printLiteral(self, ", ");
+        if (i > 0) try printLiteral(self, ", ", sink);
         const fname = self.source[f.name.start..f.name.end];
-        try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s}: ", .{fname}));
-        try emitPrintField(self, f.type_ann.*, fo);
+        try printLiteral(self, try std.fmt.allocPrint(self.arena, "{s}: ", .{fname}), sink);
+        try emitPrintField(self, f.type_ann.*, fo, sink);
         fo += self.widthOfTypeAnn(f.type_ann.*);
     }
 
-    try printLiteral(self, " }");
+    try printLiteral(self, " }", sink);
     try isa.addImmToReg(self, 2, Reg.sp); // drop the parked base
 }
 
 /// Print the field at `fo` of the struct whose base is parked at `[sp]`.
 /// Dispatches per type; a nested struct recurses (its base = base + fo).
-fn emitPrintField(self: *Emitter, t: ast.TypeAnn, fo: u16) error{OutOfMemory}!void {
+fn emitPrintField(self: *Emitter, t: ast.TypeAnn, fo: u16, sink: Sink) error{OutOfMemory}!void {
+    if (t == .tuple) {
+        // A tuple field lays out inline; render `(v0, v1, …)` from the
+        // struct base, each element at the field offset + its tuple offset.
+        try emitPrintTupleField(self, t.tuple.elems, fo, sink);
+        return;
+    }
     try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = parked base
     if (self.structNameOfTypeAnn(t)) |sub| {
         try isa.movRegToReg(self, Reg.r1, Reg.acu);
         if (fo != 0) try isa.addImmToReg(self, fo, Reg.acu); // acu = nested base
-        try emitPrintStruct(self, sub);
+        try emitPrintStruct(self, sub, sink);
         return;
     }
     if (enumDeclOfTypeAnn(self, t)) |ed| {
@@ -425,46 +616,62 @@ fn emitPrintField(self: *Emitter, t: ast.TypeAnn, fo: u16) error{OutOfMemory}!vo
             try class.emitByteLoadAtOffset(self, Reg.r1, fo, Reg.acu);
         }
         try isa.pushReg(self, Reg.acu);
-        try emitEnumDispatchAtSp(self, ed);
+        try emitEnumDispatchAtSp(self, ed, sink);
         try isa.addImmToReg(self, 2, Reg.sp);
         return;
     }
     if (isPrimNamed(self, t, "char")) {
         try class.emitByteLoadAtOffset(self, Reg.r1, fo, Reg.acu);
-        try isa.sys(self, Sys.print_char);
+        try sinkEmit(self, sink, .char);
     } else if (isPrimNamed(self, t, "fixed")) {
         try class.emitWordLoadAtOffset(self, Reg.r1, fo, Reg.acu);
-        try isa.sys(self, Sys.print_fixed);
+        try sinkEmit(self, sink, .fixed);
     } else if (isPrimNamed(self, t, "str")) {
         try class.emitWordLoadAtOffset(self, Reg.r1, fo, Reg.acu);
-        try isa.sys(self, Sys.print_str);
+        try sinkEmit(self, sink, .str);
     } else if (self.widthOfTypeAnn(t) == 1) {
         try class.emitByteLoadAtOffset(self, Reg.r1, fo, Reg.acu);
-        // `i8` is the only signed byte type — sign-extend so `print_int`
-        // (which formats a signed word) shows a negative value. `u8`
-        // routes to the unsigned printer like any unsigned int.
+        // `i8` is the only signed byte type — sign-extend so the decimal
+        // formatter (which formats a signed word) shows a negative value.
+        // `u8` routes to the unsigned formatter like any unsigned int.
         if (self.isPrimitiveTypeAnn(t, "i8")) try isa.signExtendByte(self, Reg.acu);
-        try isa.sys(self, if (self.isPrimitiveTypeAnn(t, "u8")) Sys.print_uint else Sys.print_int);
+        try sinkEmit(self, sink, if (self.isPrimitiveTypeAnn(t, "u8")) .uint else .int);
     } else {
         try class.emitWordLoadAtOffset(self, Reg.r1, fo, Reg.acu);
-        try isa.sys(self, if (self.isPrimitiveTypeAnn(t, "u16")) Sys.print_uint else Sys.print_int);
+        try sinkEmit(self, sink, if (self.isPrimitiveTypeAnn(t, "u16")) .uint else .int);
     }
 }
 
-/// Intern `text` and emit a `print_str` of it (the constant separators
-/// + field labels in a struct rendering).
-fn printLiteral(self: *Emitter, text: []const u8) error{OutOfMemory}!void {
+/// Render a struct's tuple field as `(v0, v1, …)`. The struct base is
+/// parked at `[sp]`; each element prints via the struct field path at the
+/// field's offset plus the element's offset within the tuple, so nested
+/// structs / tuples / enums recurse the same way a top-level field does.
+fn emitPrintTupleField(self: *Emitter, elems: []const *ast.TypeAnn, base_fo: u16, sink: Sink) error{OutOfMemory}!void {
+    try printLiteral(self, "(", sink);
+    var eo: u16 = base_fo;
+    for (elems, 0..) |et, i| {
+        if (i > 0) try printLiteral(self, ", ", sink);
+        try emitPrintField(self, et.*, eo, sink);
+        eo += self.widthOfTypeAnn(et.*);
+    }
+    try printLiteral(self, ")", sink);
+}
+
+/// Intern `text` and emit it to `sink` (the constant separators + field
+/// labels in an aggregate rendering).
+fn printLiteral(self: *Emitter, text: []const u8, sink: Sink) error{OutOfMemory}!void {
     const id = try strings.internString(self, text);
     try strings.emitMovStringAddrToReg(self, id, Reg.acu);
-    try isa.sys(self, Sys.print_str);
+    try sinkEmit(self, sink, .str);
 }
 
 /// Whether `print` can render every field of `sname`. Supported:
 /// scalars / bool / char / fixed (decimal/char/fixed), `str`, enums
-/// (`Enum.Variant` + printable payload), and nested supported structs.
-/// Rejected: array / tuple / `Vec` / class / reference / fn-ptr /
-/// nullable — no default rendering yet. A type cycle (a struct / enum
-/// reachable from itself) is rejected too — it has no finite rendering.
+/// (`Enum.Variant` + printable payload), tuples of supported elements,
+/// and nested supported structs. Rejected: array / `Vec` / class /
+/// reference / fn-ptr / nullable — no default rendering yet. A type cycle
+/// (a struct / enum reachable from itself) is rejected too — it has no
+/// finite rendering.
 fn printSupported(self: *const Emitter, sname: []const u8) bool {
     var visited: std.ArrayList([]const u8) = .empty;
     defer visited.deinit(self.allocator);
@@ -512,7 +719,13 @@ fn enumPrintSupportedRec(self: *const Emitter, ed: *const ast.EnumDecl, visited:
 }
 
 fn fieldPrintSupportedRec(self: *const Emitter, t: ast.TypeAnn, visited: *std.ArrayList([]const u8)) error{OutOfMemory}!bool {
-    if (t != .named) return false; // array / tuple / vec / reference / fn / nullable
+    if (t == .tuple) {
+        for (t.tuple.elems) |et| {
+            if (!try fieldPrintSupportedRec(self, et.*, visited)) return false;
+        }
+        return true;
+    }
+    if (t != .named) return false; // array / vec / reference / fn / nullable
     const name = self.source[t.named.name.start..t.named.name.end];
     if (self.struct_decls.contains(name)) return printSupportedRec(self, name, visited);
     if (self.enum_decls.get(name)) |ed| return enumPrintSupportedRec(self, ed, visited);

--- a/src/lang/codegen/strings.zig
+++ b/src/lang/codegen/strings.zig
@@ -5,18 +5,18 @@ const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const archive = @import("archive.zig");
 const class = @import("class.zig");
+const statements = @import("statements.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
 const Reg = opcodes.Reg;
 const Sys = opcodes.Sys;
 
-/// Bytes reserved per interpolated-string buffer in the data
-/// region. Sized for the worst common case (a few interp values
-/// + surrounding literal text). Programs that need larger
-/// interpolations should compose with explicit concatenation —
-/// the codegen rejects the formatted result at runtime if it
-/// overflows (the VM doesn't bounds-check the buffer writes).
+/// Bytes allocated per interpolated-string evaluation. Sized for the
+/// worst common case (a few interp values + surrounding literal text).
+/// Programs that need larger interpolations should compose with explicit
+/// concatenation — the VM doesn't bounds-check the buffer writes, so an
+/// over-long fill silently runs past the allocation.
 pub const interp_buffer_size: u16 = 64;
 
 /// One interned string literal — emitted as a null-terminated
@@ -227,9 +227,8 @@ fn emitStrCopy(self: *Emitter, ofs: i8, dst: u8) error{OutOfMemory}!void {
 
 /// Lower a `str_lit` at expression position. Single-literal
 /// strings load the pooled address directly into `acu`.
-/// Interpolated strings allocate a fixed-size buffer in the
-/// data region and emit the `format_*_to_buf` syscall sequence
-/// that fills it.
+/// Interpolated strings allocate a fresh heap buffer per evaluation
+/// and emit the `format_*_to_buf` syscall sequence that fills it.
 pub fn emitStrLitExpr(self: *Emitter, sl: ast.StrLitExpr) !void {
     if (sl.parts.len == 1 and sl.parts[0] == .lit) {
         const span = sl.parts[0].lit.span;
@@ -240,37 +239,20 @@ pub fn emitStrLitExpr(self: *Emitter, sl: ast.StrLitExpr) !void {
         return;
     }
 
-    const buf_addr = reserveInterpBuffer(self, sl.span) orelse {
-        // Diagnostic already emitted; produce a valid placeholder
-        // so downstream codegen doesn't see a bad acu shape.
-        try isa.movImmToReg(self, 0, Reg.acu);
-        return;
-    };
-
-    // r1 holds the moving write cursor. Initialize it to the
-    // buffer's base address.
-    try isa.movImmToReg(self, buf_addr, Reg.r1);
+    // A fresh heap buffer per evaluation (§3.2.2) — distinct results,
+    // including repeated evaluations of the same literal, never alias (a
+    // static per-site buffer would let a later evaluation clobber an
+    // earlier binding). `r1` is the moving write cursor; the base is
+    // parked across the fill and becomes the result. `alloc` faults
+    // `heap_exhausted` when the heap is full, like every allocating
+    // construct; the fill itself isn't bounds-checked (`interp_buffer_size`).
+    try isa.movImmToReg(self, interp_buffer_size, Reg.acu);
+    try isa.sys(self, Sys.alloc); // acu = buffer base
+    try isa.pushReg(self, Reg.acu);
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // cursor starts at the base
     try emitInterpFill(self, sl);
     try isa.sys(self, Sys.format_terminate_buf);
-    try isa.movImmToReg(self, buf_addr, Reg.acu);
-}
-
-/// Reserve `interp_buffer_size` bytes at the top of the data
-/// region for one interpolated-string site. Returns the
-/// buffer's base address. Emits `E_CODEGEN_DATA_OVERFLOW` and
-/// `null` when the data region (capped at the MMIO line) would
-/// overflow.
-pub fn reserveInterpBuffer(self: *Emitter, site_span: ast.Span) ?u16 {
-    const base = self.data_cursor;
-    // @as: widen u16 → u32 so the overflow check doesn't itself wrap.
-    const next: u32 = @as(u32, self.data_cursor) + interp_buffer_size;
-    if (next > 0xFE40) {
-        self.diagFatal(site_span, "E_CODEGEN_DATA_OVERFLOW", "static-data region exhausted — too many interpolated string sites") catch return null;
-        return null;
-    }
-    // @as: bounded by the > 0xFE40 check above; result fits u16.
-    self.data_cursor = @intCast(next);
-    return base;
+    try isa.popReg(self, Reg.acu); // result = buffer base
 }
 
 /// Emit one `format_*_to_buf` syscall per `sl.parts` entry. `r1`
@@ -279,6 +261,12 @@ pub fn reserveInterpBuffer(self: *Emitter, site_span: ast.Span) ?u16 {
 /// interp-expression evaluation so the stack-machine pattern's
 /// scratch use of `r1` doesn't trash the cursor.
 pub fn emitInterpFill(self: *Emitter, sl: ast.StrLitExpr) !void {
+    // A scalar part keeps the cursor in `r1` (fast path). A non-scalar
+    // part renders through the shared `emitRenderValue` machinery, which
+    // needs `r1` for the value base — so its cursor lives in this
+    // fp-relative slot, reserved on first use (and counted by
+    // `countFrameBytes` for the prologue).
+    var cursor_slot: ?i8 = null;
     for (sl.parts) |part| switch (part) {
         .lit => |lp| {
             const raw = self.source[lp.span.start..lp.span.end];
@@ -293,8 +281,19 @@ pub fn emitInterpFill(self: *Emitter, sl: ast.StrLitExpr) !void {
                 try self.unsupported(ip.span, "`$(expr:fmt)` format specs");
                 return;
             }
-            // Save the cursor — the interp-expression eval may
-            // pop into r1 as scratch.
+            if (!self.interpFormattable(ip.expr)) {
+                const slot = cursor_slot orelse blk: {
+                    const s = self.reserveFrameSlot(2);
+                    cursor_slot = s;
+                    break :blk s;
+                };
+                try isa.movRegToRegOffset(self, Reg.r1, Reg.fp, slot); // park cursor
+                try statements.emitRenderValue(self, ip.expr, .{ .buffer = slot });
+                try isa.movRegOffsetToReg(self, Reg.fp, slot, Reg.r1); // reload cursor
+                continue;
+            }
+            // Scalar fast path: save the cursor — the interp-expression
+            // eval may pop into `r1` as scratch.
             try isa.pushReg(self, Reg.r1);
             try self.emitExpr(ip.expr);
             try isa.popReg(self, Reg.r1);
@@ -332,19 +331,9 @@ pub fn emitPrintStrLit(self: *Emitter, sl: ast.StrLitExpr) !void {
                 try self.unsupported(ip.span, "`$(expr:fmt)` format specs");
                 return;
             }
-            if (self.isPrimitiveType(ip.expr, .char)) {
-                try self.emitExpr(ip.expr);
-                try isa.sys(self, Sys.print_char);
-            } else if (self.isPrimitiveType(ip.expr, .fixed)) {
-                try self.emitExpr(ip.expr);
-                try isa.sys(self, Sys.print_fixed);
-            } else if (self.isPrimitiveType(ip.expr, .str)) {
-                try self.emitExpr(ip.expr);
-                try isa.sys(self, Sys.print_str);
-            } else {
-                try self.emitExpr(ip.expr);
-                try isa.sys(self, if (self.isUnsignedInt(ip.expr)) Sys.print_uint else Sys.print_int);
-            }
+            // Render the value straight to the host (no buffer) — handles
+            // scalars and aggregate default renderings (§4.9) alike.
+            try statements.emitRenderValue(self, ip.expr, .host);
         },
     };
 }

--- a/src/lang/codegen/value_struct.zig
+++ b/src/lang/codegen/value_struct.zig
@@ -101,9 +101,9 @@ fn emitIntoDest(self: *Emitter, src: *const ast.Expr, sname: []const u8, dest: D
 
 // ---- tuple values (§3.4) ----
 // A tuple is an anonymous positional aggregate stored inline like a
-// struct (contiguous, byte-packed slots). #305 lowers register-width
-// elements (scalar / `str` / enum / class / reference); nested inline
-// aggregates are rejected at the dispatch sites (deferred).
+// struct (contiguous, byte-packed slots). Register-width elements
+// (scalar / `str` / enum / class / reference) store their word; a nested
+// struct / tuple element lays out inline at its offset (recursing).
 
 /// Materialize a tuple value into the frame slot based at `dest_ofs`
 /// (fp-relative).
@@ -124,18 +124,24 @@ pub fn emitTupleIntoSret(self: *Emitter, src: *const ast.Expr, elems: []const *c
 }
 
 fn emitTupleIntoDest(self: *Emitter, src: *const ast.Expr, elems: []const *const types.Type, dest: Dest) error{OutOfMemory}!void {
-    if (self.tupleHasAggregateElem(elems)) {
-        try self.unsupported(src.span(), "a tuple with a nested struct/tuple element");
-        return;
-    }
     if (src.* == .tuple_lit) {
         for (src.tuple_lit.elems, 0..) |elem, i| {
             // safety: tuple arity ≤ 4 (§3.4) fits u8.
             const info = self.tupleElemInfo(elems, @intCast(i));
-            try self.emitExpr(elem);
-            try isa.movRegToReg(self, Reg.acu, Reg.r2);
-            try destAddrToReg(self, dest.at(@intCast(info.offset)), Reg.r1);
-            try storeWidth(self, Reg.r1, info.width, Reg.r2);
+            const elem_dest = dest.at(@intCast(info.offset));
+            // An aggregate element is laid out inline at its offset
+            // (recursing like a nested struct field); a scalar element
+            // stores its value/pointer word.
+            switch (self.tupleElemAggregate(elems, @intCast(i))) {
+                .structure => |sub| try emitIntoDest(self, elem, sub, elem_dest),
+                .tuple => |nested| try emitTupleIntoDest(self, elem, nested, elem_dest),
+                .scalar => {
+                    try self.emitExpr(elem);
+                    try isa.movRegToReg(self, Reg.acu, Reg.r2);
+                    try destAddrToReg(self, elem_dest, Reg.r1);
+                    try storeWidth(self, Reg.r1, info.width, Reg.r2);
+                },
+            }
         }
         return;
     }
@@ -150,6 +156,12 @@ fn emitTupleIntoDest(self: *Emitter, src: *const ast.Expr, elems: []const *const
 /// leaving the element value in `acu` (`i8` sign-extends).
 pub fn emitTupleElemLoad(self: *Emitter, elems: []const *const types.Type, index: u8) error{OutOfMemory}!void {
     const info = self.tupleElemInfo(elems, index);
+    // An aggregate element sits inline — leave its base address in `acu`
+    // (a struct / tuple value *is* an address), no deref.
+    if (self.tupleElemAggregate(elems, index) != .scalar) {
+        if (info.offset != 0) try isa.addImmToReg(self, info.offset, Reg.acu);
+        return;
+    }
     try isa.movRegToReg(self, Reg.acu, Reg.r1);
     if (info.width == 1) {
         try class.emitByteLoadAtOffset(self, Reg.r1, info.offset, Reg.acu);
@@ -169,6 +181,14 @@ fn emitLitInto(self: *Emitter, sl: ast.StructLit, sname: []const u8, dest: Dest)
         const field_dest = dest.at(@intCast(info.offset));
         if (info.struct_name) |sub| {
             try emitIntoDest(self, value, sub, field_dest);
+        } else if (info.is_tuple) {
+            // A tuple field lays out inline; its element types come from
+            // the value expression's inferred type.
+            const elems = self.tupleElemsOf(value) orelse {
+                try self.unsupported(value.span(), "tuple struct field initialized from a non-tuple value");
+                continue;
+            };
+            try emitTupleIntoDest(self, value, elems, field_dest);
         } else {
             try self.emitExpr(value);
             try isa.movRegToReg(self, Reg.acu, Reg.r2);
@@ -184,7 +204,8 @@ fn emitLitInto(self: *Emitter, sl: ast.StructLit, sname: []const u8, dest: Dest)
 /// address).
 pub fn emitFieldLoad(self: *Emitter, sname: []const u8, field_name: []const u8) !void {
     const info = self.structFieldInfo(sname, field_name).?;
-    if (info.struct_name != null) {
+    // An aggregate field (nested struct or tuple) is addressed inline.
+    if (info.struct_name != null or info.is_tuple) {
         if (info.offset != 0) try isa.addImmToReg(self, info.offset, Reg.acu);
         return;
     }
@@ -223,14 +244,10 @@ pub fn emitFieldStore(self: *Emitter, recv: *const ast.Expr, sname: []const u8, 
     try class_storeAt(self, Reg.r1, info.offset, info.width, Reg.r2);
 }
 
-/// Lower `a == b` / `a != b` on struct operands (`negate` selects
-/// `!=`), leaving a 0/1 boolean in `acu` per §3.4 "structurally equal
-/// if fields equal". Each field compares with the same semantics its
-/// own `==` would use: scalars / `&T` / class / payload-free enum by
-/// value/pointer, `str` by content (§3.2.1), nested structs recursively.
-/// A struct whose fields are all value/pointer-comparable reduces to a
-/// fast byte compare over the packed width (no padding); a struct with
-/// any `str` field uses per-field dispatch so those compare by content.
+/// Compare two struct operands of type `sname` for structural equality,
+/// leaving `1` / `0` in `acu` (`negate` selects `!=`). Field-wise when a
+/// field needs it (`str` by content, payload-enum by slot, nested struct
+/// recursively), else a flat byte compare.
 pub fn emitEquality(self: *Emitter, lhs: *const ast.Expr, rhs: *const ast.Expr, sname: []const u8, negate: bool) error{OutOfMemory}!void {
     // Materialize BOTH operands as distinct by-value copies on the
     // stack. Pushing addresses would alias when both operands share a
@@ -548,6 +565,128 @@ fn fieldEqSupported(self: *const Emitter, t: ast.TypeAnn) bool {
         .reference, .fn_type => return true, // pointer identity
         .nullable, .array, .vec, .tuple => return false,
     }
+}
+
+// ---- tuple equality — mirrors the struct path over the element type
+// list; a struct element reuses `emitFieldwiseEq` / `needsFieldwise`. ----
+
+/// Lower `a == b` / `a != b` on tuple operands, leaving `0`/`1` in `acu`
+/// (`negate` selects `!=`). Materializes both operands as distinct stack
+/// copies (literals + value-aliasing safe), then an all-scalar tuple
+/// byte-compares; one with a `str` / payload-enum / aggregate element
+/// dispatches per element so those compare by content / value.
+pub fn emitTupleEquality(self: *Emitter, lhs: *const ast.Expr, rhs: *const ast.Expr, elems: []const *const types.Type, negate: bool) error{OutOfMemory}!void {
+    const wslot = self.tupleSlotWidth(elems);
+    try pushTupleArg(self, rhs, elems); // rhs copy at [sp + wslot ..] after the next push
+    try pushTupleArg(self, lhs, elems); // lhs copy at [sp ..]
+
+    if (needsFieldwiseTuple(self, elems)) {
+        var mismatch_patches: std.ArrayList(usize) = .empty;
+        defer mismatch_patches.deinit(self.allocator);
+        try emitTupleFieldwiseEq(self, elems, 0, wslot, &mismatch_patches);
+        try isa.movImmToReg(self, if (negate) 0 else 1, Reg.acu);
+        const end_patch = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+        const mismatch_target = try self.currentOffset();
+        for (mismatch_patches.items) |p| try isa.patchJumpTo(self, p, mismatch_target);
+        try isa.movImmToReg(self, if (negate) 1 else 0, Reg.acu);
+        try isa.patchJumpTo(self, end_patch, try self.currentOffset());
+    } else {
+        try isa.movRegToReg(self, Reg.sp, Reg.r1); // lhs copy base
+        try isa.movRegToReg(self, Reg.sp, Reg.r2);
+        try isa.addImmToReg(self, wslot, Reg.r2); // rhs copy base
+        try emitBytesEqual(self, Reg.r1, Reg.r2, self.tupleWidth(elems), negate);
+    }
+
+    try isa.addImmToReg(self, 2 * wslot, Reg.sp); // drop both copies
+}
+
+/// Per-element compare for a tuple that needs it. The lhs copy is at
+/// `[sp + lhs_off ..]`, rhs at `[sp + rhs_off ..]`; `sp` is stable. A
+/// struct element reuses the struct field-wise path at the element's
+/// offset; a nested tuple recurses; `str` / payload-enum compare by
+/// content / value; every other element by its stored word/byte.
+fn emitTupleFieldwiseEq(self: *Emitter, elems: []const *const types.Type, lhs_off: u16, rhs_off: u16, patches: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    for (elems, 0..) |et, i| {
+        // safety: tuple arity ≤ 4 (§3.4) fits u8.
+        const eo = self.tupleElemInfo(elems, @intCast(i)).offset;
+        switch (self.tupleElemAggregate(elems, @intCast(i))) {
+            .structure => |sub| try emitFieldwiseEq(self, sub, lhs_off + eo, rhs_off + eo, patches),
+            .tuple => |nested| try emitTupleFieldwiseEq(self, nested, lhs_off + eo, rhs_off + eo, patches),
+            .scalar => {
+                if (et.* == .primitive and et.primitive == .str) {
+                    try class.emitWordLoadAtOffset(self, Reg.sp, lhs_off + eo, Reg.r1);
+                    try class.emitWordLoadAtOffset(self, Reg.sp, rhs_off + eo, Reg.r2);
+                    try strings.emitContentEq(self, Reg.r1, Reg.r2, false);
+                    try isa.cmpRegImm(self, Reg.acu, 0); // acu == 0 → strings differ
+                    try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
+                } else if (payloadEnumDeclOfType(self, et)) |ed| {
+                    try class.emitWordLoadAtOffset(self, Reg.sp, lhs_off + eo, Reg.r1);
+                    try class.emitWordLoadAtOffset(self, Reg.sp, rhs_off + eo, Reg.r2);
+                    try emitEnumEqual(self, ed, Reg.r1, Reg.r2, false);
+                    try isa.cmpRegImm(self, Reg.acu, 0); // acu == 0 → slots differ
+                    try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
+                } else if (self.widthOfType(et) == 1) {
+                    try class.emitByteLoadAtOffset(self, Reg.sp, lhs_off + eo, Reg.acu);
+                    try class.emitByteLoadAtOffset(self, Reg.sp, rhs_off + eo, Reg.r3);
+                    try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+                    try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+                } else {
+                    try class.emitWordLoadAtOffset(self, Reg.sp, lhs_off + eo, Reg.acu);
+                    try class.emitWordLoadAtOffset(self, Reg.sp, rhs_off + eo, Reg.r3);
+                    try isa.cmpRegReg(self, Reg.acu, Reg.r3);
+                    try patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+                }
+            },
+        }
+    }
+}
+
+fn needsFieldwiseTuple(self: *const Emitter, elems: []const *const types.Type) bool {
+    for (elems, 0..) |et, i| {
+        switch (self.tupleElemAggregate(elems, @intCast(i))) {
+            .structure => |sub| if (needsFieldwise(self, sub)) return true,
+            .tuple => |nested| if (needsFieldwiseTuple(self, nested)) return true,
+            .scalar => {
+                if (et.* == .primitive and et.primitive == .str) return true;
+                if (payloadEnumDeclOfType(self, et) != null) return true;
+            },
+        }
+    }
+    return false;
+}
+
+/// Whether `==` can be lowered for a tuple — every element comparable
+/// (mirrors `eqSupported`): scalar / `str` / `char` / `fixed` by value or
+/// content, class / `&T` by identity, enum by tag/slot, nested struct /
+/// tuple recursively. Rejected: nullable / array / `Vec` elements.
+pub fn tupleEqSupported(self: *const Emitter, elems: []const *const types.Type) bool {
+    for (elems, 0..) |et, i| {
+        switch (self.tupleElemAggregate(elems, @intCast(i))) {
+            .structure => |sub| if (!eqSupported(self, sub)) return false,
+            .tuple => |nested| if (!tupleEqSupported(self, nested)) return false,
+            .scalar => switch (et.*) {
+                .primitive, .reference, .function => {}, // value / content / pointer identity
+                .named => |n| {
+                    if (self.enum_decls.get(n.name)) |ed| {
+                        if (self.enumHasPayload(ed) and !enumEqSupported(self, ed)) return false;
+                    }
+                    // primitive-by-name or class → handled (value / identity)
+                },
+                .optional, .array, .vec => return false,
+                // allow-strict: a `.tuple` element is classified `.tuple`
+                // by `tupleElemAggregate`, never reaching this scalar arm.
+                .tuple => unreachable,
+            },
+        }
+    }
+    return true;
+}
+
+/// The enum decl for a payload-carrying enum *type*, else `null`.
+fn payloadEnumDeclOfType(self: *const Emitter, et: *const types.Type) ?*const ast.EnumDecl {
+    if (et.* != .named) return null;
+    const ed = self.enum_decls.get(et.named.name) orelse return null;
+    return if (self.enumHasPayload(ed)) ed else null;
 }
 
 /// Copy `width` bytes from `[src]` to `[dest]` — word strides with a

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -307,6 +307,34 @@ fn parseFieldOrMethod(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
             },
         });
     }
+    // `t.0.1` — the lexer folds `0.1` into one `fixed_lit`; split its
+    // `N.M` text into two chained tuple-index accesses (nested-tuple
+    // element). The Q8.8-encoded `value` can't recover the indices, so
+    // read the raw digits.
+    if (p.check(.fixed_lit)) {
+        const tok = p.peek();
+        const txt = p.source[tok.start..tok.end];
+        const dot = std.mem.indexOfScalar(u8, txt, '.');
+        const lo: ?u8 = if (dot) |d| std.fmt.parseInt(u8, txt[0..d], 10) catch null else null;
+        const hi: ?u8 = if (dot) |d| std.fmt.parseInt(u8, txt[d + 1 ..], 10) catch null else null;
+        if (lo == null or hi == null) {
+            try p.recordError("expected a tuple element index (`.0`, `.1`, …)", "E_SYNTAX_MISSING_TOKEN");
+            return error.ParseFailed;
+        }
+        p.pos += 1;
+        // @as: `dot` is an index within the token text, well under u32.
+        const inner_end: u32 = tok.start + @as(u32, @intCast(dot.?));
+        const inner = try p.allocExpr(.{ .tuple_index = .{
+            .receiver = receiver,
+            .index = lo.?,
+            .span = .{ .start = receiver.span().start, .end = inner_end },
+        } });
+        return try p.allocExpr(.{ .tuple_index = .{
+            .receiver = inner,
+            .index = hi.?,
+            .span = .{ .start = receiver.span().start, .end = tok.end },
+        } });
+    }
     const name_tok = try p.expect(.ident, "field or method name");
     if (p.check(.lparen)) {
         p.pos += 1;

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1504,11 +1504,11 @@ fn structLitMentions(c: *const Checker, lit_fields: []const ast.StructLitField, 
 // ---------- place expression check ----------
 
 /// `true` when `e` is a valid assignment target — `ident`, `field`,
-/// `index`, or any of those wrapped in `paren`. Function-call results,
-/// arithmetic, literals, etc. are not place expressions.
+/// `tuple_index`, `index`, or any of those wrapped in `paren`. Function-
+/// call results, arithmetic, literals, etc. are not place expressions.
 fn isPlaceExpr(e: *const ast.Expr) bool {
     return switch (e.*) {
-        .ident, .field, .index => true,
+        .ident, .field, .tuple_index, .index => true,
         .paren => |p| isPlaceExpr(p.inner),
         else => false,
     };

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1250,11 +1250,9 @@ test "codegen: fixed-point `print c` uses print_fixed (Q8.8 formatting)" {
         "0.250\n");
 }
 
-test "codegen: non-print interpolation formats into a per-site data buffer" {
-    // `let s = "x=$(x)"; print s` formats into a static buffer
-    // reserved in the data region (one allocation per interp
-    // site per spec §3.2.2). Reading `s` later prints the same
-    // bytes since the buffer persists.
+test "codegen: interpolation bound to a `let` formats into a fresh heap buffer" {
+    // `let s = "x=$(x)"; print s` allocates a buffer (§3.2.2) and reads
+    // back the same bytes — the allocation outlives the statement.
     try runAndExpect(
         \\def main()
         \\  let x: i16 = 42
@@ -1262,6 +1260,73 @@ test "codegen: non-print interpolation formats into a per-site data buffer" {
         \\  print s
         \\end
     , "x=42\n");
+}
+
+test "codegen: each interpolation evaluation allocates a distinct buffer" {
+    // Two evaluations of the same interpolated literal must not alias —
+    // binding the second can't retroactively mutate the first.
+    try runAndExpect(
+        \\def tag(n: i16) -> str
+        \\  return "n=$(n)"
+        \\end
+        \\def main()
+        \\  let a = tag(1)
+        \\  let b = tag(2)
+        \\  print a
+        \\  print b
+        \\  print a == b
+        \\end
+    , "n=1\nn=2\n0\n");
+}
+
+test "codegen: `$$` collapses to a literal `$` (a lone `$` is preserved)" {
+    try runAndExpect(
+        \\def main()
+        \\  print "cost: $$5"
+        \\  print "$$$$"
+        \\end
+    , "cost: $5\n$$\n");
+}
+
+test "codegen: interpolating an aggregate renders its default form to the host" {
+    try runAndExpect(
+        \\struct S
+        \\  a: i16
+        \\  b: i16
+        \\end
+        \\def main()
+        \\  let s = S { a: 1, b: 2 }
+        \\  print "v=$(s)!"
+        \\end
+    , "v=S { a: 1, b: 2 }!\n");
+}
+
+test "codegen: interpolating an aggregate into a `let` renders into the buffer" {
+    try runAndExpect(
+        \\struct S
+        \\  name: str
+        \\  hp: i16
+        \\end
+        \\def main()
+        \\  let s = S { name: "hero", hp: 99 }
+        \\  let m = "info: $(s)"
+        \\  print m
+        \\end
+    , "info: S { name: hero, hp: 99 }\n");
+}
+
+test "codegen: interpolating a value whose type has no rendering is a clean error" {
+    // A struct with an array field has no default rendering — reject,
+    // matching `print` (§4.9), rather than emit a meaningless value.
+    try expectCodegenError(
+        \\struct S
+        \\  a: [i16; 2]
+        \\end
+        \\def main()
+        \\  let s = S { a: [1, 2] }
+        \\  print "s=$(s)"
+        \\end
+    , "E_CODEGEN_UNSUPPORTED");
 }
 
 test "codegen: format-spec `$(x:d)` is rejected with E_CODEGEN_UNSUPPORTED" {
@@ -3535,6 +3600,19 @@ test "codegen/bake: array baked into static data" {
     }
 }
 
+test "codegen/bake: a baked global past the data-region ceiling is a clean error" {
+    // `[i16; 30000]` = 60000 bytes overruns the static-data region
+    // (`data_base` 0x2000 .. `data_region_end` 0xFE40) — flag it rather
+    // than wrap the data cursor.
+    try expectCodegenError(
+        \\const TABLE = bake do
+        \\  let t: [i16; 30000] = [0; 30000]
+        \\  t
+        \\end
+        \\def main() end
+    , "E_CODEGEN_DATA_OVERFLOW");
+}
+
 test "codegen/bake: program without bake stays small (image doesn't grow to data region)" {
     // Regression: extending the image to cover the data region
     // should only happen when bake-init bytes need to ship.
@@ -4053,32 +4131,211 @@ test "codegen/tuple: passed by value through an `@inline` fn" {
     , "7\n");
 }
 
-test "codegen/tuple: `==` is not lowered yet (clean error, not address compare)" {
+test "codegen/tuple: `==` / `!=` compares element-wise" {
+    // All-scalar tuples byte-sweep; a `str` element compares by content
+    // even across distinct interpolation buffers.
+    try runAndExpect(
+        \\def main()
+        \\  let n = 1
+        \\  print (1, 2) == (1, 2)
+        \\  print (1, 2) == (1, 3)
+        \\  print (1, 2) != (1, 3)
+        \\  print ("a$(n)", 5) == ("a$(n)", 5)
+        \\  print ("a$(n)", 5) == ("b$(n)", 5)
+        \\end
+    , "1\n0\n1\n1\n0\n");
+}
+
+test "codegen/tuple: `==` recurses into a struct element (str by content)" {
+    try runAndExpect(
+        \\struct P
+        \\  name: str
+        \\end
+        \\def main()
+        \\  let n = 1
+        \\  print (P { name: "x$(n)" }, 3) == (P { name: "x$(n)" }, 3)
+        \\  print (P { name: "x$(n)" }, 3) == (P { name: "y$(n)" }, 3)
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/tuple: ordering comparison is a clean error" {
     try expectCodegenError(
         \\def main()
-        \\  let a = (1, 2)
-        \\  let b = (1, 2)
-        \\  print a == b
+        \\  print (1, 2) < (1, 3)
         \\end
     , "E_CODEGEN_UNSUPPORTED");
 }
 
-test "codegen/tuple: whole-tuple `print` is a clean error" {
-    try expectCodegenError(
+test "codegen/tuple: whole-tuple `print` renders `(v0, v1, …)`" {
+    try runAndExpect(
+        \\enum E
+        \\  case A
+        \\  case V(n: i16)
+        \\end
+        \\def main()
+        \\  print (1, "hi", -3 as i8)
+        \\  print ((1, 2), 3)
+        \\  print (E.V(7), 9)
+        \\end
+    , "(1, hi, -3)\n((1, 2), 3)\n(E.V(7), 9)\n");
+}
+
+test "codegen/tuple: nested aggregate elements construct + access" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\struct S
+        \\  p: (i16, i16)
+        \\  n: i16
+        \\end
+        \\def main()
+        \\  let t = (P { x: 1, y: 2 }, 7)
+        \\  print t.0.x
+        \\  print t.1
+        \\  let u = ((10, 20), 30)
+        \\  print u.0.0
+        \\  print u.0.1
+        \\  let s = S { p: (4, 5), n: 9 }
+        \\  print s.p.0
+        \\  print s.n
+        \\end
+    , "1\n7\n10\n20\n4\n9\n");
+}
+
+test "codegen/tuple: element store `t.N = x`" {
+    try runAndExpect(
         \\def main()
         \\  let t = (1, 2)
-        \\  print t
+        \\  t.0 = 9
+        \\  t.1 += 10
+        \\  print t.0
+        \\  print t.1
         \\end
-    , "E_CODEGEN_UNSUPPORTED");
+    , "9\n12\n");
 }
 
-test "codegen/tuple: a nested-aggregate element is a clean error" {
+test "codegen/tuple: storing into an aggregate element is a clean error" {
     try expectCodegenError(
         \\def main()
         \\  let t = ((1, 2), 3)
-        \\  print t.1
+        \\  t.0 = (9, 9)
+        \\  print 0
         \\end
     , "E_CODEGEN_UNSUPPORTED");
+}
+
+test "codegen/tuple: `==` on `@inline`-returned tuple operands compares by value" {
+    // The caller's prologue backs the inline expansion's frame, so its
+    // slots sit above any pushed operand and the comparison is exact.
+    try runAndExpect(
+        \\@inline
+        \\def pair(n: i16) -> (i16, i16)
+        \\  return (n, n * 2)
+        \\end
+        \\def main()
+        \\  print pair(3) == pair(3)
+        \\  print pair(3) == pair(4)
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/struct: `==` on `@inline`-returned struct operands compares by value" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\@inline
+        \\def mk(n: i16) -> P
+        \\  return P { x: n, y: n }
+        \\end
+        \\def main()
+        \\  print mk(3) == mk(3)
+        \\  print mk(3) == mk(4)
+        \\end
+    , "1\n0\n");
+}
+
+test "codegen/struct: `==` compares a struct literal whose field runs an `@inline` call" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\@inline
+        \\def mk(n: i16) -> P
+        \\  return P { x: n, y: n }
+        \\end
+        \\def main()
+        \\  let p = P { x: 3, y: 3 }
+        \\  print P { x: mk(3).x, y: 3 } == p
+        \\end
+    , "1\n");
+}
+
+test "codegen/inline: two `@inline` calls in one expression don't collide" {
+    // Each expansion's frame is prologue-backed, so the second call's
+    // slots can't alias the first call's result already pushed for the `+`.
+    try runAndExpect(
+        \\@inline
+        \\def sq(n: i16) -> i16
+        \\  let t = n * n
+        \\  return t
+        \\end
+        \\def main()
+        \\  print sq(3) + sq(4)
+        \\end
+    , "25\n");
+}
+
+test "codegen/inline: an aggregate-returning body with inner locals is exact" {
+    // Inner `let`s in an `@inline` body that feed a returned struct get
+    // their own prologue-backed slots — the result reads back correctly.
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\@inline
+        \\def mk(a: i16, b: i16) -> P
+        \\  let t = a + b
+        \\  let u = a - b
+        \\  return P { x: t, y: u }
+        \\end
+        \\def main()
+        \\  print mk(10, 3).x
+        \\  print mk(10, 3).y
+        \\end
+    , "13\n7\n");
+}
+
+test "codegen/tuple: `print` of a struct renders a tuple field inline" {
+    try runAndExpect(
+        \\struct S
+        \\  n: i16
+        \\  p: (i8, str)
+        \\end
+        \\def main()
+        \\  print S { n: 7, p: (-3, "hi") }
+        \\end
+    , "S { n: 7, p: (-3, hi) }\n");
+}
+
+test "codegen/tuple: return-by-value from an `@inline` fn" {
+    try runAndExpect(
+        \\@inline
+        \\def pair() -> (i16, i16)
+        \\  return (11, 22)
+        \\end
+        \\def main()
+        \\  let t = pair()
+        \\  print t.0
+        \\  print t.1
+        \\end
+    , "11\n22\n");
 }
 
 // ---------- value structs (§3.4) ----------

--- a/tests/lang/parser.test.zig
+++ b/tests/lang/parser.test.zig
@@ -256,6 +256,16 @@ test "parse: tuple index access `t.0`" {
     try std.testing.expectEqual(@as(u8, 0), init.tuple_index.index);
 }
 
+test "parse: chained tuple index `t.0.1` splits the folded fixed literal" {
+    var tree = try parseClean("let r = t.0.1");
+    defer tree.deinit();
+    const init = tree.program.statements[0].let_decl.init.?;
+    try std.testing.expect(init.* == .tuple_index);
+    try std.testing.expectEqual(@as(u8, 1), init.tuple_index.index);
+    try std.testing.expect(init.tuple_index.receiver.* == .tuple_index);
+    try std.testing.expectEqual(@as(u8, 0), init.tuple_index.receiver.tuple_index.index);
+}
+
 test "parse: `2.0` still lexes as a fixed literal, not a tuple index" {
     var tree = try parseClean("let r = 2.0");
     defer tree.deinit();


### PR DESCRIPTION
## Summary

Completes tuple support (§3.4) by lowering the five combinations deferred from #305, plus correctness fixes folded in while completing them. All three adversarial review passes came back clean.

### Tuple completion (the issues)
- **#327** structural `==` / `!=` — element-wise, mirroring struct equality (`str` by content, nested struct/tuple/payload-enum recurse; ordering stays rejected).
- **#328** whole-tuple `print` — `(v0, v1, …)`, recursing into nested aggregates; a struct with a tuple field renders inline too.
- **#329** nested aggregate elements — `(P, i16)`, `((1, 2), 3)`, struct-with-tuple-field; `.N` / `.field` address them inline; chained `t.0.1` now parses (the parser splits the `0.1` the lexer folds into a fixed literal).
- **#330** element store — `t.N = x` (and `t.N += …` / `t.N++`); `.N` is a place expression. Storing into an aggregate element is a clean `E_CODEGEN_UNSUPPORTED`.
- **#331** tuple return from `@inline` — materializes into the caller frame like the struct path.

### Folded-in fixes
- **`@inline` frame-model rewrite** — inline expansion frames (args, return slot, body locals) are now reserved up front by the caller's prologue (`countFrameBytes` walks the inline call graph) instead of self-backing with `sub sp` at expansion time. Inline slots sit above the entry `sp`, where pushed operands never reach, so a mid-expression inline call no longer aliases live stack. Fixes pre-existing silent miscompiles: `sq(3) + sq(4)`, `mk(a, b).x` (inner-local aggregate return), and `==`/`!=` on `@inline`-returned aggregates.
- **Interpolation per-evaluation allocation** (§3.2.2) — repeated evaluations of `"…$(x)…"` get a fresh heap buffer, so an earlier binding can't be retroactively mutated.
- **Non-scalar interpolation renders** — `"$(struct)"` / `"$(tuple)"` / `"$(enum)"` embed the §4.9 default rendering via the same renderer `print` uses (host + buffer sinks), instead of formatting the address as an integer.
- **`$$` → `$`** (§3.2.2) — the escape was passing through verbatim.
- **`E_CODEGEN_DATA_OVERFLOW`** now guards the data-global region directly, matching its documented scope.

### Verification
- `zig build ci` green (Debug/ReleaseSafe/ReleaseFast/ReleaseSmall × linux-x64/macos-aarch64/windows-x64/windows-aarch64/wasm32-wasi).
- Adversarial review passes over the inline-frame rewrite, interpolation rendering, and tuple lowering — all confirmed clean after fixes.

Closes #327, #328, #329, #330, #331.