### PR TITLE
feat(lang/codegen): arrays — literal, repeat, indexed load/store

### DIFF
--- a/.changeset/lang-codegen-arrays.md
+++ b/.changeset/lang-codegen-arrays.md
@@ -1,0 +1,28 @@
+---
+bump: minor
+---
+
+Fixed-size arrays `[T; N]` now lower end-to-end in the gero-lang
+compiler: array literals `[a, b, c]`, repeat literals `[value; count]`,
+and indexed read/write `arr[i]` / `arr[i] = x`.
+
+Element `T` is any type — a scalar (`i8` / `u8` / `i16` / `u16`, sign-
+extending an `i8` on load) or an aggregate (`struct`, tuple, or nested
+`[T; N]`), laid out inline at `i * elem_width`. Arrays are value types:
+binding, passing, and returning one copies its bytes; a repeat literal
+constructs the value once and replicates it into each independent slot.
+
+Indexing carries the same bounds contract as the arithmetic-overflow
+trap. A constant out-of-range index is a compile error
+(`E_TYPE_INDEX_OOR`); a runtime out-of-range index faults to vector
+`$02` in debug builds and is unchecked in release / size. A non-integer
+index is rejected (`E_TYPE_MISMATCH`). The typechecker now resolves
+`arr[i]` to the element type instead of leaving it untyped.
+
+Aggregate literals store directly into an lvalue — `arr[i] = Pos { x: 1,
+y: 2 }`, `ts[i] = (3, 4)`, `grid[i] = [5, 6]` — with no temporary
+binding. The destination address is parked on the stack while the
+literal's fields evaluate, so the value materializes in place. The same
+mechanism fixes assigning an aggregate literal into a struct field
+(`obj.field = Pos { ... }`) and adds tuple-field stores (`obj.pair = (a,
+b)`), which previously required spelling the value into a `let` first.

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -324,7 +324,7 @@ PICO-8, Sonic, early Doom used.
 
 | Form | Example | Notes |
 |------|---------|-------|
-| Array (fixed-size) | `[u8; 64]` | N is comptime. Stack-allocated if local. Literals: `[a, b, c]` for explicit elements or `[value; count]` to repeat a single value. |
+| Array (fixed-size) | `[u8; 64]` | N is comptime. Stack-allocated if local; value-copy on assignment / pass / return. Element `T` is any type — scalar or aggregate (`struct` / tuple / nested `[T; N]`). Literals: `[a, b, c]` (explicit) or `[value; count]` (repeat). Index read/write `arr[i]` / `arr[i] = x`; an aggregate literal stores in place (`arr[i] = Pos { x: 1, y: 2 }`). A constant out-of-range index is a compile error (`E_TYPE_INDEX_OOR`); a runtime out-of-range index faults to vector `$02` in debug builds (unchecked in release / size, like the arithmetic-overflow trap). |
 | Dynamic array | `Vec(i16)` | Growable buffer with `push` / `pop` / `len` / `at`. See §3.4.3. |
 | Tuple | `(i16, str)` | Anonymous heterogeneous pair / triple / etc. Max 4 elements (5+ → use a struct). Destructurable in `let` and `match`. Element access `.0` / `.1` / …, element store `t.N = x`, value-copy + pass / return by value, structural `==` / `!=`, and `(v0, v1, …)` print. |
 | Optional | `T?` | Nullable pointer type — see §3.4.1. |

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -235,6 +235,7 @@ Raised by the typechecker after parsing succeeds.
 | `E_TYPE_RECURSIVE_STRUCT` | A struct contains itself by value (directly or transitively, through a struct / array / tuple field) — infinite size, no layout. Use `Vec(T)` or `&T` for a recursive shape. |
 | `E_TYPE_NOT_A_TUPLE` | `.N` element access on a non-tuple value. |
 | `E_TYPE_TUPLE_INDEX_OOR` | Tuple element index `.N` is past the tuple's arity. |
+| `E_TYPE_INDEX_OOR` | A constant array index `arr[N]` is negative or past the array's length. |
 | `E_TYPE_TUPLE_TOO_MANY` | A tuple has more than 4 elements (§3.4) — use a struct instead. |
 | `E_TYPE_TUPLE_ARITY` | Tuple-destructuring pattern's element count doesn't match the init's tuple arity. |
 | `E_TYPE_REDEFINED` | A name is declared twice in the same scope. |
@@ -766,6 +767,7 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_TYPE_RECURSIVE_STRUCT` | Typechecker | v0.3 |
 | `E_TYPE_NOT_A_TUPLE` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_INDEX_OOR` | Typechecker | v0.3 |
+| `E_TYPE_INDEX_OOR` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_TOO_MANY` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_ARITY` | Typechecker | v0.3 |
 | `E_TYPE_REDEFINED` | Typechecker | v0.3 |

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -747,6 +747,21 @@ pub const Emitter = struct {
         return ofs;
     }
 
+    /// Element type / width / count of an `[T; N]` array — peeling a
+    /// reference. `null` when the expression isn't array-typed.
+    pub const ArrayInfo = struct { elem: *const Type, elem_width: u16, count: u32, signed_byte: bool };
+
+    /// Resolve the `ArrayInfo` of an array-typed expression (peeling a
+    /// reference); `null` when `e` isn't array-typed.
+    pub fn arrayInfoOf(self: *const Emitter, e: *const ast.Expr) ?ArrayInfo {
+        const t = self.typeOf(e) orelse return null;
+        const peeled = if (t.* == .reference) t.reference else t;
+        if (peeled.* != .array) return null;
+        const elem = peeled.array.elem;
+        const signed_byte = elem.* == .primitive and elem.primitive == .i8;
+        return .{ .elem = elem, .elem_width = self.widthOfType(elem), .count = peeled.array.len, .signed_byte = signed_byte };
+    }
+
     /// Reserve `bytes` (2-aligned) of frame space and return the base
     /// offset, without registering a name. For anonymous slots (inline
     /// arg bindings) whose names bind into a scope set up afterward.
@@ -791,6 +806,10 @@ pub const Emitter = struct {
                 var total: u16 = 0;
                 for (elems) |elem| total +%= self.widthOfType(elem);
                 return total;
+            },
+            .array => |a| {
+                // @as: nested-array width stays ≤ the i8 frame cap.
+                return @intCast(@as(u32, self.widthOfType(a.elem)) * a.len);
             },
             else => return 2,
         }
@@ -1833,6 +1852,28 @@ pub const Emitter = struct {
         if (et.* == .tuple) return .{ .tuple = et.tuple };
         if (et.* == .named and self.struct_decls.contains(et.named.name)) return .{ .structure = et.named.name };
         return .scalar;
+    }
+
+    /// Classifies an array element type — a register-width scalar, an
+    /// inline named struct, a nested tuple, or a nested array — so array
+    /// construction / indexing can recurse into aggregate elements (each
+    /// laid out inline at `i * elem_width`).
+    pub const ArrayElemKind = union(enum) {
+        scalar,
+        structure: []const u8,
+        tuple: []const *const Type,
+        array: struct { elem: *const Type, len: u32 },
+    };
+
+    /// Classify an array's element type. A class / enum / reference is a
+    /// register-width scalar (stored as its pointer / value word).
+    pub fn arrayElemKindOf(self: *const Emitter, elem: *const Type) ArrayElemKind {
+        return switch (elem.*) {
+            .array => |a| .{ .array = .{ .elem = a.elem, .len = a.len } },
+            .tuple => |t| .{ .tuple = t },
+            .named => |n| if (self.struct_decls.contains(n.name)) .{ .structure = n.name } else .scalar,
+            else => .scalar,
+        };
     }
 
     /// `target = value` (and compound / inc-dec desugarings) — see

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -50,10 +50,10 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .char_lit => |c| try isa.movImmToReg(self, c.value, Reg.acu),
         .paren => |p| try emitExpr(self, p.inner),
         .ident => |i| {
-            // A struct- or tuple-typed binding evaluates to its base
-            // address — aggregate values are addressed inline, not
+            // A struct- / tuple- / array-typed binding evaluates to its
+            // base address — aggregate values are addressed inline, not
             // loaded as a word.
-            if (self.structNameOf(e) != null or self.tupleElemsOf(e) != null) {
+            if (self.structNameOf(e) != null or self.tupleElemsOf(e) != null or self.arrayInfoOf(e) != null) {
                 try self.emitAddrOf(e);
                 return;
             }
@@ -91,6 +91,7 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .method_call => |m| try emitMethodCall(self, m, e),
         .field => |f| try emitFieldExpr(self, f, e),
         .tuple_index => |ti| try emitTupleIndexExpr(self, ti),
+        .index => |ix| try emitIndexExpr(self, ix),
         .self_expr => |se| {
             // `self` inside a method body lives at fp+4 (the first
             // implicit param). Outside a method it's a typecheck
@@ -243,6 +244,50 @@ fn emitTupleIndexExpr(self: *Emitter, ti: ast.TupleIndexExpr) !void {
     };
     try emitExpr(self, ti.receiver); // acu = tuple base address
     try value_struct.emitTupleElemLoad(self, elems, ti.index);
+}
+
+/// Lower an array index read `arr[i]` — resolve the element at
+/// `base + i*elem_width`. A constant index folds to a fixed offset
+/// (the typechecker already bounds-checked it); a runtime index is
+/// bounds-trapped (debug) then scaled. A scalar element loads its
+/// word/byte; an aggregate element leaves its address (see `emitArrayElem`).
+fn emitIndexExpr(self: *Emitter, ix: ast.IndexExpr) !void {
+    const info = self.arrayInfoOf(ix.receiver) orelse {
+        try self.unsupported(ix.span, "indexing a non-array value");
+        return;
+    };
+    if (ix.index.* == .int_lit) {
+        try emitExpr(self, ix.receiver); // acu = base address
+        try isa.movRegToReg(self, Reg.acu, Reg.r1);
+        // @as: const index × elem_width within the (≤127-byte) array.
+        const offset: u16 = @intCast(ix.index.int_lit.value * info.elem_width);
+        try emitArrayElem(self, Reg.r1, offset, info);
+        return;
+    }
+    try value_struct.emitIndexAddr(self, ix, info); // acu = element address
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try emitArrayElem(self, Reg.r1, 0, info);
+}
+
+/// Resolve array element `[base + offset]`: load a scalar element into
+/// `acu` (sign-extending an `i8`); for an aggregate element leave its base
+/// address in `acu` — an aggregate value *is* an address, so `.field` /
+/// `.N` / further indexing resolve against it without a deref.
+fn emitArrayElem(self: *Emitter, base: u8, offset: u16, info: codegen.Emitter.ArrayInfo) !void {
+    switch (self.arrayElemKindOf(info.elem)) {
+        .scalar => {
+            if (info.elem_width == 1) {
+                try class.emitByteLoadAtOffset(self, base, offset, Reg.acu);
+                if (info.signed_byte) try isa.signExtendByte(self, Reg.acu);
+            } else {
+                try class.emitWordLoadAtOffset(self, base, offset, Reg.acu);
+            }
+        },
+        else => {
+            try isa.movRegToReg(self, base, Reg.acu);
+            if (offset != 0) try isa.addImmToReg(self, offset, Reg.acu);
+        },
+    }
 }
 
 /// Lower an `is` test. Two shapes:

--- a/src/lang/codegen/overflow.zig
+++ b/src/lang/codegen/overflow.zig
@@ -72,3 +72,22 @@ pub fn emitOverflowTrap(self: *Emitter, signedness: Signedness) !void {
     const target = try self.currentOffset();
     try isa.patchJumpTo(self, skip_patch, target);
 }
+
+/// Fault vector raised by the array-bounds trap (out-of-bounds, ISA §6).
+pub const bounds_vector: u8 = 0x02;
+
+/// Emit a debug-mode bounds check for a runtime array index in `reg`
+/// against the fixed length `len`: when `reg >= len` (unsigned), raise
+/// vector `$02`. Elided in release / size mode (matches the overflow
+/// trap). `cmp` sets `C = 0` exactly when `reg >= len`; there is no
+/// jump-on-carry-set, so the in-bounds path skips via an extra `jmp`.
+pub fn emitBoundsTrap(self: *Emitter, reg: u8, len: u16) !void {
+    if (self.optimize != .debug) return;
+    try isa.cmpRegImm(self, reg, len); // reg - len; C = 0 ⇒ reg >= len (OOB)
+    const oob = try isa.emitJumpPlaceholder(self, Op.jcc_addr); // OOB → trap
+    const in_bounds = try isa.emitJumpPlaceholder(self, Op.jmp_addr); // else skip
+    try isa.patchJumpTo(self, oob, try self.currentOffset());
+    try self.emitByte(Op.int_imm8);
+    try self.emitByte(bounds_vector);
+    try isa.patchJumpTo(self, in_bounds, try self.currentOffset());
+}

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -134,6 +134,53 @@ pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
         }
         return;
     }
+    // `arr[i] = value` — store into element `i` at base + i*elem_width.
+    if (a.target.* == .index) {
+        const ix = a.target.index;
+        const info = self.arrayInfoOf(ix.receiver) orelse {
+            try self.unsupported(a.span, "indexed store on a non-array value");
+            return;
+        };
+        switch (self.arrayElemKindOf(info.elem)) {
+            .scalar => {
+                if (ix.index.* == .int_lit) {
+                    // Constant index — fixed offset (typechecker bounds-checked).
+                    try self.emitExpr(a.value);
+                    try isa.pushReg(self, Reg.acu);
+                    try self.emitExpr(ix.receiver); // acu = array base
+                    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+                    try isa.popReg(self, Reg.r2); // r2 = value
+                    // @as: const index × elem_width within the (≤127-byte) array.
+                    const offset: u16 = @intCast(@as(i32, ix.index.int_lit.value) * info.elem_width);
+                    try storeArrayElem(self, Reg.r1, offset, info, Reg.r2);
+                } else {
+                    // Runtime index — eval the value first, then the
+                    // bounds-trapped element address (which parks the array
+                    // base, leaving the value safely below it on the stack).
+                    try self.emitExpr(a.value);
+                    try isa.pushReg(self, Reg.acu); // [parked] value
+                    try value_struct.emitIndexAddr(self, ix, info); // acu = element address
+                    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+                    try isa.popReg(self, Reg.r2); // r2 = value
+                    try storeArrayElem(self, Reg.r1, 0, info, Reg.r2);
+                }
+            },
+            // Aggregate element — materialize the value straight into the
+            // slot (a literal lands in place; any other value is copied).
+            else => {
+                if (ix.index.* == .int_lit) {
+                    try self.emitExpr(ix.receiver); // acu = array base
+                    // @as: const index × elem_width within the (≤127-byte) array.
+                    const offset: u16 = @intCast(@as(i32, ix.index.int_lit.value) * info.elem_width);
+                    if (offset != 0) try isa.addImmToReg(self, offset, Reg.acu);
+                } else {
+                    try value_struct.emitIndexAddr(self, ix, info); // acu = element address
+                }
+                try value_struct.emitAggregateStoreInto(self, a.value, info.elem, Reg.acu);
+            },
+        }
+        return;
+    }
     if (a.target.* != .ident) {
         try self.unsupported(a.span, "non-ident assignment targets (field / index)");
         return;
@@ -151,6 +198,13 @@ pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
     if (self.tupleElemsOf(a.target)) |elems| {
         if (self.locals.get(name)) |ofs| {
             try value_struct.emitTupleInto(self, a.value, elems, ofs);
+            return;
+        }
+    }
+    // Array-typed reassignment — same inline value copy (full width).
+    if (self.arrayInfoOf(a.target)) |info| {
+        if (self.locals.get(name)) |ofs| {
+            try value_struct.emitArrayInto(self, a.value, info.elem, info.count, ofs);
             return;
         }
     }
@@ -183,6 +237,15 @@ pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
         return;
     }
     try self.unsupported(a.target.span(), "assignment target not in scope");
+}
+
+/// Store scalar `src` into array element `[base + offset]` as a word/byte.
+fn storeArrayElem(self: *Emitter, base: u8, offset: u16, info: codegen.Emitter.ArrayInfo, src: u8) !void {
+    if (info.elem_width == 1) {
+        try class.emitByteStoreAtOffset(self, base, offset, src);
+    } else {
+        try class.emitWordStoreAtOffset(self, base, offset, src);
+    }
 }
 
 /// `target++` / `target--` — desugars to `target = target ± 1` and
@@ -236,6 +299,27 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
             if (tuple_elems) |elems| {
                 try value_struct.emitTupleInto(self, init_expr, elems, slot);
             } else try self.unsupported(d.span, "tuple binding initialized from a non-tuple value");
+        }
+        return;
+    }
+
+    // Array-typed binding — inline value semantics (§3.4), sized by the
+    // element width × count. Element access lives in expr/statements.
+    const arr_info: ?Emitter.ArrayInfo = if (d.init) |e| self.arrayInfoOf(e) else null;
+    const ann_array = if (d.type_ann) |t| t.* == .array else false;
+    if (arr_info != null or ann_array) {
+        const width: u16 = if (d.type_ann) |t|
+            self.widthOfTypeAnn(t.*)
+        else blk: {
+            const info = arr_info.?;
+            // @as: array width capped by the i8 frame-offset limit.
+            break :blk @intCast(@as(u32, info.elem_width) * info.count);
+        };
+        const slot = try self.allocLocalSized(dup_name, width);
+        if (d.init) |init_expr| {
+            if (arr_info) |info| {
+                try value_struct.emitArrayInto(self, init_expr, info.elem, info.count, slot);
+            } else try self.unsupported(d.span, "array binding initialized from a non-array value");
         }
         return;
     }

--- a/src/lang/codegen/value_struct.zig
+++ b/src/lang/codegen/value_struct.zig
@@ -16,6 +16,7 @@ const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const class = @import("class.zig");
 const strings = @import("strings.zig");
+const overflow = @import("overflow.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -27,11 +28,15 @@ const Reg = opcodes.Reg;
 /// outgoing argument — `ofs` ≥ 0 from the current `sp`). `indirect` is
 /// the buffer pointed to by a frame slot holding an address (`ptr_ofs`)
 /// plus a field `delta` — used to write a returned struct into the
-/// caller's sret destination.
+/// caller's sret destination. `indirect_sp` is the buffer pointed to by
+/// a pointer parked on the stack (`sp_ofs`) plus `delta` — used to
+/// materialize an aggregate value straight into a runtime-computed lvalue
+/// (an array element / struct field) without a temporary binding.
 const Dest = union(enum) {
     frame: i16,
     sp: i16,
     indirect: struct { ptr_ofs: i16, delta: i16 },
+    indirect_sp: struct { sp_ofs: i16, delta: i16 },
 
     /// Shift the destination deeper by `delta` bytes (a nested field).
     fn at(self: Dest, delta: i16) Dest {
@@ -39,14 +44,16 @@ const Dest = union(enum) {
             .frame => |o| .{ .frame = o + delta },
             .sp => |o| .{ .sp = o + delta },
             .indirect => |ind| .{ .indirect = .{ .ptr_ofs = ind.ptr_ofs, .delta = ind.delta + delta } },
+            .indirect_sp => |ind| .{ .indirect_sp = .{ .sp_ofs = ind.sp_ofs, .delta = ind.delta + delta } },
         };
     }
 };
 
-/// `reg = base + ofs` for a destination. The `sp` form re-reads `sp`
-/// and `indirect` re-loads its pointer slot — both valid because every
-/// field-value expression restores `sp` and leaves the frame slot
-/// untouched, so the destination base stays stable across fields.
+/// `reg = base + ofs` for a destination. The `sp` form re-reads `sp`,
+/// `indirect` re-loads its frame pointer slot, and `indirect_sp` re-loads
+/// the parked stack pointer — all valid because every field-value
+/// expression restores `sp` and leaves the frame slot untouched, so the
+/// destination base stays stable across fields.
 fn destAddrToReg(self: *Emitter, dest: Dest, reg: u8) !void {
     switch (dest) {
         .frame => |ofs| try frameAddrToReg(self, ofs, reg),
@@ -58,6 +65,11 @@ fn destAddrToReg(self: *Emitter, dest: Dest, reg: u8) !void {
             try isa.movRegToReg(self, Reg.fp, reg);
             if (ind.ptr_ofs > 0) try isa.addImmToReg(self, @intCast(ind.ptr_ofs), reg);
             try isa.movRegOffsetToReg(self, reg, 0, reg); // reg = stored pointer
+            if (ind.delta > 0) try isa.addImmToReg(self, @intCast(ind.delta), reg);
+        },
+        .indirect_sp => |ind| {
+            // safety: the parked pointer sits at a small, in-range sp offset.
+            try isa.movRegOffsetToReg(self, Reg.sp, @intCast(ind.sp_ofs), reg); // reg = parked pointer
             if (ind.delta > 0) try isa.addImmToReg(self, @intCast(ind.delta), reg);
         },
     }
@@ -171,6 +183,159 @@ pub fn emitTupleElemLoad(self: *Emitter, elems: []const *const types.Type, index
     }
 }
 
+// ---- array values (§3.4) ----
+// `[T; N]` is a homogeneous positional aggregate, inline + contiguous;
+// element `i` sits at offset `i * elem_width`. A scalar element stores
+// its word/byte; an aggregate element (struct / tuple / nested array)
+// lays out inline at its offset, recursing like a nested struct field.
+// Element access is in `expr.zig` (load) / `statements.zig` (store).
+
+/// Materialize an array value into the frame slot at `dest_ofs`: a list
+/// literal `[a, b, c]` (materialize each element), a repeat `[v; N]`
+/// (fill), or another array value (byte-copied for value semantics).
+pub fn emitArrayInto(self: *Emitter, src: *const ast.Expr, elem: *const types.Type, count: u32, dest_ofs: i16) error{OutOfMemory}!void {
+    try emitArrayIntoDest(self, src, elem, count, .{ .frame = dest_ofs });
+}
+
+fn emitArrayIntoDest(self: *Emitter, src: *const ast.Expr, elem: *const types.Type, count: u32, dest: Dest) error{OutOfMemory}!void {
+    const ew = self.widthOfType(elem);
+    if (src.* == .list_lit) {
+        for (src.list_lit.elems, 0..) |e, i| {
+            // @as: i*elem_width stays within the 127-byte frame slot.
+            try emitElemInto(self, e, elem, dest.at(@intCast(i * ew)));
+        }
+        return;
+    }
+    if (src.* == .list_repeat) {
+        try emitArrayRepeat(self, src.list_repeat, elem, count, dest);
+        return;
+    }
+    // Another array value — byte-copy its contiguous slots in.
+    try self.emitExpr(src); // acu = source base
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try destAddrToReg(self, dest, Reg.r2);
+    // @as: total array width ≤ the frame cap.
+    try copyBytes(self, Reg.r1, Reg.r2, @intCast(@as(u32, ew) * count));
+}
+
+/// Materialize one array element (of element type `elem`) into `dest`.
+/// A scalar stores its word/byte; an aggregate recurses into the matching
+/// struct / tuple / nested-array layout at the destination.
+fn emitElemInto(self: *Emitter, e: *const ast.Expr, elem: *const types.Type, dest: Dest) error{OutOfMemory}!void {
+    switch (self.arrayElemKindOf(elem)) {
+        .structure => |sname| try emitIntoDest(self, e, sname, dest),
+        .tuple => |elems| try emitTupleIntoDest(self, e, elems, dest),
+        .array => |sub| try emitArrayIntoDest(self, e, sub.elem, sub.len, dest),
+        .scalar => {
+            try self.emitExpr(e);
+            try isa.movRegToReg(self, Reg.acu, Reg.r2);
+            try destAddrToReg(self, dest, Reg.r1);
+            try storeWidth(self, Reg.r1, self.widthOfType(elem), Reg.r2);
+        },
+    }
+}
+
+fn emitArrayRepeat(self: *Emitter, lr: ast.ListRepeatLit, elem: *const types.Type, count: u32, dest: Dest) error{OutOfMemory}!void {
+    const ew = self.widthOfType(elem);
+    switch (self.arrayElemKindOf(elem)) {
+        .scalar => {
+            // @as: total array width ≤ the frame cap.
+            const total: u16 = @intCast(@as(u32, ew) * count);
+            // Zero-fill (the common buffer init) collapses to one `bfill`.
+            if (lr.value.* == .int_lit and lr.value.int_lit.value == 0) {
+                try destAddrToReg(self, dest, Reg.r1);
+                try isa.movImmToReg(self, total, Reg.r2);
+                try isa.movImmToReg(self, 0, Reg.r3);
+                try self.emitByte(Op.bfill);
+                try self.emitByte(Reg.r1); // dst
+                try self.emitByte(Reg.r2); // len
+                try self.emitByte(Reg.r3); // val
+                return;
+            }
+            // Otherwise evaluate the value once and replicate the register.
+            try self.emitExpr(lr.value);
+            try isa.movRegToReg(self, Reg.acu, Reg.r3); // r3 = value (preserved)
+            var i: u32 = 0;
+            while (i < count) : (i += 1) {
+                // @as: i*elem_width ≤ the frame cap.
+                try destAddrToReg(self, dest.at(@intCast(i * ew)), Reg.r1);
+                try storeWidth(self, Reg.r1, ew, Reg.r3);
+            }
+        },
+        // An aggregate value is constructed once into slot 0, then its
+        // bytes are copied into each remaining slot (single eval, value
+        // semantics — matches `let b = a` aggregate copy).
+        else => {
+            if (count == 0) return;
+            try emitElemInto(self, lr.value, elem, dest.at(0));
+            var i: u32 = 1;
+            while (i < count) : (i += 1) {
+                try destAddrToReg(self, dest.at(0), Reg.r1); // src = slot 0
+                // @as: i*elem_width ≤ the frame cap.
+                try destAddrToReg(self, dest.at(@intCast(i * ew)), Reg.r2); // dst = slot i
+                try copyBytes(self, Reg.r1, Reg.r2, ew);
+            }
+        },
+    }
+}
+
+/// Scale index register `reg` by `elem_width` so it becomes a byte offset
+/// into the array. Power-of-two widths shift in place; others multiply
+/// (which clobbers `r1` / `r3` and acu's high half — `reg` must be none
+/// of `r1` / `r3`; every call site passes `acu`).
+pub fn scaleIndex(self: *Emitter, reg: u8, elem_width: u16) error{OutOfMemory}!void {
+    switch (elem_width) {
+        0, 1 => {},
+        2 => try isa.shlRegImm(self, reg, 1),
+        4 => try isa.shlRegImm(self, reg, 2),
+        8 => try isa.shlRegImm(self, reg, 3),
+        else => {
+            // `mul dst, src` writes the product's low half to dst and the
+            // high half to acu — so multiply through r1 (never acu) and copy
+            // the low half back, leaving the scaled index in reg. Clobbers
+            // r1 / r3 / acu-high (all dead at every call site).
+            try isa.movRegToReg(self, reg, Reg.r1); // r1 = index
+            try isa.movImmToReg(self, elem_width, Reg.r3); // r3 = elem_width
+            try isa.mulRegReg(self, Reg.r3, Reg.r1); // r1 = index*elem_width (low half)
+            try isa.movRegToReg(self, Reg.r1, reg); // reg = scaled index
+        },
+    }
+}
+
+/// Leave the runtime element address (`base + index * elem_width`) of
+/// `ix` in `acu`. Bounds-trapped in debug. Self-balancing on the stack
+/// (parks `base` internally), so a caller may keep other values parked
+/// below. Clobbers `r1` (base) and `r3` (scale scratch).
+pub fn emitIndexAddr(self: *Emitter, ix: ast.IndexExpr, info: codegen.Emitter.ArrayInfo) error{OutOfMemory}!void {
+    try self.emitExpr(ix.receiver); // acu = base
+    try isa.pushReg(self, Reg.acu);
+    try self.emitExpr(ix.index); // acu = index
+    // @as: array length fits u16.
+    try overflow.emitBoundsTrap(self, Reg.acu, @intCast(info.count));
+    try scaleIndex(self, Reg.acu, info.elem_width);
+    try isa.popReg(self, Reg.r1); // r1 = base
+    try isa.addRegToAcu(self, Reg.r1); // acu = base + index*elem_width
+}
+
+/// Store an aggregate `rhs` into the destination whose base address is in
+/// `addr_reg` (an array element of element type `elem`). The pointer is
+/// parked on the stack so a struct / tuple / nested-array literal
+/// materializes directly into the slot — and any other aggregate value is
+/// byte-copied — without a temporary binding. `elem` must be aggregate
+/// (scalar element stores take the word/byte path).
+pub fn emitAggregateStoreInto(self: *Emitter, rhs: *const ast.Expr, elem: *const types.Type, addr_reg: u8) error{OutOfMemory}!void {
+    try isa.pushReg(self, addr_reg); // [sp + 0] = destination pointer
+    const dest = Dest{ .indirect_sp = .{ .sp_ofs = 0, .delta = 0 } };
+    switch (self.arrayElemKindOf(elem)) {
+        .structure => |sname| try emitIntoDest(self, rhs, sname, dest),
+        .tuple => |elems| try emitTupleIntoDest(self, rhs, elems, dest),
+        .array => |sub| try emitArrayIntoDest(self, rhs, sub.elem, sub.len, dest),
+        // A scalar element never reaches this aggregate store path.
+        .scalar => unreachable,
+    }
+    try isa.addImmToReg(self, 2, Reg.sp); // drop the parked pointer
+}
+
 fn emitLitInto(self: *Emitter, sl: ast.StructLit, sname: []const u8, dest: Dest) error{OutOfMemory}!void {
     const sd = self.struct_decls.get(sname).?;
     for (sd.fields) |df| {
@@ -221,21 +386,30 @@ pub fn emitFieldLoad(self: *Emitter, sname: []const u8, field_name: []const u8) 
 }
 
 /// Store `value` into field `field_name` of the struct addressed by
-/// `recv`. A nested struct field copies the value's bytes.
+/// `recv`. An aggregate field (nested struct / tuple) materializes the
+/// value directly into the field slot through a stack-parked pointer — a
+/// literal lands in place, any other aggregate value is byte-copied — so
+/// no temporary binding is needed.
 pub fn emitFieldStore(self: *Emitter, recv: *const ast.Expr, sname: []const u8, field_name: []const u8, value: *const ast.Expr) !void {
     const info = self.structFieldInfo(sname, field_name).?;
-    // Evaluate the value first and stash it on the stack — computing
-    // the receiver's address reuses acu, so the value can't stay there.
-    if (info.struct_name) |sub| {
-        try self.emitExpr(value);
-        try isa.pushReg(self, Reg.acu);
-        try self.emitExpr(recv);
+    if (info.struct_name != null or info.is_tuple) {
+        // Compute the field's address and park it, then materialize the
+        // value through it — `sp` stays put across the value's fields.
+        try self.emitExpr(recv); // acu = receiver base
         if (info.offset != 0) try isa.addImmToReg(self, info.offset, Reg.acu);
-        try isa.movRegToReg(self, Reg.acu, Reg.r2);
-        try isa.popReg(self, Reg.r1);
-        try copyBytes(self, Reg.r1, Reg.r2, self.structWidth(sub));
+        try isa.pushReg(self, Reg.acu); // [sp + 0] = field pointer
+        const dest = Dest{ .indirect_sp = .{ .sp_ofs = 0, .delta = 0 } };
+        if (info.struct_name) |sub| {
+            try emitIntoDest(self, value, sub, dest);
+        } else if (self.tupleElemsOf(value)) |elems| {
+            try emitTupleIntoDest(self, value, elems, dest);
+        } else {
+            try self.unsupported(value.span(), "tuple field assigned from a non-tuple value");
+        }
+        try isa.addImmToReg(self, 2, Reg.sp); // drop the parked pointer
         return;
     }
+    // Scalar field — evaluate the value, then store it as a word/byte.
     try self.emitExpr(value);
     try isa.pushReg(self, Reg.acu);
     try self.emitExpr(recv);

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -1143,8 +1143,35 @@ pub const Checker = struct {
                 return elems[ti.index];
             },
             .index => |ix| {
-                _ = try self.inferExpr(ix.receiver, null);
-                _ = try self.inferExpr(ix.index, null);
+                const recv_ty = try self.inferExpr(ix.receiver, null);
+                const idx_ty = try self.inferExpr(ix.index, null);
+                if (idx_ty) |it| {
+                    const is_int = it.* == .primitive and switch (it.primitive) {
+                        .i8, .u8, .i16, .u16 => true,
+                        else => false,
+                    };
+                    if (!is_int) {
+                        const ty_s = try types.render(self.arena, it.*);
+                        const msg = try std.fmt.allocPrint(self.arena, "array index must be an integer, found `{s}`", .{ty_s});
+                        try self.emitSpan("E_TYPE_MISMATCH", ix.index.span(), msg);
+                    }
+                }
+                if (peelReference(recv_ty)) |peeled| {
+                    if (peeled.* == .array) {
+                        // A literal index outside the fixed length is a
+                        // compile-time error (runtime indices trap in debug).
+                        if (ix.index.* == .int_lit) {
+                            const v: i64 = ix.index.int_lit.value;
+                            const len: i64 = peeled.array.len;
+                            if (v < 0 or v >= len) {
+                                const suffix: []const u8 = if (peeled.array.len == 1) "" else "s";
+                                const msg = try std.fmt.allocPrint(self.arena, "array index {d} out of range — array has {d} element{s}", .{ v, peeled.array.len, suffix });
+                                try self.emitSpan("E_TYPE_INDEX_OOR", ix.index.span(), msg);
+                            }
+                        }
+                        return peeled.array.elem;
+                    }
+                }
                 return null;
             },
             .do_expr => |d| {

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -5940,3 +5940,340 @@ test "codegen/struct: `print` of a struct with an array field is rejected" {
         \\end
     , "E_CODEGEN_UNSUPPORTED");
 }
+
+// ---------- arrays: literal / repeat / indexing (#306) ----------
+
+test "codegen/array: repeat-zero init + constant index (the issue example)" {
+    try runAndExpect(
+        \\def main()
+        \\  let xs: [i16; 4] = [0; 4]
+        \\  print xs[0]
+        \\  print xs[3]
+        \\end
+    , "0\n0\n");
+}
+
+test "codegen/array: literal elements load at their offsets" {
+    try runAndExpect(
+        \\def main()
+        \\  let xs: [i16; 3] = [10, 20, 30]
+        \\  print xs[0]
+        \\  print xs[1]
+        \\  print xs[2]
+        \\end
+    , "10\n20\n30\n");
+}
+
+test "codegen/array: repeat with a non-zero value" {
+    try runAndExpect(
+        \\def main()
+        \\  let xs: [i16; 3] = [7; 3]
+        \\  print xs[2]
+        \\end
+    , "7\n");
+}
+
+test "codegen/array: runtime index (read)" {
+    try runAndExpect(
+        \\def main()
+        \\  let xs: [i16; 3] = [10, 20, 30]
+        \\  let i: i16 = 2
+        \\  print xs[i]
+        \\end
+    , "30\n");
+}
+
+test "codegen/array: indexed store (constant + runtime)" {
+    try runAndExpect(
+        \\def main()
+        \\  let xs: [i16; 4] = [0; 4]
+        \\  xs[1] = 99
+        \\  let j: i16 = 3
+        \\  xs[j] = 77
+        \\  print xs[1]
+        \\  print xs[3]
+        \\end
+    , "99\n77\n");
+}
+
+test "codegen/array: byte elements (u8) load + store" {
+    try runAndExpect(
+        \\def main()
+        \\  let bs: [u8; 4] = [0; 4]
+        \\  bs[2] = 200
+        \\  print bs[2]
+        \\end
+    , "200\n");
+}
+
+test "codegen/array: value semantics — copy on bind, no aliasing" {
+    try runAndExpect(
+        \\def main()
+        \\  let a: [i16; 3] = [1, 2, 3]
+        \\  let b: [i16; 3] = a
+        \\  b[0] = 9
+        \\  print a[0]
+        \\  print b[0]
+        \\end
+    , "1\n9\n");
+}
+
+test "codegen/array: runtime out-of-bounds index traps (debug halts)" {
+    // The bounds check faults to vector $02 (unhandled → VM halts), so
+    // the post-index `print` never runs — output stops at the pre-print.
+    try runAndExpect(
+        \\def main()
+        \\  let xs: [i16; 3] = [0; 3]
+        \\  let i: i16 = 5
+        \\  print 1
+        \\  let v: i16 = xs[i]
+        \\  print v
+        \\end
+    , "1\n");
+}
+
+// ---------- arrays of aggregate elements (struct / tuple / nested) ----------
+
+test "codegen/array: struct elements — literal, const + runtime field access" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let ps: [Pos; 2] = [Pos { x: 1, y: 2 }, Pos { x: 3, y: 4 }]
+        \\  print ps[0].x
+        \\  print ps[1].y
+        \\  let i: i16 = 1
+        \\  print ps[i].x
+        \\end
+    , "1\n4\n3\n");
+}
+
+test "codegen/array: struct elements — repeat constructs once per slot" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let ps: [Pos; 3] = [Pos { x: 7, y: 8 }; 3]
+        \\  print ps[2].x
+        \\  print ps[0].y
+        \\end
+    , "7\n8\n");
+}
+
+test "codegen/array: struct elements — indexed store (const + runtime)" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let ps: [Pos; 3] = [Pos { x: 0, y: 0 }; 3]
+        \\  ps[0] = Pos { x: 9, y: 9 }
+        \\  let i: i16 = 2
+        \\  ps[i] = Pos { x: 5, y: 6 }
+        \\  print ps[0].x
+        \\  print ps[2].y
+        \\  print ps[1].x
+        \\end
+    , "9\n6\n0\n");
+}
+
+test "codegen/array: struct elements — value semantics on bind" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let a: [Pos; 2] = [Pos { x: 1, y: 1 }, Pos { x: 2, y: 2 }]
+        \\  let b: [Pos; 2] = a
+        \\  b[0] = Pos { x: 9, y: 9 }
+        \\  print a[0].x
+        \\  print b[0].x
+        \\end
+    , "1\n9\n");
+}
+
+test "codegen/array: tuple elements — literal + element access" {
+    try runAndExpect(
+        \\def main()
+        \\  let ts: [(i16, i16); 2] = [(1, 2), (3, 4)]
+        \\  print ts[0].0
+        \\  print ts[1].1
+        \\end
+    , "1\n4\n");
+}
+
+test "codegen/array: nested arrays — index into the inner array" {
+    try runAndExpect(
+        \\def main()
+        \\  let grid: [[i16; 2]; 2] = [[1, 2], [3, 4]]
+        \\  print grid[0][1]
+        \\  print grid[1][0]
+        \\end
+    , "2\n3\n");
+}
+
+test "codegen/array: tuple elements — store a tuple literal in place" {
+    try runAndExpect(
+        \\def main()
+        \\  let ts: [(i16, i16); 2] = [(0, 0); 2]
+        \\  ts[0] = (1, 2)
+        \\  let i: i16 = 1
+        \\  ts[i] = (3, 4)
+        \\  print ts[0].0
+        \\  print ts[1].1
+        \\end
+    , "1\n4\n");
+}
+
+test "codegen/array: nested arrays — store an array literal in place" {
+    try runAndExpect(
+        \\def main()
+        \\  let grid: [[i16; 2]; 2] = [[0, 0]; 2]
+        \\  grid[0] = [1, 2]
+        \\  let i: i16 = 1
+        \\  grid[i] = [3, 4]
+        \\  print grid[0][1]
+        \\  print grid[1][0]
+        \\end
+    , "2\n3\n");
+}
+
+test "codegen/array: aggregate store survives calls in the value's fields" {
+    // The destination pointer is parked on the stack while the value's
+    // fields evaluate; a call in a field (which pushes args, then restores
+    // sp) must leave that parked pointer reachable.
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def five() -> i16
+        \\  return 5
+        \\end
+        \\def main()
+        \\  let ps: [Pos; 2] = [Pos { x: 0, y: 0 }; 2]
+        \\  let i: i16 = 1
+        \\  ps[i] = Pos { x: five() + 1, y: five() * 2 }
+        \\  print ps[1].x
+        \\  print ps[1].y
+        \\end
+    , "6\n10\n");
+}
+
+test "codegen/struct: assign a struct literal into a nested struct field" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\struct Line
+        \\  a: Pos
+        \\  b: Pos
+        \\end
+        \\def main()
+        \\  let ln: Line = Line { a: Pos { x: 1, y: 2 }, b: Pos { x: 3, y: 4 } }
+        \\  ln.a = Pos { x: 9, y: 8 }
+        \\  print ln.a.x
+        \\  print ln.a.y
+        \\  print ln.b.x
+        \\end
+    , "9\n8\n3\n");
+}
+
+test "codegen/struct: assign a tuple literal into a tuple field" {
+    try runAndExpect(
+        \\struct Holder
+        \\  pair: (i16, i16)
+        \\  tag: i16
+        \\end
+        \\def main()
+        \\  let h: Holder = Holder { pair: (1, 2), tag: 7 }
+        \\  h.pair = (8, 9)
+        \\  print h.pair.0
+        \\  print h.pair.1
+        \\  print h.tag
+        \\end
+    , "8\n9\n7\n");
+}
+
+test "codegen/array: runtime index scales a non-power-of-2 element width (word fields)" {
+    // A 6-byte element (three i16) needs `index * 6` via a multiply, not a
+    // shift — exercises the mul-scale path for both read and write.
+    try runAndExpect(
+        \\struct Tri
+        \\  a: i16
+        \\  b: i16
+        \\  c: i16
+        \\end
+        \\def main()
+        \\  let arr: [Tri; 3] = [Tri { a: 1, b: 2, c: 3 }; 3]
+        \\  let i: i16 = 2
+        \\  arr[i] = Tri { a: 10, b: 20, c: 30 }
+        \\  print arr[0].a
+        \\  print arr[2].a
+        \\  print arr[2].c
+        \\  let j: i16 = 1
+        \\  print arr[j].b
+        \\end
+    , "1\n10\n30\n2\n");
+}
+
+test "codegen/array: runtime index scales an odd element width (byte fields)" {
+    // A 3-byte element (three u8) — an odd, non-power-of-2 width.
+    try runAndExpect(
+        \\struct Bytes3
+        \\  a: u8
+        \\  b: u8
+        \\  c: u8
+        \\end
+        \\def main()
+        \\  let arr: [Bytes3; 4] = [Bytes3 { a: 0, b: 0, c: 0 }; 4]
+        \\  let i: i16 = 3
+        \\  arr[i] = Bytes3 { a: 7, b: 8, c: 9 }
+        \\  print arr[3].a
+        \\  print arr[3].c
+        \\  print arr[0].a
+        \\  let j: i16 = 3
+        \\  print arr[j].b
+        \\end
+    , "7\n9\n0\n8\n");
+}
+
+test "codegen/array: reassignment copies the full width (value semantics)" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let ps1: [Pos; 2] = [Pos { x: 10, y: 20 }, Pos { x: 30, y: 40 }]
+        \\  let ps2: [Pos; 2] = [Pos { x: 50, y: 60 }, Pos { x: 70, y: 80 }]
+        \\  ps2 = ps1
+        \\  print ps2[0].x
+        \\  print ps2[1].x
+        \\  ps2[0].x = 999
+        \\  print ps1[0].x
+        \\  print ps2[0].x
+        \\end
+    , "10\n30\n10\n999\n");
+}
+
+test "codegen/array: scalar-array reassignment stays independent" {
+    try runAndExpect(
+        \\def main()
+        \\  let xs1: [i16; 3] = [1, 2, 3]
+        \\  let xs2: [i16; 3] = [0, 0, 0]
+        \\  xs2 = xs1
+        \\  xs2[0] = 99
+        \\  print xs1[0]
+        \\  print xs2[0]
+        \\  print xs2[2]
+        \\end
+    , "1\n99\n3\n");
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2441,6 +2441,24 @@ test "typecheck/stdlib: math.sat_add rejects fixed (integer-only)" {
     , "E_TYPE_MISMATCH");
 }
 
+test "typecheck/array: out-of-range constant index is rejected" {
+    try expectCode(
+        \\def main()
+        \\  let xs: [i16; 3] = [0; 3]
+        \\  print xs[5]
+        \\end
+    , "E_TYPE_INDEX_OOR");
+}
+
+test "typecheck/array: non-integer index is rejected" {
+    try expectCode(
+        \\def main()
+        \\  let xs: [i16; 3] = [0; 3]
+        \\  print xs["x"]
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
 test "typecheck/stdlib: test.assert_eq rejects a non-scalar operand" {
     try expectCode(
         \\struct P


### PR DESCRIPTION
Lowers fixed-size arrays `[T; N]` end-to-end (the front-end already type-checked them; only codegen was missing).

## What works

- **Construction** — array literals `[a, b, c]`, repeat literals `[value; count]` (zero-fill collapses to one `bfill`; a non-zero / aggregate value is evaluated once and replicated into independent slots).
- **Indexed read/write** — `arr[i]` and `arr[i] = x`, both constant and runtime indices.
- **Element types** — scalar (`i8`/`u8`/`i16`/`u16`, sign-extending `i8` on load) *and* aggregate (`struct`, tuple, nested `[T; N]`), laid out inline at `i * elem_width`. Aggregate elements support field/element access (`arr[i].x`, `ts[i].0`, `grid[i][j]`) and in-place mutation (`arr[i].x = 5`).
- **Value semantics** — binding, passing, returning, and reassigning copy the full width; `let b = a` / `a2 = a1` produce independent arrays.
- **Aggregate literals store in place** — `arr[i] = Pos { x: 1, y: 2 }`, `ts[i] = (3, 4)`, with no temporary binding. The destination address is parked on the stack while the literal's fields evaluate (a new `indirect_sp` destination). The same mechanism fixes assigning an aggregate literal into a struct field (`obj.field = Pos { ... }`) and adds tuple-field stores (`obj.pair = (a, b)`).

## Bounds

Per the agreed model (mirrors the arithmetic-overflow trap): a constant out-of-range index is a compile error (`E_TYPE_INDEX_OOR`); a runtime out-of-range index faults to vector `$02` in debug builds and is unchecked in release / size. A non-integer index is `E_TYPE_MISMATCH`.

## Verification

Full `zig build ci` green (all release modes + cross-targets). An adversarial probe pass surfaced — and this PR fixes — two real defects in the first cut: `mul` writes its product's high half to `acu` (so non-power-of-2 element-width scaling clobbered the index), and array-to-array reassignment fell through to a 2-byte scalar store. Both are now covered by tests.

## Spec / docs

`docs/gero-lang.md` §3.4 pins the array element-type / indexing / bounds contract; `docs/lang-diagnostics.md` registers `E_TYPE_INDEX_OOR`.

Closes #306.