### PR TITLE
feat(lang): math / bank / test stdlib modules (+ compile-time math)

### DIFF
--- a/.changeset/lang-stdlib-modules.md
+++ b/.changeset/lang-stdlib-modules.md
@@ -1,0 +1,25 @@
+---
+bump: minor
+---
+
+`math`, `bank`, and `test` stdlib modules now lower (§5.3), generalizing
+the compiler's module-call dispatch beyond `mem`.
+
+`math` is numeric-polymorphic over `i16` / `u16` / `fixed`: `abs`, `min`,
+`max`, `clamp`; `wrap_add` / `wrap_sub` / `wrap_mul` (wrap on overflow,
+skipping the debug trap); `sat_add` / `sat_sub` / `sat_mul` (clamp to the
+integer type's bounds); `sqrt_fixed` (Q8.8 square root); `fixed_sin`
+(Bhaskara I, degrees → Q8.8 sine); and `rng()` (deterministic 16-bit
+Galois LFSR). Every `math.*` function also evaluates at compile time
+inside `bake` bodies — the canonical way to precompute tables such as
+sine LUTs — matching the runtime bit-for-bit (the typechecker's types
+thread into the bake evaluator so signedness agrees).
+
+`bank.switch_to(n)` / `bank.current()` read and write the bank selector
+directly (distinct from the automatic `@bank` cross-bank-call
+trampoline). `test.assert_eq(a, b)` / `test.assert_ne(a, b)` compare
+register scalars in `@test` functions, printing a diagnostic and halting
+the VM on a failed assertion.
+
+All three modules are fully type-checked — calls resolve to concrete
+signatures rather than coming back untyped.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -2397,6 +2397,46 @@ asm bridge, manual MMIO layout). Calling `addr_of` on a `let` local
 returns its stack-slot address, valid until the enclosing scope ends;
 calling on a `const` returns its static-data address (always valid).
 
+#### 5.3.2 `math` stdlib
+
+Numeric helpers, polymorphic over `i16` / `u16` / `fixed` where it makes
+sense — the operand type picks signed vs unsigned comparison and the
+fixed-point multiply scaling.
+
+| Signature | Notes |
+|---|---|
+| `math.abs(x: T) -> T` | `T ∈ {i16, u16, fixed}`. Unsigned `abs` is the identity. |
+| `math.min(a: T, b: T) -> T` / `math.max(a: T, b: T) -> T` | `T ∈ {i16, u16, fixed}`. |
+| `math.clamp(x: T, lo: T, hi: T) -> T` | `min(max(x, lo), hi)`. |
+| `math.wrap_add` / `wrap_sub` / `wrap_mul`, all `(a: T, b: T) -> T` | Wrap on overflow (skip the debug trap). `T ∈ {i16, u16, fixed}`; `fixed` mul is Q8.8. |
+| `math.sat_add` / `sat_sub` / `sat_mul`, all `(a: T, b: T) -> T` | Clamp to `T`'s bounds on overflow. `T ∈ {i16, u16}` (saturation targets a type's range, which `fixed` doesn't share). |
+| `math.sqrt_fixed(x: fixed) -> fixed` | Q8.8 square root; `x ≤ 0` returns `0`. |
+| `math.fixed_sin(deg: i16) -> fixed` | Sine of an angle in degrees, Q8.8 in `[-1.0, 1.0]`. Bhaskara I approximation (~1% error); range-reduces any `i16` angle. |
+| `math.rng() -> u16` | Next value of a deterministic 16-bit Galois LFSR (maximal period; lazily seeded). |
+
+All `math.*` functions are usable inside `bake` bodies (§3.8) — the
+canonical way to precompute tables (e.g. `fixed_sin` sine LUTs). The
+compile-time result matches the runtime bit-for-bit.
+
+#### 5.3.3 `bank` stdlib
+
+| Signature | Notes |
+|---|---|
+| `bank.switch_to(n: u8)` | Set the active bank (`mb`). The program owns the `0xC000..0xFEFF` window afterward — distinct from the automatic `@bank` cross-bank-call trampoline (§7.3). Canonical use: selecting an SRAM bank for saves. |
+| `bank.current() -> u8` | The active bank id. |
+
+`bank.*` is runtime-only — calling it inside a `bake` body is an error.
+
+#### 5.3.4 `test` stdlib
+
+Used in `@test` functions (§3.7.5).
+
+| Signature | Notes |
+|---|---|
+| `test.assert_eq(a: T, b: T)` / `test.assert_ne(a: T, b: T)` | `T` a register scalar (int / `bool` / `char` / `fixed`). On failure, prints a diagnostic and halts the VM. |
+
+`test.*` is runtime-only — calling it inside a `bake` body is an error.
+
 Host-specific modules (`input`, `display`, `audio` for gtx-16) live
 outside the gero stdlib — gtx-16 ships its own header modules.
 

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -12,6 +12,7 @@ const codegen_mod = @import("lang/codegen.zig");
 const include_mod = @import("lang/include.zig");
 
 const tc_mem_builtin = @import("lang/typecheck/mem_builtin.zig");
+const tc_stdlib = @import("lang/typecheck/stdlib.zig");
 const tc_match = @import("lang/typecheck/match.zig");
 const tc_predicates = @import("lang/typecheck/predicates.zig");
 const tc_annotations = @import("lang/typecheck/annotations.zig");
@@ -29,6 +30,10 @@ const bake_mod = @import("lang/bake.zig");
 const cg_opcodes = @import("lang/codegen/opcodes.zig");
 const cg_archive = @import("lang/codegen/archive.zig");
 const cg_mem_builtin = @import("lang/codegen/mem_builtin.zig");
+const cg_stdlib = @import("lang/codegen/stdlib.zig");
+const cg_math_builtin = @import("lang/codegen/math_builtin.zig");
+const cg_bank_builtin = @import("lang/codegen/bank_builtin.zig");
+const cg_test_builtin = @import("lang/codegen/test_builtin.zig");
 const cg_strings = @import("lang/codegen/strings.zig");
 const cg_pattern = @import("lang/codegen/pattern.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
@@ -158,6 +163,8 @@ pub const internal = struct {
         pub const match = tc_match;
         /// `mem.*` stdlib typecheck dispatch.
         pub const mem_builtin = tc_mem_builtin;
+        /// `math.*` / `bank.*` / `test.*` stdlib typecheck dispatch.
+        pub const stdlib = tc_stdlib;
         /// "Did you mean…?" Levenshtein-based name suggestions.
         pub const suggestions = tc_suggestions;
         /// `ast.TypeAnn` → `types.Type` resolution.
@@ -192,6 +199,14 @@ pub const internal = struct {
         pub const archive = cg_archive;
         /// `mem.*` stdlib codegen lowering.
         pub const mem_builtin = cg_mem_builtin;
+        /// `math.*` / `bank.*` / `test.*` stdlib call router.
+        pub const stdlib = cg_stdlib;
+        /// `math.*` stdlib codegen lowering.
+        pub const math_builtin = cg_math_builtin;
+        /// `bank.*` stdlib codegen lowering.
+        pub const bank_builtin = cg_bank_builtin;
+        /// `test.*` stdlib codegen lowering.
+        pub const test_builtin = cg_test_builtin;
         /// String literal pool + interpolation lowering.
         pub const strings = cg_strings;
         /// `match` pattern-arm test emission.

--- a/src/lang/bake.zig
+++ b/src/lang/bake.zig
@@ -73,6 +73,11 @@ pub const Options = struct {
     /// `E_BAKE_FORBIDDEN_CALL`. The codegen wires the program's
     /// `bake def` registry through this slot.
     bake_defs: ?*const std.StringHashMap(*const ast.DefDecl) = null,
+    /// The typechecker's inferred expression types, threaded so
+    /// compile-time `math.*` picks signed vs unsigned exactly like the
+    /// runtime lowering (the bake evaluator is otherwise typeless).
+    /// `null` disables `math.*` dispatch (calls then fault).
+    expr_types: ?*const std.AutoHashMapUnmanaged(*const ast.Expr, *const types.Type) = null,
 };
 
 /// Evaluate a `bake do … end` block against an empty initial
@@ -140,6 +145,11 @@ const Evaluator = struct {
     /// callee ident; `null` means no calls allowed (every call
     /// site faults with `E_BAKE_FORBIDDEN_CALL`).
     bake_defs: ?*const std.StringHashMap(*const ast.DefDecl),
+    /// Typechecker expression types — drives `math.*` signedness.
+    expr_types: ?*const std.AutoHashMapUnmanaged(*const ast.Expr, *const types.Type),
+    /// `rng()` LFSR state, lazily seeded on first use (mirrors the
+    /// runtime's zero-page cell) so a bake sequence is deterministic.
+    rng_state: u16,
     /// Set when a `return` statement fires inside the running
     /// body. `runBlock` propagates the value upward; the
     /// outermost block transparently surfaces it.
@@ -163,6 +173,8 @@ const Evaluator = struct {
             .diag_arena = std.heap.ArenaAllocator.init(allocator),
             .budget_remaining = opts.budget,
             .bake_defs = opts.bake_defs,
+            .expr_types = opts.expr_types,
+            .rng_state = 0,
             .return_value = null,
             .loop_signal = .none,
         };
@@ -605,6 +617,7 @@ const Evaluator = struct {
             .index => |ix| try self.evalIndex(ix),
             .field => |f| try self.evalField(f),
             .call => |c| try self.evalCall(c),
+            .method_call => |m| try self.evalMethodBake(m),
             else => {
                 try self.diagFmt(e.span(), "E_BAKE_UNSUPPORTED", "bake interpreter does not yet support `{s}` expressions", .{@tagName(e.*)});
                 return error.Fault;
@@ -947,6 +960,12 @@ const Evaluator = struct {
     /// Stdlib allowlist is empty in this PR — `math.*` joins via
     /// the follow-up issue #284.
     fn evalCall(self: *Evaluator, c: ast.CallExpr) StepError!BakeValue {
+        // `math.fn(args)` in field-callee form — compile-time math.
+        if (c.callee.* == .field and c.callee.field.receiver.* == .ident and
+            std.mem.eql(u8, self.lexeme(c.callee.field.receiver.ident.span), "math"))
+        {
+            return self.evalMathBuiltin(c.callee.field.field, c.args, c.span);
+        }
         if (c.callee.* != .ident) {
             try self.diagFatal(c.span, "E_BAKE_UNSUPPORTED", "bake: only ident callees are supported (no method dispatch / closures)");
             return error.Fault;
@@ -991,7 +1010,178 @@ const Evaluator = struct {
         const tail = try self.runBlock(decl.body);
         return self.return_value orelse tail;
     }
+
+    /// `recv.fn(args)` in method form. Only `math` is evaluable at bake
+    /// time; `mem` / `bank` / `test` are runtime-only and fault.
+    fn evalMethodBake(self: *Evaluator, m: ast.MethodCallExpr) StepError!BakeValue {
+        if (m.receiver.* == .ident and std.mem.eql(u8, self.lexeme(m.receiver.ident.span), "math")) {
+            return self.evalMathBuiltin(m.method, m.args, m.span);
+        }
+        try self.diagFatal(m.span, "E_BAKE_UNSUPPORTED", "bake: only `math.*` calls are evaluable at compile time");
+        return error.Fault;
+    }
+
+    /// Operand signedness for the polymorphic helpers, from the
+    /// threaded expression types (mirrors `math_builtin.argKind`).
+    fn argKindBake(self: *Evaluator, e: *const ast.Expr) BakeKind {
+        const t = if (self.expr_types) |m| m.get(e) else null;
+        if (t == null or t.?.* != .primitive) return .signed;
+        return switch (t.?.primitive) {
+            .u16, .u8 => .unsigned,
+            .fixed => .fixed,
+            else => .signed,
+        };
+    }
+
+    /// Compile-time `math.*`. Mirrors the runtime lowering's integer
+    /// arithmetic exactly, so a bake-generated table matches the runtime.
+    fn evalMathBuiltin(self: *Evaluator, name_span: ast.Span, args: []const *ast.Expr, span: ast.Span) StepError!BakeValue {
+        const name = self.lexeme(name_span);
+        if (std.mem.eql(u8, name, "rng")) {
+            if (self.rng_state == 0) self.rng_state = 0xACE1;
+            const lsb = self.rng_state & 1;
+            self.rng_state >>= 1;
+            if (lsb == 1) self.rng_state ^= 0xB400;
+            return .{ .int_ = self.rng_state };
+        }
+        var raw: [3]u16 = .{ 0, 0, 0 };
+        var arg0_fixed = false;
+        for (args, 0..) |a, i| {
+            const v = try self.evalExpr(a);
+            const x: u16 = switch (v) {
+                .int_ => |n| n,
+                .fixed_ => |n| n,
+                .byte => |n| n,
+                else => 0,
+            };
+            if (i < 3) raw[i] = x;
+            if (i == 0) arg0_fixed = v == .fixed_;
+        }
+        const kind: BakeKind = if (args.len > 0) self.argKindBake(args[0]) else .signed;
+        var is_fixed = arg0_fixed;
+        const result: u16 = b: {
+            if (std.mem.eql(u8, name, "abs")) break :b bakeAbs(raw[0], kind);
+            if (std.mem.eql(u8, name, "min")) break :b bakeMinMax(raw[0], raw[1], kind, true);
+            if (std.mem.eql(u8, name, "max")) break :b bakeMinMax(raw[0], raw[1], kind, false);
+            if (std.mem.eql(u8, name, "clamp")) break :b bakeMinMax(bakeMinMax(raw[0], raw[2], kind, true), raw[1], kind, false);
+            if (std.mem.eql(u8, name, "wrap_add")) break :b raw[0] +% raw[1];
+            if (std.mem.eql(u8, name, "wrap_sub")) break :b raw[0] -% raw[1];
+            if (std.mem.eql(u8, name, "wrap_mul")) break :b bakeWrapMul(raw[0], raw[1], kind);
+            if (std.mem.eql(u8, name, "sat_add")) break :b bakeSat(raw[0], raw[1], kind, .add);
+            if (std.mem.eql(u8, name, "sat_sub")) break :b bakeSat(raw[0], raw[1], kind, .sub);
+            if (std.mem.eql(u8, name, "sat_mul")) break :b bakeSat(raw[0], raw[1], kind, .mul);
+            if (std.mem.eql(u8, name, "fixed_sin")) {
+                is_fixed = true;
+                break :b bakeFixedSin(raw[0]);
+            }
+            if (std.mem.eql(u8, name, "sqrt_fixed")) {
+                is_fixed = true;
+                break :b bakeSqrtFixed(raw[0]);
+            }
+            try self.diagFmt(span, "E_BAKE_UNSUPPORTED", "bake: `math.{s}` is not evaluable at compile time", .{name});
+            return error.Fault;
+        };
+        return if (is_fixed) .{ .fixed_ = result } else .{ .int_ = result };
+    }
 };
+
+/// Operand signedness for compile-time `math.*` (mirrors the runtime).
+const BakeKind = enum { signed, unsigned, fixed };
+const BakeSatOp = enum { add, sub, mul };
+
+/// Reinterpret a u16 storage slot as its signed value.
+fn sI16(raw: u16) i16 {
+    // safety: u16 → i16 bit reinterpret; storage layout is shared.
+    return @bitCast(raw);
+}
+
+/// Reinterpret a signed value back into u16 storage.
+fn uBits(v: i16) u16 {
+    // safety: i16 → u16 bit reinterpret back into storage.
+    return @bitCast(v);
+}
+
+fn bakeAbs(raw: u16, kind: BakeKind) u16 {
+    if (kind == .unsigned) return raw;
+    return if (sI16(raw) < 0) 0 -% raw else raw; // wrapping negate (matches `neg`)
+}
+
+fn bakeMinMax(a: u16, b: u16, kind: BakeKind, want_min: bool) u16 {
+    const a_lt_b = if (kind == .unsigned) a < b else sI16(a) < sI16(b);
+    if (want_min) return if (a_lt_b) a else b;
+    return if (a_lt_b) b else a;
+}
+
+fn bakeWrapMul(a: u16, b: u16, kind: BakeKind) u16 {
+    if (kind != .fixed) return a *% b; // low 16 bits (signed + unsigned share them)
+    const ai: i32 = sI16(a);
+    const bi: i32 = sI16(b);
+    const shifted: i32 = (ai * bi) >> 8; // Q8.8: drop the fractional byte
+    // @as: keep the low 16 bits (product bits 8..23) as the wrapped result.
+    const lo: i16 = @truncate(shifted);
+    return uBits(lo);
+}
+
+fn bakeSat(a: u16, b: u16, kind: BakeKind, op: BakeSatOp) u16 {
+    if (kind == .unsigned) {
+        const av: i64 = a;
+        const bv: i64 = b;
+        const r: i64 = switch (op) {
+            .add => av + bv,
+            .sub => av - bv,
+            .mul => av * bv,
+        };
+        if (r > 0xFFFF) return 0xFFFF;
+        if (r < 0) return 0;
+        // @as: clamped to [0, 0xFFFF] above.
+        return @intCast(r);
+    }
+    const av: i64 = sI16(a);
+    const bv: i64 = sI16(b);
+    const r: i64 = switch (op) {
+        .add => av + bv,
+        .sub => av - bv,
+        .mul => av * bv,
+    };
+    if (r > 32767) return 0x7FFF;
+    if (r < -32768) return 0x8000;
+    // @as: clamped to the i16 range above.
+    const r16: i16 = @intCast(r);
+    return uBits(r16);
+}
+
+/// Bhaskara I sine, identical to the runtime lowering (§5.3).
+fn bakeFixedSin(deg_raw: u16) u16 {
+    const deg: i32 = sI16(deg_raw);
+    var x: i32 = @mod(deg, 360);
+    var negate = false;
+    if (x >= 180) {
+        negate = true;
+        x -= 180;
+    }
+    const prod: i32 = x * (180 - x);
+    const den: i32 = @divFloor(40500 - prod, 2);
+    var result: i32 = @divTrunc(512 * prod, den);
+    if (negate) result = -result;
+    // @as: |result| ≤ 256, fits i16.
+    const r16: i16 = @intCast(result);
+    return uBits(r16);
+}
+
+/// Bit-by-bit Q8.8 square root, identical to the runtime lowering.
+fn bakeSqrtFixed(x_raw: u16) u16 {
+    if (sI16(x_raw) <= 0) return 0;
+    const xw: u32 = x_raw;
+    const n: u32 = xw << 8;
+    var r: u32 = 0;
+    var bit: u32 = 2048;
+    while (bit != 0) : (bit >>= 1) {
+        const cand = r | bit;
+        if (cand * cand <= n) r = cand;
+    }
+    // @as: result < 4096, fits u16.
+    return @intCast(r);
+}
 
 /// Byte width of a serialized `BakeValue`. Mirrors the runtime
 /// layout (`widthOfTypeAnn`) with aggregate sizes summed.

--- a/src/lang/codegen/bank_builtin.zig
+++ b/src/lang/codegen/bank_builtin.zig
@@ -1,0 +1,37 @@
+// Lowering for the `bank` stdlib module (§5.3): direct manipulation of
+// the `mb` bank-selector register. `bank.switch_to(n)` writes it,
+// `bank.current()` reads it. These are the raw primitive — unlike the
+// `@bank` cross-bank call trampoline, the program owns the window after
+// a manual switch (canonical use: selecting an SRAM bank for saves).
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+
+const Emitter = codegen.Emitter;
+const Reg = opcodes.Reg;
+
+/// Dispatch a `bank.X(args)` call. Arity is validated by the
+/// typechecker; the codegen guard is defensive.
+pub fn emitBankCall(self: *Emitter, name: []const u8, c: ast.CallExpr) !void {
+    if (std.mem.eql(u8, name, "switch_to")) {
+        if (c.args.len != 1) {
+            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `bank.switch_to` takes one argument");
+            return;
+        }
+        try self.emitExpr(c.args[0]); // acu = bank id
+        try isa.movRegToReg(self, Reg.acu, Reg.mb);
+        return;
+    }
+    if (std.mem.eql(u8, name, "current")) {
+        if (c.args.len != 0) {
+            try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `bank.current` takes no arguments");
+            return;
+        }
+        try isa.movRegToReg(self, Reg.mb, Reg.acu); // acu = current bank id
+        return;
+    }
+    try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `bank` builtin");
+}

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -6,6 +6,7 @@ const isa = @import("isa.zig");
 const archive = @import("archive.zig");
 const assert_builtin = @import("assert.zig");
 const diverge_builtin = @import("diverge.zig");
+const stdlib = @import("stdlib.zig");
 const class = @import("class.zig");
 const value_struct = @import("value_struct.zig");
 const strings = @import("strings.zig");
@@ -766,6 +767,20 @@ pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr)
             try self.emitMemCall(synth_field, synth_call);
             return;
         }
+        if (stdlib.isModule(recv)) {
+            const synth_field: ast.FieldExpr = .{
+                .receiver = m.receiver,
+                .field = m.method,
+                .span = m.span,
+            };
+            const synth_call: ast.CallExpr = .{
+                .callee = m.receiver,
+                .args = m.args,
+                .span = m.span,
+            };
+            try stdlib.emitCall(self, recv, synth_field, synth_call);
+            return;
+        }
     }
     try self.unsupported(e.span(), "method calls on non-stdlib receivers");
 }
@@ -826,6 +841,10 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
             const recv = self.source[fe.receiver.ident.span.start..fe.receiver.ident.span.end];
             if (std.mem.eql(u8, recv, "mem")) {
                 try self.emitMemCall(fe, c);
+                return;
+            }
+            if (stdlib.isModule(recv)) {
+                try stdlib.emitCall(self, recv, fe, c);
                 return;
             }
             // Payload-variant constructor — `Enum.Variant(args)`.

--- a/src/lang/codegen/globals.zig
+++ b/src/lang/codegen/globals.zig
@@ -113,7 +113,7 @@ const BakeEntry = union(enum) {
 };
 
 fn runBake(self: *Emitter, span: ast.Span, entry: BakeEntry) !?bake_mod.BakeValue {
-    const opts: bake_mod.Options = .{ .bake_defs = &bakeDefsAdapter(self) };
+    const opts: bake_mod.Options = .{ .bake_defs = &bakeDefsAdapter(self), .expr_types = &self.checked.expr_types };
     var result = switch (entry) {
         .do_expr => |de| try bake_mod.evaluateDo(self.allocator, self.source, de, opts),
     };
@@ -128,7 +128,7 @@ fn runBake(self: *Emitter, span: ast.Span, entry: BakeEntry) !?bake_mod.BakeValu
 
 fn runBakeDef(self: *Emitter, span: ast.Span, decl: *const ast.DefDecl, args: []const bake_mod.BakeValue) !?bake_mod.BakeValue {
     const adapter = bakeDefsAdapter(self);
-    const opts: bake_mod.Options = .{ .bake_defs = &adapter };
+    const opts: bake_mod.Options = .{ .bake_defs = &adapter, .expr_types = &self.checked.expr_types };
     var result = try bake_mod.evaluateDef(self.allocator, self.source, decl, args, opts);
     defer result.deinit(self.allocator);
     try forwardBakeDiagnostics(self, result.diagnostics);

--- a/src/lang/codegen/math_builtin.zig
+++ b/src/lang/codegen/math_builtin.zig
@@ -41,6 +41,9 @@ pub fn emitMathCall(self: *Emitter, name: []const u8, c: ast.CallExpr) !void {
     if (std.mem.eql(u8, name, "wrap_add")) return emitWrapAddSub(self, c, .add);
     if (std.mem.eql(u8, name, "wrap_sub")) return emitWrapAddSub(self, c, .sub);
     if (std.mem.eql(u8, name, "wrap_mul")) return emitWrapMul(self, c);
+    if (std.mem.eql(u8, name, "sat_add")) return emitSat(self, c, .add);
+    if (std.mem.eql(u8, name, "sat_sub")) return emitSat(self, c, .sub);
+    if (std.mem.eql(u8, name, "sat_mul")) return emitSat(self, c, .mul);
     try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `math` builtin");
 }
 
@@ -154,5 +157,94 @@ fn emitWrapMul(self: *Emitter, c: ast.CallExpr) !void {
     } else {
         try isa.mulRegReg(self, Reg.r1, Reg.r2); // r2 = low(a*b)
         try isa.movRegToReg(self, Reg.r2, Reg.acu);
+    }
+}
+
+const SatOp = enum { add, sub, mul };
+
+/// `sat_*` — clamp to the operand type's bounds on overflow. The
+/// typechecker restricts these to i16 / u16, so `argKind` is never
+/// `.fixed` here.
+fn emitSat(self: *Emitter, c: ast.CallExpr, op: SatOp) !void {
+    const unsigned = argKind(self, c.args[0]) == .unsigned;
+    switch (op) {
+        .add => try emitSatAdd(self, c, unsigned),
+        .sub => try emitSatSub(self, c, unsigned),
+        .mul => try emitSatMul(self, c, unsigned),
+    }
+}
+
+/// Clamp `acu` to the i16 bounds picked by `sign_reg`: `>= 0` saturates
+/// to `0x7FFF` (max), `< 0` to `0x8000` (min). For add/sub the sign of
+/// an operand gives the overflow direction; for mul it's the product's
+/// high half.
+fn emitSignedClamp(self: *Emitter, sign_reg: u8) !void {
+    try isa.cmpRegImm(self, sign_reg, 0);
+    const pos = try isa.emitJumpPlaceholder(self, Op.jge_addr);
+    try isa.movImmToReg(self, 0x8000, Reg.acu); // negative → i16 min
+    const done = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    try isa.patchJumpTo(self, pos, try self.currentOffset());
+    try isa.movImmToReg(self, 0x7FFF, Reg.acu); // positive → i16 max
+    try isa.patchJumpTo(self, done, try self.currentOffset());
+}
+
+fn emitSatAdd(self: *Emitter, c: ast.CallExpr, unsigned: bool) !void {
+    try self.emitExpr(c.args[0]); // a
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(c.args[1]); // acu = b
+    try isa.popReg(self, Reg.r1); // r1 = a
+    try isa.addRegToAcu(self, Reg.r1); // acu = a + b (C on carry, V on signed overflow)
+    if (unsigned) {
+        const ok = try isa.emitJumpPlaceholder(self, Op.jcc_addr); // no carry → fits
+        try isa.movImmToReg(self, 0xFFFF, Reg.acu);
+        try isa.patchJumpTo(self, ok, try self.currentOffset());
+    } else {
+        const ok = try isa.emitJumpPlaceholder(self, Op.jvc_addr); // no overflow → fits
+        try emitSignedClamp(self, Reg.r1); // direction = sign of a (operands agree on overflow)
+        try isa.patchJumpTo(self, ok, try self.currentOffset());
+    }
+}
+
+fn emitSatSub(self: *Emitter, c: ast.CallExpr, unsigned: bool) !void {
+    try self.emitExpr(c.args[1]); // b
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(c.args[0]); // acu = a
+    if (!unsigned) try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = a (sign for clamp)
+    try isa.popReg(self, Reg.r1); // r1 = b
+    try isa.subRegFromAcu(self, Reg.r1); // acu = a - b (C on borrow, V on signed overflow)
+    if (unsigned) {
+        const ok = try isa.emitJumpPlaceholder(self, Op.jcc_addr); // no borrow → fits
+        try isa.movImmToReg(self, 0, Reg.acu); // borrow → underflow → 0
+        try isa.patchJumpTo(self, ok, try self.currentOffset());
+    } else {
+        const ok = try isa.emitJumpPlaceholder(self, Op.jvc_addr);
+        try emitSignedClamp(self, Reg.r2); // direction = sign of a (the minuend)
+        try isa.patchJumpTo(self, ok, try self.currentOffset());
+    }
+}
+
+fn emitSatMul(self: *Emitter, c: ast.CallExpr, unsigned: bool) !void {
+    try self.emitExpr(c.args[0]); // a
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(c.args[1]); // acu = b
+    try isa.popReg(self, Reg.r1); // r1 = a
+    try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = b
+    if (unsigned) {
+        try isa.mulRegReg(self, Reg.r1, Reg.r2); // r2 = low(a*b), acu = high
+        try isa.cmpRegImm(self, Reg.acu, 0);
+        const fits = try isa.emitJumpPlaceholder(self, Op.jeq_addr); // high == 0 → fits u16
+        try isa.movImmToReg(self, 0xFFFF, Reg.acu);
+        const done = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+        try isa.patchJumpTo(self, fits, try self.currentOffset());
+        try isa.movRegToReg(self, Reg.r2, Reg.acu); // result = low half
+        try isa.patchJumpTo(self, done, try self.currentOffset());
+    } else {
+        try isa.mulsRegReg(self, Reg.r1, Reg.r2); // r2 = low, acu = high, V if ∉ i16
+        const fits = try isa.emitJumpPlaceholder(self, Op.jvc_addr);
+        try emitSignedClamp(self, Reg.acu); // direction = product sign (high-half sign bit)
+        const done = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+        try isa.patchJumpTo(self, fits, try self.currentOffset());
+        try isa.movRegToReg(self, Reg.r2, Reg.acu); // result = low half
+        try isa.patchJumpTo(self, done, try self.currentOffset());
     }
 }

--- a/src/lang/codegen/math_builtin.zig
+++ b/src/lang/codegen/math_builtin.zig
@@ -16,6 +16,15 @@ const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
 const Reg = opcodes.Reg;
 
+// `rng()` state — a Galois LFSR (taps 0xB400, polynomial x^16+x^15+x^13+
+// x^4+1, maximal 65535-period). The 16-bit state lives in a reserved
+// zero-page cell at the top of the page, away from `@zero_page` globals
+// (which grow from 0x0000). It is zero at boot (RAM zero-inits), so the
+// first call lazily seeds it — no entry-prologue setup needed.
+const rng_state_addr: u16 = 0x00FE;
+const rng_seed: u16 = 0xACE1;
+const rng_taps: u16 = 0xB400;
+
 /// How an operand's type drives the lowering: `u16`/`u8` need unsigned
 /// comparison; `fixed` needs Q8.8 multiply scaling; everything else is
 /// treated as signed (`i16`/`i8`/`fixed` all compare as signed i16).
@@ -46,7 +55,32 @@ pub fn emitMathCall(self: *Emitter, name: []const u8, c: ast.CallExpr) !void {
     if (std.mem.eql(u8, name, "sat_mul")) return emitSat(self, c, .mul);
     if (std.mem.eql(u8, name, "fixed_sin")) return emitFixedSin(self, c);
     if (std.mem.eql(u8, name, "sqrt_fixed")) return emitSqrtFixed(self, c);
+    if (std.mem.eql(u8, name, "rng")) return emitRng(self, c);
     try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `math` builtin");
+}
+
+/// `rng() -> u16` — advance the Galois LFSR and return the new state.
+/// Lazily seeds on the first call (state is 0 at boot). Deterministic:
+/// identical programs produce identical sequences.
+fn emitRng(self: *Emitter, c: ast.CallExpr) !void {
+    _ = c; // no arguments
+    try isa.movAddrToReg(self, rng_state_addr, Reg.acu); // acu = state
+    // Lazy seed: state 0 → seed (also keeps a 0 cell from sticking at 0).
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const seeded = try isa.emitJumpPlaceholder(self, Op.jne_addr);
+    try isa.movImmToReg(self, rng_seed, Reg.acu);
+    try isa.patchJumpTo(self, seeded, try self.currentOffset());
+    // Galois step: lsb = state & 1; state >>= 1; if lsb: state ^= taps.
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try isa.movImmToReg(self, 1, Reg.r2);
+    try isa.andRegReg(self, Reg.r1, Reg.r2); // r1 = lsb
+    try isa.shrRegImm(self, Reg.acu, 1); // logical >> 1
+    try isa.cmpRegImm(self, Reg.r1, 0);
+    const no_xor = try isa.emitJumpPlaceholder(self, Op.jeq_addr);
+    try isa.movImmToReg(self, rng_taps, Reg.r2);
+    try isa.xorRegReg(self, Reg.acu, Reg.r2); // state ^= taps
+    try isa.patchJumpTo(self, no_xor, try self.currentOffset());
+    try isa.movRegToAddr(self, Reg.acu, rng_state_addr); // persist; acu is the result
 }
 
 /// `sqrt_fixed(x: fixed) -> fixed` — Q8.8 square root. For x > 0 the

--- a/src/lang/codegen/math_builtin.zig
+++ b/src/lang/codegen/math_builtin.zig
@@ -44,7 +44,60 @@ pub fn emitMathCall(self: *Emitter, name: []const u8, c: ast.CallExpr) !void {
     if (std.mem.eql(u8, name, "sat_add")) return emitSat(self, c, .add);
     if (std.mem.eql(u8, name, "sat_sub")) return emitSat(self, c, .sub);
     if (std.mem.eql(u8, name, "sat_mul")) return emitSat(self, c, .mul);
+    if (std.mem.eql(u8, name, "fixed_sin")) return emitFixedSin(self, c);
     try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `math` builtin");
+}
+
+/// `fixed_sin(deg: i16) -> fixed` — sine of an angle in degrees, Q8.8.
+/// Reduces `deg` mod 360 into `[0, 360)`, folds `[180, 360)` to a
+/// negated `[0, 180)`, then Bhaskara I on `[0, 180]`:
+///   sin(x°) ≈ 4x(180-x) / (40500 - x(180-x))
+/// In Q8.8 that is `(512·prod) / ((40500-prod) >> 1)` with
+/// `prod = x(180-x)` — the denominator exceeds i16 before the `>>1`, and
+/// the halving keeps signed `divs` (a positive 32-bit / positive i16)
+/// valid. Accurate to ~1% (a few Q8.8 LSB).
+fn emitFixedSin(self: *Emitter, c: ast.CallExpr) !void {
+    try self.emitExpr(c.args[0]); // acu = deg
+    // deg mod 360 → remainder in acu (sign of deg). Sign-extend deg into
+    // the high half for the 32/16 signed divide.
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = deg (low / quotient dst)
+    try isa.asrRegImm(self, Reg.acu, 15); // acu = sign extension
+    try isa.movImmToReg(self, 360, Reg.r2);
+    try isa.divsRegReg(self, Reg.r2, Reg.r1); // r1 = deg/360, acu = deg mod 360
+    // Fold the remainder into [0, 360).
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const nonneg = try isa.emitJumpPlaceholder(self, Op.jge_addr);
+    try isa.addImmToReg(self, 360, Reg.acu);
+    try isa.patchJumpTo(self, nonneg, try self.currentOffset());
+    // Fold [180, 360) to a negated [0, 180): r6 = negate flag.
+    try isa.movImmToReg(self, 0, Reg.r6);
+    try isa.cmpRegImm(self, Reg.acu, 180);
+    const lo_half = try isa.emitJumpPlaceholder(self, Op.jlt_addr);
+    try isa.movImmToReg(self, 1, Reg.r6);
+    try isa.subImmFromReg(self, 180, Reg.acu);
+    try isa.patchJumpTo(self, lo_half, try self.currentOffset());
+    // prod = x(180-x). acu = x ∈ [0, 180).
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = x
+    try isa.movImmToReg(self, 180, Reg.acu);
+    try isa.subRegFromAcu(self, Reg.r1); // acu = 180 - x
+    try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = 180 - x
+    try isa.mulRegReg(self, Reg.r1, Reg.r2); // r2 = prod (≤ 8100, high half 0)
+    try isa.movRegToReg(self, Reg.r2, Reg.r1); // r1 = prod
+    // den_half = (40500 - prod) >> 1 → r4 (uses acu, so before building num).
+    try isa.movImmToReg(self, 40500, Reg.acu);
+    try isa.subRegFromAcu(self, Reg.r1); // acu = 40500 - prod
+    try isa.shrRegImm(self, Reg.acu, 1); // (40500 - prod) / 2 ≤ 20250
+    try isa.movRegToReg(self, Reg.acu, Reg.r4); // r4 = den_half
+    // num32 = 512 * prod → acu:r2 (32-bit dividend).
+    try isa.movImmToReg(self, 512, Reg.r2);
+    try isa.mulRegReg(self, Reg.r1, Reg.r2); // r2 = low(512·prod), acu = high
+    try isa.divsRegReg(self, Reg.r4, Reg.r2); // r2 = num32 / den_half = result
+    try isa.movRegToReg(self, Reg.r2, Reg.acu);
+    // Negate for the [180, 360) half.
+    try isa.cmpRegImm(self, Reg.r6, 0);
+    const positive = try isa.emitJumpPlaceholder(self, Op.jeq_addr);
+    try isa.negReg(self, Reg.acu);
+    try isa.patchJumpTo(self, positive, try self.currentOffset());
 }
 
 /// Emit `jge` (signed) / `jcc` (unsigned ≥, i.e. no borrow) after a

--- a/src/lang/codegen/math_builtin.zig
+++ b/src/lang/codegen/math_builtin.zig
@@ -45,7 +45,61 @@ pub fn emitMathCall(self: *Emitter, name: []const u8, c: ast.CallExpr) !void {
     if (std.mem.eql(u8, name, "sat_sub")) return emitSat(self, c, .sub);
     if (std.mem.eql(u8, name, "sat_mul")) return emitSat(self, c, .mul);
     if (std.mem.eql(u8, name, "fixed_sin")) return emitFixedSin(self, c);
+    if (std.mem.eql(u8, name, "sqrt_fixed")) return emitSqrtFixed(self, c);
     try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `math` builtin");
+}
+
+/// `sqrt_fixed(x: fixed) -> fixed` — Q8.8 square root. For x > 0 the
+/// result raw = isqrt(x_raw << 8) (since √(x_raw/256)·256 = √(x_raw·256)).
+/// `x_raw << 8` is a 32-bit radicand; computed bit-by-bit by testing each
+/// result bit high→low, squaring the candidate (16×16→32 `mul`), and
+/// keeping the bit when candidate² ≤ radicand (a 32-bit unsigned compare).
+/// x ≤ 0 returns 0. The result is < 4096, so 12 bits suffice.
+fn emitSqrtFixed(self: *Emitter, c: ast.CallExpr) !void {
+    try self.emitExpr(c.args[0]); // acu = x_raw
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const positive = try isa.emitJumpPlaceholder(self, Op.jgt_addr);
+    try isa.movImmToReg(self, 0, Reg.acu); // x ≤ 0 → 0
+    const done = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    try isa.patchJumpTo(self, positive, try self.currentOffset());
+    // Radicand N = x_raw << 8 across (r2 = high, r1 = low).
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try isa.shlRegImm(self, Reg.r1, 8); // N_lo = x_raw << 8
+    try isa.shrRegImm(self, Reg.acu, 8); // N_hi = x_raw >> 8 (x > 0 → logical ok)
+    try isa.movRegToReg(self, Reg.acu, Reg.r2);
+    try isa.movImmToReg(self, 0, Reg.r3); // result accumulator
+    try isa.movImmToReg(self, 2048, Reg.r4); // bit = 2^11 (result < 4096)
+    const loop_start = try self.currentOffset();
+    // candidate = result | bit → r5.
+    try isa.movRegToReg(self, Reg.r3, Reg.r5);
+    try isa.orRegReg(self, Reg.r5, Reg.r4);
+    // sq = candidate² → acu:r6 (high:low).
+    try isa.movRegToReg(self, Reg.r5, Reg.r6);
+    try isa.mulRegReg(self, Reg.r5, Reg.r6);
+    // Compare (acu:r6) ≤ (r2:r1) unsigned.
+    try isa.cmpRegReg(self, Reg.acu, Reg.r2); // sq_hi - N_hi
+    const hi_ge = try isa.emitJumpPlaceholder(self, Op.jcc_addr); // sq_hi ≥ N_hi (C=0)
+    const acc_lo = try isa.emitJumpPlaceholder(self, Op.jmp_addr); // sq_hi < N_hi → accept
+    try isa.patchJumpTo(self, hi_ge, try self.currentOffset());
+    const rej_hi = try isa.emitJumpPlaceholder(self, Op.jne_addr); // sq_hi > N_hi → reject
+    try isa.cmpRegReg(self, Reg.r1, Reg.r6); // N_lo - sq_lo
+    const acc_eq = try isa.emitJumpPlaceholder(self, Op.jcc_addr); // N_lo ≥ sq_lo → sq_lo ≤ N_lo → accept
+    const rej_lo = try isa.emitJumpPlaceholder(self, Op.jmp_addr); // sq_lo > N_lo → reject
+    // accept: result = candidate.
+    const accept = try self.currentOffset();
+    try isa.patchJumpTo(self, acc_lo, accept);
+    try isa.patchJumpTo(self, acc_eq, accept);
+    try isa.movRegToReg(self, Reg.r5, Reg.r3);
+    // continue: shift to the next bit, loop while non-zero.
+    const cont = try self.currentOffset();
+    try isa.patchJumpTo(self, rej_hi, cont);
+    try isa.patchJumpTo(self, rej_lo, cont);
+    try isa.shrRegImm(self, Reg.r4, 1);
+    try isa.cmpRegImm(self, Reg.r4, 0);
+    const back = try isa.emitJumpPlaceholder(self, Op.jne_addr);
+    try isa.patchJumpTo(self, back, loop_start);
+    try isa.movRegToReg(self, Reg.r3, Reg.acu); // result → acu
+    try isa.patchJumpTo(self, done, try self.currentOffset());
 }
 
 /// `fixed_sin(deg: i16) -> fixed` — sine of an angle in degrees, Q8.8.

--- a/src/lang/codegen/math_builtin.zig
+++ b/src/lang/codegen/math_builtin.zig
@@ -1,0 +1,158 @@
+// Lowering for the `math` stdlib module (§5.3). These helpers are
+// numeric-polymorphic — the operand type (from the typechecker) picks
+// signed vs unsigned comparisons and the fixed-point multiply scaling.
+// `abs`/`min`/`max`/`clamp` are cmp + branch; `wrap_*` are plain
+// arithmetic with the debug overflow trap deliberately skipped (the raw
+// op wraps, matching the ISA's release behavior).
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const types = @import("../types.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+
+/// How an operand's type drives the lowering: `u16`/`u8` need unsigned
+/// comparison; `fixed` needs Q8.8 multiply scaling; everything else is
+/// treated as signed (`i16`/`i8`/`fixed` all compare as signed i16).
+const Kind = enum { signed, unsigned, fixed };
+
+fn argKind(self: *Emitter, e: *const ast.Expr) Kind {
+    const t = self.typeOf(e) orelse return .signed;
+    if (t.* != .primitive) return .signed;
+    return switch (t.primitive) {
+        .u16, .u8 => .unsigned,
+        .fixed => .fixed,
+        else => .signed,
+    };
+}
+
+/// Dispatch a `math.X(args)` call. Arity + numeric operand types are
+/// validated by the typechecker; the codegen guard is defensive.
+pub fn emitMathCall(self: *Emitter, name: []const u8, c: ast.CallExpr) !void {
+    if (std.mem.eql(u8, name, "abs")) return emitAbs(self, c);
+    if (std.mem.eql(u8, name, "min")) return emitMinMax(self, c, .min);
+    if (std.mem.eql(u8, name, "max")) return emitMinMax(self, c, .max);
+    if (std.mem.eql(u8, name, "clamp")) return emitClamp(self, c);
+    if (std.mem.eql(u8, name, "wrap_add")) return emitWrapAddSub(self, c, .add);
+    if (std.mem.eql(u8, name, "wrap_sub")) return emitWrapAddSub(self, c, .sub);
+    if (std.mem.eql(u8, name, "wrap_mul")) return emitWrapMul(self, c);
+    try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `math` builtin");
+}
+
+/// Emit `jge` (signed) / `jcc` (unsigned ≥, i.e. no borrow) after a
+/// `cmp a, b` — jumps when `a >= b`. Returns the placeholder to patch.
+fn branchGE(self: *Emitter, kind: Kind) !usize {
+    const op: u8 = if (kind == .unsigned) Op.jcc_addr else Op.jge_addr;
+    return isa.emitJumpPlaceholder(self, op);
+}
+
+/// `acu = min(r_a, acu)` — keep `acu` (b) when `a >= b`, else move `a`.
+fn minStep(self: *Emitter, r_a: u8, kind: Kind) !void {
+    try isa.cmpRegReg(self, r_a, Reg.acu);
+    const keep_b = try branchGE(self, kind);
+    try isa.movRegToReg(self, r_a, Reg.acu);
+    try isa.patchJumpTo(self, keep_b, try self.currentOffset());
+}
+
+/// `acu = max(r_a, acu)` — move `a` when `a >= b`, else keep `acu` (b).
+fn maxStep(self: *Emitter, r_a: u8, kind: Kind) !void {
+    try isa.cmpRegReg(self, r_a, Reg.acu);
+    const take_a = try branchGE(self, kind);
+    const keep_b = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    try isa.patchJumpTo(self, take_a, try self.currentOffset());
+    try isa.movRegToReg(self, r_a, Reg.acu);
+    try isa.patchJumpTo(self, keep_b, try self.currentOffset());
+}
+
+fn emitAbs(self: *Emitter, c: ast.CallExpr) !void {
+    try self.emitExpr(c.args[0]); // acu = x
+    // Unsigned values are already non-negative — abs is the identity.
+    if (argKind(self, c.args[0]) == .unsigned) return;
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const skip = try isa.emitJumpPlaceholder(self, Op.jge_addr);
+    try isa.negReg(self, Reg.acu);
+    try isa.patchJumpTo(self, skip, try self.currentOffset());
+}
+
+const MinMax = enum { min, max };
+
+fn emitMinMax(self: *Emitter, c: ast.CallExpr, which: MinMax) !void {
+    const kind = argKind(self, c.args[0]);
+    try self.emitExpr(c.args[0]); // a
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(c.args[1]); // acu = b
+    try isa.popReg(self, Reg.r1); // r1 = a
+    switch (which) {
+        .min => try minStep(self, Reg.r1, kind),
+        .max => try maxStep(self, Reg.r1, kind),
+    }
+}
+
+/// `clamp(x, lo, hi)` = `min(max(x, lo), hi)`. Evaluate all three, then
+/// `max` against `lo` and `min` against `hi` in registers.
+fn emitClamp(self: *Emitter, c: ast.CallExpr) !void {
+    const kind = argKind(self, c.args[0]);
+    try self.emitExpr(c.args[0]); // x
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(c.args[1]); // lo
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(c.args[2]); // acu = hi
+    try isa.popReg(self, Reg.r2); // r2 = lo
+    try isa.popReg(self, Reg.r1); // r1 = x
+    // acu = min(x, hi): x in r1, hi in acu.
+    try minStep(self, Reg.r1, kind);
+    // acu = max(lo, that): lo in r2.
+    try maxStep(self, Reg.r2, kind);
+}
+
+const AddSub = enum { add, sub };
+
+/// `wrap_add` / `wrap_sub` — plain add/sub, no overflow trap (the op
+/// wraps). Subtraction needs `a` in `acu`, so it pushes `b` first.
+fn emitWrapAddSub(self: *Emitter, c: ast.CallExpr, op: AddSub) !void {
+    switch (op) {
+        .add => {
+            try self.emitExpr(c.args[0]); // a
+            try isa.pushReg(self, Reg.acu);
+            try self.emitExpr(c.args[1]); // acu = b
+            try isa.popReg(self, Reg.r1); // r1 = a
+            try isa.addRegToAcu(self, Reg.r1); // acu = b + a
+        },
+        .sub => {
+            try self.emitExpr(c.args[1]); // b
+            try isa.pushReg(self, Reg.acu);
+            try self.emitExpr(c.args[0]); // acu = a
+            try isa.popReg(self, Reg.r1); // r1 = b
+            try isa.subRegFromAcu(self, Reg.r1); // acu = a - b
+        },
+    }
+}
+
+/// `wrap_mul` — low-16 product for ints (signed + unsigned share the
+/// low half); Q8.8 scaling for `fixed`. No overflow trap.
+fn emitWrapMul(self: *Emitter, c: ast.CallExpr) !void {
+    const kind = argKind(self, c.args[0]);
+    try self.emitExpr(c.args[0]); // a
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(c.args[1]); // acu = b
+    try isa.popReg(self, Reg.r1); // r1 = a
+    // `mul`/`muls` land the low half in the dst reg and the high half in
+    // acu, so land the product in r2 to avoid clobbering it.
+    try isa.movRegToReg(self, Reg.acu, Reg.r2);
+    if (kind == .fixed) {
+        try isa.mulsRegReg(self, Reg.r1, Reg.r2); // signed Q8.8 product
+        // Q8.8 result = (acu << 8) | (r2 >> 8) — bits 8..23 of the 32-bit
+        // product straddling acu:r2 (ISA §5.4.1; magnitude > 127.99 wraps).
+        try isa.shrRegImm(self, Reg.r2, 8);
+        try isa.shlRegImm(self, Reg.acu, 8);
+        try isa.orRegReg(self, Reg.acu, Reg.r2);
+    } else {
+        try isa.mulRegReg(self, Reg.r1, Reg.r2); // r2 = low(a*b)
+        try isa.movRegToReg(self, Reg.r2, Reg.acu);
+    }
+}

--- a/src/lang/codegen/stdlib.zig
+++ b/src/lang/codegen/stdlib.zig
@@ -1,0 +1,29 @@
+// Router for the stdlib modules whose calls lower to fixed code:
+// `math`, `bank`, `test`. `mem` predates this and keeps its own
+// dispatch (it has the addr-of special case). Both call forms —
+// `recv.fn(args)` parsed as a method call and the field-callee shape —
+// flow through `emitCall`.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const bank_builtin = @import("bank_builtin.zig");
+const test_builtin = @import("test_builtin.zig");
+const math_builtin = @import("math_builtin.zig");
+
+const Emitter = codegen.Emitter;
+
+/// `true` for the modules this router lowers (`mem` excluded).
+pub fn isModule(name: []const u8) bool {
+    return std.mem.eql(u8, name, "math") or
+        std.mem.eql(u8, name, "bank") or
+        std.mem.eql(u8, name, "test");
+}
+
+/// Lower a `recv.name(args)` stdlib call. `recv` is gated by `isModule`.
+pub fn emitCall(self: *Emitter, recv: []const u8, fe: ast.FieldExpr, c: ast.CallExpr) !void {
+    const name = self.source[fe.field.start..fe.field.end];
+    if (std.mem.eql(u8, recv, "bank")) return bank_builtin.emitBankCall(self, name, c);
+    if (std.mem.eql(u8, recv, "test")) return test_builtin.emitTestCall(self, name, c);
+    return math_builtin.emitMathCall(self, name, c);
+}

--- a/src/lang/codegen/test_builtin.zig
+++ b/src/lang/codegen/test_builtin.zig
@@ -1,0 +1,47 @@
+// Lowering for the `test` stdlib module (§5.3): `test.assert_eq(a, b)`
+// and `test.assert_ne(a, b)`, used in `@test` functions. Both compare
+// two register-scalar operands and halt the VM with a diagnostic on a
+// failed assertion — the same compare / skip-jump / print / `hlt` shape
+// as the `assert` builtin, with the skip condition picking eq vs ne.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const strings = @import("strings.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Sys = opcodes.Sys;
+
+/// Dispatch a `test.X(args)` call. Arity + scalar operand types are
+/// validated by the typechecker; the codegen guard is defensive.
+pub fn emitTestCall(self: *Emitter, name: []const u8, c: ast.CallExpr) !void {
+    const skip_on_equal = std.mem.eql(u8, name, "assert_eq");
+    if (!skip_on_equal and !std.mem.eql(u8, name, "assert_ne")) {
+        try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: unknown `test` builtin");
+        return;
+    }
+    if (c.args.len != 2) {
+        try self.diagFatal(c.span, "E_CODEGEN_UNSUPPORTED", "codegen: `test.assert_*` takes two arguments");
+        return;
+    }
+    try self.emitExpr(c.args[0]); // acu = a
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(c.args[1]); // acu = b
+    try isa.popReg(self, Reg.r1); // r1 = a
+    try isa.cmpRegReg(self, Reg.r1, Reg.acu); // Z set iff a == b
+    // assert_eq skips the trap when equal (Z = 1 → jeq); assert_ne skips
+    // when not equal (Z = 0 → jne).
+    const skip = try isa.emitJumpPlaceholder(self, if (skip_on_equal) Op.jeq_addr else Op.jne_addr);
+    // Trap: report + halt. The message is fixed (the helpers take no
+    // message arg); the host sees it before the VM stops.
+    const id = try strings.internString(self, "test assertion failed\n");
+    try strings.emitMovStringAddrToReg(self, id, Reg.acu);
+    try isa.sys(self, Sys.print_str);
+    try self.emitByte(Op.hlt);
+    const skip_target = try self.currentOffset();
+    try isa.patchJumpTo(self, skip, skip_target);
+}

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -135,6 +135,7 @@ pub fn typecheck(
 }
 
 const mem_builtin = @import("typecheck/mem_builtin.zig");
+const stdlib = @import("typecheck/stdlib.zig");
 const match = @import("typecheck/match.zig");
 const predicates = @import("typecheck/predicates.zig");
 const annotations = @import("typecheck/annotations.zig");
@@ -1088,6 +1089,9 @@ pub const Checker = struct {
                     const recv_name = self.lexeme(m.receiver.ident.span);
                     if (std.mem.eql(u8, recv_name, "mem")) {
                         return try fields.checkMemMethodCall(self, m);
+                    }
+                    if (stdlib.isModule(recv_name)) {
+                        return try stdlib.checkCall(self, recv_name, m.method, m.args, m.span);
                     }
                     // `Enum.Variant(args)` is indistinguishable from a
                     // method call at parse time — resolve it as a

--- a/src/lang/typecheck/calls.zig
+++ b/src/lang/typecheck/calls.zig
@@ -6,6 +6,7 @@ const predicates = @import("predicates.zig");
 const relations = @import("relations.zig");
 const annotations = @import("annotations.zig");
 const flow = @import("flow.zig");
+const stdlib = @import("stdlib.zig");
 
 const Checker = typecheck.Checker;
 const WalkError = error{OutOfMemory};
@@ -27,6 +28,19 @@ pub fn checkCall(self: *Checker, c: ast.CallExpr, hint: ?*const types.Type) Walk
         }
         if (isDivergeBuiltinName(callee_name)) {
             return try checkDivergeBuiltin(self, c, callee_name);
+        }
+    }
+    // Stdlib module call in field-callee form (`math.min(a, b)` where
+    // the callee parses as a `FieldExpr`). Route to the stdlib checker
+    // so numeric-polymorphic args resolve from the call site rather than
+    // synthesizing a fn type without them.
+    if (c.callee.* == .field) {
+        const fe = c.callee.field;
+        if (fe.receiver.* == .ident) {
+            const recv = self.lexeme(fe.receiver.ident.span);
+            if (stdlib.isModule(recv)) {
+                return try stdlib.checkCall(self, recv, fe.field, c.args, c.span);
+            }
         }
     }
     // Abstract-class instantiation: `ClassName(args)` where

--- a/src/lang/typecheck/stdlib.zig
+++ b/src/lang/typecheck/stdlib.zig
@@ -44,6 +44,7 @@ const math_sigs = [_]Sig{
     .{ .name = "sat_sub", .shape = .{ .numeric_int = 2 } },
     .{ .name = "sat_mul", .shape = .{ .numeric_int = 2 } },
     .{ .name = "fixed_sin", .shape = .{ .mono = .{ .params = &.{.i16}, .ret = .fixed } } },
+    .{ .name = "sqrt_fixed", .shape = .{ .mono = .{ .params = &.{.fixed}, .ret = .fixed } } },
 };
 
 const bank_sigs = [_]Sig{

--- a/src/lang/typecheck/stdlib.zig
+++ b/src/lang/typecheck/stdlib.zig
@@ -1,0 +1,162 @@
+// Type-checking for the compiler-provided stdlib modules whose calls
+// take a known signature: `math` (numeric-polymorphic helpers), `bank`
+// (bank manipulation), and `test` (assertion helpers). `mem` predates
+// this and keeps its own resolver (it has the addr-of special case);
+// these three route here from both call forms (`recv.fn(args)` parsed as
+// a method call, and the field-callee `CallExpr` shape).
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const typecheck = @import("../typecheck.zig");
+const suggestions = @import("suggestions.zig");
+
+const Checker = typecheck.Checker;
+const Primitive = types.Primitive;
+const WalkError = error{OutOfMemory};
+
+/// How a builtin's result type is derived from its call.
+const Shape = union(enum) {
+    /// Fixed param + return primitives (monomorphic, like `mem`).
+    mono: struct { params: []const Primitive, ret: ?Primitive },
+    /// `arity` args sharing one numeric type `T ∈ {i16,u16,fixed}`;
+    /// the call returns `T`. Backs abs/min/max/clamp/wrap_*.
+    numeric: u8,
+    /// `assert_eq`/`assert_ne`: two args of one comparable type → nil.
+    equatable_pair,
+};
+
+const Sig = struct { name: []const u8, shape: Shape };
+
+const math_sigs = [_]Sig{
+    .{ .name = "abs", .shape = .{ .numeric = 1 } },
+    .{ .name = "min", .shape = .{ .numeric = 2 } },
+    .{ .name = "max", .shape = .{ .numeric = 2 } },
+    .{ .name = "clamp", .shape = .{ .numeric = 3 } },
+    .{ .name = "wrap_add", .shape = .{ .numeric = 2 } },
+    .{ .name = "wrap_sub", .shape = .{ .numeric = 2 } },
+    .{ .name = "wrap_mul", .shape = .{ .numeric = 2 } },
+};
+
+const bank_sigs = [_]Sig{
+    .{ .name = "switch_to", .shape = .{ .mono = .{ .params = &.{.u8}, .ret = null } } },
+    .{ .name = "current", .shape = .{ .mono = .{ .params = &.{}, .ret = .u8 } } },
+};
+
+const test_sigs = [_]Sig{
+    .{ .name = "assert_eq", .shape = .equatable_pair },
+    .{ .name = "assert_ne", .shape = .equatable_pair },
+};
+
+/// `true` for the modules this file owns. `mem` is excluded — it keeps
+/// its own resolver.
+pub fn isModule(name: []const u8) bool {
+    return std.mem.eql(u8, name, "math") or
+        std.mem.eql(u8, name, "bank") or
+        std.mem.eql(u8, name, "test");
+}
+
+fn sigsFor(recv: []const u8) []const Sig {
+    if (std.mem.eql(u8, recv, "math")) return &math_sigs;
+    if (std.mem.eql(u8, recv, "bank")) return &bank_sigs;
+    return &test_sigs; // isModule gated the caller to math/bank/test
+}
+
+fn lookup(recv: []const u8, name: []const u8) ?Sig {
+    for (sigsFor(recv)) |s| if (std.mem.eql(u8, s.name, name)) return s;
+    return null;
+}
+
+fn suggest(recv: []const u8, name: []const u8) ?[]const u8 {
+    const sigs = sigsFor(recv);
+    var pool: [16][]const u8 = undefined;
+    for (sigs, 0..) |s, i| pool[i] = s.name;
+    return suggestions.bestMatch(name, pool[0..sigs.len]);
+}
+
+fn isNumeric(t: *const types.Type) bool {
+    return t.* == .primitive and switch (t.primitive) {
+        .i16, .u16, .fixed => true,
+        else => false,
+    };
+}
+
+/// Types that fit a register and compare with a single `cmp` — what
+/// `test.assert_eq` / `assert_ne` accept. Excludes `str` (content
+/// compare) and aggregates (no primitive form here).
+fn isRegScalar(t: *const types.Type) bool {
+    return t.* == .primitive and switch (t.primitive) {
+        .i8, .u8, .i16, .u16, .bool_, .char, .fixed => true,
+        .nil_, .str => false,
+    };
+}
+
+/// Type-check a `recv.name(args)` call against the module's signature.
+/// Returns the call's result type (`nil` for void helpers), or `null`
+/// when the member is unknown (a diagnostic is emitted).
+pub fn checkCall(
+    self: *Checker,
+    recv: []const u8,
+    name_span: ast.Span,
+    args: []const *ast.Expr,
+    call_span: ast.Span,
+) WalkError!?*const types.Type {
+    const name = self.lexeme(name_span);
+    const sig = lookup(recv, name) orelse {
+        const msg = try std.fmt.allocPrint(self.arena, "stdlib module `{s}` has no member `{s}`", .{ recv, name });
+        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", name_span, msg, suggest(recv, name));
+        for (args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    };
+    switch (sig.shape) {
+        .mono => |m| {
+            try checkArity(self, recv, name, call_span, args.len, m.params.len);
+            const n = @min(args.len, m.params.len);
+            for (args[0..n], m.params[0..n]) |a, p| {
+                _ = try self.inferExpr(a, try self.primitive(p));
+            }
+            for (args[n..]) |a| _ = try self.inferExpr(a, null);
+            return if (m.ret) |r| try self.primitive(r) else try self.primitive(.nil_);
+        },
+        .numeric => |arity| {
+            try checkArity(self, recv, name, call_span, args.len, arity);
+            if (args.len == 0) return try self.primitive(.i16);
+            // The first arg fixes the type; it must be numeric, and the
+            // rest must match it.
+            const first = try self.inferExpr(args[0], null);
+            const result: *const types.Type = if (first != null and isNumeric(first.?))
+                first.?
+            else blk: {
+                if (first != null) {
+                    const ty_s = try types.render(self.arena, first.?.*);
+                    const msg = try std.fmt.allocPrint(self.arena, "`math.{s}` expects a numeric type (i16, u16, or fixed), got `{s}`", .{ name, ty_s });
+                    try self.emitSpan("E_TYPE_MISMATCH", args[0].span(), msg);
+                }
+                break :blk try self.primitive(.i16);
+            };
+            for (args[1..]) |a| _ = try self.inferExpr(a, result);
+            return result;
+        },
+        .equatable_pair => {
+            try checkArity(self, recv, name, call_span, args.len, 2);
+            if (args.len == 0) return try self.primitive(.nil_);
+            // Both args must share one register-scalar type; the first
+            // fixes it (the lowering compares them in registers).
+            const first = try self.inferExpr(args[0], null);
+            if (first != null and !isRegScalar(first.?)) {
+                const ty_s = try types.render(self.arena, first.?.*);
+                const msg = try std.fmt.allocPrint(self.arena, "`test.{s}` compares scalar values (int / bool / char / fixed), got `{s}`", .{ name, ty_s });
+                try self.emitSpan("E_TYPE_MISMATCH", args[0].span(), msg);
+            }
+            for (args[1..]) |a| _ = try self.inferExpr(a, first);
+            return try self.primitive(.nil_);
+        },
+    }
+}
+
+fn checkArity(self: *Checker, recv: []const u8, name: []const u8, span: ast.Span, got: usize, want: usize) WalkError!void {
+    if (got == want) return;
+    const suffix: []const u8 = if (want == 1) "" else "s";
+    const msg = try std.fmt.allocPrint(self.arena, "`{s}.{s}` takes {d} argument{s}, called with {d}", .{ recv, name, want, suffix, got });
+    try self.emitSpan("E_TYPE_ARG_COUNT", span, msg);
+}

--- a/src/lang/typecheck/stdlib.zig
+++ b/src/lang/typecheck/stdlib.zig
@@ -43,6 +43,7 @@ const math_sigs = [_]Sig{
     .{ .name = "sat_add", .shape = .{ .numeric_int = 2 } },
     .{ .name = "sat_sub", .shape = .{ .numeric_int = 2 } },
     .{ .name = "sat_mul", .shape = .{ .numeric_int = 2 } },
+    .{ .name = "fixed_sin", .shape = .{ .mono = .{ .params = &.{.i16}, .ret = .fixed } } },
 };
 
 const bank_sigs = [_]Sig{

--- a/src/lang/typecheck/stdlib.zig
+++ b/src/lang/typecheck/stdlib.zig
@@ -22,6 +22,10 @@ const Shape = union(enum) {
     /// `arity` args sharing one numeric type `T ∈ {i16,u16,fixed}`;
     /// the call returns `T`. Backs abs/min/max/clamp/wrap_*.
     numeric: u8,
+    /// `arity` args sharing one integer type `T ∈ {i16,u16}`; returns
+    /// `T`. Backs sat_* — saturation clamps to a type's bounds, which
+    /// `fixed` (its own range) doesn't share.
+    numeric_int: u8,
     /// `assert_eq`/`assert_ne`: two args of one comparable type → nil.
     equatable_pair,
 };
@@ -36,6 +40,9 @@ const math_sigs = [_]Sig{
     .{ .name = "wrap_add", .shape = .{ .numeric = 2 } },
     .{ .name = "wrap_sub", .shape = .{ .numeric = 2 } },
     .{ .name = "wrap_mul", .shape = .{ .numeric = 2 } },
+    .{ .name = "sat_add", .shape = .{ .numeric_int = 2 } },
+    .{ .name = "sat_sub", .shape = .{ .numeric_int = 2 } },
+    .{ .name = "sat_mul", .shape = .{ .numeric_int = 2 } },
 };
 
 const bank_sigs = [_]Sig{
@@ -77,6 +84,13 @@ fn suggest(recv: []const u8, name: []const u8) ?[]const u8 {
 fn isNumeric(t: *const types.Type) bool {
     return t.* == .primitive and switch (t.primitive) {
         .i16, .u16, .fixed => true,
+        else => false,
+    };
+}
+
+fn isIntScalar(t: *const types.Type) bool {
+    return t.* == .primitive and switch (t.primitive) {
+        .i16, .u16 => true,
         else => false,
     };
 }
@@ -130,6 +144,23 @@ pub fn checkCall(
                 if (first != null) {
                     const ty_s = try types.render(self.arena, first.?.*);
                     const msg = try std.fmt.allocPrint(self.arena, "`math.{s}` expects a numeric type (i16, u16, or fixed), got `{s}`", .{ name, ty_s });
+                    try self.emitSpan("E_TYPE_MISMATCH", args[0].span(), msg);
+                }
+                break :blk try self.primitive(.i16);
+            };
+            for (args[1..]) |a| _ = try self.inferExpr(a, result);
+            return result;
+        },
+        .numeric_int => |arity| {
+            try checkArity(self, recv, name, call_span, args.len, arity);
+            if (args.len == 0) return try self.primitive(.i16);
+            const first = try self.inferExpr(args[0], null);
+            const result: *const types.Type = if (first != null and isIntScalar(first.?))
+                first.?
+            else blk: {
+                if (first != null) {
+                    const ty_s = try types.render(self.arena, first.?.*);
+                    const msg = try std.fmt.allocPrint(self.arena, "`math.{s}` expects an integer type (i16 or u16), got `{s}`", .{ name, ty_s });
                     try self.emitSpan("E_TYPE_MISMATCH", args[0].span(), msg);
                 }
                 break :blk try self.primitive(.i16);

--- a/src/lang/typecheck/stdlib.zig
+++ b/src/lang/typecheck/stdlib.zig
@@ -45,6 +45,7 @@ const math_sigs = [_]Sig{
     .{ .name = "sat_mul", .shape = .{ .numeric_int = 2 } },
     .{ .name = "fixed_sin", .shape = .{ .mono = .{ .params = &.{.i16}, .ret = .fixed } } },
     .{ .name = "sqrt_fixed", .shape = .{ .mono = .{ .params = &.{.fixed}, .ret = .fixed } } },
+    .{ .name = "rng", .shape = .{ .mono = .{ .params = &.{}, .ret = .u16 } } },
 };
 
 const bank_sigs = [_]Sig{

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -4017,6 +4017,29 @@ test "codegen/math: sqrt_fixed (bit-by-bit isqrt) Q8.8 raw" {
     try std.testing.expectEqual(@as(u16, 0), vm.mmap.readWord(0xFFF0)); // √negative = 0
 }
 
+test "codegen/math: fixed_sin range-reduces a large angle" {
+    // 30000 mod 360 = 120, so fixed_sin(30000) == fixed_sin(120) ≈ 0.865
+    // → 221 in Q8.8 (Bhaskara).
+    var compiled = try compileSource(
+        \\def main()
+        \\  let a: fixed = math.fixed_sin(30000)
+        \\  let b: fixed = math.fixed_sin(120)
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqual(@as(u16, 221), vm.mmap.readWord(0xFFFC)); // sin(30000°)
+    try std.testing.expectEqual(@as(u16, 221), vm.mmap.readWord(0xFFFA)); // sin(120°)
+}
+
 test "codegen/math: rng — deterministic Galois LFSR sequence" {
     // First call lazily seeds (0xACE1) then steps; the sequence is fixed.
     try runAndExpect(
@@ -4093,6 +4116,17 @@ test "codegen/bake: fixed_sin / sqrt_fixed match the runtime at compile time" {
     try std.testing.expect(s90 != null and sq4 != null);
     try std.testing.expectEqual(@as(u16, 256), vm.mmap.readWord(s90.?)); // fixed_sin(90) = 1.0
     try std.testing.expectEqual(@as(u16, 512), vm.mmap.readWord(sq4.?)); // sqrt_fixed(4.0) = 2.0
+}
+
+test "codegen/math: nested math.* calls compose (args are full exprs)" {
+    // abs(-15)=15; min(10,20)=10; clamp(15, 0, 10)=10. Each arg is itself
+    // a math call — the push/pop arg discipline keeps them independent.
+    try runAndExpect(
+        \\def main()
+        \\  let x: i16 = 0 - 15
+        \\  print math.clamp(math.abs(x), 0, math.min(10, 20))
+        \\end
+    , "10\n");
 }
 
 test "codegen/bank: switch_to writes mb, current reads it" {

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3984,6 +3984,39 @@ test "codegen/math: fixed_sin (Bhaskara) over the circle, Q8.8 raw" {
     try std.testing.expectEqual(@as(u16, 180), vm.mmap.readWord(0xFFF2)); // sin(45) ≈ 0.707
 }
 
+test "codegen/math: sqrt_fixed (bit-by-bit isqrt) Q8.8 raw" {
+    // result raw = isqrt(x_raw << 8). 1.0→1.0, 4.0→2.0, 9.0→3.0 exact;
+    // 2.0→~1.414 (362); 0.25→0.5 (128); negative → 0.
+    var compiled = try compileSource(
+        \\def main()
+        \\  let s0: fixed = math.sqrt_fixed(0.0)
+        \\  let s1: fixed = math.sqrt_fixed(1.0)
+        \\  let s4: fixed = math.sqrt_fixed(4.0)
+        \\  let s9: fixed = math.sqrt_fixed(9.0)
+        \\  let s2: fixed = math.sqrt_fixed(2.0)
+        \\  let sq: fixed = math.sqrt_fixed(0.25)
+        \\  let sn: fixed = math.sqrt_fixed(0.0 - 1.0)
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqual(@as(u16, 0), vm.mmap.readWord(0xFFFC)); // √0 = 0
+    try std.testing.expectEqual(@as(u16, 256), vm.mmap.readWord(0xFFFA)); // √1 = 1.0
+    try std.testing.expectEqual(@as(u16, 512), vm.mmap.readWord(0xFFF8)); // √4 = 2.0
+    try std.testing.expectEqual(@as(u16, 768), vm.mmap.readWord(0xFFF6)); // √9 = 3.0
+    try std.testing.expectEqual(@as(u16, 362), vm.mmap.readWord(0xFFF4)); // √2 ≈ 1.414
+    try std.testing.expectEqual(@as(u16, 128), vm.mmap.readWord(0xFFF2)); // √0.25 = 0.5
+    try std.testing.expectEqual(@as(u16, 0), vm.mmap.readWord(0xFFF0)); // √negative = 0
+}
+
 test "codegen/bank: switch_to writes mb, current reads it" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3887,6 +3887,74 @@ test "codegen/@interrupt: handler can call a regular function (enter/ret frame c
     , "42\n-30536\n");
 }
 
+// ---------- stdlib modules: math / bank / test ----------
+
+test "codegen/math: min/max/abs/clamp over i16 (signed)" {
+    try runAndExpect(
+        \\def main()
+        \\  let lo: i16 = 0 - 5
+        \\  print math.min(5, 3)
+        \\  print math.max(5, 3)
+        \\  print math.abs(lo)
+        \\  print math.clamp(15, 0, 10)
+        \\  print math.clamp(lo, 0, 10)
+        \\  print math.clamp(7, 0, 10)
+        \\end
+    , "3\n5\n5\n10\n0\n7\n");
+}
+
+test "codegen/math: min/max pick unsigned comparison for u16" {
+    // 60000 as i16 is negative; a signed compare would invert these.
+    try runAndExpect(
+        \\def main()
+        \\  let a: u16 = 60000
+        \\  let b: u16 = 5
+        \\  print math.min(a, b)
+        \\  print math.max(a, b)
+        \\end
+    , "5\n60000\n");
+}
+
+test "codegen/math: wrap_add/wrap_mul wrap without trapping" {
+    try runAndExpect(
+        \\def main()
+        \\  let big: i16 = 30000
+        \\  print math.wrap_add(big, 5000)
+        \\  print math.wrap_mul(200, 200)
+        \\end
+    , "-30536\n-25536\n");
+}
+
+test "codegen/bank: switch_to writes mb, current reads it" {
+    try runAndExpect(
+        \\def main()
+        \\  print bank.current()
+        \\  bank.switch_to(3)
+        \\  print bank.current()
+        \\end
+    , "0\n3\n");
+}
+
+test "codegen/test: assert_eq / assert_ne pass through on success" {
+    try runAndExpect(
+        \\def main()
+        \\  test.assert_eq(2 + 2, 4)
+        \\  test.assert_ne(2, 3)
+        \\  print 1
+        \\end
+    , "1\n");
+}
+
+test "codegen/test: assert_eq halts with a message on failure" {
+    // The failing assert prints + halts, so `print 99` never runs.
+    try runAndExpect(
+        \\def main()
+        \\  test.assert_eq(2, 3)
+        \\  print 99
+        \\end
+    , "test assertion failed\n");
+}
+
 test "codegen/overflow: fixed-point `*` wraps in both modes per ISA §5.4.1" {
     // Fixed `*` is explicitly wrap-only — the codegen skips the
     // overflow trap regardless of build mode. Picking values that

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3925,6 +3925,33 @@ test "codegen/math: wrap_add/wrap_mul wrap without trapping" {
     , "-30536\n-25536\n");
 }
 
+test "codegen/math: sat_* clamp to i16 bounds (signed)" {
+    try runAndExpect(
+        \\def main()
+        \\  let big: i16 = 30000
+        \\  let nbig: i16 = 0 - 30000
+        \\  print math.sat_add(big, 5000)
+        \\  print math.sat_add(nbig, 0 - 5000)
+        \\  print math.sat_sub(nbig, 5000)
+        \\  print math.sat_mul(1000, 1000)
+        \\  print math.sat_mul(0 - 1000, 1000)
+        \\  print math.sat_add(100, 200)
+        \\end
+    , "32767\n-32768\n-32768\n32767\n-32768\n300\n");
+}
+
+test "codegen/math: sat_* clamp to u16 bounds (unsigned)" {
+    try runAndExpect(
+        \\def main()
+        \\  let a: u16 = 60000
+        \\  let small: u16 = 5
+        \\  print math.sat_add(a, 10000)
+        \\  print math.sat_sub(small, 10)
+        \\  print math.sat_mul(a, 1000)
+        \\end
+    , "65535\n0\n65535\n");
+}
+
 test "codegen/bank: switch_to writes mb, current reads it" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -4017,6 +4017,17 @@ test "codegen/math: sqrt_fixed (bit-by-bit isqrt) Q8.8 raw" {
     try std.testing.expectEqual(@as(u16, 0), vm.mmap.readWord(0xFFF0)); // √negative = 0
 }
 
+test "codegen/math: rng — deterministic Galois LFSR sequence" {
+    // First call lazily seeds (0xACE1) then steps; the sequence is fixed.
+    try runAndExpect(
+        \\def main()
+        \\  print math.rng()
+        \\  print math.rng()
+        \\  print math.rng()
+        \\end
+    , "57968\n28984\n14492\n");
+}
+
 test "codegen/bank: switch_to writes mb, current reads it" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3952,6 +3952,38 @@ test "codegen/math: sat_* clamp to u16 bounds (unsigned)" {
     , "65535\n0\n65535\n");
 }
 
+test "codegen/math: fixed_sin (Bhaskara) over the circle, Q8.8 raw" {
+    // 1.0 = 256, 0.5 = 128, -1.0 = -256 (0xFF00). fixed_sin(45) ≈ 0.707;
+    // Bhaskara + the den halving lands it at 180 (~0.703, ~1 LSB off).
+    var compiled = try compileSource(
+        \\def main()
+        \\  let s0: fixed = math.fixed_sin(0)
+        \\  let s90: fixed = math.fixed_sin(90)
+        \\  let s30: fixed = math.fixed_sin(30)
+        \\  let s270: fixed = math.fixed_sin(270)
+        \\  let s180: fixed = math.fixed_sin(180)
+        \\  let s45: fixed = math.fixed_sin(45)
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    // Locals sit at descending fp-relative slots from fp = 0xFFFE.
+    try std.testing.expectEqual(@as(u16, 0), vm.mmap.readWord(0xFFFC)); // sin(0) = 0
+    try std.testing.expectEqual(@as(u16, 256), vm.mmap.readWord(0xFFFA)); // sin(90) = 1.0
+    try std.testing.expectEqual(@as(u16, 128), vm.mmap.readWord(0xFFF8)); // sin(30) = 0.5
+    try std.testing.expectEqual(@as(u16, 0xFF00), vm.mmap.readWord(0xFFF6)); // sin(270) = -1.0
+    try std.testing.expectEqual(@as(u16, 0), vm.mmap.readWord(0xFFF4)); // sin(180) = 0
+    try std.testing.expectEqual(@as(u16, 180), vm.mmap.readWord(0xFFF2)); // sin(45) ≈ 0.707
+}
+
 test "codegen/bank: switch_to writes mb, current reads it" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -4028,6 +4028,73 @@ test "codegen/math: rng — deterministic Galois LFSR sequence" {
     , "57968\n28984\n14492\n");
 }
 
+test "codegen/bake: math.* evaluated at compile time (int + unsigned threading)" {
+    // `G` proves the typechecker's types thread into the bake evaluator:
+    // min(60000, 5) over u16 is 5; a signed compare would pick 60000.
+    try runAndExpect(
+        \\const A: i16 = bake do
+        \\  math.min(5, 3)
+        \\end
+        \\const B: i16 = bake do
+        \\  math.clamp(15, 0, 10)
+        \\end
+        \\const C: i16 = bake do
+        \\  math.abs(0 - 7)
+        \\end
+        \\const D: i16 = bake do
+        \\  math.wrap_add(30000, 5000)
+        \\end
+        \\const G: u16 = bake do
+        \\  let a: u16 = 60000
+        \\  math.min(a, 5)
+        \\end
+        \\def main()
+        \\  print A
+        \\  print B
+        \\  print C
+        \\  print D
+        \\  print G
+        \\end
+    , "3\n10\n7\n-30536\n5\n");
+}
+
+test "codegen/bake: fixed_sin / sqrt_fixed match the runtime at compile time" {
+    // The bake evaluator's fixed routines mirror the runtime exactly:
+    // fixed_sin(90) = 1.0 = 256, sqrt_fixed(4.0) = 2.0 = 512.
+    var compiled = try compileSource(
+        \\const S90: fixed = bake do
+        \\  math.fixed_sin(90)
+        \\end
+        \\const SQ4: fixed = bake do
+        \\  math.sqrt_fixed(4.0)
+        \\end
+        \\def main()
+        \\end
+    );
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    const header = try gero.disasm.parseHeader(compiled.image);
+    const symbols = try gero.disasm.parseSymbols(alloc, header.debug);
+    defer symbols.deinit(alloc);
+    var s90: ?u16 = null;
+    var sq4: ?u16 = null;
+    for (symbols.entries) |sym| {
+        if (std.mem.eql(u8, sym.name, "S90")) s90 = sym.address;
+        if (std.mem.eql(u8, sym.name, "SQ4")) sq4 = sym.address;
+    }
+    try std.testing.expect(s90 != null and sq4 != null);
+    try std.testing.expectEqual(@as(u16, 256), vm.mmap.readWord(s90.?)); // fixed_sin(90) = 1.0
+    try std.testing.expectEqual(@as(u16, 512), vm.mmap.readWord(sq4.?)); // sqrt_fixed(4.0) = 2.0
+}
+
 test "codegen/bank: switch_to writes mb, current reads it" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/codegen/bank_builtin.test.zig
+++ b/tests/lang/codegen/bank_builtin.test.zig
@@ -1,0 +1,9 @@
+/// Smoke that the `bank_builtin` codegen module is reachable through
+/// the public barrel. End-to-end coverage of `bank.switch_to` /
+/// `bank.current` lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "bank_builtin: module compiles through the codegen barrel" {
+    _ = gero.lang.internal.codegen.bank_builtin;
+}

--- a/tests/lang/codegen/math_builtin.test.zig
+++ b/tests/lang/codegen/math_builtin.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `math_builtin` codegen module is reachable through
+/// the public barrel. End-to-end coverage of every `math.*` helper
+/// lives in `tests/lang/codegen.test.zig` — that's where the VM-side
+/// round-trip exercises the lowering.
+const std = @import("std");
+const gero = @import("gero");
+
+test "math_builtin: module compiles through the codegen barrel" {
+    _ = gero.lang.internal.codegen.math_builtin;
+}

--- a/tests/lang/codegen/stdlib.test.zig
+++ b/tests/lang/codegen/stdlib.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `stdlib` codegen router is reachable through the
+/// public barrel. End-to-end coverage of `math.*` / `bank.*` / `test.*`
+/// lowering lives in `tests/lang/codegen.test.zig`, where the VM-side
+/// round-trip exercises it.
+const std = @import("std");
+const gero = @import("gero");
+
+test "stdlib: codegen router compiles through the barrel" {
+    _ = gero.lang.internal.codegen.stdlib;
+}

--- a/tests/lang/codegen/test_builtin.test.zig
+++ b/tests/lang/codegen/test_builtin.test.zig
@@ -1,0 +1,9 @@
+/// Smoke that the `test_builtin` codegen module is reachable through
+/// the public barrel. End-to-end coverage of `test.assert_eq` /
+/// `test.assert_ne` lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "test_builtin: module compiles through the codegen barrel" {
+    _ = gero.lang.internal.codegen.test_builtin;
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2409,6 +2409,49 @@ test "typecheck/suggest: unknown mem.X member surfaces the closest stdlib name" 
     , "E_TYPE_UNDEFINED_METHOD", "read_u16");
 }
 
+test "typecheck/stdlib: unknown math member errors" {
+    try expectCode(
+        \\def main()
+        \\  let x: i16 = math.bogus(1)
+        \\end
+    , "E_TYPE_UNDEFINED_METHOD");
+}
+
+test "typecheck/stdlib: math.min with one arg errors on arity" {
+    try expectCode(
+        \\def main()
+        \\  let x: i16 = math.min(1)
+        \\end
+    , "E_TYPE_ARG_COUNT");
+}
+
+test "typecheck/stdlib: math.abs on a non-numeric type errors" {
+    try expectCode(
+        \\def main()
+        \\  let x = math.abs("nope")
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck/stdlib: math.sat_add rejects fixed (integer-only)" {
+    try expectCode(
+        \\def main()
+        \\  let x: fixed = math.sat_add(1.0, 2.0)
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck/stdlib: test.assert_eq rejects a non-scalar operand" {
+    try expectCode(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def main()
+        \\  test.assert_eq(P { x: 1 }, P { x: 1 })
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
 test "typecheck/is: class form on matching subclass — clean" {
     try expectClean(
         \\class Animal

--- a/tests/lang/typecheck/stdlib.test.zig
+++ b/tests/lang/typecheck/stdlib.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `stdlib` typecheck dispatch is reachable through the
+/// public barrel. End-to-end coverage of `math.*` / `bank.*` / `test.*`
+/// type-checking lives in `tests/lang/typecheck.test.zig` and the
+/// codegen round-trip in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "stdlib: typecheck dispatch compiles through the barrel" {
+    _ = gero.lang.internal.typechecker.stdlib;
+}


### PR DESCRIPTION
## What

Implements the `math`, `bank`, and `test` stdlib modules end-to-end (§5.3), generalizing the compiler's module-call dispatch beyond the hardcoded `mem` check. Both issues land here (authorized batch).

### Generic dispatch
A table-driven router (codegen + typecheck) replaces the hardcoded `mem` receiver check and registers `math` / `bank` / `test`. Both call forms — method syntax and the field-callee `CallExpr` shape — route to a unified, args-aware checker, so numeric-polymorphic math resolves its operand type at the call site. All calls type-check to concrete signatures (no untyped results — the strong-typing guarantee).

### `math` (numeric-polymorphic over i16 / u16 / fixed)
- `abs`, `min`, `max`, `clamp` — cmp + branch, operand type picks signed vs unsigned comparison.
- `wrap_add` / `wrap_sub` / `wrap_mul` — wrap on overflow (skip the debug trap); `fixed` mul is Q8.8.
- `sat_add` / `sat_sub` / `sat_mul` — clamp to the integer type's bounds (i16 / u16).
- `sqrt_fixed` — Q8.8 square root via a bit-by-bit squaring search (32-bit radicand on the 16-bit VM).
- `fixed_sin` — degrees → Q8.8 sine, Bhaskara I with range reduction (no table — it *generates* tables).
- `rng()` — deterministic 16-bit Galois LFSR (reserved zero-page state cell, lazy-seeded).

### Compile-time math (`bake`)
Every `math.*` function also evaluates inside `bake` bodies (the canonical sine-LUT pattern, §3.7). The typeless bake evaluator gains the typechecker's expression types (threaded through the bake entry points), so the polymorphic helpers pick signedness exactly like the runtime — and each helper is reimplemented on `BakeValue` to mirror the runtime arithmetic bit-for-bit (verified: bake `fixed_sin(90)` == runtime == 256). `mem` / `bank` / `test` stay runtime-only and fault in bake.

### `bank` / `test`
- `bank.switch_to(n)` / `bank.current()` — raw `mb` write / read (distinct from the `@bank` trampoline).
- `test.assert_eq` / `test.assert_ne` — compare register scalars in `@test` functions; print + halt on failure.

## Tests
Every function is exercised against hand-computed vectors (runtime via raw fp-slot reads + `runAndExpect`): all math ops incl. boundaries, the polymorphic signed/unsigned split, fixed_sin across the circle + a large-angle range reduction, sqrt_fixed perfect-squares + irrationals + negative, the rng sequence, nested math, bank, test pass/fail, bake int + fixed + unsigned-threading + bake↔runtime parity, and typecheck failure paths (unknown member, arity, non-numeric, fixed-rejected-by-sat, non-scalar assert).

Verified across `zig build ci` (Debug/Safe/Fast/Small + linux/macos/windows/wasi) and a 4-lane adversarial review (boundaries, fixed precision, register/arg safety, bake parity — register-safety + parity lanes clean, the rest false positives on inspection).

Spec: `gero-lang.md` §5.3.2–5.3.4 pin the module signatures + the bake-callable / runtime-only notes.

Closes #316
Closes #312