### PR TITLE
fix(lang/codegen): clean diagnostics for over-large programs instead of panics

### DIFF
--- a/.changeset/lang-codegen-image-overflow.md
+++ b/.changeset/lang-codegen-image-overflow.md
@@ -1,0 +1,20 @@
+---
+bump: patch
+---
+
+A program too large to compile now reports a clean diagnostic instead of
+panicking the compiler. Three pathological-size narrowings were hardened:
+
+- **Image overflow** — when the image (code + interned string pool +
+  data) outgrows the addressable 16-bit space, the offset → address
+  conversions clamp at the ceiling during emission (so codegen completes)
+  and a post-emit size check against `0xFE40` reports the new
+  `E_CODEGEN_IMAGE_OVERFLOW`.
+- **Frame / parameter overflow** — a function (or lambda) whose static
+  frame estimate exceeds `u16`, or whose parameter list overruns the
+  `i16` offset range, no longer panics on the prologue's narrowing cast;
+  the over-127-byte frame is reported as `E_CODEGEN_FRAME_TOO_LARGE` as
+  the body emits.
+- **Bank overflow** — a `@bank` def whose code exceeds the 16 KiB bank
+  window is now rejected with `E_CODEGEN_BANK_OVERFLOW` rather than
+  silently truncated to a faulting image.

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -736,6 +736,8 @@ should have already enforced.
 | `E_CODEGEN_NO_SELF` | `super.method` / `self` used outside a method body. |
 | `E_CODEGEN_ZP_OVERFLOW` | The zero-page region is exhausted — too many `@zero_page` globals. |
 | `E_CODEGEN_DATA_OVERFLOW` | The static data region is exhausted — too many data globals. |
+| `E_CODEGEN_IMAGE_OVERFLOW` | The program image (code + interned strings + data) exceeds the addressable ceiling (`0xFE40`) — too much code. |
+| `E_CODEGEN_BANK_OVERFLOW` | A `@bank` def's code exceeds the 16 KiB bank window. |
 | `E_CODEGEN_DEFER_NO_BLOCK` | A `defer` was emitted with no enclosing block frame (internal invariant). |
 | `E_CODEGEN_LOOP_JUMP_NO_LOOP` | `break` / `continue` reached codegen outside any loop (internal — the typechecker normally catches this). |
 | `E_CODEGEN_LAMBDA_NOT_ANALYZED` | Internal: a lambda body was missing from the closure-analysis pass. |
@@ -830,6 +832,8 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_CODEGEN_NO_SELF` | Codegen | v0.3 |
 | `E_CODEGEN_ZP_OVERFLOW` | Codegen | v0.3 |
 | `E_CODEGEN_DATA_OVERFLOW` | Codegen | v0.3 |
+| `E_CODEGEN_IMAGE_OVERFLOW` | Codegen | v0.3 |
+| `E_CODEGEN_BANK_OVERFLOW` | Codegen | v0.3 |
 | `E_CODEGEN_DEFER_NO_BLOCK` | Codegen | v0.3 |
 | `E_CODEGEN_LOOP_JUMP_NO_LOOP` | Codegen | v0.3 |
 | `E_CODEGEN_LAMBDA_NOT_ANALYZED` | Codegen | v0.3 |

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -38,11 +38,22 @@ pub const ivt_base: u16 = 0x1000;
 pub const code_base: u16 = 0x1100;
 /// First byte of static-data emission.
 pub const data_base: u16 = 0x2000;
-/// Upper bound (exclusive) of the static-data region. Data globals grow
-/// up from `data_base` and must stay below the host IO / command surface
-/// just above (gtx-16 maps its command surface at `0xFE50`); past this a
-/// global can't be addressed safely.
+/// Upper bound (exclusive) of the static-data region — and of the whole
+/// program image. Code, the interned string pool, and data globals all
+/// grow toward this and must stay below the host IO / command surface
+/// just above (gtx-16 maps its command surface at `0xFE50`); past it an
+/// address can't be reached (data → `E_CODEGEN_DATA_OVERFLOW`, the whole
+/// image → `E_CODEGEN_IMAGE_OVERFLOW`).
 pub const data_region_end: u16 = 0xFE40;
+
+/// Convert a buffer-local `offset` under code base `base` to a u16
+/// address, clamping at the u16 ceiling. An over-large image yields a
+/// meaningless (clamped) address but never panics on the narrowing cast —
+/// the post-emit `E_CODEGEN_IMAGE_OVERFLOW` check rejects it cleanly.
+pub fn offsetToAddr(base: u16, offset: usize) u16 {
+    // @as: clamped to ≤ 0xFFFF before the narrow, so it can't truncate.
+    return @intCast(@min(@as(usize, base) + offset, 0xFFFF));
+}
 
 // ---------- .gx file constants (re-exported from archive) ----------
 
@@ -210,6 +221,36 @@ pub fn compile(
     }
 
     try emitter.emitProgram(checked.program, opts.entry_name);
+
+    // Reject an image that overruns the addressable ceiling before
+    // assembling it — the address narrowing during emission clamped
+    // (never panicked), so the size is meaningful here. The code buffer
+    // (code + interned string pool) and the data globals both grow toward
+    // `data_region_end`; past it nothing downstream (heap, IO page) has
+    // room.
+    // @as: widen the u16 bases to usize for the byte-length math.
+    const image_top: usize = @max(@as(usize, code_base) + emitter.code.items.len, @as(usize, emitter.data_cursor));
+    // A `@bank` def's code lives in a separate 16 KiB window buffer; the
+    // archive would silently truncate one that overran it (and the
+    // address clamp above hides the spilled jump targets), so reject it.
+    var bank_overflow = false;
+    var bank_it = emitter.banks.valueIterator();
+    while (bank_it.next()) |b| {
+        if (b.items.len > archive.bank_disk_size) bank_overflow = true;
+    }
+    if (image_top > data_region_end or bank_overflow) {
+        if (bank_overflow) {
+            try emitter.diagFatal(.{ .start = 0, .end = 0 }, "E_CODEGEN_BANK_OVERFLOW", "a `@bank` def's code exceeds the 16 KiB bank window — split it across banks or reduce its size");
+        } else {
+            try emitter.diagFatal(.{ .start = 0, .end = 0 }, "E_CODEGEN_IMAGE_OVERFLOW", "program image (code + interned strings + data) exceeds the addressable ceiling — reduce program size");
+        }
+        return .{
+            .image = try allocator.alloc(u8, 0),
+            .diagnostics = try diagnostics.toOwnedSlice(allocator),
+            .diag_arena = diag_arena,
+            .allocator = allocator,
+        };
+    }
 
     // Build base image: zeros from 0x0000 up to `code_base`, then
     // the emitted code. The static-data region gets folded in only
@@ -1303,9 +1344,7 @@ pub const Emitter = struct {
         self.current_bank = null;
         defer self.current_bank = saved_bank;
 
-        // @as: narrow usize → u16; base image fits in 64 KiB.
-        const tramp_offset: u16 = @intCast(self.code.items.len);
-        self.trampoline_addr = code_base + tramp_offset;
+        self.trampoline_addr = offsetToAddr(code_base, self.code.items.len);
 
         // Save the caller's bank, switch via r2, call the target in r1,
         // restore. The byte sequence is the listing in the doc above.
@@ -1788,9 +1827,7 @@ pub const Emitter = struct {
     /// Resolve a code-buffer offset to its run-time address.
     /// Picks `bank_window_base` or `code_base` from `current_bank`.
     pub fn codeOffsetToAddress(self: *const Emitter, offset: usize) u16 {
-        // @as: per-buffer offsets stay ≤ 64 KiB by ISA constraint.
-        const ofs: u16 = @intCast(offset);
-        return if (self.current_bank != null) bank_window_base + ofs else code_base + ofs;
+        return offsetToAddr(if (self.current_bank != null) bank_window_base else code_base, offset);
     }
 
     /// Mutable view into the active code buffer. Used for emit-

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -211,9 +211,7 @@ pub fn emitVtables(self: *Emitter) !void {
         const class_name = entry.key_ptr.*;
         const layout = self.class_layouts.getPtr(class_name) orelse continue;
 
-        // @as: currentOffset returns usize, narrow to u16 — base image is ≤ 64 KiB.
-        const offset: u16 = @intCast(try self.currentOffset());
-        layout.vtable_addr = codegen_mod.code_base +% offset;
+        layout.vtable_addr = codegen_mod.offsetToAddr(codegen_mod.code_base, try self.currentOffset());
 
         // Iterate in slot order — each slot's address comes from
         // the class that actually owns the method (inherited

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -80,9 +80,8 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     }
 
     const dup_name = try self.arena.dupe(u8, label);
-    // @as: per-buffer code offset stays ≤ 64 KiB.
-    const code_offset: u16 = @intCast(try self.currentOffset());
-    const addr: u16 = if (bank_target) |_| bank_window_base + code_offset else codegen.code_base + code_offset;
+    const base = if (bank_target) |_| bank_window_base else codegen.code_base;
+    const addr = codegen.offsetToAddr(base, try self.currentOffset());
     try self.fn_addresses.put(self.arena, dup_name, addr);
 
     // Bind params to positive fp-relative offsets. `call` leaves the
@@ -109,16 +108,22 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     // `return` copies the result there instead of into `acu`.
     self.current_ret_struct = if (def.ret_type) |rt| self.structNameOfTypeAnn(rt.*) else null;
     self.current_ret_is_tuple = if (def.ret_type) |rt| rt.* == .tuple else false;
-    // @as: sits past the params; the frame-size cap keeps it small.
-    self.sret_param_ofs = @intCast(param_ofs);
+    // A param list overrunning the fp range already set `frame_overflow`
+    // above, so this clamped value is unused; the clamp only keeps the
+    // narrowing from panicking on a pathologically long param list.
+    // @as: clamp `param_ofs` into i16 before the narrowing cast.
+    self.sret_param_ofs = @intCast(@min(param_ofs, @as(i32, std.math.maxInt(i16))));
 
     // Reserve the frame up front (fixed reservation — a real allocator
     // would compute live ranges). The sret scratch buffer (holds a
     // returned struct until its consumer copies it out) is carved first
     // so its offset stays stable across the body.
     const scratch_bytes: u16 = self.global_sret_scratch;
-    // @as: frame size capped well below u16 by the i8 offset cap.
-    const reserve_bytes: u16 = @intCast(self.countFrameBytes(def.body) + scratch_bytes);
+    // A frame past the 127-byte fp range is caught by `reserveFrameSlot`
+    // as the body emits (→ `E_CODEGEN_FRAME_TOO_LARGE`); this clamp only
+    // keeps the static estimate's narrowing from panicking on a huge frame.
+    // @as: clamp the frame estimate into u16 before the narrowing cast.
+    const reserve_bytes: u16 = @intCast(@min(self.countFrameBytes(def.body) + scratch_bytes, @as(usize, std.math.maxInt(u16))));
     if (reserve_bytes > 0) try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
     if (scratch_bytes > 0) self.sret_scratch_ofs = try self.allocLocalSized("\x00sret", scratch_bytes);
 

--- a/src/lang/codegen/isa.zig
+++ b/src/lang/codegen/isa.zig
@@ -267,9 +267,7 @@ pub fn emitJumpPlaceholder(self: *Emitter, op: u8) !usize {
 /// current code buffer.
 pub fn patchJumpTo(self: *Emitter, patch_offset: usize, target_offset: usize) !void {
     const buf = try self.currentCode();
-    // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
-    const target_in_buffer: u16 = @intCast(target_offset);
-    const target_addr: u16 = self.currentBufferBase() +% target_in_buffer;
+    const target_addr = codegen.offsetToAddr(self.currentBufferBase(), target_offset);
     // safety: u16 → 2 LE bytes; both casts are byte-masks.
     buf.items[patch_offset] = @intCast(target_addr & 0xFF);
     buf.items[patch_offset + 1] = @intCast(target_addr >> 8);
@@ -279,9 +277,7 @@ pub fn patchJumpTo(self: *Emitter, patch_offset: usize, target_offset: usize) !v
 /// the current buffer. Used for loop back-edges.
 pub fn emitJumpBack(self: *Emitter, target_offset: usize) !void {
     try self.emitByte(Op.jmp_addr);
-    // @as: usize → u16; per-buffer offset stays ≤ 64 KiB.
-    const target_in_buffer: u16 = @intCast(target_offset);
-    try self.emitU16Le(self.currentBufferBase() +% target_in_buffer);
+    try self.emitU16Le(codegen.offsetToAddr(self.currentBufferBase(), target_offset));
 }
 
 /// `jmp reg` (0x91) — indirect jump via the register's value.

--- a/src/lang/codegen/lambda.zig
+++ b/src/lang/codegen/lambda.zig
@@ -374,9 +374,7 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
     }
 
     const dup_label = try self.arena.dupe(u8, li.label);
-    // @as: narrow usize code offset to u16; per-buffer offset stays ≤ 64 KiB.
-    const code_offset: u16 = @intCast(try self.currentOffset());
-    const addr: u16 = codegen_mod.code_base + code_offset;
+    const addr = codegen_mod.offsetToAddr(codegen_mod.code_base, try self.currentOffset());
     try self.fn_addresses.put(self.arena, dup_label, addr);
 
     // env_ptr is the hidden first param at fp+4. Register it
@@ -421,8 +419,11 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
     // any other fn).
     const frame_bytes = self.countFrameBytes(lambda.body);
     if (frame_bytes > 0) {
-        // @as: frame size caps well below u16 by the i8 offset cap.
-        const reserve_bytes: u16 = @intCast(frame_bytes);
+        // An over-127 frame is caught by `reserveFrameSlot` as the body
+        // emits (→ frame-too-large); this clamp only keeps the narrowing
+        // from panicking on a huge frame.
+        // @as: clamp the frame estimate into u16 before the narrowing cast.
+        const reserve_bytes: u16 = @intCast(@min(frame_bytes, @as(usize, std.math.maxInt(u16))));
         try isa.subImmFromReg(self, reserve_bytes, Reg.sp);
     }
 

--- a/src/lang/codegen/strings.zig
+++ b/src/lang/codegen/strings.zig
@@ -54,9 +54,7 @@ pub fn emitStringPool(self: *Emitter) !void {
     defer self.current_bank = saved_bank;
 
     for (self.strings.items) |*s| {
-        // @as: usize → u16; base image fits in 16-bit address space.
-        const offset: u16 = @intCast(try self.currentOffset());
-        s.address = codegen.code_base +% offset;
+        s.address = codegen.offsetToAddr(codegen.code_base, try self.currentOffset());
         for (s.bytes) |b| try self.emitByte(b);
         try self.emitByte(0);
     }

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1421,6 +1421,136 @@ test "codegen: zero-page overflow emits E_CODEGEN_ZP_OVERFLOW" {
     try std.testing.expect(found);
 }
 
+test "codegen: an over-large image emits E_CODEGEN_IMAGE_OVERFLOW (no panic)" {
+    // ~5000 `print`s of distinct strings push the code buffer + string
+    // pool past the addressable ceiling (0xFE40); the address narrowing
+    // must clamp and surface a clean diagnostic, not panic on the cast.
+    var source: std.ArrayList(u8) = .empty;
+    defer source.deinit(alloc);
+    try source.appendSlice(alloc, "def main()\n");
+    var i: usize = 0;
+    while (i < 5000) : (i += 1) {
+        const line = try std.fmt.allocPrint(alloc, "  print \"message string number {d}\"\n", .{i});
+        defer alloc.free(line);
+        try source.appendSlice(alloc, line);
+    }
+    try source.appendSlice(alloc, "end");
+
+    var stream = try gero.lang.tokenize(alloc, source.items);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source.items, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source.items, &tree.program);
+    defer checked.deinit();
+
+    var compiled = try gero.lang.compile(alloc, source.items, &checked, .{});
+    defer compiled.deinit();
+    try std.testing.expect(compiled.hasErrors());
+
+    var found = false;
+    for (compiled.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_CODEGEN_IMAGE_OVERFLOW")) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+test "codegen: a `@bank` def overrunning its 16 KiB window fails cleanly" {
+    // A banked def whose code exceeds the bank window would be silently
+    // truncated by the archive (and the address clamp hides the spill);
+    // reject it with `E_CODEGEN_BANK_OVERFLOW` instead.
+    var source: std.ArrayList(u8) = .empty;
+    defer source.deinit(alloc);
+    try source.appendSlice(alloc, "@bank 1\ndef huge(x: i16) -> i16\n  let s: i16 = x\n");
+    var i: usize = 0;
+    while (i < 260) : (i += 1) {
+        const line = try std.fmt.allocPrint(alloc, "  if s < {d}\n    s = s + 1\n  else\n    s = s - 1\n  end\n", .{i});
+        defer alloc.free(line);
+        try source.appendSlice(alloc, line);
+    }
+    try source.appendSlice(alloc, "  return s\nend\ndef main()\n  print huge(0)\nend");
+
+    var stream = try gero.lang.tokenize(alloc, source.items);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source.items, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source.items, &tree.program);
+    defer checked.deinit();
+
+    var compiled = try gero.lang.compile(alloc, source.items, &checked, .{});
+    defer compiled.deinit();
+    try std.testing.expect(compiled.hasErrors());
+    var found = false;
+    for (compiled.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_CODEGEN_BANK_OVERFLOW")) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+test "codegen: a frame whose static size overflows u16 fails cleanly (no panic)" {
+    // ~33000 uninitialized locals make `countFrameBytes` exceed `0xFFFF`;
+    // the prologue's frame-size narrowing must clamp (the over-127 frame
+    // is reported as `E_CODEGEN_FRAME_TOO_LARGE`), not panic.
+    var source: std.ArrayList(u8) = .empty;
+    defer source.deinit(alloc);
+    try source.appendSlice(alloc, "def main()\n");
+    var i: usize = 0;
+    while (i < 33000) : (i += 1) {
+        const line = try std.fmt.allocPrint(alloc, "  let v{d}: u16\n", .{i});
+        defer alloc.free(line);
+        try source.appendSlice(alloc, line);
+    }
+    try source.appendSlice(alloc, "end");
+
+    var stream = try gero.lang.tokenize(alloc, source.items);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source.items, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source.items, &tree.program);
+    defer checked.deinit();
+
+    var compiled = try gero.lang.compile(alloc, source.items, &checked, .{});
+    defer compiled.deinit();
+    try std.testing.expect(compiled.hasErrors());
+    var found = false;
+    for (compiled.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_CODEGEN_FRAME_TOO_LARGE")) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+test "codegen: a param list whose offset overflows i16 fails cleanly (no panic)" {
+    // ~17000 params push the running param offset past `i16` range; the
+    // post-loop `sret_param_ofs` narrowing must clamp rather than panic
+    // (the params overrun the fp range → `E_CODEGEN_FRAME_TOO_LARGE`).
+    var source: std.ArrayList(u8) = .empty;
+    defer source.deinit(alloc);
+    try source.appendSlice(alloc, "def big(");
+    var i: usize = 0;
+    while (i < 17000) : (i += 1) {
+        if (i > 0) try source.appendSlice(alloc, ", ");
+        const p = try std.fmt.allocPrint(alloc, "p{d}: i16", .{i});
+        defer alloc.free(p);
+        try source.appendSlice(alloc, p);
+    }
+    try source.appendSlice(alloc, ") -> i16\n  return p0\nend\ndef main() end");
+
+    var stream = try gero.lang.tokenize(alloc, source.items);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source.items, stream);
+    defer tree.deinit();
+    var checked = try gero.lang.typecheck(alloc, source.items, &tree.program);
+    defer checked.deinit();
+
+    var compiled = try gero.lang.compile(alloc, source.items, &checked, .{});
+    defer compiled.deinit();
+    try std.testing.expect(compiled.hasErrors());
+    var found = false;
+    for (compiled.diagnostics) |d| {
+        if (std.mem.eql(u8, d.code, "E_CODEGEN_FRAME_TOO_LARGE")) found = true;
+    }
+    try std.testing.expect(found);
+}
+
 // ---------- enum codegen (nullary variants) ----------
 
 test "codegen: a nullary enum value renders as `Enum.Variant`" {


### PR DESCRIPTION
## Summary

A program too large to compile — or a `@bank` def too large for its window — panicked the compiler (an unguarded `usize → u16` narrowing: *"integer does not fit in destination type"*) instead of producing a clean diagnostic. This hardens every pathological-size narrowing in codegen so each route reports a clean error and exits non-zero.

### Fixes
- **Image overflow** → `E_CODEGEN_IMAGE_OVERFLOW` — when the image (code + interned strings + data) outgrows the addressable space. All offset → address conversions route through one saturating `offsetToAddr` helper so emission completes; a post-emit size check (`0xFE40`) reports the error before assembly.
- **Frame / parameter overflow** → `E_CODEGEN_FRAME_TOO_LARGE` — a function/lambda whose static frame exceeds `u16`, or whose param list overruns the `i16` offset range, clamps the prologue cast and surfaces the existing over-127-byte diagnostic (rather than panicking before it can fire).
- **Bank overflow** → `E_CODEGEN_BANK_OVERFLOW` — a `@bank` def whose code exceeds the 16 KiB window (the address clamp would otherwise hide a silent archive truncation, producing a faulting image at exit 0).

### Verification
- `zig build ci` green (all release modes + cross-targets).
- Three adversarial review passes over the oversized-program space (which surfaced the frame/param and bank cases, all fixed here), plus a manual sweep of 8 overflow routes — every route yields a clean diagnostic, no panic / silent truncation. Normal programs (including medium multi-KB programs and small banked defs) compile + run unchanged — the clamp never alters a valid program's addresses.

### Out of scope (pre-existing, surfaced during review)
Cross-bank **parameter** passing (`@bank N def f(a, b)`) silently returns garbage — a pre-existing cross-bank-trampoline frame-offset bug, unrelated to this fix (those addresses are tiny and never clamped). Flagged for a separate PR.