### PR TITLE
feat(lang/codegen): pattern destructuring — let / if let / while let / match

### DIFF
--- a/.changeset/lang-codegen-destructuring.md
+++ b/.changeset/lang-codegen-destructuring.md
@@ -23,6 +23,11 @@ The destructuring matcher also gives `match` tuple and struct patterns
 (`case (a, b) =>`, `case Player { hp, mp } =>`), which previously only
 lowered enum-variant and literal arms.
 
+Enum variants now carry aggregate payloads (`case At(Coord)`): the value
+is stored inline in the `[tag | payload]` slot (the enum owns a copy, so
+mutating the source can't change it), and `if let At(c) = loc` /
+`if let At(Coord { x, y }) = loc` bind or further destructure it.
+
 Payload / element / field binders are now typed from the matched value
 (the variant's payload type, the tuple's slot type, the struct's field
 type) rather than left untyped — `if let E.Hit(n) = e` gives `n` the

--- a/.changeset/lang-codegen-destructuring.md
+++ b/.changeset/lang-codegen-destructuring.md
@@ -1,0 +1,29 @@
+---
+bump: minor
+---
+
+Pattern destructuring now lowers at every binding site — `let`, `if let`,
+`while let`, and `match` arms share one matcher.
+
+`let` binds an irrefutable pattern: `let (a, b) = pt`, `let Pos { x, y } =
+p`, and a single-variant `let Wrap.Of(n) = w`. A refutable pattern in a
+`let` (a literal / range / or-pattern, or a multi-variant enum) is a
+compile error (`E_TYPE_REFUTABLE_LET`) — use `if let` / `match` for a
+pattern that can fail.
+
+`if let` / `while let` test any pattern in conditional / loop position,
+binding on a match and skipping (running the `else`, or exiting the loop)
+otherwise: `if let Event.Click(x, y) = e when x < 128`, `while let
+Item.Potion(n) = inv.next()`. `when` guards run after the bind. Inline
+binders (tuple elements, struct fields) alias the materialized scrutinee
+slot; an enum payload — behind the value's `[tag | payload]` pointer —
+loads into its own slot.
+
+The destructuring matcher also gives `match` tuple and struct patterns
+(`case (a, b) =>`, `case Player { hp, mp } =>`), which previously only
+lowered enum-variant and literal arms.
+
+Payload / element / field binders are now typed from the matched value
+(the variant's payload type, the tuple's slot type, the struct's field
+type) rather than left untyped — `if let E.Hit(n) = e` gives `n` the
+payload type, so the body type-checks under the strong-typing rule.

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -236,6 +236,7 @@ Raised by the typechecker after parsing succeeds.
 | `E_TYPE_NOT_A_TUPLE` | `.N` element access on a non-tuple value. |
 | `E_TYPE_TUPLE_INDEX_OOR` | Tuple element index `.N` is past the tuple's arity. |
 | `E_TYPE_INDEX_OOR` | A constant array index `arr[N]` is negative or past the array's length. |
+| `E_TYPE_REFUTABLE_LET` | A `let` binding uses a refutable pattern (a literal / range / or-pattern, or a multi-variant enum) that can fail to match — use `if let` / `match` instead (§4.2). |
 | `E_TYPE_TUPLE_TOO_MANY` | A tuple has more than 4 elements (§3.4) — use a struct instead. |
 | `E_TYPE_TUPLE_ARITY` | Tuple-destructuring pattern's element count doesn't match the init's tuple arity. |
 | `E_TYPE_REDEFINED` | A name is declared twice in the same scope. |
@@ -768,6 +769,7 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_TYPE_NOT_A_TUPLE` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_INDEX_OOR` | Typechecker | v0.3 |
 | `E_TYPE_INDEX_OOR` | Typechecker | v0.3 |
+| `E_TYPE_REFUTABLE_LET` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_TOO_MANY` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_ARITY` | Typechecker | v0.3 |
 | `E_TYPE_REDEFINED` | Typechecker | v0.3 |

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -36,6 +36,7 @@ const cg_bank_builtin = @import("lang/codegen/bank_builtin.zig");
 const cg_test_builtin = @import("lang/codegen/test_builtin.zig");
 const cg_strings = @import("lang/codegen/strings.zig");
 const cg_pattern = @import("lang/codegen/pattern.zig");
+const cg_destructure = @import("lang/codegen/destructure.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 const cg_class = @import("lang/codegen/class.zig");
@@ -211,6 +212,8 @@ pub const internal = struct {
         pub const strings = cg_strings;
         /// `match` pattern-arm test emission.
         pub const pattern = cg_pattern;
+        /// Pattern destructuring (`let` / `if let` / `while let` binds).
+        pub const destructure = cg_destructure;
         /// Expression lowering.
         pub const expr_emit = cg_expr_emit;
         /// Control-flow lowering (if / while / for / match / break / continue / defer).

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -934,7 +934,7 @@ pub const Emitter = struct {
                 else
                     2;
                 for (ms.arms) |a| {
-                    n += ownSlotBinderBytes(a.pattern, false);
+                    n += self.ownSlotBinderBytes(a.pattern, false);
                     n += self.countFrameBytesDepth(a.body, depth);
                 }
                 break :blk n;
@@ -1127,7 +1127,7 @@ pub const Emitter = struct {
             alignUpU16(self.widthOfType(ty.?), 2)
         else
             2;
-        return scrut + ownSlotBinderBytes(pat, false);
+        return scrut + self.ownSlotBinderBytes(pat, false);
     }
 
     /// Frame bytes an `if let` / `while let` head reserves: a 2-byte slot
@@ -1140,31 +1140,56 @@ pub const Emitter = struct {
     }
 
     /// Frame bytes for the binders that need their own slot — enum-payload
-    /// binders (loaded from behind the value's pointer) and the temp that
-    /// parks a nested enum's pointer. Inline binders (`behind == false`)
-    /// alias the scrutinee slot and cost nothing.
-    fn ownSlotBinderBytes(pat: *const ast.Pattern, behind: bool) usize {
+    /// binders (loaded from behind the value's pointer), an aggregate
+    /// payload's sized copy, and the temp that parks a nested enum's
+    /// pointer. Inline binders (`behind == false`) alias the scrutinee
+    /// slot and cost nothing.
+    fn ownSlotBinderBytes(self: *const Emitter, pat: *const ast.Pattern, behind: bool) usize {
         return switch (pat.*) {
             .ident => if (behind) 2 else 0,
             .tuple_pattern => |t| blk: {
                 var n: usize = 0;
-                for (t.elems) |e| n += ownSlotBinderBytes(e, behind);
+                for (t.elems) |e| n += self.ownSlotBinderBytes(e, behind);
                 break :blk n;
             },
             .struct_pattern => |st| blk: {
                 var n: usize = 0;
-                for (st.fields) |f| n += ownSlotBinderBytes(f.sub, behind);
+                for (st.fields) |f| n += self.ownSlotBinderBytes(f.sub, behind);
                 break :blk n;
             },
             .variant_pattern => |vp| blk: {
                 // A variant behind a pointer parks its slot pointer in a
                 // temp first; payload binders then live behind it.
                 var n: usize = if (behind) 2 else 0;
-                for (vp.args) |a| n += ownSlotBinderBytes(a, true);
+                const path = self.source[vp.path.start..vp.path.end];
+                const dot = std.mem.indexOfScalar(u8, path, '.');
+                const ed = if (dot) |d| self.enum_decls.get(path[0..d]) else null;
+                const vname = if (dot) |d| path[d + 1 ..] else path;
+                for (vp.args, 0..) |a, i| {
+                    const pann: ?ast.TypeAnn = if (ed) |e| self.variantPayloadAnn(e, vname, i) else null;
+                    // An aggregate payload is copied into a sized slot the
+                    // binder owns; its sub-binders alias that copy.
+                    if (pann) |ann| if (self.structNameOfTypeAnn(ann) != null or ann == .tuple or ann == .array) {
+                        n += alignUpU16(self.widthOfTypeAnn(ann), 2);
+                        n += self.ownSlotBinderBytes(a, false);
+                        continue;
+                    };
+                    n += self.ownSlotBinderBytes(a, true);
+                }
                 break :blk n;
             },
             else => 0,
         };
+    }
+
+    /// The `i`-th payload field's type annotation for variant `vname` of
+    /// `ed`, or `null` when the variant / index doesn't resolve.
+    fn variantPayloadAnn(self: *const Emitter, ed: *const ast.EnumDecl, vname: []const u8, i: usize) ?ast.TypeAnn {
+        for (ed.variants) |v| {
+            if (!std.mem.eql(u8, self.source[v.name.start..v.name.end], vname)) continue;
+            return if (i < v.payload.len) v.payload[i].type_ann.* else null;
+        }
+        return null;
     }
 
     // ---------- program + def emission ----------

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -815,6 +815,64 @@ pub const Emitter = struct {
         }
     }
 
+    /// Resolve a surface `TypeAnn` to an arena `types.Type` so the
+    /// destructuring matcher can thread one type representation (struct
+    /// field / enum payload types come from AST `TypeAnn`s, tuple slots
+    /// from inferred `types.Type`s). `Vec` / fn-types — never destructured
+    /// through a binder — return `null`.
+    pub fn typeAnnToType(self: *const Emitter, t: ast.TypeAnn) error{OutOfMemory}!?*const Type {
+        switch (t) {
+            .named => |n| {
+                const name = self.source[n.name.start..n.name.end];
+                const prim: ?types_mod.Primitive = if (std.mem.eql(u8, name, "i8"))
+                    .i8
+                else if (std.mem.eql(u8, name, "u8"))
+                    .u8
+                else if (std.mem.eql(u8, name, "i16"))
+                    .i16
+                else if (std.mem.eql(u8, name, "u16"))
+                    .u16
+                else if (std.mem.eql(u8, name, "bool"))
+                    .bool_
+                else if (std.mem.eql(u8, name, "nil"))
+                    .nil_
+                else if (std.mem.eql(u8, name, "str"))
+                    .str
+                else if (std.mem.eql(u8, name, "fixed"))
+                    .fixed
+                else if (std.mem.eql(u8, name, "char"))
+                    .char
+                else
+                    null;
+                if (prim) |p| return try types_mod.mkPrimitive(self.arena, p);
+                return try types_mod.mkNamed(self.arena, name, n.name);
+            },
+            .tuple => |tt| {
+                const elems = try self.arena.alloc(*const Type, tt.elems.len);
+                for (tt.elems, 0..) |e, i| elems[i] = (try self.typeAnnToType(e.*)) orelse return null;
+                const out = try self.arena.create(Type);
+                out.* = .{ .tuple = elems };
+                return out;
+            },
+            .array => |a| {
+                const elem = (try self.typeAnnToType(a.elem.*)) orelse return null;
+                if (a.len_expr.* != .int_lit) return null;
+                // safety: int-lit length → low 16 bits, spec §3.4 caps the count.
+                const raw: u32 = @bitCast(a.len_expr.int_lit.value);
+                return try types_mod.mkArray(self.arena, elem, raw & 0xFFFF);
+            },
+            .reference => |r| {
+                const inner = (try self.typeAnnToType(r.inner.*)) orelse return null;
+                return try types_mod.mkReference(self.arena, inner);
+            },
+            .nullable => |o| {
+                const inner = (try self.typeAnnToType(o.inner.*)) orelse return null;
+                return try types_mod.mkOptional(self.arena, inner);
+            },
+            .vec, .fn_type => return null,
+        }
+    }
+
     /// Bytes of frame space the body could need so the prologue can
     /// `sub frame_bytes, sp`. A scalar local is 2 bytes; a struct
     /// local takes its full (2-aligned) width. Reserves space for
@@ -845,7 +903,7 @@ pub const Emitter = struct {
             .if_stmt => |is_| blk: {
                 var n: usize = 0;
                 for (is_.arms) |a| {
-                    if (a.let_pattern) |p| n += countBindingBytes(p.*);
+                    if (a.let_pattern) |p| n += self.letArmFrameBytes(p, a.let_expr);
                     // `if expr is Class as h` — `h` parks the
                     // instance pointer in a fresh local slot.
                     if (a.cond) |c| if (c.* == .is_test and c.is_test.classBinding() != null) {
@@ -858,7 +916,7 @@ pub const Emitter = struct {
             },
             .while_stmt => |ws| blk: {
                 var n: usize = 0;
-                if (ws.let_pattern) |p| n += countBindingBytes(p.*);
+                if (ws.let_pattern) |p| n += self.letArmFrameBytes(p, ws.let_expr);
                 n += self.countFrameBytesDepth(ws.body, depth);
                 break :blk n;
             },
@@ -867,11 +925,16 @@ pub const Emitter = struct {
             .for_stmt => |fs| 2 + 2 + self.countFrameBytesDepth(fs.body, depth),
             .repeat_stmt => |rs| self.countFrameBytesDepth(rs.body, depth),
             .match_stmt => |ms| blk: {
-                // 1 scratch slot to bind the scrutinee when it isn't
-                // already an ident (so subsequent cmps don't re-eval).
-                var n: usize = if (ms.scrutinee.* == .ident) 0 else 2;
+                // The scrutinee is materialized into a slot once (full width
+                // for a tuple / struct, else a word); each arm's binders
+                // then alias it or load from behind its pointer.
+                const scrut_ty = self.typeOf(ms.scrutinee);
+                var n: usize = if (scrut_ty != null and self.isInlineAggregateType(scrut_ty.?))
+                    alignUpU16(self.widthOfType(scrut_ty.?), 2)
+                else
+                    2;
                 for (ms.arms) |a| {
-                    n += countBindingBytes(a.pattern.*);
+                    n += ownSlotBinderBytes(a.pattern, false);
                     n += self.countFrameBytesDepth(a.body, depth);
                 }
                 break :blk n;
@@ -1031,7 +1094,10 @@ pub const Emitter = struct {
     /// (struct fields summed), 2 for scalars. Non-ident patterns
     /// (destructuring) reserve minimally — lowering them is separate.
     fn letFrameBytes(self: *const Emitter, d: ast.LetDecl) usize {
-        if (d.pattern.* != .ident) return 2;
+        if (d.pattern.* != .ident) {
+            const ty = if (d.init) |e| self.typeOf(e) else null;
+            return self.destructureFrameBytes(d.pattern, ty);
+        }
         const w: u16 = if (d.type_ann) |t|
             self.widthOfTypeAnn(t.*)
         else if (d.init) |e|
@@ -1041,16 +1107,60 @@ pub const Emitter = struct {
         return alignUpU16(w, 2);
     }
 
-    /// Frame bytes a pattern's binders introduce. A bare ident binds
-    /// one 2-byte slot; a variant pattern binds one per payload field.
-    /// These must be reserved so a binder slot doesn't overlap the
-    /// stack-push region used by later binary ops.
-    fn countBindingBytes(pat: ast.Pattern) usize {
-        return switch (pat) {
-            .ident => 2,
-            .variant_pattern => |vp| blk: {
+    /// `true` when a value of `ty` lives inline as contiguous bytes (a
+    /// tuple / struct / array) — vs a register-width scalar / enum-pointer
+    /// / class-pointer.
+    pub fn isInlineAggregateType(self: *const Emitter, ty: *const Type) bool {
+        return switch (ty.*) {
+            .tuple, .array => true,
+            .named => |n| self.struct_decls.contains(n.name),
+            else => false,
+        };
+    }
+
+    /// Frame bytes a destructure of `pat` against `ty` reserves: the
+    /// materialized scrutinee slot (full width for an inline aggregate,
+    /// else a word) plus a slot per enum-payload binder. Inline
+    /// tuple / struct binders alias the scrutinee slot, costing nothing.
+    fn destructureFrameBytes(self: *const Emitter, pat: *const ast.Pattern, ty: ?*const Type) usize {
+        const scrut: usize = if (ty != null and self.isInlineAggregateType(ty.?))
+            alignUpU16(self.widthOfType(ty.?), 2)
+        else
+            2;
+        return scrut + ownSlotBinderBytes(pat, false);
+    }
+
+    /// Frame bytes an `if let` / `while let` head reserves: a 2-byte slot
+    /// for a bare-ident binder, else the full destructure footprint
+    /// (scrutinee slot + payload binders) against the scrutinee's type.
+    fn letArmFrameBytes(self: *const Emitter, pat: *const ast.Pattern, let_expr: ?*const ast.Expr) usize {
+        if (pat.* == .ident) return 2;
+        const ty = if (let_expr) |e| self.typeOf(e) else null;
+        return self.destructureFrameBytes(pat, ty);
+    }
+
+    /// Frame bytes for the binders that need their own slot — enum-payload
+    /// binders (loaded from behind the value's pointer) and the temp that
+    /// parks a nested enum's pointer. Inline binders (`behind == false`)
+    /// alias the scrutinee slot and cost nothing.
+    fn ownSlotBinderBytes(pat: *const ast.Pattern, behind: bool) usize {
+        return switch (pat.*) {
+            .ident => if (behind) 2 else 0,
+            .tuple_pattern => |t| blk: {
                 var n: usize = 0;
-                for (vp.args) |arg| n += countBindingBytes(arg.*);
+                for (t.elems) |e| n += ownSlotBinderBytes(e, behind);
+                break :blk n;
+            },
+            .struct_pattern => |st| blk: {
+                var n: usize = 0;
+                for (st.fields) |f| n += ownSlotBinderBytes(f.sub, behind);
+                break :blk n;
+            },
+            .variant_pattern => |vp| blk: {
+                // A variant behind a pointer parks its slot pointer in a
+                // temp first; payload binders then live behind it.
+                var n: usize = if (behind) 2 else 0;
+                for (vp.args) |a| n += ownSlotBinderBytes(a, true);
                 break :blk n;
             },
             else => 0,
@@ -1297,22 +1407,6 @@ pub const Emitter = struct {
         const ty = self.typeOf(e) orelse return null;
         if (ty.* != .named) return null;
         return self.enum_decls.get(ty.named.name);
-    }
-
-    /// Resolve the enum a `match` dispatches on. Prefers the
-    /// scrutinee's inferred type; falls back to a variant arm's path
-    /// (`EnumName.Variant`) when the scrutinee carries no recorded
-    /// type, so payload-enum lowering doesn't depend on inference
-    /// reaching every scrutinee form.
-    pub fn enumDeclForMatch(self: *const Emitter, ms: ast.MatchStmt) ?*const ast.EnumDecl {
-        if (self.enumDeclForExpr(ms.scrutinee)) |ed| return ed;
-        for (ms.arms) |arm| {
-            if (arm.pattern.* != .variant_pattern) continue;
-            const path = self.source[arm.pattern.variant_pattern.path.start..arm.pattern.variant_pattern.path.end];
-            const dot = std.mem.indexOfScalar(u8, path, '.') orelse continue;
-            if (self.enum_decls.get(path[0..dot])) |ed| return ed;
-        }
-        return null;
     }
 
     /// Scan top-level `def`s, recording each name → its `@bank N`
@@ -1691,17 +1785,6 @@ pub const Emitter = struct {
     /// Delegated to `codegen/control_flow.zig`.
     fn emitMatchStmt(self: *Emitter, ms: ast.MatchStmt) !void {
         return control_flow.emitMatchStmt(self, ms);
-    }
-
-    /// Delegated to `codegen/pattern.zig`.
-    fn emitPatternTest(
-        self: *Emitter,
-        pat: ast.Pattern,
-        scrutinee_ofs: i8,
-        scrutinee_is_ident: bool,
-        skip_patches: *std.ArrayList(usize),
-    ) !void {
-        return pattern.emitPatternTest(self, pat, scrutinee_ofs, scrutinee_is_ident, skip_patches);
     }
 
     /// Class name when `e` is a registered class (auto-derefs one

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -4,6 +4,7 @@ const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const pattern = @import("pattern.zig");
+const destructure = @import("destructure.zig");
 const class = @import("class.zig");
 
 const Emitter = codegen.Emitter;
@@ -18,51 +19,6 @@ pub fn emitScopedBody(self: *Emitter, body: []const ast.Statement) error{OutOfMe
     try pushBlock(self);
     for (body) |s| try self.emitStatement(s);
     try popBlockWithDefers(self);
-}
-
-/// Bind a payload-enum arm's variant payload fields to fresh locals,
-/// loaded straight from `[ptr + field_offset]`. Runs after the tag
-/// test and before the guard / body so both can read the binders.
-fn emitPayloadBinders(
-    self: *Emitter,
-    arm: ast.MatchArm,
-    scrutinee_ofs: i8,
-    scrutinee_is_ident: bool,
-    scrutinee: *const ast.Expr,
-    ed: *const ast.EnumDecl,
-) error{OutOfMemory}!void {
-    if (arm.pattern.* != .variant_pattern or arm.pattern.variant_pattern.args.len == 0) return;
-    const vp = arm.pattern.variant_pattern;
-    const path = self.source[vp.path.start..vp.path.end];
-    const tail = if (std.mem.lastIndexOfScalar(u8, path, '.')) |d| path[d + 1 ..] else path;
-    for (ed.variants) |v| {
-        if (!std.mem.eql(u8, self.source[v.name.start..v.name.end], tail)) continue;
-        // Reload the slot pointer into r1, then read each binder.
-        if (scrutinee_is_ident) {
-            try self.emitExpr(scrutinee);
-        } else {
-            try isa.movRegOffsetToReg(self, Reg.fp, scrutinee_ofs, Reg.acu);
-        }
-        try isa.movRegToReg(self, Reg.acu, Reg.r1);
-        for (vp.args, 0..) |arg, i| {
-            if (arg.* != .ident or i >= v.payload.len) continue;
-            const ofs = self.variantFieldOffset(v, i);
-            const fty = v.payload[i].type_ann.*;
-            if (self.widthOfTypeAnn(fty) == 1) {
-                try class.emitByteLoadAtOffset(self, Reg.r1, ofs, Reg.acu);
-                // `i8` is the only signed byte type — sign-extend so a
-                // negative payload keeps its sign through the binder
-                // (`u8` / `bool` / `char` stay zero-extended).
-                if (self.isPrimitiveTypeAnn(fty, "i8")) try isa.signExtendByte(self, Reg.acu);
-            } else {
-                try class.emitWordLoadAtOffset(self, Reg.r1, ofs, Reg.acu);
-            }
-            const name = self.source[arg.ident.name.start..arg.ident.name.end];
-            const local_ofs = try self.allocLocal(try self.arena.dupe(u8, name));
-            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, local_ofs);
-        }
-        return;
-    }
 }
 
 /// Lower a `do…end` block at statement position — opens a
@@ -229,12 +185,11 @@ fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
         try self.emitCondBranch(c);
         return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
     }
-    // `if let pat = expr [when guard]` — ident-binder form.
-    const pat = arm.let_pattern.?.*;
+    // `if let pat = expr [when guard]`.
     const expr = arm.let_expr.?;
-    try self.emitExpr(expr);
-    switch (pat) {
+    switch (arm.let_pattern.?.*) {
         .ident => |id| {
+            try self.emitExpr(expr);
             const name = self.source[id.name.start..id.name.end];
             const dup = try self.arena.dupe(u8, name);
             const ofs = try self.allocLocal(dup);
@@ -250,11 +205,32 @@ fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
             try isa.cmpRegImm(self, Reg.r1, 0);
             return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
         },
-        else => {
-            try self.unsupported(arm.span, "`if let` patterns other than a bare ident");
-            return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
-        },
+        else => return try emitLetPatternTest(self, arm.let_pattern.?, expr, arm.let_guard),
     }
+}
+
+/// Lower a non-ident `if let` / `while let` head: materialize the
+/// scrutinee, run the destructuring matcher (+ optional `when` guard),
+/// and funnel every mismatch into a single "skip body" jump — returned
+/// for the caller to resolve to the else-arm / loop-exit. The matched
+/// path jumps over that skip into the body.
+fn emitLetPatternTest(self: *Emitter, pat: *const ast.Pattern, expr: *const ast.Expr, guard: ?*const ast.Expr) !usize {
+    const ty = self.typeOf(expr);
+    const slot = try destructure.materializeScrutinee(self, expr, ty);
+    var skip: std.ArrayList(usize) = .empty;
+    defer skip.deinit(self.allocator);
+    try destructure.emitMatchPattern(self, pat, slot, ty, &skip);
+    if (guard) |g| {
+        try self.emitExpr(g);
+        try isa.cmpRegImm(self, Reg.acu, 0);
+        try skip.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
+    }
+    const body_jump = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    const skip_here = try self.currentOffset();
+    for (skip.items) |p| try isa.patchJumpTo(self, p, skip_here);
+    const combined = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    try isa.patchJumpTo(self, body_jump, try self.currentOffset());
+    return combined;
 }
 
 // ---------- while / repeat / for ----------
@@ -283,10 +259,9 @@ pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
         try self.emitCondBranch(c);
         break :blk try isa.emitJumpPlaceholder(self, Op.jeq_addr);
     } else blk: {
-        const pat = ws.let_pattern.?.*;
-        try self.emitExpr(ws.let_expr.?);
-        switch (pat) {
+        switch (ws.let_pattern.?.*) {
             .ident => |id| {
+                try self.emitExpr(ws.let_expr.?);
                 const name = self.source[id.name.start..id.name.end];
                 const dup = try self.arena.dupe(u8, name);
                 const ofs = try self.allocLocal(dup);
@@ -300,10 +275,7 @@ pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
                 try isa.cmpRegImm(self, Reg.r1, 0);
                 break :blk try isa.emitJumpPlaceholder(self, Op.jeq_addr);
             },
-            else => {
-                try self.unsupported(ws.span, "`while let` patterns other than a bare ident");
-                break :blk try isa.emitJumpPlaceholder(self, Op.jeq_addr);
-            },
+            else => break :blk try emitLetPatternTest(self, ws.let_pattern.?, ws.let_expr.?, ws.let_guard),
         }
     };
 
@@ -484,54 +456,23 @@ pub fn emitMatchStmt(self: *Emitter, ms: ast.MatchStmt) !void {
 }
 
 fn emitMatchSequential(self: *Emitter, ms: ast.MatchStmt) !void {
-    // Bind the scrutinee to a slot so subsequent arms can re-test
-    // it without re-evaluating side effects. Skip the bind if the
-    // source already wrote an ident — direct loads stay cheap.
-    const scrutinee_ofs: i8 = blk: {
-        switch (ms.scrutinee.*) {
-            .ident => break :blk 0,
-            else => {
-                try self.emitExpr(ms.scrutinee);
-                const ofs = try self.allocLocal(try self.arena.dupe(u8, "\x00__match"));
-                try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
-                break :blk ofs;
-            },
-        }
-    };
-    const scrutinee_is_ident = ms.scrutinee.* == .ident;
-
-    // Payload-carrying enums are a `[tag | payload]` slot addressed
-    // by pointer (§3.6). The scrutinee load yields that pointer, so
-    // dispatch reads the tag byte from `[ptr]` and arms extract their
-    // payload binders from the slot. Payload-free enums stay a bare
-    // register tag (the common path below).
-    const enum_decl = self.enumDeclForMatch(ms);
-    const is_payload_enum = if (enum_decl) |ed| self.enumHasPayload(ed) else false;
+    // Materialize the scrutinee into a slot once so every arm re-tests it
+    // without re-evaluating side effects. The destructuring matcher walks
+    // each arm's pattern against that slot — tag tests + payload binders
+    // for enums, element binds for tuple / struct patterns, leaf compares
+    // for literals / ranges / or-patterns.
+    const scrut_ty = self.typeOf(ms.scrutinee);
+    const slot = try destructure.materializeScrutinee(self, ms.scrutinee, scrut_ty);
 
     var end_patches: std.ArrayList(usize) = .empty;
     defer end_patches.deinit(self.allocator);
 
     for (ms.arms) |arm| {
-        if (scrutinee_is_ident) {
-            try self.emitExpr(ms.scrutinee);
-        } else {
-            try isa.movRegOffsetToReg(self, Reg.fp, scrutinee_ofs, Reg.acu);
-        }
-        if (is_payload_enum) {
-            // acu = slot pointer → load the tag byte into acu.
-            try isa.movRegToReg(self, Reg.acu, Reg.r1);
-            try class.emitByteLoadAtOffset(self, Reg.r1, 0, Reg.acu);
-        }
-
         var skip_patches: std.ArrayList(usize) = .empty;
         defer skip_patches.deinit(self.allocator);
-        try pattern.emitPatternTest(self, arm.pattern.*, scrutinee_ofs, scrutinee_is_ident, &skip_patches);
-
-        // Bind payload binders before the guard so a `when` clause can
-        // reference them (`case Hit(d) when d > 10`).
-        if (is_payload_enum) {
-            try emitPayloadBinders(self, arm, scrutinee_ofs, scrutinee_is_ident, ms.scrutinee, enum_decl.?);
-        }
+        // Binders land before the guard so a `when` clause can read them
+        // (`case Hit(d) when d > 10`).
+        try destructure.emitMatchPattern(self, arm.pattern, slot, scrut_ty, &skip_patches);
 
         if (arm.guard) |g| {
             try self.emitExpr(g);

--- a/src/lang/codegen/destructure.zig
+++ b/src/lang/codegen/destructure.zig
@@ -140,12 +140,21 @@ fn matchVariant(self: *Emitter, vp: ast.VariantPattern, ofs: i8, ty: ?*const Typ
 /// The pointer is reloaded per field — prior binders / nested recursion
 /// churn registers, so `r1` can't be assumed live across calls.
 fn bindPayload(self: *Emitter, arg: *const ast.Pattern, scrut_ofs: i8, off: u16, fty_ann: ast.TypeAnn, skip: *std.ArrayList(usize)) error{OutOfMemory}!void {
-    // An aggregate payload (struct / tuple / array) isn't a register-width
-    // slot value — its inline layout isn't lowered here (matches enum `==`
-    // / `print`, which also don't handle aggregate payloads). Reject it
-    // cleanly rather than load a single word of a wider value.
+    // An aggregate payload (struct / tuple / array) lays out inline within
+    // the slot at `off` (the enum owns its bytes — §3.6). Copy it into a
+    // fresh sized slot the binder owns, then bind / recurse against that.
     if (self.structNameOfTypeAnn(fty_ann) != null or fty_ann == .tuple or fty_ann == .array) {
-        try self.unsupported(arg.span(), "binding an enum payload of struct / tuple / array type");
+        if (arg.* == .wildcard) return;
+        const w = self.widthOfTypeAnn(fty_ann);
+        const slot_name: []const u8 = if (arg.* == .ident)
+            try self.arena.dupe(u8, self.source[arg.ident.name.start..arg.ident.name.end])
+        else
+            "\x00__pl";
+        const dest = try self.allocLocalSized(slot_name, w);
+        try copyInlinePayload(self, scrut_ofs, off, w, dest);
+        // An ident binds the copied aggregate directly (the slot is its
+        // value); any other pattern destructures the copy in place.
+        if (arg.* != .ident) try emitMatchPattern(self, arg, dest, try self.typeAnnToType(fty_ann), skip);
         return;
     }
     switch (arg.*) {
@@ -169,6 +178,15 @@ fn bindPayload(self: *Emitter, arg: *const ast.Pattern, scrut_ofs: i8, off: u16,
             try pattern.emitLeafTest(self, arg.*, skip);
         },
     }
+}
+
+/// Copy a `w`-byte inline aggregate payload at `[<slot ptr at fp+scrut_ofs>
+/// + off]` into the frame slot at `dest`.
+fn copyInlinePayload(self: *Emitter, scrut_ofs: i8, off: u16, w: u16, dest: i8) error{OutOfMemory}!void {
+    try isa.movRegOffsetToReg(self, Reg.fp, scrut_ofs, Reg.r1); // r1 = slot pointer
+    if (off > 0) try isa.addImmToReg(self, off, Reg.r1); // r1 = &payload aggregate
+    try frameAddr(self, dest, Reg.r2);
+    try value_struct.copyBytes(self, Reg.r1, Reg.r2, w);
 }
 
 fn loadPayload(self: *Emitter, scrut_ofs: i8, off: u16, fty_ann: ast.TypeAnn, reg: u8) error{OutOfMemory}!void {

--- a/src/lang/codegen/destructure.zig
+++ b/src/lang/codegen/destructure.zig
@@ -1,0 +1,206 @@
+// Pattern destructuring (§4.2 / §4.4.1 / §4.5.2 / §4.8.1) — shared by
+// `let` binds, `if let` / `while let`, and `match` arms. The scrutinee is
+// materialized into a frame slot; the matcher walks the pattern against
+// that slot, binding idents (an inline binder aliases the slot sub-region
+// directly; an enum payload — behind the value's `[tag|payload]` pointer —
+// loads into a fresh slot) and emitting tests for refutable shapes (each
+// mismatch pushes a skip-jump patch the caller resolves to the else /
+// loop-exit / next-arm).
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const class = @import("class.zig");
+const value_struct = @import("value_struct.zig");
+const pattern = @import("pattern.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Type = types.Type;
+
+/// Materialize `expr` (type `ty`) into a fresh frame slot, returning its
+/// fp-relative offset — the root the matcher destructures from. An inline
+/// aggregate (tuple / struct / array) is copied whole so its bytes are
+/// private + stable; a scalar / enum / class stores its word (value or
+/// `[tag|payload]` slot pointer).
+pub fn materializeScrutinee(self: *Emitter, expr: *const ast.Expr, ty: ?*const Type) error{OutOfMemory}!i8 {
+    if (ty != null and self.isInlineAggregateType(ty.?)) {
+        const width = self.widthOfType(ty.?);
+        const slot = try self.allocLocalSized("\x00__scrut", width);
+        switch (ty.?.*) {
+            .tuple => |elems| try value_struct.emitTupleInto(self, expr, elems, slot),
+            .array => |a| try value_struct.emitArrayInto(self, expr, a.elem, a.len, slot),
+            .named => |n| try value_struct.emitInto(self, expr, n.name, slot),
+            // `isInlineAggregateType` admits only tuple / array / struct.
+            else => unreachable,
+        }
+        return slot;
+    }
+    try self.emitExpr(expr);
+    const slot = try self.allocLocal("\x00__scrut");
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, slot);
+    return slot;
+}
+
+/// Match `pat` against the component inline at `[fp + ofs]` (type `ty`).
+/// Binds idents and recurses into tuple / struct / variant sub-patterns;
+/// a refutable leaf or variant tag pushes a skip patch onto `skip`.
+pub fn emitMatchPattern(self: *Emitter, pat: *const ast.Pattern, ofs: i8, ty: ?*const Type, skip: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    switch (pat.*) {
+        .wildcard => {},
+        .ident => |ip| {
+            // Inline binder: alias the slot sub-region — no load, no slot.
+            const name = try self.arena.dupe(u8, self.source[ip.name.start..ip.name.end]);
+            try self.locals.put(self.arena, name, ofs);
+        },
+        .tuple_pattern => |tp| {
+            const elems: ?[]const *const Type = if (ty != null and ty.?.* == .tuple) ty.?.tuple else null;
+            for (tp.elems, 0..) |elem, i| {
+                const et: ?*const Type = if (elems != null and i < elems.?.len) elems.?[i] else null;
+                const eo: i8 = if (elems) |es|
+                    // @as: element offset within a ≤127-byte frame slot fits i8.
+                    ofs + @as(i8, @intCast(self.tupleElemInfo(es, @intCast(i)).offset))
+                else
+                    ofs;
+                try emitMatchPattern(self, elem, eo, et, skip);
+            }
+        },
+        .struct_pattern => |sp| try matchStruct(self, sp, ofs, ty, skip),
+        .variant_pattern => |vp| try matchVariant(self, vp, ofs, ty, skip),
+        else => {
+            try loadInline(self, ofs, ty, Reg.acu);
+            try pattern.emitLeafTest(self, pat.*, skip);
+        },
+    }
+}
+
+fn matchStruct(self: *Emitter, sp: ast.StructPattern, ofs: i8, ty: ?*const Type, skip: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    const sname: []const u8 = if (ty != null and ty.?.* == .named) ty.?.named.name else self.source[sp.type_name.start..sp.type_name.end];
+    const sd = self.struct_decls.get(sname);
+    for (sp.fields) |f| {
+        const fname = self.source[f.name.start..f.name.end];
+        const info = self.structFieldInfo(sname, fname) orelse continue;
+        // @as: field offset within a ≤127-byte frame slot fits i8.
+        const fo: i8 = ofs + @as(i8, @intCast(info.offset));
+        const fty: ?*const Type = blk: {
+            const decl = sd orelse break :blk null;
+            for (decl.fields) |df| {
+                if (std.mem.eql(u8, self.source[df.name.start..df.name.end], fname))
+                    break :blk try self.typeAnnToType(df.type_ann.*);
+            }
+            break :blk null;
+        };
+        try emitMatchPattern(self, f.sub, fo, fty, skip);
+    }
+}
+
+fn matchVariant(self: *Emitter, vp: ast.VariantPattern, ofs: i8, ty: ?*const Type, skip: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    const path = self.source[vp.path.start..vp.path.end];
+    const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
+        try self.diagFatal(vp.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: variant pattern must be `EnumName.Variant`");
+        return;
+    };
+    const enum_name = path[0..dot];
+    const variant_name = path[dot + 1 ..];
+    const ed = self.enum_decls.get(enum_name) orelse {
+        try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum in variant pattern");
+        return;
+    };
+    const tag = self.variantTag(enum_name, variant_name) orelse {
+        try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in pattern");
+        return;
+    };
+    if (!self.enumHasPayload(ed)) {
+        // Payload-free: the inline value IS the tag.
+        try loadInline(self, ofs, ty, Reg.acu);
+        try isa.cmpRegImm(self, Reg.acu, tag);
+        try skip.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+        return;
+    }
+    // Payload enum: [fp+ofs] holds the `[tag|payload]` slot pointer.
+    try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.r1); // r1 = pointer
+    try class.emitByteLoadAtOffset(self, Reg.r1, 0, Reg.acu); // acu = tag byte
+    try isa.cmpRegImm(self, Reg.acu, tag);
+    try skip.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+    for (ed.variants) |v| {
+        if (!std.mem.eql(u8, self.source[v.name.start..v.name.end], variant_name)) continue;
+        for (vp.args, 0..) |arg, i| {
+            if (i >= v.payload.len) break;
+            try bindPayload(self, arg, ofs, self.variantFieldOffset(v, i), v.payload[i].type_ann.*, skip);
+        }
+        return;
+    }
+}
+
+/// Bind / test one enum payload field at `[<ptr at fp+scrut_ofs> + off]`.
+/// The pointer is reloaded per field — prior binders / nested recursion
+/// churn registers, so `r1` can't be assumed live across calls.
+fn bindPayload(self: *Emitter, arg: *const ast.Pattern, scrut_ofs: i8, off: u16, fty_ann: ast.TypeAnn, skip: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    // An aggregate payload (struct / tuple / array) isn't a register-width
+    // slot value — its inline layout isn't lowered here (matches enum `==`
+    // / `print`, which also don't handle aggregate payloads). Reject it
+    // cleanly rather than load a single word of a wider value.
+    if (self.structNameOfTypeAnn(fty_ann) != null or fty_ann == .tuple or fty_ann == .array) {
+        try self.unsupported(arg.span(), "binding an enum payload of struct / tuple / array type");
+        return;
+    }
+    switch (arg.*) {
+        .wildcard => {},
+        .ident => |ip| {
+            try loadPayload(self, scrut_ofs, off, fty_ann, Reg.acu);
+            const name = try self.arena.dupe(u8, self.source[ip.name.start..ip.name.end]);
+            const slot = try self.allocLocal(name);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, slot);
+        },
+        .variant_pattern => {
+            // A nested enum payload — park its pointer in a temp slot + recurse.
+            try isa.movRegOffsetToReg(self, Reg.fp, scrut_ofs, Reg.r1);
+            try class.emitWordLoadAtOffset(self, Reg.r1, off, Reg.acu);
+            const temp = try self.allocLocal("\x00__pl");
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, temp);
+            try emitMatchPattern(self, arg, temp, try self.typeAnnToType(fty_ann), skip);
+        },
+        else => {
+            try loadPayload(self, scrut_ofs, off, fty_ann, Reg.acu);
+            try pattern.emitLeafTest(self, arg.*, skip);
+        },
+    }
+}
+
+fn loadPayload(self: *Emitter, scrut_ofs: i8, off: u16, fty_ann: ast.TypeAnn, reg: u8) error{OutOfMemory}!void {
+    try isa.movRegOffsetToReg(self, Reg.fp, scrut_ofs, Reg.r1); // r1 = slot pointer
+    if (self.widthOfTypeAnn(fty_ann) == 1) {
+        try class.emitByteLoadAtOffset(self, Reg.r1, off, reg);
+        if (self.isPrimitiveTypeAnn(fty_ann, "i8")) try isa.signExtendByte(self, reg);
+    } else {
+        try class.emitWordLoadAtOffset(self, Reg.r1, off, reg);
+    }
+}
+
+/// Load the inline scalar value at `[fp + ofs]` into `reg` (sign-extends
+/// an `i8`). `reg` must not be `r1` (used as the byte-load address).
+fn loadInline(self: *Emitter, ofs: i8, ty: ?*const Type, reg: u8) error{OutOfMemory}!void {
+    const w: u16 = if (ty) |t| self.widthOfType(t) else 2;
+    if (w == 1) {
+        try frameAddr(self, ofs, Reg.r1);
+        try class.emitByteLoadAtOffset(self, Reg.r1, 0, reg);
+        if (ty != null and ty.?.* == .primitive and ty.?.primitive == .i8) try isa.signExtendByte(self, reg);
+    } else {
+        try isa.movRegOffsetToReg(self, Reg.fp, ofs, reg);
+    }
+}
+
+/// `reg = fp + ofs` — the address of a frame slot.
+fn frameAddr(self: *Emitter, ofs: i8, reg: u8) error{OutOfMemory}!void {
+    try isa.movRegToReg(self, Reg.fp, reg);
+    if (ofs < 0) {
+        // @as: |ofs| ≤ 127 fits u16.
+        try isa.subImmFromReg(self, @intCast(-@as(i16, ofs)), reg);
+    } else if (ofs > 0) {
+        try isa.addImmToReg(self, @intCast(ofs), reg);
+    }
+}

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -137,40 +137,48 @@ pub fn emitEnumConstruct(
     tag: u8,
     args: []const *ast.Expr,
 ) !void {
-    // Evaluate the payload args onto the stack first (no frame slot —
-    // an uncounted local would overlap the prologue's reservation).
-    for (args) |arg| {
-        try emitExpr(self, arg);
-        try isa.pushReg(self, Reg.acu);
-    }
-
-    // Allocate the slot; `acu` → pointer, kept in `r1` across the
-    // stores below.
+    // Allocate the `[tag | payload]` slot first and park its pointer on
+    // the stack — argument evaluation can clobber every register, so the
+    // pointer is reloaded from `[sp]` for each field store.
     try isa.movImmToReg(self, self.enumSlotSize(ed), Reg.acu);
     try self.emitByte(Op.sys);
     try self.emitByte(opcodes.Sys.alloc);
-    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try isa.pushReg(self, Reg.acu); // [sp] = slot pointer
 
     // Tag byte at offset 0.
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1);
     try isa.movImmToReg(self, tag, Reg.r2);
     try class.emitByteStoreAtOffset(self, Reg.r1, 0, Reg.r2);
 
-    // Pop the args in reverse (stack is LIFO) and store each at its
-    // field offset.
-    var i = args.len;
-    while (i > 0) {
-        i -= 1;
-        try isa.popReg(self, Reg.r2);
+    for (args, 0..) |arg, i| {
         const ofs = self.variantFieldOffset(variant, i);
-        if (self.widthOfTypeAnn(variant.payload[i].type_ann.*) == 1) {
-            try class.emitByteStoreAtOffset(self, Reg.r1, ofs, Reg.r2);
+        const ann = variant.payload[i].type_ann.*;
+        if (self.structNameOfTypeAnn(ann) != null or ann == .tuple or ann == .array) {
+            // Aggregate payload — materialize it inline into the slot
+            // field (a literal lands in place, a value is copied) so the
+            // enum owns the bytes (value semantics; no dangling temp).
+            try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1);
+            try isa.movRegToReg(self, Reg.r1, Reg.acu);
+            if (ofs > 0) try isa.addImmToReg(self, ofs, Reg.acu);
+            const ty = (try self.typeAnnToType(ann)) orelse {
+                try self.unsupported(arg.span(), "enum payload of this type");
+                continue;
+            };
+            try value_struct.emitAggregateStoreInto(self, arg, ty, Reg.acu);
         } else {
-            try class.emitWordStoreAtOffset(self, Reg.r1, ofs, Reg.r2);
+            try emitExpr(self, arg); // acu = scalar value / pointer
+            try isa.movRegToReg(self, Reg.acu, Reg.r2);
+            try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1);
+            if (self.widthOfTypeAnn(ann) == 1) {
+                try class.emitByteStoreAtOffset(self, Reg.r1, ofs, Reg.r2);
+            } else {
+                try class.emitWordStoreAtOffset(self, Reg.r1, ofs, Reg.r2);
+            }
         }
     }
 
     // Result is the slot pointer.
-    try isa.movRegToReg(self, Reg.r1, Reg.acu);
+    try isa.popReg(self, Reg.acu);
 }
 
 /// `acu`. Field access on non-enum receivers is not yet

--- a/src/lang/codegen/pattern.zig
+++ b/src/lang/codegen/pattern.zig
@@ -16,8 +16,6 @@ const Reg = opcodes.Reg;
 pub fn emitPatternTest(
     self: *Emitter,
     pat: ast.Pattern,
-    scrutinee_ofs: i8,
-    scrutinee_is_ident: bool,
     skip_patches: *std.ArrayList(usize),
 ) !void {
     switch (pat) {
@@ -31,6 +29,36 @@ pub fn emitPatternTest(
             const ofs = try self.allocLocal(dup);
             try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
         },
+        .int_lit, .char_lit, .bool_lit, .nil_lit, .range_pattern, .or_pattern => try emitLeafTest(self, pat, skip_patches),
+        .variant_pattern => |vp| {
+            // Payload binders don't affect the tag test — they're
+            // extracted into locals by the match lowerer once the tag
+            // matches. The test is the tag comparison either way.
+            const path = self.source[vp.path.start..vp.path.end];
+            const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
+                try self.diagFatal(vp.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: variant pattern must be `EnumName.Variant`");
+                return;
+            };
+            const enum_name = path[0..dot];
+            const variant_name = path[dot + 1 ..];
+            const tag = self.variantTag(enum_name, variant_name) orelse {
+                try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in match pattern");
+                return;
+            };
+            try isa.cmpRegImm(self, Reg.acu, tag);
+            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
+        },
+        else => try self.unsupported(pat.span(), "this pattern shape"),
+    }
+}
+
+/// Test a scalar value sitting in `acu` against a leaf pattern — a
+/// literal (`42` / `'A'` / `true` / `nil`), a range, or an or-pattern of
+/// those. A mismatch pushes a forward-skip patch onto `skip_patches`;
+/// a match falls through. Shared by `emitPatternTest` (match) and the
+/// destructuring matcher (`destructure.zig`).
+pub fn emitLeafTest(self: *Emitter, pat: ast.Pattern, skip_patches: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    switch (pat) {
         .int_lit => |lit| {
             // @as: parser holds int_lit.value as i32; literals fit i16 by typecheck rule.
             const trimmed: i16 = @truncate(lit.value);
@@ -55,8 +83,8 @@ pub fn emitPatternTest(
         .range_pattern => |rp| {
             // Lower `start..end` as: cmp acu, start; jlt skip;
             //                       cmp acu, end;   j(g[te]) skip.
-            // Endpoints must be compile-time integer literals so
-            // they emit as immediate operands.
+            // Endpoints must be compile-time integer literals so they
+            // emit as immediate operands.
             if (rp.start.* != .int_lit or rp.end.* != .int_lit) {
                 try self.unsupported(rp.span, "non-literal range pattern endpoints");
                 return;
@@ -76,51 +104,25 @@ pub fn emitPatternTest(
             try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, above_bound_op));
         },
         .or_pattern => |op_| {
-            // Each alt emits its own cmp + branch. A match jumps
-            // OVER the remaining alts to the body. A non-match
-            // falls through to the next alt. After the last alt,
-            // a non-match jumps to the shared skip target.
+            // Each alt emits its own cmp + branch. A match jumps OVER the
+            // remaining alts to the body; a non-match falls through to the
+            // next alt. After the last alt, a non-match jumps to the
+            // shared skip target. The scrutinee stays in `acu` throughout,
+            // so each alt re-tests the same value.
             var match_patches: std.ArrayList(usize) = .empty;
             defer match_patches.deinit(self.allocator);
-
             for (op_.alts) |alt| {
                 var alt_skip: std.ArrayList(usize) = .empty;
                 defer alt_skip.deinit(self.allocator);
-                try emitPatternTest(self, alt.*, scrutinee_ofs, scrutinee_is_ident, &alt_skip);
-                // The alt matched if we reach this point — jump
-                // to the shared "body entry" label.
+                try emitLeafTest(self, alt.*, &alt_skip);
                 try match_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
-                // Failure-skips of this alt land at the next alt
-                // (or, after the final alt, at the outer skip).
                 const after_alt = try self.currentOffset();
                 for (alt_skip.items) |p| try isa.patchJumpTo(self, p, after_alt);
             }
-            // None of the alts matched — punt to the outer skip
-            // set.
             try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jmp_addr));
-            // All match-patches resolve to the byte after the
-            // outer skip jump — i.e. the body's first byte.
             const body_offset = try self.currentOffset();
             for (match_patches.items) |p| try isa.patchJumpTo(self, p, body_offset);
         },
-        .variant_pattern => |vp| {
-            // Payload binders don't affect the tag test — they're
-            // extracted into locals by the match lowerer once the tag
-            // matches. The test is the tag comparison either way.
-            const path = self.source[vp.path.start..vp.path.end];
-            const dot = std.mem.indexOfScalar(u8, path, '.') orelse {
-                try self.diagFatal(vp.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: variant pattern must be `EnumName.Variant`");
-                return;
-            };
-            const enum_name = path[0..dot];
-            const variant_name = path[dot + 1 ..];
-            const tag = self.variantTag(enum_name, variant_name) orelse {
-                try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in match pattern");
-                return;
-            };
-            try isa.cmpRegImm(self, Reg.acu, tag);
-            try skip_patches.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jne_addr));
-        },
-        else => try self.unsupported(pat.span(), "this pattern shape"),
+        else => try self.unsupported(pat.span(), "non-leaf pattern in leaf test"),
     }
 }

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -11,6 +11,7 @@ const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const class = @import("class.zig");
 const value_struct = @import("value_struct.zig");
+const destructure = @import("destructure.zig");
 const lambda = @import("lambda.zig");
 const strings = @import("strings.zig");
 
@@ -263,11 +264,29 @@ pub fn emitIncDec(self: *Emitter, id: ast.IncDecStmt) !void {
     try emitAssign(self, .{ .target = id.target, .op = .set, .value = rhs, .span = id.span });
 }
 
+/// `let PATTERN = init` for a non-ident pattern (§4.2) — materialize the
+/// initializer into a slot and destructure it. The pattern is irrefutable
+/// (the typechecker rejects refutable `let`s), so a single-variant enum's
+/// tag test is never taken; its skip resolves to fall-through.
+fn emitDestructureLet(self: *Emitter, d: ast.LetDecl) !void {
+    const init_expr = d.init orelse {
+        try self.unsupported(d.span, "destructuring `let` without an initializer");
+        return;
+    };
+    const ty = self.typeOf(init_expr);
+    const slot = try destructure.materializeScrutinee(self, init_expr, ty);
+    var skip: std.ArrayList(usize) = .empty;
+    defer skip.deinit(self.allocator);
+    try destructure.emitMatchPattern(self, d.pattern, slot, ty, &skip);
+    const after = try self.currentOffset();
+    for (skip.items) |p| try isa.patchJumpTo(self, p, after);
+}
+
 /// `let name [: T] [= init]` — reserve the binding's slot (full width
 /// for a struct, one word otherwise) and lower its initializer.
 pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
     if (d.pattern.* != .ident) {
-        try self.unsupported(d.span, "non-ident `let` patterns");
+        try emitDestructureLet(self, d);
         return;
     }
     const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -497,6 +497,12 @@ pub const Checker = struct {
                 try self.checkStoreCompat(d.init.?.span(), ann_ty.?, init_ty.?);
             }
         }
+        // A `let` pattern must be irrefutable (§4.2) — a literal / range /
+        // multi-variant enum can't be guaranteed to match. Surface a
+        // diagnostic and still bind so the body type-checks.
+        if (d.pattern.* != .ident and self.isRefutable(d.pattern)) {
+            try self.emitSpan("E_TYPE_REFUTABLE_LET", d.pattern.span(), "refutable pattern in `let` — use `if let` or `match` for a pattern that can fail to match");
+        }
         switch (d.pattern.*) {
             .ident => |i| {
                 const ty = ann_ty orelse init_ty;
@@ -519,7 +525,7 @@ pub const Checker = struct {
                 }
             },
             .tuple_pattern => try self.checkLetTupleDestructure(d.pattern, init_ty),
-            else => try self.registerPatternBindings(d.pattern),
+            else => try self.registerBindingsFromType(d.pattern, ann_ty orelse init_ty),
         }
     }
 
@@ -668,7 +674,7 @@ pub const Checker = struct {
 
         for (arms, 0..) |arm, i| {
             if (arm.cond) |c| try self.requireBool(c);
-            if (arm.let_expr) |e| _ = try self.inferExpr(e, null);
+            const let_ty: ?*const types.Type = if (arm.let_expr) |e| try self.inferExpr(e, null) else null;
 
             const arm_gain: ?[]const u8 = if (i == 0 and nil_flow != null and nil_flow.?.is_neq)
                 nil_flow.?.name
@@ -690,7 +696,7 @@ pub const Checker = struct {
             var child: Scope = .init(self.arena, saved);
             self.current_scope = &child;
             defer self.current_scope = saved;
-            if (arm.let_pattern) |pat| try self.registerPatternBindings(pat);
+            if (arm.let_pattern) |pat| try self.registerBindingsFromType(pat, let_ty);
             if (arm.let_guard) |g| try self.requireBool(g);
             try self.walkArmBodyWithIsBinding(arm.body, is_binding);
             if (added) self.popNonNil(arm_gain.?);
@@ -739,14 +745,14 @@ pub const Checker = struct {
 
     fn checkWhile(self: *Checker, ws: ast.WhileStmt) WalkError!void {
         if (ws.cond) |c| try self.requireBool(c);
-        if (ws.let_expr) |e| _ = try self.inferExpr(e, null);
+        const let_ty: ?*const types.Type = if (ws.let_expr) |e| try self.inferExpr(e, null) else null;
         // `while let PAT = expr [when guard]` binds PAT for the guard
         // and loop body — same scoping as `if let` / match arms.
         const saved = self.current_scope;
         var child: Scope = .init(self.arena, saved);
         self.current_scope = &child;
         defer self.current_scope = saved;
-        if (ws.let_pattern) |pat| try self.registerPatternBindings(pat);
+        if (ws.let_pattern) |pat| try self.registerBindingsFromType(pat, let_ty);
         if (ws.let_guard) |g| try self.requireBool(g);
         try self.walkStatementSequence(ws.body);
     }
@@ -924,11 +930,15 @@ pub const Checker = struct {
         }
     }
 
-    /// Register one binder with a known type — the typed counterpart
-    /// to `registerPatternBindings`, used where the value's type is
-    /// known (an enum-variant payload field). A bare ident binds at
-    /// `ty`; nested destructuring falls back to the untyped walk.
-    pub fn registerTypedBinding(self: *Checker, pat: *const ast.Pattern, ty: ?*const types.Type) WalkError!void {
+    /// Register every binder a pattern introduces, typing each from the
+    /// matched value's type `ty`: tuple elements from the tuple's slot
+    /// types, struct fields from the declared field types, enum-variant
+    /// payload binders from the variant's payload types. Idents bind at
+    /// the resolved type; wildcards / literals bind nothing. The
+    /// type-propagating, recursive counterpart to `registerPatternBindings`
+    /// — used by `if let` / `while let` and `match` arms so no binder is
+    /// left `null`-typed (the strong-typing rule).
+    pub fn registerBindingsFromType(self: *Checker, pat: *const ast.Pattern, ty: ?*const types.Type) WalkError!void {
         switch (pat.*) {
             .ident => |i| try self.registerName(self.lexeme(i.name), .{
                 .kind = .let_binding,
@@ -936,8 +946,98 @@ pub const Checker = struct {
                 .ty = ty,
             }),
             .wildcard, .int_lit, .str_lit, .char_lit, .bool_lit, .nil_lit, .range_pattern => {},
-            else => try self.registerPatternBindings(pat),
+            .or_pattern => |o| for (o.alts) |alt| try self.registerBindingsFromType(alt, ty),
+            .tuple_pattern => |t| {
+                const slots: ?[]const *const types.Type = if (ty) |it|
+                    (if (it.* == .tuple and it.tuple.len == t.elems.len) it.tuple else null)
+                else
+                    null;
+                if (slots) |s| {
+                    for (t.elems, s) |elem, slot_ty| try self.registerBindingsFromType(elem, slot_ty);
+                } else for (t.elems) |elem| try self.registerPatternBindings(elem);
+            },
+            .struct_pattern => |st| try self.registerStructBindings(st, ty),
+            .variant_pattern => |vp| try self.registerVariantBindings(vp, ty),
         }
+    }
+
+    /// Type a struct pattern's field binders from the struct's declared
+    /// field types — the matched type names the struct (else the pattern's
+    /// own type name). An unresolved struct falls back to the untyped walk.
+    fn registerStructBindings(self: *Checker, st: ast.StructPattern, ty: ?*const types.Type) WalkError!void {
+        const sname: []const u8 = if (ty != null and ty.?.* == .named)
+            ty.?.named.name
+        else
+            self.lexeme(st.type_name);
+        const sd = self.struct_registry.get(sname) orelse {
+            for (st.fields) |f| try self.registerPatternBindings(f.sub);
+            return;
+        };
+        for (st.fields) |f| {
+            const fname = self.lexeme(f.name);
+            const fty: ?*const types.Type = blk: {
+                for (sd.fields) |df| {
+                    if (std.mem.eql(u8, self.lexeme(df.name), fname))
+                        break :blk try type_resolve.resolveType(self, df.type_ann);
+                }
+                break :blk null;
+            };
+            try self.registerBindingsFromType(f.sub, fty);
+        }
+    }
+
+    /// Type an enum-variant pattern's payload binders from the variant's
+    /// declared payload types — resolving the enum from the matched type,
+    /// else the variant path's head. An unresolved enum / variant falls
+    /// back to the untyped walk.
+    fn registerVariantBindings(self: *Checker, vp: ast.VariantPattern, ty: ?*const types.Type) WalkError!void {
+        const ed: ?*const ast.EnumDecl = blk: {
+            if (ty) |it| if (self.enumDeclForType(it.*)) |e| break :blk e;
+            const head = match.splitPath(self.lexeme(vp.path)).head;
+            break :blk if (head.len > 0) self.enum_registry.get(head) else null;
+        };
+        if (ed) |e| {
+            const tail = match.splitPath(self.lexeme(vp.path)).tail;
+            for (e.variants) |*v| {
+                if (!std.mem.eql(u8, self.lexeme(v.name), tail)) continue;
+                for (vp.args, 0..) |arg, i| {
+                    const aty: ?*const types.Type = if (i < v.payload.len)
+                        try type_resolve.resolveType(self, v.payload[i].type_ann)
+                    else
+                        null;
+                    try self.registerBindingsFromType(arg, aty);
+                }
+                return;
+            }
+        }
+        for (vp.args) |arg| try self.registerPatternBindings(arg);
+    }
+
+    /// `true` when `pat` can fail to match its type — a literal / range /
+    /// or-pattern, or a multi-variant enum variant, directly or within a
+    /// tuple / struct / variant sub-pattern. Drives the `let`-must-be-
+    /// irrefutable rule (§4.2).
+    fn isRefutable(self: *const Checker, pat: *const ast.Pattern) bool {
+        return switch (pat.*) {
+            .wildcard, .ident => false,
+            .int_lit, .str_lit, .char_lit, .bool_lit, .nil_lit, .range_pattern, .or_pattern => true,
+            .tuple_pattern => |t| {
+                for (t.elems) |e| if (self.isRefutable(e)) return true;
+                return false;
+            },
+            .struct_pattern => |st| {
+                for (st.fields) |f| if (self.isRefutable(f.sub)) return true;
+                return false;
+            },
+            .variant_pattern => |vp| {
+                const head = match.splitPath(self.lexeme(vp.path)).head;
+                const ed = if (head.len > 0) self.enum_registry.get(head) else null;
+                // A variant of a multi-variant (or unknown) enum is refutable.
+                if (ed == null or ed.?.variants.len != 1) return true;
+                for (vp.args) |a| if (self.isRefutable(a)) return true;
+                return false;
+            },
+        };
     }
 
     /// `true` when `name` appears anywhere in `body` — drives the

--- a/src/lang/typecheck/match.zig
+++ b/src/lang/typecheck/match.zig
@@ -3,7 +3,6 @@ const ast = @import("../ast.zig");
 const types = @import("../types.zig");
 const scope_mod = @import("../scope.zig");
 const typecheck = @import("../typecheck.zig");
-const type_resolve = @import("type_resolve.zig");
 
 const Scope = scope_mod.Scope;
 const Checker = typecheck.Checker;
@@ -43,7 +42,7 @@ pub fn checkMatch(self: *Checker, ms: ast.MatchStmt) WalkError!void {
         var child: Scope = .init(self.arena, saved);
         self.current_scope = &child;
         defer self.current_scope = saved;
-        try registerArmBindings(self, arm.pattern, enum_decl);
+        try self.registerBindingsFromType(arm.pattern, scrut_ty);
         if (arm.guard) |g| try self.requireBool(g);
         try self.walkStatementSequence(arm.body);
     }
@@ -264,29 +263,6 @@ fn resolveMatchEnum(self: *Checker, ms: ast.MatchStmt, scrut_ty: ?*const types.T
         if (head.len > 0) if (self.enum_registry.get(head)) |ed| return ed;
     }
     return null;
-}
-
-/// Register a match arm's bindings, typing enum-variant payload
-/// binders from the variant's declared field types — `case E.A(n)`
-/// gives `n` the payload's type, not unknown. Non-variant patterns
-/// (or an unresolved scrutinee enum) fall back to the untyped walk.
-fn registerArmBindings(self: *Checker, pat: *const ast.Pattern, enum_decl: ?*const ast.EnumDecl) WalkError!void {
-    if (enum_decl) |ed| if (pat.* == .variant_pattern) {
-        const vp = pat.variant_pattern;
-        const tail = splitPath(self.lexeme(vp.path)).tail;
-        for (ed.variants) |*v| {
-            if (!std.mem.eql(u8, self.lexeme(v.name), tail)) continue;
-            for (vp.args, 0..) |arg, i| {
-                const ty: ?*const types.Type = if (i < v.payload.len)
-                    try type_resolve.resolveType(self, v.payload[i].type_ann)
-                else
-                    null;
-                try self.registerTypedBinding(arg, ty);
-            }
-            return;
-        }
-    };
-    try self.registerPatternBindings(pat);
 }
 
 /// Split a variant path `EnumName.Variant` at the last `.` into its

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -6442,3 +6442,44 @@ test "codegen/destructure: i8 payload binder sign-extends" {
         \\end
     , "-5\n");
 }
+
+test "codegen/destructure: aggregate enum payload — inline copy + value semantics" {
+    // The struct payload is stored inline in the enum slot (the enum owns a
+    // copy), so mutating the source after construction can't change it.
+    try runAndExpect(
+        \\struct Coord
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\enum Loc
+        \\  case At(Coord)
+        \\end
+        \\def main()
+        \\  let cv: Coord = Coord { x: 5, y: 6 }
+        \\  let l: Loc = Loc.At(cv)
+        \\  cv.x = 999
+        \\  if let Loc.At(c) = l
+        \\    print c.x
+        \\    print c.y
+        \\  end
+        \\end
+    , "5\n6\n");
+}
+
+test "codegen/destructure: aggregate enum payload destructures in place" {
+    try runAndExpect(
+        \\struct Coord
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\enum Loc
+        \\  case At(Coord)
+        \\end
+        \\def main()
+        \\  if let Loc.At(Coord { x, y }) = Loc.At(Coord { x: 1, y: 2 })
+        \\    print x
+        \\    print y
+        \\  end
+        \\end
+    , "1\n2\n");
+}

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -6277,3 +6277,168 @@ test "codegen/array: scalar-array reassignment stays independent" {
         \\end
     , "1\n99\n3\n");
 }
+
+// ---------- pattern destructuring: let / if let / while let (#308) ----------
+
+test "codegen/destructure: let tuple binds element-wise" {
+    try runAndExpect(
+        \\def main()
+        \\  let (a, b) = (10, 20)
+        \\  print a
+        \\  print b
+        \\end
+    , "10\n20\n");
+}
+
+test "codegen/destructure: let struct binds named fields" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let Pos { x, y } = Pos { x: 3, y: 4 }
+        \\  print x
+        \\  print y
+        \\end
+    , "3\n4\n");
+}
+
+test "codegen/destructure: let single-variant enum binds the payload" {
+    try runAndExpect(
+        \\enum Wrap
+        \\  case Of(i16, i16)
+        \\end
+        \\def main()
+        \\  let Wrap.Of(a, b) = Wrap.Of(5, 6)
+        \\  print a
+        \\  print b
+        \\end
+    , "5\n6\n");
+}
+
+test "codegen/destructure: let tuple binders are independent copies" {
+    try runAndExpect(
+        \\def main()
+        \\  let p: (i16, i16) = (1, 2)
+        \\  let (a, b) = p
+        \\  a = 99
+        \\  print a
+        \\  print b
+        \\end
+    , "99\n2\n");
+}
+
+test "codegen/destructure: if let enum payload + else on no match" {
+    try runAndExpect(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(i16)
+        \\end
+        \\def main()
+        \\  let it: Item = Item.Potion(42)
+        \\  if let Item.Potion(n) = it
+        \\    print n
+        \\  else
+        \\    print 0
+        \\  end
+        \\  if let Item.Sword = it
+        \\    print 1
+        \\  else
+        \\    print 9
+        \\  end
+        \\end
+    , "42\n9\n");
+}
+
+test "codegen/destructure: if let multi-payload + when guard" {
+    try runAndExpect(
+        \\enum Ev
+        \\  case Click(i16, i16)
+        \\end
+        \\def main()
+        \\  if let Ev.Click(x, y) = Ev.Click(40, 7) when x < 128
+        \\    print x
+        \\    print y
+        \\  end
+        \\  if let Ev.Click(x, y) = Ev.Click(200, 7) when x < 128
+        \\    print x
+        \\  else
+        \\    print 0
+        \\  end
+        \\end
+    , "40\n7\n0\n");
+}
+
+test "codegen/destructure: if let tuple destructures in conditional position" {
+    try runAndExpect(
+        \\def main()
+        \\  if let (a, b) = (100, 200)
+        \\    print a
+        \\    print b
+        \\  end
+        \\end
+    , "100\n200\n");
+}
+
+test "codegen/destructure: while let drains a producer" {
+    try runAndExpect(
+        \\enum Cmd
+        \\  case Go(i16)
+        \\  case Stop
+        \\end
+        \\def poll(i: i16) -> Cmd
+        \\  if i < 3
+        \\    return Cmd.Go(i)
+        \\  end
+        \\  return Cmd.Stop
+        \\end
+        \\def main()
+        \\  let i: i16 = 0
+        \\  while let Cmd.Go(n) = poll(i)
+        \\    print n
+        \\    i = i + 1
+        \\  end
+        \\  print 99
+        \\end
+    , "0\n1\n2\n99\n");
+}
+
+test "codegen/destructure: match on a tuple binds elements" {
+    try runAndExpect(
+        \\def main()
+        \\  match (7, 8)
+        \\    case (x, y) => print x
+        \\                   print y
+        \\  end
+        \\end
+    , "7\n8\n");
+}
+
+test "codegen/destructure: match on a struct binds fields" {
+    try runAndExpect(
+        \\struct Pos
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  match Pos { x: 1, y: 2 }
+        \\    case Pos { x, y } => print x
+        \\                         print y
+        \\  end
+        \\end
+    , "1\n2\n");
+}
+
+test "codegen/destructure: i8 payload binder sign-extends" {
+    try runAndExpect(
+        \\enum Tag
+        \\  case V(i8)
+        \\end
+        \\def main()
+        \\  if let Tag.V(n) = Tag.V(-5)
+        \\    print n
+        \\  end
+        \\end
+    , "-5\n");
+}

--- a/tests/lang/codegen/destructure.test.zig
+++ b/tests/lang/codegen/destructure.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `destructure` module is reachable through the
+/// public barrel. End-to-end destructuring coverage (`let (a, b)`,
+/// `let P { x, y }`, `if let E.A(n)`, `while let` + `when` guards)
+/// lives in the integration tests in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/destructure: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.destructure;
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2661,3 +2661,43 @@ test "typecheck/shadow: `let assert` is rejected" {
         \\end
     , "E_BUILTIN_SHADOW");
 }
+
+test "typecheck/destructure: refutable `let` pattern is rejected" {
+    try expectCode(
+        \\enum Item
+        \\  case Sword
+        \\  case Potion(i16)
+        \\end
+        \\def main()
+        \\  let Item.Potion(n) = Item.Potion(5)
+        \\  print n
+        \\end
+    , "E_TYPE_REFUTABLE_LET");
+}
+
+test "typecheck/destructure: a single-variant `let` enum pattern is irrefutable" {
+    try expectClean(
+        \\enum Wrap
+        \\  case Of(i16)
+        \\end
+        \\def main()
+        \\  let Wrap.Of(n) = Wrap.Of(5)
+        \\  print n + 1
+        \\end
+    );
+}
+
+test "typecheck/destructure: an if-let payload binder is typed from the variant" {
+    // `n` resolves to the payload's `i16`, so the typed arithmetic on it
+    // checks — a `null`-typed binder would surface as an untyped use.
+    try expectClean(
+        \\enum Item
+        \\  case Potion(i16)
+        \\end
+        \\def main()
+        \\  if let Item.Potion(n) = Item.Potion(5)
+        \\    print n + 1
+        \\  end
+        \\end
+    );
+}


### PR DESCRIPTION
Lowers pattern destructuring at every binding site (the front-end already type-checked these — only codegen lowering + typed binders were missing).

## What works

- **`let`** binds an irrefutable pattern: `let (a, b) = pt`, `let Pos { x, y } = p`, single-variant `let Wrap.Of(n) = w`. A refutable pattern in `let` (literal / range / or-pattern / multi-variant enum) is a compile error (`E_TYPE_REFUTABLE_LET`, §4.2).
- **`if let` / `while let`** test any pattern in conditional / loop position, binding on a match and skipping (running `else`, or exiting the loop) otherwise — `if let Event.Click(x, y) = e when x < 128`, `while let Item.Potion(n) = inv.next()`. `when` guards run after the bind.
- **`match`** gained tuple and struct patterns (`case (a, b) =>`, `case Player { hp, mp } =>`) as a side-benefit of routing its sequential path through the shared matcher — previously only variant / literal arms lowered.
- **Aggregate enum payloads** (`case At(Coord)`) now store inline in the `[tag | payload]` slot — the enum owns a copy (value semantics) — and `if let At(c) = loc` / `if let At(Coord { x, y }) = loc` bind or further destructure them.

## How

A recursive matcher (`destructure.zig`) materializes the scrutinee into a frame slot, then walks the pattern: inline binders (tuple elements, struct fields) **alias** the slot sub-region (value semantics free — the slot is a private copy); an enum payload, behind the value's `[tag|payload]` pointer, loads into its own slot; refutable shapes push a skip jump funnelled to the else / loop-exit / next-arm. The leaf-test logic (literal / range / or) is extracted from the match path and shared (`emitLeafTest`). Aggregate enum payloads reuse the `emitAggregateStoreInto` machinery to materialize inline.

Typecheck side: one recursive `registerBindingsFromType` types every binder from the matched value (variant payload type / tuple slot type / struct field type) — no more `null`-typed binders (the strong-typing rule the issue calls out).

## Verification

Full `zig build ci` green (all release modes + cross-targets); 1900+ tests pass with no match regressions. A 3-lane adversarial probe (value-semantics / frame-nesting / control-edge) confirmed value semantics, frame accounting, sign-extension, nesting, guards, and no cross-arm contamination. The one defect it surfaced — a struct-typed enum payload binding garbage (the payload was stored as a dangling pointer) — is now fixed end-to-end (construction stores inline; destructure reads inline).

Commits: typecheck (typed binders + refutable-let) · codegen (the matcher + 4-site rewiring) · aggregate enum payloads inline.

Closes #308.