### PR TITLE
fix(lang/codegen): frame-transparent, interrupt-safe cross-bank calls

### DIFF
--- a/.changeset/lang-codegen-cross-bank-params.md
+++ b/.changeset/lang-codegen-cross-bank-params.md
@@ -22,5 +22,13 @@ calls can neither corrupt the shared save-stack nor an in-flight call.
 Banked programs now run their stack in low RAM instead of leaving it at
 the boot `sp` (`0xFFFE`). The boot stack grows down through the IO page
 and the bank window (`0xC000..0xFEFF`), which is bank-switched for a
-banked program — so call frames would corrupt across a bank hop.
-Unbanked programs keep the boot `sp` and are unchanged.
+banked program — so call frames would corrupt across a bank hop. Both
+`sp` and `fp` move (the entry's own locals are `fp`-relative). Unbanked
+programs keep the boot `sp` and are unchanged.
+
+`@interrupt` handlers are now transparent to the interrupted code.
+Interrupt entry preserves only `ip`/`fp`/`flg`, so the compiler saves +
+restores the general-purpose registers around the handler body and
+gives the handler its own stack frame. Previously a handler clobbered
+the interrupted code's live registers, and a handler with locals
+aliased the interrupted frame and misaligned its `rti`.

--- a/.changeset/lang-codegen-cross-bank-params.md
+++ b/.changeset/lang-codegen-cross-bank-params.md
@@ -1,0 +1,26 @@
+---
+bump: patch
+---
+
+Cross-bank calls (`@bank N`) now pass parameters and return values
+correctly. The trampoline is frame-transparent: the callee reads its
+arguments at the same frame offsets as a direct call, so banked
+functions that take parameters — and that return structs / tuples —
+work instead of reading six bytes of stale stack.
+
+Nested cross-bank calls unwind correctly. Each level parks its (bank,
+return-address) on a small save-stack in low RAM, so a banked function
+calling another banked function restores the caller's bank on return.
+
+Cross-bank calls are interrupt-safe. The trampoline masks interrupts
+around its save-stack critical sections and both enters and returns via
+`rti`, which restores the saved interrupt state and jumps atomically —
+so the target and return-address ride the stack rather than a register
+across any unmask, and an `@interrupt` handler that itself cross-bank-
+calls can neither corrupt the shared save-stack nor an in-flight call.
+
+Banked programs now run their stack in low RAM instead of leaving it at
+the boot `sp` (`0xFFFE`). The boot stack grows down through the IO page
+and the bank window (`0xC000..0xFEFF`), which is bank-switched for a
+banked program — so call frames would corrupt across a bank hop.
+Unbanked programs keep the boot `sp` and are unchanged.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -2560,14 +2560,19 @@ const INTRO = "Welcome to Mistwood..."
 ```
 
 The compiler places this module's compiled output in bank 5. Cross-
-bank calls compile to:
+bank calls are **transparent**: parameters, return values, and struct
+/ tuple passing follow the same ABI as a direct call. The compiler
+routes each cross-bank call through a shared `__call_bank` trampoline
+that saves the caller's bank, switches to the target, runs the callee,
+and restores the bank on return. The trampoline parks each level's
+(bank, return-address) on a small save-stack in low RAM, so nested
+cross-bank calls — including one re-entered from an `@interrupt`
+handler — unwind correctly; its bank-switch critical sections run with
+interrupts masked.
 
-```asm
-push mb                     ; save current bank
-mov #5, mb                  ; switch
-call town__intro_addr
-pop mb                      ; restore
-```
+Because the bank window (`$C000..$FEFF`) is bank-switched, a banked
+program runs its stack in low RAM (the conventional stack range,
+above) so call frames never land in switched memory.
 
 Per-declaration banking is also supported — useful when only some
 items in a module need to live in a specific bank:
@@ -2583,8 +2588,7 @@ def boss_battle_data() -> [u8; 256]
 end
 ```
 
-Cross-bank calls go through the trampoline pattern above; intra-bank
-calls compile to plain `call addr` with no overhead.
+Intra-bank calls compile to plain `call addr` with no overhead.
 
 ---
 

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -982,7 +982,7 @@ Module-level visibility is controlled by the `local` keyword
 
 | Annotation | Applies to | Effect |
 |------------|------------|--------|
-| `@interrupt N` | `def` | Bind this function as the handler for vector `N` (gero ISA §6.1). The compiler emits the `rti` epilogue automatically and writes the function address into `mem[$1000 + 2 * N]` at boot. The function body must take no parameters and return nothing. |
+| `@interrupt N` | `def` | Bind this function as the handler for vector `N` (gero ISA §6.1). The compiler makes the handler transparent to the interrupted code: interrupt entry preserves only `ip`/`fp`/`flg` (ISA §6.2), so the compiler saves + restores the general-purpose registers around the body and gives the handler its own stack frame. It emits the `rti` epilogue automatically and writes the function address into `mem[$1000 + 2 * N]` at boot. The function body must take no parameters and return nothing. |
 
 ```
 @interrupt $06              -- vblank

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -608,6 +608,11 @@ When an interrupt fires (and is not masked — see §6.4):
 3. Set `ip ← mem[0x1000 + 2 * vector]`.
 4. Continue dispatch.
 
+Only `ip`, `fp`, and `flg` are saved. General-purpose registers
+(`acu`, `r1`–`r6`) are **not** preserved — a handler must save and
+restore any it clobbers (6502 `pha`/`pla` discipline). The gero-lang
+compiler does this automatically for `@interrupt` handlers.
+
 ### 6.3 Exit sequence (`rti`)
 
 1. Pop `flg`, `fp`, `ip` (reverse order).

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -81,6 +81,13 @@ const bank_save_top: u16 = bank_save_base + bank_save_slot_bytes * bank_save_lev
 // growing down toward the save-stack at `bank_save_ptr`.
 const bank_stack_top: u16 = 0x0FFE;
 
+// GP registers an `@interrupt` handler saves on entry + restores before
+// `rti`, so it's transparent to the interrupted code (the VM saves only
+// `ip`/`fp`/`flg`). All of them: regular codegen uses `acu`/`r1`–`r3`
+// and the cross-bank trampoline `r4`–`r6`, and a handler may exercise
+// either — saving the full set keeps it correct regardless of which.
+const isr_saved_regs = [_]u8{ Reg.acu, Reg.r1, Reg.r2, Reg.r3, Reg.r4, Reg.r5, Reg.r6 };
+
 // ---------- .gx file constants (re-exported from archive) ----------
 
 const bank_window_base = archive.bank_window_base;
@@ -1368,11 +1375,39 @@ pub const Emitter = struct {
     }
 
     /// Move the runtime stack into low RAM for banked programs so call
-    /// frames stay out of the bank-switched window. No-op (keeps the
-    /// boot `sp`) for unbanked programs. Emit before the frame reserve.
+    /// frames stay out of the bank-switched window. Sets both `sp` and
+    /// `fp` (the entry's own locals are `fp`-relative, so `fp` must move
+    /// too). No-op (keeps the boot `sp`/`fp`) for unbanked programs.
+    /// Emit before the frame reserve.
     pub fn relocateBankStack(self: *Emitter) !void {
         if (!self.hasBankedDefs()) return;
         try isa.movImmToReg(self, bank_stack_top, Reg.sp);
+        try isa.movRegToReg(self, Reg.sp, Reg.fp);
+    }
+
+    /// `@interrupt` prologue: interrupt entry saves only `ip`/`fp`/`flg`,
+    /// so a handler must preserve every GP register it might clobber for
+    /// the interrupted code to resume intact. Push them, then give the
+    /// handler its own frame (`fp = sp`) so its locals don't alias the
+    /// interrupted frame. `mb` is left alone — a handler never changes it
+    /// except via the cross-bank trampoline, which restores it. Emit
+    /// before the frame reserve.
+    pub fn emitIsrPrologue(self: *Emitter) !void {
+        for (isr_saved_regs) |r| try isa.pushReg(self, r);
+        try isa.movRegToReg(self, Reg.sp, Reg.fp);
+    }
+
+    /// `@interrupt` epilogue: release the frame, restore the saved GP
+    /// registers (reverse push order), then `rti`. Replaces the bare
+    /// `rti` at every handler exit (fall-off + explicit `return`).
+    pub fn emitIsrEpilogue(self: *Emitter) !void {
+        try isa.movRegToReg(self, Reg.fp, Reg.sp); // release the frame
+        var i: usize = isr_saved_regs.len;
+        while (i > 0) {
+            i -= 1;
+            try isa.popReg(self, isr_saved_regs[i]);
+        }
+        try self.emitByte(Op.rti_op);
     }
 
     /// Emit the cross-bank call trampoline in the base image (always

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -55,6 +55,32 @@ pub fn offsetToAddr(base: u16, offset: usize) u16 {
     return @intCast(@min(@as(usize, base) + offset, 0xFFFF));
 }
 
+// ---------- cross-bank save-stack (codegen-internal) ----------
+
+// A software save-stack for the `__call_bank` trampoline: each cross-bank
+// call parks (saved `mb`, caller return-ip) here so nested cross-bank
+// calls — including one re-entered from an `@interrupt` handler — unwind
+// correctly. It sits at the bottom of low RAM, below `code_base` /
+// `data_base` and always mapped regardless of `mb`. Banked programs run
+// their runtime stack from the top of low RAM (`bank_stack_top`) growing
+// down toward this area, so the two share low RAM — roughly 3.5 KB of
+// runtime stack before they meet (untrapped, as with any stack overflow).
+const bank_save_ptr: u16 = 0x0100; // 2-byte cell holding the live save-sp
+const bank_save_slot_bytes: u16 = 4; // one (mb, return-ip) pair per level
+const bank_save_mb_ofs: i8 = 0; // saved `mb` within a slot
+const bank_save_ret_ofs: i8 = 2; // saved caller return-ip within a slot
+const bank_save_levels: u16 = 64; // max cross-bank nesting depth
+const bank_save_base: u16 = bank_save_ptr + 2; // first save-area byte
+const bank_save_top: u16 = bank_save_base + bank_save_slot_bytes * bank_save_levels; // initial save-sp (grows down)
+
+// Initial `sp` for banked programs. The boot default (`0xFFFE`) puts
+// the runtime stack in the IO page + bank window (`0xC000..0xFEFF`,
+// bank-switched) — so call frames would land in bank-mapped memory and
+// corrupt across a bank hop. Banked programs instead start the stack at
+// the top of low RAM (the ISA's canonical stack home, always flat),
+// growing down toward the save-stack at `bank_save_ptr`.
+const bank_stack_top: u16 = 0x0FFE;
+
 // ---------- .gx file constants (re-exported from archive) ----------
 
 const bank_window_base = archive.bank_window_base;
@@ -1324,38 +1350,118 @@ pub const Emitter = struct {
         return false;
     }
 
-    /// Emit the `__call_bank` cross-bank trampoline (10 bytes) in
-    /// the base image. Caller sets `r1 = target_addr`,
-    /// `r2 = target_bank`, then `call __call_bank`.
+    /// `true` when any top-level def carries `@bank N`. Cross-bank
+    /// calls are then possible, so the entry prologue seeds the
+    /// save-stack pointer.
+    fn hasBankedDefs(self: *const Emitter) bool {
+        var it = self.fn_banks.valueIterator();
+        while (it.next()) |b| if (b.* != null) return true;
+        return false;
+    }
+
+    /// Seed the cross-bank save-stack pointer to the top of its area.
+    /// Emitted once in the entry prologue, only when the program has
+    /// banked defs — the first `__call_bank` then finds a valid slot.
+    pub fn seedBankSaveStack(self: *Emitter) !void {
+        if (!self.hasBankedDefs()) return;
+        try isa.movImmToAddr(self, bank_save_top, bank_save_ptr);
+    }
+
+    /// Move the runtime stack into low RAM for banked programs so call
+    /// frames stay out of the bank-switched window. No-op (keeps the
+    /// boot `sp`) for unbanked programs. Emit before the frame reserve.
+    pub fn relocateBankStack(self: *Emitter) !void {
+        if (!self.hasBankedDefs()) return;
+        try isa.movImmToReg(self, bank_stack_top, Reg.sp);
+    }
+
+    /// Emit the cross-bank call trampoline in the base image (always
+    /// reachable regardless of `mb`). A caller pushes `target_bank`
+    /// then `target_addr`, then `call __call_bank`.
     ///
-    /// ```
-    /// push mb         ; 31 0C
-    /// mov r2, mb      ; 11 03 0C
-    /// call r1         ; A1 02
-    /// pop mb          ; 32 0C
-    /// ret             ; A2
-    /// ```
+    /// The trampoline is frame-transparent: it pops its own return
+    /// frame + the stack-passed target, parks (caller `mb`, caller
+    /// return-ip) on the save-stack, then rebuilds the callee's frame
+    /// below `arg0` and enters via `rti` so the callee reads `arg0` at
+    /// `[fp+4]` exactly as a direct call would. The `__bank_return`
+    /// continuation (entered when the callee returns) restores `mb` +
+    /// the caller return-ip. Both the save-stack push / pop and the
+    /// bank-switched entry / exit run with interrupts masked: `sei`
+    /// guards the critical section, and `rti` restores the saved `flg`
+    /// (and jumps) atomically — so no register stays live across an
+    /// unmask, and an `@interrupt` handler that itself cross-bank-calls
+    /// can neither corrupt the shared save-stack nor the target.
     fn emitCallBankTrampoline(self: *Emitter) !void {
-        // The trampoline must live in the base image (always
-        // reachable regardless of `mb`). Save / restore the
-        // bank-routing state explicitly even though we expect the
-        // caller to be in the base buffer already.
         const saved_bank = self.current_bank;
         self.current_bank = null;
         defer self.current_bank = saved_bank;
+        // `__bank_return` emits first so its address is a known immediate
+        // for the `__call_bank` continuation push.
+        const bank_return_addr = try self.emitBankReturn();
+        try self.emitCallBankEntry(bank_return_addr);
+    }
 
+    /// Emit `__bank_return` — the continuation the callee returns to.
+    /// On entry sp is at arg0, fp = caller fp, `acu` holds the result.
+    /// Pops the save-stack under a mask, restores the caller's bank, and
+    /// returns via `rti` (atomic flg-restore + jump). Returns its own
+    /// address for the entry half to push as the callee's return-ip.
+    fn emitBankReturn(self: *Emitter) !u16 {
+        const bank_return_addr = offsetToAddr(code_base, self.code.items.len);
+        try isa.movRegToReg(self, Reg.flg, Reg.r6); // save flg (incl. I bit)
+        try isa.sei(self);
+        try isa.movAddrToReg(self, bank_save_ptr, Reg.r4);
+        try isa.movRegOffsetToReg(self, Reg.r4, bank_save_mb_ofs, Reg.r5); // saved mb
+        try isa.movRegOffsetToReg(self, Reg.r4, bank_save_ret_ofs, Reg.r3); // caller return-ip
+        try isa.addImmToReg(self, bank_save_slot_bytes, Reg.r4);
+        try isa.movRegToAddr(self, Reg.r4, bank_save_ptr);
+        try isa.movRegToReg(self, Reg.r5, Reg.mb); // restore caller bank
+        // `rti` pops flg, then fp, then return-ip — push them reversed
+        // (return-ip deepest, saved flg on top); `rti` restores the
+        // interrupt state and jumps to the caller in one step.
+        try isa.pushReg(self, Reg.r3); // caller return-ip
+        try isa.pushReg(self, Reg.fp); // caller fp (rti re-sets it; unchanged)
+        try isa.pushReg(self, Reg.r6); // saved flg
+        try self.emitByte(Op.rti_op);
+        return bank_return_addr;
+    }
+
+    /// Emit `__call_bank` — the entry callers target (records
+    /// `trampoline_addr`). Pops its own return frame + the stack-passed
+    /// target, parks (caller mb, caller return-ip) on the save-stack,
+    /// then rebuilds the callee's frame below arg0 and enters via `rti`.
+    /// `bank_return_addr` becomes the callee's return-ip.
+    fn emitCallBankEntry(self: *Emitter, bank_return_addr: u16) !void {
         self.trampoline_addr = offsetToAddr(code_base, self.code.items.len);
-
-        // Save the caller's bank, switch via r2, call the target in r1,
-        // restore. The byte sequence is the listing in the doc above.
-        try self.emitByte(Op.push_reg);
-        try self.emitByte(Reg.mb);
-        try isa.movRegToReg(self, Reg.r2, Reg.mb);
-        try self.emitByte(Op.call_reg);
-        try self.emitByte(Reg.r1);
-        try self.emitByte(Op.pop_reg);
-        try self.emitByte(Reg.mb);
-        try self.emitByte(Op.ret_op);
+        // Mask before touching the save-stack: r3 (caller return-ip) +
+        // r4 (save-sp) must survive the read-modify-write, and an
+        // interrupt clobbers all general registers.
+        try isa.movRegToReg(self, Reg.flg, Reg.r6); // save flg
+        try isa.sei(self);
+        try isa.popReg(self, Reg.r3); // caller return-ip
+        try isa.popReg(self, Reg.fp); // caller old fp
+        try isa.popReg(self, Reg.r1); // target address
+        try isa.popReg(self, Reg.r2); // target bank; sp now at arg0
+        // Park (caller mb, caller return-ip) on the save-stack.
+        try isa.movAddrToReg(self, bank_save_ptr, Reg.r4);
+        try isa.subImmFromReg(self, bank_save_slot_bytes, Reg.r4);
+        try isa.movRegToReg(self, Reg.mb, Reg.r5);
+        try isa.movRegToRegOffset(self, Reg.r5, Reg.r4, bank_save_mb_ofs);
+        try isa.movRegToRegOffset(self, Reg.r3, Reg.r4, bank_save_ret_ofs);
+        try isa.movRegToAddr(self, Reg.r4, bank_save_ptr);
+        try isa.movRegToReg(self, Reg.r2, Reg.mb); // switch to target bank
+        // Rebuild the callee's frame directly below arg0: (caller fp,
+        // __bank_return) become its (old_fp, return-ip), so its `ret`
+        // lands in __bank_return and it reads arg0 at [fp+4].
+        try isa.pushReg(self, Reg.fp); // callee [fp+2] = old fp
+        try isa.pushImm16(self, bank_return_addr); // callee [fp+0] = return-ip
+        try isa.movRegToReg(self, Reg.sp, Reg.fp); // callee fp = sp
+        // Enter via `rti`: target address rides the stack (not a
+        // register) across the atomic flg-restore + jump.
+        try isa.pushReg(self, Reg.r1); // rti return-ip = target address
+        try isa.pushReg(self, Reg.fp); // rti fp = callee fp
+        try isa.pushReg(self, Reg.r6); // rti flg = saved flg
+        try self.emitByte(Op.rti_op);
     }
 
     /// Register every top-level `let` / `const` as a `Global` —

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -114,6 +114,12 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     // @as: clamp `param_ofs` into i16 before the narrowing cast.
     self.sret_param_ofs = @intCast(@min(param_ofs, @as(i32, std.math.maxInt(i16))));
 
+    // Banked programs relocate the stack into low RAM (the ISA's flat
+    // stack home) before reserving any frame, so call frames never land
+    // in the bank-switched window. Must precede the frame reserve below;
+    // non-banked programs keep the boot `sp` (no-op).
+    if (self.is_entry) try self.relocateBankStack();
+
     // Reserve the frame up front (fixed reservation — a real allocator
     // would compute live ranges). The sret scratch buffer (holds a
     // returned struct until its consumer copies it out) is carved first
@@ -137,6 +143,10 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     // its IVT slot before the body runs — boot leaves `flg.I = 0`, so an
     // interrupt could otherwise fire against an uninitialized vector.
     if (self.is_entry) try emitIvtInit(self);
+
+    // Entry-def prologue: seed the cross-bank save-stack pointer before
+    // any cross-bank call (no-op when the program has no banked defs).
+    if (self.is_entry) try self.seedBankSaveStack();
 
     // Entry-def prologue: seed every non-`bake` top-level `let` / `const`
     // slot with its initializer before the body can read it.

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -120,6 +120,11 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     // non-banked programs keep the boot `sp` (no-op).
     if (self.is_entry) try self.relocateBankStack();
 
+    // `@interrupt` handlers save the GP registers + open their own frame
+    // before reserving locals, so they're transparent to the interrupted
+    // code (interrupt entry preserves only ip/fp/flg).
+    if (is_isr) try self.emitIsrPrologue();
+
     // Reserve the frame up front (fixed reservation — a real allocator
     // would compute live ranges). The sret scratch buffer (holds a
     // returned struct until its consumer copies it out) is carved first
@@ -163,7 +168,7 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     if (self.is_entry) {
         try isa.hlt(self);
     } else if (is_isr) {
-        try self.emitByte(Op.rti_op);
+        try self.emitIsrEpilogue();
     } else {
         try self.emitByte(Op.ret_op);
     }

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -887,15 +887,18 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
 
     if (cross_bank) {
         // Trampoline path:
-        //   mov <target_addr>, r1   ; patched at end
-        //   mov <target_bank>,  r2  ; literal at emit time
-        //   call __call_bank        ; patched at end
-        try self.emitByte(Op.mov_imm16_reg);
-        const addr_patch_offset = try self.currentOffset();
-        try self.emitU16Le(0); // placeholder
-        try self.emitByte(Reg.r1);
+        //   push <target_bank>   ; literal at emit time
+        //   push <target_addr>   ; patched at end
+        //   call __call_bank     ; patched at end
+        // The target rides the stack (atomic immediate pushes), not a
+        // register, so no value is live across an interruptible
+        // boundary; `__call_bank` pops both. Bank is pushed first so
+        // the address lands on top and is popped first.
         const target_bank_byte: u8 = target_bank orelse 0;
-        try isa.movImmToReg(self, target_bank_byte, Reg.r2);
+        try isa.pushImm16(self, target_bank_byte);
+        try self.emitByte(Op.push_imm16);
+        const addr_patch_offset = try self.currentOffset();
+        try self.emitU16Le(0); // target-address placeholder
         try self.emitByte(Op.call_addr);
         const tramp_patch_offset = try self.currentOffset();
         try self.emitU16Le(0);

--- a/src/lang/codegen/isa.zig
+++ b/src/lang/codegen/isa.zig
@@ -51,6 +51,18 @@ pub fn movRegToAddr(self: *Emitter, src: u8, addr: u16) !void {
     try self.emitU16Le(addr);
 }
 
+/// `mov imm16, [addr]` (0x14) — store a 16-bit immediate to addr.
+pub fn movImmToAddr(self: *Emitter, imm: u16, addr: u16) !void {
+    try self.emitByte(Op.mov_imm16_addr);
+    try self.emitU16Le(imm);
+    try self.emitU16Le(addr);
+}
+
+/// `sei` (0xB3) — set the interrupt-disable flag (block IRQs).
+pub fn sei(self: *Emitter) !void {
+    try self.emitByte(Op.sei_op);
+}
+
 /// `mov [zp], reg` (0x1A) — load 16-bit word from zp slot.
 pub fn movZpToReg(self: *Emitter, zp: u8, dst: u8) !void {
     try self.emitByte(Op.mov_zp_to_reg);
@@ -94,6 +106,12 @@ pub fn movlRegToZp(self: *Emitter, src: u8, zp: u8) !void {
     try self.emitByte(Op.movl_reg_to_zp);
     try self.emitByte(src);
     try self.emitByte(zp);
+}
+
+/// `push imm16` (0x30) — push a 16-bit immediate.
+pub fn pushImm16(self: *Emitter, imm: u16) !void {
+    try self.emitByte(Op.push_imm16);
+    try self.emitU16Le(imm);
 }
 
 /// `push reg` (0x31).

--- a/src/lang/codegen/opcodes.zig
+++ b/src/lang/codegen/opcodes.zig
@@ -34,6 +34,8 @@ pub const Op = struct {
     /// store: [zp] ← reg.lo (byte store).
     pub const movl_reg_to_zp: u8 = 0x2B;
 
+    /// `push imm16` — push a 16-bit immediate onto the stack.
+    pub const push_imm16: u8 = 0x30;
     /// `push reg` — push register onto the stack.
     pub const push_reg: u8 = 0x31;
     /// `pop reg` — pop top of stack into register.
@@ -125,6 +127,10 @@ pub const Op = struct {
     pub const call_reg: u8 = 0xA1;
     /// `ret` — return from call.
     pub const ret_op: u8 = 0xA2;
+    /// `sei` — set interrupt-disable (`flg.I ← 1`, block IRQs). The
+    /// matching clear is done by restoring a saved `flg`, not `cli`,
+    /// so the prior interrupt-enable state is preserved.
+    pub const sei_op: u8 = 0xB3;
     /// `rti` — return from interrupt (pop flg/fp/ip).
     pub const rti_op: u8 = 0xFD;
 
@@ -148,12 +154,21 @@ pub const Reg = struct {
     pub const r2: u8 = 0x03;
     /// General-purpose register 3.
     pub const r3: u8 = 0x04;
+    /// General-purpose register 4.
+    pub const r4: u8 = 0x05;
+    /// General-purpose register 5.
+    pub const r5: u8 = 0x06;
+    /// General-purpose register 6.
+    pub const r6: u8 = 0x07;
     /// Stack pointer.
     pub const sp: u8 = 0x0A;
     /// Frame pointer.
     pub const fp: u8 = 0x0B;
     /// Memory-bank selector — selects the active SRAM bank window.
     pub const mb: u8 = 0x0C;
+    /// Status flags (Z/N/C/V/I). Read/written as a whole register to
+    /// save + restore the interrupt-disable bit across a critical section.
+    pub const flg: u8 = 0x0E;
 };
 
 /// `sys` syscall ids per `src/vm/handlers/system.zig::SyscallId`.

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -326,7 +326,7 @@ pub fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
     if (self.is_entry) {
         try isa.hlt(self);
     } else if (self.is_isr) {
-        try self.emitByte(Op.rti_op);
+        try self.emitIsrEpilogue();
     } else {
         try self.emitByte(Op.ret_op);
     }

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -795,8 +795,12 @@ test "codegen: banked program relocates the stack out of the bank window" {
     defer vm.deinit();
     const loaded = try gero.vm.parseGx(compiled.image);
     try vm.boot(alloc, loaded);
-    _ = gero.vm.step(&vm); // execute the stack-relocation instruction
+    // Both sp and fp move into low RAM — the entry's own locals are
+    // fp-relative, so fp must move too or they'd stay in the IO page.
+    _ = gero.vm.step(&vm); // mov #bank_stack_top, sp
+    _ = gero.vm.step(&vm); // mov sp, fp
     try std.testing.expectEqual(@as(u16, 0x0FFE), vm.regs.read(.sp));
+    try std.testing.expectEqual(@as(u16, 0x0FFE), vm.regs.read(.fp));
 }
 
 test "codegen: cross-bank call in a loop keeps the save-stack balanced" {
@@ -3736,6 +3740,151 @@ test "codegen/overflow: custom `@interrupt $05` handler fires on overflow" {
     }
     try std.testing.expect(trap_addr != null);
     try std.testing.expectEqual(@as(u16, 1), vm.mmap.readWord(trap_addr.?));
+}
+
+test "codegen/@interrupt: handler preserves acu across the interrupted computation" {
+    // The overflow trap fires mid-expression (`a + b` overflows) with the
+    // wrapped sum live in acu; the handler clobbers acu (writes a global).
+    // Interrupt entry saves only ip/fp/flg, so without the handler saving
+    // acu the resumed `let c = a + b` would store the handler's value.
+    // 30000 + 5000 wraps to -30536 (i16).
+    try runAndExpect(
+        \\let trap_fired: i16 = 0
+        \\@interrupt $05
+        \\def on_overflow()
+        \\  trap_fired = 1
+        \\end
+        \\def main()
+        \\  let a: i16 = 30000
+        \\  let b: i16 = 5000
+        \\  let c: i16 = a + b
+        \\  print c
+        \\end
+    , "-30536\n");
+}
+
+test "codegen/@interrupt: handler with locals gets its own frame + clean rti" {
+    // An ISR with locals needs its own frame (fp=sp) and a frame release
+    // before rti; otherwise its locals alias the interrupted frame and
+    // rti pops a misaligned stack. Fire it via the overflow trap: main
+    // must resume + print the wrapped sum, and the handler's local-based
+    // computation (20 + 22) must land in its global.
+    var compiled = try compileSource(
+        \\let trapped: i16 = 0
+        \\@interrupt $05
+        \\def on_overflow()
+        \\  let x: i16 = 20
+        \\  let y: i16 = 22
+        \\  trapped = x + y
+        \\end
+        \\def main()
+        \\  let a: i16 = 30000
+        \\  let b: i16 = 5000
+        \\  let c: i16 = a + b
+        \\  print c
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // main resumed cleanly (rti landed correctly) and printed the sum.
+    try std.testing.expectEqualStrings("-30536\n", writer.written());
+    // the handler computed x + y = 42 in its own frame.
+    const header = try gero.disasm.parseHeader(compiled.image);
+    const symbols = try gero.disasm.parseSymbols(alloc, header.debug);
+    defer symbols.deinit(alloc);
+    var trapped_addr: ?u16 = null;
+    for (symbols.entries) |sym| {
+        if (std.mem.eql(u8, sym.name, "trapped")) trapped_addr = sym.address;
+    }
+    try std.testing.expect(trapped_addr != null);
+    try std.testing.expectEqual(@as(u16, 42), vm.mmap.readWord(trapped_addr.?));
+}
+
+test "codegen/@interrupt: handler can cross-bank-call (preserves acu across it)" {
+    // A handler that cross-bank-calls exercises the trampoline (which
+    // uses r1..r6) from inside the ISR. The ISR prologue saves the GP
+    // registers, so main's interrupted computation (live in acu) survives
+    // both the handler and its cross-bank call. 30000 + 30000 wraps to
+    // -5536; helper(21) = 42 lands in the global.
+    var compiled = try compileSource(
+        \\let result: i16 = 0
+        \\@bank 2
+        \\def helper(x: i16) -> i16
+        \\  return x * 2
+        \\end
+        \\@interrupt $05
+        \\def on_overflow()
+        \\  result = helper(21)
+        \\end
+        \\def main()
+        \\  let a: i16 = 30000
+        \\  let c: i16 = a + a
+        \\  print c
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("-5536\n", writer.written());
+    const header = try gero.disasm.parseHeader(compiled.image);
+    const symbols = try gero.disasm.parseSymbols(alloc, header.debug);
+    defer symbols.deinit(alloc);
+    var result_addr: ?u16 = null;
+    for (symbols.entries) |sym| {
+        if (std.mem.eql(u8, sym.name, "result")) result_addr = sym.address;
+    }
+    try std.testing.expect(result_addr != null);
+    try std.testing.expectEqual(@as(u16, 42), vm.mmap.readWord(result_addr.?));
+}
+
+test "codegen/@interrupt: empty handler's prologue/epilogue stay balanced" {
+    // A body-less handler still runs the register save/restore + frame
+    // open/release; the pushes and pops must balance so `rti` finds the
+    // VM-pushed flg/fp/ip. main resumes + prints the wrapped sum.
+    try runAndExpect(
+        \\@interrupt $05
+        \\def noop()
+        \\end
+        \\def main()
+        \\  let c: i16 = 30000 + 5000
+        \\  print c
+        \\end
+    , "-30536\n");
+}
+
+test "codegen/@interrupt: handler can call a regular function (enter/ret frame composes)" {
+    // The handler opens its own frame (fp=sp), then calls a regular fn
+    // whose enter/ret push + restore a nested frame on top. The handler
+    // prints during the trap, then main resumes — exercising both the
+    // frame composition and acu preservation across the call.
+    try runAndExpect(
+        \\def dbl(n: i16) -> i16
+        \\  return n * 2
+        \\end
+        \\@interrupt $05
+        \\def handler()
+        \\  print dbl(21)
+        \\end
+        \\def main()
+        \\  let c: i16 = 30000 + 5000
+        \\  print c
+        \\end
+    , "42\n-30536\n");
 }
 
 test "codegen/overflow: fixed-point `*` wraps in both modes per ISA §5.4.1" {

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -696,6 +696,129 @@ test "codegen: cross-bank call goes through __call_bank trampoline + executes co
     try std.testing.expectEqualStrings("42\n", writer.written());
 }
 
+test "codegen: cross-bank call reads its parameters at the right frame offset" {
+    // The trampoline is frame-transparent: the callee must read arg0 at
+    // [fp+4] exactly as a direct call would, despite the bank hop.
+    var compiled = try compileSource(
+        \\@bank 2
+        \\def add(a: i16, b: i16) -> i16
+        \\  return a + b
+        \\end
+        \\
+        \\def main()
+        \\  print add(10, 32)
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("42\n", writer.written());
+}
+
+test "codegen: nested cross-bank calls restore mb + unwind through the save-stack" {
+    // main → outer (bank 2) → inner (bank 1): the save-stack must
+    // restore mb to bank 2 when inner returns so outer finishes its
+    // arithmetic in its own bank, then to the base image for main.
+    var compiled = try compileSource(
+        \\@bank 1
+        \\def inner(x: i16) -> i16
+        \\  return x * 2
+        \\end
+        \\
+        \\@bank 2
+        \\def outer(x: i16) -> i16
+        \\  return inner(x) + 1
+        \\end
+        \\
+        \\def main()
+        \\  print outer(20)
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings("41\n", writer.written());
+}
+
+test "codegen: cross-bank call returning a struct preserves the sret ABI" {
+    // The hidden sret pointer is pushed above the args; the frame-
+    // transparent trampoline must leave it (and the args) in place so
+    // the callee copies its result back to the caller's scratch slot.
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\@bank 2
+        \\def mk(a: i16, b: i16) -> Pos
+        \\  return Pos { x: a, y: b }
+        \\end
+        \\def main()
+        \\  let p: Pos = mk(10, 32)
+        \\  print p.x
+        \\  print p.y
+        \\end
+    , "10\n32\n");
+}
+
+test "codegen: banked program relocates the stack out of the bank window" {
+    // The boot sp (0xFFFE) would place call frames in the IO page +
+    // bank window (0xC000..0xFEFF, bank-switched); a banked program's
+    // entry must move the stack into low RAM as its first instruction.
+    var compiled = try compileSource(
+        \\@bank 2
+        \\def town() -> i16
+        \\  return 42
+        \\end
+        \\def main()
+        \\  print town()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var vm = gero.vm.VM.init(alloc);
+    defer vm.deinit();
+    const loaded = try gero.vm.parseGx(compiled.image);
+    try vm.boot(alloc, loaded);
+    _ = gero.vm.step(&vm); // execute the stack-relocation instruction
+    try std.testing.expectEqual(@as(u16, 0x0FFE), vm.regs.read(.sp));
+}
+
+test "codegen: cross-bank call in a loop keeps the save-stack balanced" {
+    // Each call pushes then pops one save-stack level; an imbalance
+    // would drift the save-sp and corrupt a later iteration's return.
+    try runAndExpect(
+        \\@bank 2
+        \\def dbl(x: i16) -> i16
+        \\  return x * 2
+        \\end
+        \\def main()
+        \\  let i: i16 = 0
+        \\  let acc: i16 = 0
+        \\  while i < 4
+        \\    acc = acc + dbl(i)
+        \\    i = i + 1
+        \\  end
+        \\  print acc
+        \\end
+    , "12\n");
+}
+
 test "codegen: byte-store to @addr global uses movl (does not clobber adjacent byte)" {
     var compiled = try compileSource(
         \\@addr $FE40


### PR DESCRIPTION
## What

Two coupled correctness fixes for `@bank` / `@interrupt` codegen.

### 1. Frame-transparent, interrupt-safe cross-bank calls
The `@bank` cross-bank trampoline was frame-opaque — its `push mb` + re-`call` inserted 6 bytes between the pushed args and the callee frame, so banked functions read every parameter 6 bytes too shallow (e.g. `add(10, 32)` printed `4375` instead of `42`).

- **Trampoline (the param fix):** caller pushes the target atomically (`push imm16`); `__call_bank` parks `(bank, return-ip)` on a low-RAM save-stack, rebuilds the callee frame below `arg0`, and enters via the rti-trick. Callee reads `arg0` at `[fp+4]` exactly like a direct call → parameters, struct/tuple returns, and nested cross-bank calls all work.
- **Interrupt-safe:** save-stack critical sections run under `sei`; the target + return addresses ride the stack (never a register) across the atomic `rti`. No register-liveness window remains in the trampoline.
- **Stack relocation:** banked programs move `sp` **and `fp`** into low RAM; the boot `0xFFFE` grows into the IO page + bank-switched window, which would corrupt frames across a bank hop. Unbanked unchanged.

### 2. `@interrupt` handlers are transparent to the interrupted code
Interrupt entry preserves only `ip`/`fp`/`flg` (ISA §6.2), so a handler that clobbered a GP register corrupted whatever the interrupted code had live there.

- Handlers now save/restore `acu`/`r1`–`r6` and get their own frame (`fp=sp`). This also fixes a **latent pre-existing bug**: a handler with locals aliased the interrupted frame and misaligned its `rti`.
- Factored into `emitIsrPrologue`/`emitIsrEpilogue`, used at every handler exit (fall-off + explicit `return`).

Both hardenings (closing the register-liveness windows, relocating the stack, ISR register preservation) were folded in per maintainer direction rather than deferred.

## Tests
- cross-bank params (`add(10, 32)` → `42`), nested cross-bank + `mb` restore (`41`), struct-return sret ABI, cross-bank-in-a-loop (save-stack balance), banked stack relocated (`sp`+`fp`).
- `@interrupt`: acu survives the trap handler (`-30536`, would be `1` unbroken), handler-with-locals own frame + clean `rti`, handler cross-bank-calls (composes with the trampoline), empty handler balance, handler calls a regular function (enter/ret frame composition).

## Notes
Surfaced during the #333 review as a pre-existing cross-bank bug; no dedicated issue. Unblocks #312 (banked stdlib module calls). Specs updated: `gero-lang.md` §7.3 (transparent trampoline) + `@interrupt` annotation, `isa.md` §6.2 (GP registers not VM-preserved).

Verified across `zig build ci` (Debug/Safe/Fast/Small + linux/macos/windows/wasi) and a multi-lane adversarial review of the ISR frame/register model.