### PR TITLE
feat(lang/codegen): Vec(T) — growable dynamic array

### DIFF
--- a/.changeset/lang-codegen-vec.md
+++ b/.changeset/lang-codegen-vec.md
@@ -19,11 +19,14 @@ Method binders are typed from the receiver's element type (`v.at(i)`
 yields `T`, `v.len()` yields `u16`), and `Vec.new` / `with_capacity`
 infer `T` from the binding's annotation.
 
+`pop()` and `get(i)` return `T?`. To make them work for scalar elements,
+`T?` now extends to scalars: a scalar `T?` is a tagged 4-byte
+`{present, value}` value (pointer-like `T?` stays a single nullable word).
+`if let n = opt` unwraps an optional (binds `n` to the value when present,
+runs `else` when nil), and `opt == nil` / `!= nil` test the tag.
+
 `Vec.from` parses now that a name after `.` accepts the `from` keyword
 (otherwise reserved for `use … from`).
 
-`pop` / `get` (which return `T?`) are not yet lowered — `T?` is currently
-pointer-like-only, so scalar-element `pop` / `get` await a tagged
-scalar-optional representation. The heap is a bump allocator with no free,
-so a growing `push` leaks the old buffer (the documented cost on a 16-bit
-target).
+The heap is a bump allocator with no free, so a growing `push` leaks the
+old buffer (the documented cost on a 16-bit target).

--- a/.changeset/lang-codegen-vec.md
+++ b/.changeset/lang-codegen-vec.md
@@ -1,0 +1,29 @@
+---
+bump: minor
+---
+
+`Vec(T)` — the growable dynamic array (§3.4.3) — is now implemented. The
+value is a 6-byte `(ptr, len, cap)` header stored inline like a struct;
+the backing buffer lives on the heap (`sys alloc`).
+
+Constructors: `Vec.new()` (empty), `Vec.with_capacity(n)`, and
+`Vec.from([a, b, c])` (copied from a fixed array). Operations: `push`
+(doubles capacity when full — growth allocates a new buffer and copies),
+`len`, `cap`, `at(i)` (bounds-trapped to `$02` in debug), `set(i, x)`,
+`v[i]` / `v[i] = x` (sugar for `at` / `set`), `clear` (keeps the buffer),
+and `slice(a, b)` (a borrowed view aliasing the parent — mutating the
+slice mutates the parent). Binding a Vec copies its header; element type
+`T` can be scalar or aggregate.
+
+Method binders are typed from the receiver's element type (`v.at(i)`
+yields `T`, `v.len()` yields `u16`), and `Vec.new` / `with_capacity`
+infer `T` from the binding's annotation.
+
+`Vec.from` parses now that a name after `.` accepts the `from` keyword
+(otherwise reserved for `use … from`).
+
+`pop` / `get` (which return `T?`) are not yet lowered — `T?` is currently
+pointer-like-only, so scalar-element `pop` / `get` await a tagged
+scalar-optional representation. The heap is a bump allocator with no free,
+so a growing `push` leaks the old buffer (the documented cost on a 16-bit
+target).

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -12,6 +12,7 @@ const codegen_mod = @import("lang/codegen.zig");
 const include_mod = @import("lang/include.zig");
 
 const tc_mem_builtin = @import("lang/typecheck/mem_builtin.zig");
+const tc_vec_builtin = @import("lang/typecheck/vec_builtin.zig");
 const tc_stdlib = @import("lang/typecheck/stdlib.zig");
 const tc_match = @import("lang/typecheck/match.zig");
 const tc_predicates = @import("lang/typecheck/predicates.zig");
@@ -37,6 +38,7 @@ const cg_test_builtin = @import("lang/codegen/test_builtin.zig");
 const cg_strings = @import("lang/codegen/strings.zig");
 const cg_pattern = @import("lang/codegen/pattern.zig");
 const cg_destructure = @import("lang/codegen/destructure.zig");
+const cg_vec_builtin = @import("lang/codegen/vec_builtin.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 const cg_class = @import("lang/codegen/class.zig");
@@ -164,6 +166,8 @@ pub const internal = struct {
         pub const match = tc_match;
         /// `mem.*` stdlib typecheck dispatch.
         pub const mem_builtin = tc_mem_builtin;
+        /// `Vec(T)` method / constructor type-checking.
+        pub const vec_builtin = tc_vec_builtin;
         /// `math.*` / `bank.*` / `test.*` stdlib typecheck dispatch.
         pub const stdlib = tc_stdlib;
         /// "Did you mean…?" Levenshtein-based name suggestions.
@@ -214,6 +218,8 @@ pub const internal = struct {
         pub const pattern = cg_pattern;
         /// Pattern destructuring (`let` / `if let` / `while let` binds).
         pub const destructure = cg_destructure;
+        /// `Vec(T)` lowering (construct / push / at / slice / …).
+        pub const vec_builtin = cg_vec_builtin;
         /// Expression lowering.
         pub const expr_emit = cg_expr_emit;
         /// Control-flow lowering (if / while / for / match / break / continue / defer).

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -815,8 +815,38 @@ pub const Emitter = struct {
             // A `Vec(T)` value is a 6-byte `(ptr, len, cap)` header (§3.4.3),
             // stored inline like a struct; its backing buffer is on the heap.
             .vec => return vec_builtin.header_size,
+            // A scalar `T?` is a 4-byte `{present, value}` header; a
+            // pointer-like `T?` is a single nullable-pointer word.
+            .optional => |inner| return if (isScalarOptional(inner)) opt_scalar_size else 2,
             else => return 2,
         }
+    }
+
+    /// Optional-value layout. A scalar `T?` is a tagged 4-byte
+    /// `{present, value}` header (present @0, value @2); a pointer-like `T?`
+    /// is a single nullable-pointer word (0 = nil).
+    pub const opt_present_ofs: u16 = 0;
+    /// Byte offset of the value word in a scalar `T?`.
+    pub const opt_value_ofs: u16 = 2;
+    /// Byte size of a scalar `T?` (`{present, value}`).
+    pub const opt_scalar_size: u16 = 4;
+
+    /// Whether an optional with element type `inner` uses the tagged scalar
+    /// representation (vs a nullable pointer).
+    pub fn isScalarOptional(inner: *const Type) bool {
+        return inner.* == .primitive and switch (inner.primitive) {
+            .i8, .u8, .i16, .u16, .char, .bool_, .fixed => true,
+            else => false,
+        };
+    }
+
+    /// Inner type of a scalar-optional-typed expression (peeling a
+    /// reference), or `null` — the 4-byte `{present, value}` form only.
+    pub fn scalarOptionalElemOf(self: *const Emitter, e: *const ast.Expr) ?*const Type {
+        const t = self.typeOf(e) orelse return null;
+        const inner = if (t.* == .reference) t.reference else t;
+        if (inner.* != .optional) return null;
+        return if (isScalarOptional(inner.optional)) inner.optional else null;
     }
 
     /// Resolve a surface `TypeAnn` to an arena `types.Type` so the
@@ -1701,6 +1731,11 @@ pub const Emitter = struct {
             },
             // A `Vec(T)` value is a 6-byte inline header (§3.4.3).
             .vec => vec_builtin.header_size,
+            // Scalar `T?` → 4-byte tagged header; pointer-like → word.
+            .nullable => |o| blk: {
+                const inner = (self.typeAnnToType(o.inner.*) catch null) orelse break :blk 2;
+                break :blk if (isScalarOptional(inner)) opt_scalar_size else 2;
+            },
             else => 2,
         };
     }

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -21,6 +21,7 @@ const globals = @import("codegen/globals.zig");
 const def_emit = @import("codegen/def.zig");
 const statements = @import("codegen/statements.zig");
 const isa = @import("codegen/isa.zig");
+const vec_builtin = @import("codegen/vec_builtin.zig");
 const bake_mod = @import("bake.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
@@ -811,6 +812,9 @@ pub const Emitter = struct {
                 // @as: nested-array width stays ≤ the i8 frame cap.
                 return @intCast(@as(u32, self.widthOfType(a.elem)) * a.len);
             },
+            // A `Vec(T)` value is a 6-byte `(ptr, len, cap)` header (§3.4.3),
+            // stored inline like a struct; its backing buffer is on the heap.
+            .vec => return vec_builtin.header_size,
             else => return 2,
         }
     }
@@ -1695,6 +1699,8 @@ pub const Emitter = struct {
                 for (xs.elems) |elem| total +%= self.widthOfTypeAnn(elem.*);
                 break :blk total;
             },
+            // A `Vec(T)` value is a 6-byte inline header (§3.4.3).
+            .vec => vec_builtin.header_size,
             else => 2,
         };
     }

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -185,8 +185,13 @@ fn emitIfArmTest(self: *Emitter, arm: ast.IfArm) !usize {
         try self.emitCondBranch(c);
         return try isa.emitJumpPlaceholder(self, Op.jeq_addr);
     }
-    // `if let pat = expr [when guard]`.
+    // `if let pat = expr [when guard]`. An optional scrutinee unwraps
+    // (§3.4.1) — route it (even a bare ident) through the matcher.
     const expr = arm.let_expr.?;
+    const is_optional = if (self.typeOf(expr)) |t| t.* == .optional else false;
+    if (is_optional or arm.let_pattern.?.* != .ident) {
+        return try emitLetPatternTest(self, arm.let_pattern.?, expr, arm.let_guard);
+    }
     switch (arm.let_pattern.?.*) {
         .ident => |id| {
             try self.emitExpr(expr);
@@ -259,6 +264,12 @@ pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
         try self.emitCondBranch(c);
         break :blk try isa.emitJumpPlaceholder(self, Op.jeq_addr);
     } else blk: {
+        // An optional scrutinee unwraps (§3.4.1) — route it (even a bare
+        // ident) through the matcher.
+        const is_optional = if (self.typeOf(ws.let_expr.?)) |t| t.* == .optional else false;
+        if (is_optional or ws.let_pattern.?.* != .ident) {
+            break :blk try emitLetPatternTest(self, ws.let_pattern.?, ws.let_expr.?, ws.let_guard);
+        }
         switch (ws.let_pattern.?.*) {
             .ident => |id| {
                 try self.emitExpr(ws.let_expr.?);

--- a/src/lang/codegen/destructure.zig
+++ b/src/lang/codegen/destructure.zig
@@ -15,6 +15,7 @@ const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const class = @import("class.zig");
 const value_struct = @import("value_struct.zig");
+const vec_builtin = @import("vec_builtin.zig");
 const pattern = @import("pattern.zig");
 
 const Emitter = codegen.Emitter;
@@ -28,6 +29,13 @@ const Type = types.Type;
 /// private + stable; a scalar / enum / class stores its word (value or
 /// `[tag|payload]` slot pointer).
 pub fn materializeScrutinee(self: *Emitter, expr: *const ast.Expr, ty: ?*const Type) error{OutOfMemory}!i8 {
+    // An optional scrutinee (`if let n = v.pop()`) — materialize the
+    // tagged / pointer optional into a slot, then the matcher unwraps it.
+    if (ty != null and ty.?.* == .optional) {
+        const slot = try self.allocLocalSized("\x00__scrut", self.widthOfType(ty.?));
+        try vec_builtin.emitOptionalInto(self, expr, ty.?.optional, slot);
+        return slot;
+    }
     if (ty != null and self.isInlineAggregateType(ty.?)) {
         const width = self.widthOfType(ty.?);
         const slot = try self.allocLocalSized("\x00__scrut", width);
@@ -50,6 +58,23 @@ pub fn materializeScrutinee(self: *Emitter, expr: *const ast.Expr, ty: ?*const T
 /// Binds idents and recurses into tuple / struct / variant sub-patterns;
 /// a refutable leaf or variant tag pushes a skip patch onto `skip`.
 pub fn emitMatchPattern(self: *Emitter, pat: *const ast.Pattern, ofs: i8, ty: ?*const Type, skip: *std.ArrayList(usize)) error{OutOfMemory}!void {
+    // Optional scrutinee — unwrap (§3.4.1: `if let` matches the inner
+    // value): test present (skip on absent), then match `pat` against the
+    // value. A scalar `T?` keeps present @0 + value @2; a pointer-like `T?`
+    // is the value itself (0 = nil).
+    if (ty) |t| if (t.* == .optional) {
+        const inner = t.optional;
+        const scalar = codegen.Emitter.isScalarOptional(inner);
+        // present is at offset 0 (scalar tag) or is the pointer itself.
+        const present_at: i8 = ofs;
+        // @as: the value offset (2) keeps the slot within the i8 frame cap.
+        const value_at: i8 = if (scalar) ofs + @as(i8, @intCast(codegen.Emitter.opt_value_ofs)) else ofs;
+        try isa.movRegOffsetToReg(self, Reg.fp, present_at, Reg.acu);
+        try isa.cmpRegImm(self, Reg.acu, 0);
+        try skip.append(self.allocator, try isa.emitJumpPlaceholder(self, Op.jeq_addr));
+        try emitMatchPattern(self, pat, value_at, inner, skip);
+        return;
+    };
     switch (pat.*) {
         .wildcard => {},
         .ident => |ip| {

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -9,6 +9,7 @@ const diverge_builtin = @import("diverge.zig");
 const stdlib = @import("stdlib.zig");
 const class = @import("class.zig");
 const value_struct = @import("value_struct.zig");
+const vec_builtin = @import("vec_builtin.zig");
 const strings = @import("strings.zig");
 const lambda = @import("lambda.zig");
 const overflow = @import("overflow.zig");
@@ -50,10 +51,12 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .char_lit => |c| try isa.movImmToReg(self, c.value, Reg.acu),
         .paren => |p| try emitExpr(self, p.inner),
         .ident => |i| {
-            // A struct- / tuple- / array-typed binding evaluates to its
-            // base address — aggregate values are addressed inline, not
-            // loaded as a word.
-            if (self.structNameOf(e) != null or self.tupleElemsOf(e) != null or self.arrayInfoOf(e) != null) {
+            // A struct- / tuple- / array- / Vec-typed binding evaluates to
+            // its base address — inline aggregates (incl. the 6-byte Vec
+            // header) are addressed in place, not loaded as a word.
+            if (self.structNameOf(e) != null or self.tupleElemsOf(e) != null or
+                self.arrayInfoOf(e) != null or vec_builtin.elemOf(self, e) != null)
+            {
                 try self.emitAddrOf(e);
                 return;
             }
@@ -260,6 +263,11 @@ fn emitTupleIndexExpr(self: *Emitter, ti: ast.TupleIndexExpr) !void {
 /// bounds-trapped (debug) then scaled. A scalar element loads its
 /// word/byte; an aggregate element leaves its address (see `emitArrayElem`).
 fn emitIndexExpr(self: *Emitter, ix: ast.IndexExpr) !void {
+    // `v[i]` on a Vec — sugar for `v.at(i)` (bounds-trapped element load).
+    if (vec_builtin.elemOf(self, ix.receiver)) |elem| {
+        try vec_builtin.emitIndexLoad(self, ix.receiver, ix.index, elem);
+        return;
+    }
     const info = self.arrayInfoOf(ix.receiver) orelse {
         try self.unsupported(ix.span, "indexing a non-array value");
         return;
@@ -787,6 +795,12 @@ pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr)
     if (self.classNameOf(m.receiver)) |cname| {
         const mname = self.source[m.method.start..m.method.end];
         try class.emitMethodDispatch(self, m.receiver, cname, mname, m.args, m.span);
+        return;
+    }
+    // Vec-typed receiver — builtin method (`v.push` / `v.len` / `v.at` / …).
+    if (vec_builtin.elemOf(self, m.receiver)) |elem| {
+        const mname = self.source[m.method.start..m.method.end];
+        try vec_builtin.emitMethod(self, m.receiver, mname, m.args, elem);
         return;
     }
     if (m.receiver.* == .ident) {

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -51,11 +51,13 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .char_lit => |c| try isa.movImmToReg(self, c.value, Reg.acu),
         .paren => |p| try emitExpr(self, p.inner),
         .ident => |i| {
-            // A struct- / tuple- / array- / Vec-typed binding evaluates to
-            // its base address — inline aggregates (incl. the 6-byte Vec
-            // header) are addressed in place, not loaded as a word.
+            // A struct- / tuple- / array- / Vec- / scalar-optional-typed
+            // binding evaluates to its base address — inline aggregates
+            // (incl. the 6-byte Vec header + the 4-byte `{present, value}`
+            // optional) are addressed in place, not loaded as a word.
             if (self.structNameOf(e) != null or self.tupleElemsOf(e) != null or
-                self.arrayInfoOf(e) != null or vec_builtin.elemOf(self, e) != null)
+                self.arrayInfoOf(e) != null or vec_builtin.elemOf(self, e) != null or
+                self.scalarOptionalElemOf(e) != null)
             {
                 try self.emitAddrOf(e);
                 return;
@@ -402,7 +404,41 @@ fn payloadEnumComparison(self: *Emitter, b: ast.BinaryExpr) ?*const ast.EnumDecl
 /// (`and`, `or`) take a separate path so the RHS isn't always
 /// evaluated. Comparison ops materialize a `0` / `1` in `acu`.
 /// Fixed-point `*` / `/` get a Q8.8 scaling tail per ISA §5.4.1.
+/// When `b` is `<scalar optional> == nil` / `!= nil`, the scalar-optional
+/// operand and its inner type, else `null`. The optional must be the
+/// scalar (`{present, value}`) form; pointer optionals compare as a word.
+fn scalarOptionalNilCompare(self: *Emitter, b: ast.BinaryExpr) ?*const ast.Expr {
+    if (b.op != .eq and b.op != .neq) return null;
+    if (b.rhs.* == .nil_lit and self.scalarOptionalElemOf(b.lhs) != null) return b.lhs;
+    if (b.lhs.* == .nil_lit and self.scalarOptionalElemOf(b.rhs) != null) return b.rhs;
+    return null;
+}
+
+/// Leave `1`/`0` in `acu` for `<scalar optional> == nil` (`negate` =>
+/// `!= nil`) — testing the `present` tag rather than the header address.
+fn emitScalarOptionalNilCompare(self: *Emitter, opt_expr: *const ast.Expr, negate: bool) error{OutOfMemory}!void {
+    try emitExpr(self, opt_expr); // acu = optional header address
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try class.emitWordLoadAtOffset(self, Reg.r1, codegen.Emitter.opt_present_ofs, Reg.acu); // acu = present
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const absent = try isa.emitJumpPlaceholder(self, Op.jeq_addr);
+    try isa.movImmToReg(self, if (negate) 1 else 0, Reg.acu); // present → `!= nil`
+    const done = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    try isa.patchJumpTo(self, absent, try self.currentOffset());
+    try isa.movImmToReg(self, if (negate) 0 else 1, Reg.acu); // absent → `== nil`
+    try isa.patchJumpTo(self, done, try self.currentOffset());
+}
+
+/// Lower a binary expression, leaving the result in `acu`. Handles the
+/// value-aggregate comparison special cases (struct / tuple / scalar-
+/// optional `==` / `!=`) before the scalar arithmetic / comparison path.
 pub fn emitBinary(self: *Emitter, b: ast.BinaryExpr) !void {
+    // A scalar optional compared to `nil` — test the `present` tag (the
+    // header evaluates to an address, so a plain `cmp` would never be nil).
+    if (scalarOptionalNilCompare(self, b)) |opt_expr| {
+        try emitScalarOptionalNilCompare(self, opt_expr, b.op == .neq);
+        return;
+    }
     switch (b.op) {
         .log_and, .log_or => {
             try emitShortCircuitBool(self, b);
@@ -604,6 +640,13 @@ pub fn emitCondBranch(self: *Emitter, e: *const ast.Expr) !void {
         const b = e.binary;
         switch (b.op) {
             .eq, .neq, .lt, .lte, .gt, .gte => {
+                // A scalar optional vs `nil` — test the `present` tag, then
+                // compare the 0/1 to 0 so the branch consumes its flags.
+                if (scalarOptionalNilCompare(self, b)) |opt_expr| {
+                    try emitScalarOptionalNilCompare(self, opt_expr, b.op == .neq);
+                    try isa.cmpRegImm(self, Reg.acu, 0);
+                    return;
+                }
                 // A struct operand compares structurally (byte-wise);
                 // the resulting 0/1 in acu is then tested against 0 so
                 // the branch consumes its flags like any scalar cond.

--- a/src/lang/codegen/isa.zig
+++ b/src/lang/codegen/isa.zig
@@ -146,6 +146,15 @@ pub fn addRegToAcu(self: *Emitter, reg: u8) !void {
     try self.emitByte(reg);
 }
 
+/// `bcpy dst, src, len` (0x2C) — copy `len` (register) bytes from `[src]`
+/// to `[dst]`. All three operands are registers holding addresses / count.
+pub fn bcpy(self: *Emitter, dst: u8, src: u8, len: u8) !void {
+    try self.emitByte(Op.bcpy);
+    try self.emitByte(dst);
+    try self.emitByte(src);
+    try self.emitByte(len);
+}
+
 /// `sub reg` (0x45) — `acu ← acu - reg`.
 pub fn subRegFromAcu(self: *Emitter, reg: u8) !void {
     try self.emitByte(Op.sub_reg_acu);

--- a/src/lang/codegen/overflow.zig
+++ b/src/lang/codegen/overflow.zig
@@ -91,3 +91,16 @@ pub fn emitBoundsTrap(self: *Emitter, reg: u8, len: u16) !void {
     try self.emitByte(bounds_vector);
     try isa.patchJumpTo(self, in_bounds, try self.currentOffset());
 }
+
+/// Like `emitBoundsTrap` but against a runtime length in `len_reg` — used
+/// for `Vec` indexing, whose length isn't known at compile time.
+pub fn emitBoundsTrapReg(self: *Emitter, reg: u8, len_reg: u8) !void {
+    if (self.optimize != .debug) return;
+    try isa.cmpRegReg(self, reg, len_reg); // reg - len; C = 0 ⇒ reg >= len (OOB)
+    const oob = try isa.emitJumpPlaceholder(self, Op.jcc_addr);
+    const in_bounds = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    try isa.patchJumpTo(self, oob, try self.currentOffset());
+    try self.emitByte(Op.int_imm8);
+    try self.emitByte(bounds_vector);
+    try isa.patchJumpTo(self, in_bounds, try self.currentOffset());
+}

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -12,6 +12,7 @@ const isa = @import("isa.zig");
 const class = @import("class.zig");
 const value_struct = @import("value_struct.zig");
 const destructure = @import("destructure.zig");
+const vec_builtin = @import("vec_builtin.zig");
 const lambda = @import("lambda.zig");
 const strings = @import("strings.zig");
 
@@ -138,6 +139,11 @@ pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
     // `arr[i] = value` — store into element `i` at base + i*elem_width.
     if (a.target.* == .index) {
         const ix = a.target.index;
+        // `v[i] = x` on a Vec — sugar for `v.set(i, x)`.
+        if (vec_builtin.elemOf(self, ix.receiver)) |elem| {
+            try vec_builtin.emitIndexStore(self, ix.receiver, ix.index, a.value, elem);
+            return;
+        }
         const info = self.arrayInfoOf(ix.receiver) orelse {
             try self.unsupported(a.span, "indexed store on a non-array value");
             return;
@@ -264,6 +270,39 @@ pub fn emitIncDec(self: *Emitter, id: ast.IncDecStmt) !void {
     try emitAssign(self, .{ .target = id.target, .op = .set, .value = rhs, .span = id.span });
 }
 
+/// Element type of a Vec-typed `let` binding — from its annotation, else
+/// the initializer's type. `null` when the binding isn't a Vec.
+fn vecBindingElem(self: *Emitter, d: ast.LetDecl) ?*const types.Type {
+    if (d.type_ann) |t| if (t.* == .vec) return self.typeAnnToType(t.vec.elem.*) catch null;
+    if (d.init) |e| return vec_builtin.elemOf(self, e);
+    return null;
+}
+
+/// `true` when `mc` is a `Vec.<ctor>(...)` constructor call.
+fn isVecConstructorCall(self: *const Emitter, mc: ast.MethodCallExpr) bool {
+    if (mc.receiver.* != .ident) return false;
+    if (!std.mem.eql(u8, self.source[mc.receiver.ident.span.start..mc.receiver.ident.span.end], "Vec")) return false;
+    return vec_builtin.isConstructor(self.source[mc.method.start..mc.method.end]);
+}
+
+/// `true` when `mc` is a `v.slice(a, b)` call on a Vec receiver — handled
+/// specially in a `let` so the new header lands directly in the binding.
+fn isVecSliceCall(self: *const Emitter, mc: ast.MethodCallExpr) bool {
+    if (mc.args.len != 2) return false;
+    if (!std.mem.eql(u8, self.source[mc.method.start..mc.method.end], "slice")) return false;
+    return vec_builtin.elemOf(self, mc.receiver) != null;
+}
+
+/// `reg = fp + ofs` — the address of a frame slot.
+fn emitFrameAddr(self: *Emitter, ofs: i16, reg: u8) !void {
+    try isa.movRegToReg(self, Reg.fp, reg);
+    if (ofs < 0) {
+        try isa.subImmFromReg(self, @intCast(-ofs), reg);
+    } else if (ofs > 0) {
+        try isa.addImmToReg(self, @intCast(ofs), reg);
+    }
+}
+
 /// `let PATTERN = init` for a non-ident pattern (§4.2) — materialize the
 /// initializer into a slot and destructure it. The pattern is irrefutable
 /// (the typechecker rejects refutable `let`s), so a single-variant enum's
@@ -304,6 +343,27 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
     if (struct_name) |sname| {
         const slot = try self.allocLocalSized(dup_name, self.structWidth(sname));
         if (d.init) |init_expr| try value_struct.emitInto(self, init_expr, sname, slot);
+        return;
+    }
+
+    // Vec-typed binding — the 6-byte `(ptr, len, cap)` header (§3.4.3). A
+    // `Vec.<ctor>(...)` materializes it; any other Vec value is byte-copied.
+    if (vecBindingElem(self, d)) |elem| {
+        const slot = try self.allocLocalSized(dup_name, vec_builtin.header_size);
+        if (d.init) |init_expr| {
+            if (init_expr.* == .method_call and isVecConstructorCall(self, init_expr.method_call)) {
+                const mc = init_expr.method_call;
+                try vec_builtin.emitConstructInto(self, self.source[mc.method.start..mc.method.end], mc.args, elem, slot);
+            } else if (init_expr.* == .method_call and isVecSliceCall(self, init_expr.method_call)) {
+                const mc = init_expr.method_call;
+                try vec_builtin.emitSliceInto(self, mc.receiver, mc.args[0], mc.args[1], elem, slot);
+            } else {
+                try self.emitExpr(init_expr); // acu = source header address
+                try isa.movRegToReg(self, Reg.acu, Reg.r1);
+                try emitFrameAddr(self, slot, Reg.r2);
+                try value_struct.copyBytes(self, Reg.r1, Reg.r2, vec_builtin.header_size);
+            }
+        }
         return;
     }
 

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -270,6 +270,20 @@ pub fn emitIncDec(self: *Emitter, id: ast.IncDecStmt) !void {
     try emitAssign(self, .{ .target = id.target, .op = .set, .value = rhs, .span = id.span });
 }
 
+/// The optional type of a `T?`-typed `let` binding — from its annotation,
+/// else the initializer's type. `null` when the binding isn't optional.
+fn optBindingType(self: *Emitter, d: ast.LetDecl) ?*const types.Type {
+    if (d.type_ann) |t| if (t.* == .nullable) {
+        const ot = self.typeAnnToType(t.*) catch null;
+        if (ot != null and ot.?.* == .optional) return ot;
+    };
+    if (d.init) |e| {
+        const it = self.typeOf(e);
+        if (it != null and it.?.* == .optional) return it;
+    }
+    return null;
+}
+
 /// Element type of a Vec-typed `let` binding — from its annotation, else
 /// the initializer's type. `null` when the binding isn't a Vec.
 fn vecBindingElem(self: *Emitter, d: ast.LetDecl) ?*const types.Type {
@@ -330,6 +344,13 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
     }
     const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
     const dup_name = try self.arena.dupe(u8, name);
+
+    // Optional-typed binding — the tagged / pointer optional (§3.4.1).
+    if (optBindingType(self, d)) |opt| {
+        const slot = try self.allocLocalSized(dup_name, self.widthOfType(opt));
+        if (d.init) |init_expr| try vec_builtin.emitOptionalInto(self, init_expr, opt.optional, slot);
+        return;
+    }
 
     // Struct-typed binding: reserve the full inline slot and materialize
     // the initializer (literal fields or a value copy) straight into it

--- a/src/lang/codegen/vec_builtin.zig
+++ b/src/lang/codegen/vec_builtin.zig
@@ -1,0 +1,313 @@
+// `Vec(T)` lowering (§3.4.3) — a growable dynamic array. The value is a
+// 6-byte `(ptr, len, cap)` header stored inline (like a struct); the
+// backing buffer lives on the heap (`sys alloc`, a bump allocator — growth
+// allocates a new buffer and copies, leaking the old one). This covers the
+// non-optional surface; `pop` / `get` (which return `T?`) await the scalar-
+// optional model.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const codegen = @import("../codegen.zig");
+const opcodes = @import("opcodes.zig");
+const isa = @import("isa.zig");
+const class = @import("class.zig");
+const value_struct = @import("value_struct.zig");
+const overflow = @import("overflow.zig");
+
+const Emitter = codegen.Emitter;
+const Op = opcodes.Op;
+const Reg = opcodes.Reg;
+const Type = types.Type;
+
+/// Byte size of a `Vec` value's inline header.
+pub const header_size: u16 = 6;
+const ptr_ofs: u16 = 0;
+const len_ofs: u16 = 2;
+const cap_ofs: u16 = 4;
+
+/// Element type of a Vec-typed expression (peeling a reference), or `null`.
+pub fn elemOf(self: *const Emitter, e: *const ast.Expr) ?*const Type {
+    const t = self.typeOf(e) orelse return null;
+    const inner = if (t.* == .reference) t.reference else t;
+    return if (inner.* == .vec) inner.vec else null;
+}
+
+/// `true` when `name` is a `Vec.<name>(...)` constructor.
+pub fn isConstructor(name: []const u8) bool {
+    return std.mem.eql(u8, name, "new") or
+        std.mem.eql(u8, name, "with_capacity") or
+        std.mem.eql(u8, name, "from");
+}
+
+// ---- constructors — materialize the 6-byte header into a frame slot ----
+
+/// Materialize a `Vec.<method>(...)` result into the frame slot at
+/// `dest_ofs`. `elem` is the element type (sizing the buffer).
+pub fn emitConstructInto(self: *Emitter, method: []const u8, args: []const *ast.Expr, elem: *const Type, dest_ofs: i16) error{OutOfMemory}!void {
+    const ew = self.widthOfType(elem);
+    if (std.mem.eql(u8, method, "new")) {
+        // {ptr: 0, len: 0, cap: 0} — no buffer.
+        try frameAddr(self, dest_ofs, Reg.r1);
+        try isa.movImmToReg(self, 0, Reg.acu);
+        try class.emitWordStoreAtOffset(self, Reg.r1, ptr_ofs, Reg.acu);
+        try class.emitWordStoreAtOffset(self, Reg.r1, len_ofs, Reg.acu);
+        try class.emitWordStoreAtOffset(self, Reg.r1, cap_ofs, Reg.acu);
+        return;
+    }
+    if (std.mem.eql(u8, method, "with_capacity")) {
+        // cap = n; ptr = alloc(n * ew); len = 0.
+        try self.emitExpr(args[0]); // acu = n
+        try isa.pushReg(self, Reg.acu); // [sp] = n
+        try scaleBytes(self, Reg.acu, ew); // acu = n * ew
+        try emitAlloc(self, Reg.acu); // acu = buffer ptr
+        try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = ptr
+        try isa.popReg(self, Reg.r3); // r3 = n (cap)
+        try frameAddr(self, dest_ofs, Reg.r1); // r1 = header addr
+        try class.emitWordStoreAtOffset(self, Reg.r1, ptr_ofs, Reg.r2);
+        try class.emitWordStoreAtOffset(self, Reg.r1, cap_ofs, Reg.r3);
+        try isa.movImmToReg(self, 0, Reg.acu);
+        try class.emitWordStoreAtOffset(self, Reg.r1, len_ofs, Reg.acu);
+        return;
+    }
+    // `from([..])` — materialize a fixed array into a fresh exact-fit
+    // buffer (the literal lands directly in the heap slot).
+    const arr_ty = self.typeOf(args[0]) orelse {
+        try self.unsupported(args[0].span(), "`Vec.from` expects a fixed-array argument");
+        return;
+    };
+    if (arr_ty.* != .array) {
+        try self.unsupported(args[0].span(), "`Vec.from` expects a fixed-array argument");
+        return;
+    }
+    // @as: array count fits u16 (bounded by the i8 frame cap on the source).
+    const n: u16 = @intCast(arr_ty.array.len);
+    const bytes: u16 = n *% ew;
+    try isa.movImmToReg(self, bytes, Reg.acu);
+    try emitAlloc(self, Reg.acu); // acu = buffer ptr
+    try isa.pushReg(self, Reg.acu); // [sp] = buffer ptr
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.acu); // acu = buffer ptr (dest)
+    try value_struct.emitAggregateStoreInto(self, args[0], arr_ty, Reg.acu); // array → [buffer]
+    try isa.popReg(self, Reg.r2); // r2 = buffer ptr
+    try frameAddr(self, dest_ofs, Reg.r1); // r1 = header addr
+    try class.emitWordStoreAtOffset(self, Reg.r1, ptr_ofs, Reg.r2);
+    try isa.movImmToReg(self, n, Reg.acu);
+    try class.emitWordStoreAtOffset(self, Reg.r1, len_ofs, Reg.acu);
+    try class.emitWordStoreAtOffset(self, Reg.r1, cap_ofs, Reg.acu);
+}
+
+/// Materialize a `recv.slice(a, b)` borrowed view into the frame slot at
+/// `dest_ofs`: a new header aliasing the parent's buffer (`ptr = parent.ptr
+/// + a*ew`, `len = cap = b - a`). Mutating the slice mutates the parent.
+pub fn emitSliceInto(self: *Emitter, recv: *const ast.Expr, a: *const ast.Expr, b: *const ast.Expr, elem: *const Type, dest_ofs: i16) error{OutOfMemory}!void {
+    const ew = self.widthOfType(elem);
+    try self.emitExpr(b); // acu = b
+    try isa.pushReg(self, Reg.acu); // [sp] = b
+    try self.emitExpr(a); // acu = a
+    try isa.pushReg(self, Reg.acu); // [sp] = a, [sp+2] = b
+    // new ptr = parent.ptr + a*ew.
+    try headerAddr(self, recv, Reg.r1); // r1 = parent header addr
+    try class.emitWordLoadAtOffset(self, Reg.r1, ptr_ofs, Reg.r2); // r2 = parent ptr
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.acu); // acu = a
+    try scaleBytes(self, Reg.acu, ew); // acu = a*ew
+    try isa.addRegToAcu(self, Reg.r2); // acu = parent.ptr + a*ew
+    try isa.movRegToReg(self, Reg.acu, Reg.r3); // r3 = new ptr
+    // new len = cap = b - a.
+    try isa.movRegOffsetToReg(self, Reg.sp, 2, Reg.acu); // acu = b
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = a
+    try isa.subRegFromAcu(self, Reg.r1); // acu = b - a
+    try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = len
+    try frameAddr(self, dest_ofs, Reg.r1); // r1 = header addr
+    try class.emitWordStoreAtOffset(self, Reg.r1, ptr_ofs, Reg.r3);
+    try class.emitWordStoreAtOffset(self, Reg.r1, len_ofs, Reg.r2);
+    try class.emitWordStoreAtOffset(self, Reg.r1, cap_ofs, Reg.r2);
+    try isa.addImmToReg(self, 4, Reg.sp); // drop a, b
+}
+
+// ---- instance methods — receiver evaluates to the header's base address ----
+
+/// Lower `recv.<method>(args)` for a Vec receiver of element type `elem`.
+pub fn emitMethod(self: *Emitter, recv: *const ast.Expr, method: []const u8, args: []const *ast.Expr, elem: *const Type) error{OutOfMemory}!void {
+    const ew = self.widthOfType(elem);
+    if (std.mem.eql(u8, method, "len")) {
+        try headerAddr(self, recv, Reg.r1);
+        try class.emitWordLoadAtOffset(self, Reg.r1, len_ofs, Reg.acu);
+        return;
+    }
+    if (std.mem.eql(u8, method, "cap")) {
+        try headerAddr(self, recv, Reg.r1);
+        try class.emitWordLoadAtOffset(self, Reg.r1, cap_ofs, Reg.acu);
+        return;
+    }
+    if (std.mem.eql(u8, method, "clear")) {
+        try headerAddr(self, recv, Reg.r1);
+        try isa.movImmToReg(self, 0, Reg.acu);
+        try class.emitWordStoreAtOffset(self, Reg.r1, len_ofs, Reg.acu);
+        return;
+    }
+    if (std.mem.eql(u8, method, "at")) {
+        try emitIndexLoad(self, recv, args[0], elem);
+        return;
+    }
+    if (std.mem.eql(u8, method, "set")) {
+        try emitIndexStore(self, recv, args[0], args[1], elem);
+        return;
+    }
+    if (std.mem.eql(u8, method, "push")) {
+        try emitPush(self, recv, args[0], ew);
+        return;
+    }
+    if (std.mem.eql(u8, method, "slice")) {
+        // A `slice` returns a new Vec value — only lowered when its result
+        // binds to a `let` (which routes through `emitSliceInto`).
+        try self.unsupported(recv.span(), "`Vec.slice` result must bind to a `let`");
+        return;
+    }
+    try self.unsupported(recv.span(), "this Vec method");
+}
+
+/// `acu = &element[idx]` of the Vec at `recv`, debug-bounds-trapped against
+/// `len` ($02). Clobbers r1 / r3 / acu; balances its own stack use.
+pub fn emitElemAddr(self: *Emitter, recv: *const ast.Expr, idx_expr: *const ast.Expr, ew: u16) error{OutOfMemory}!void {
+    try headerAddr(self, recv, Reg.acu); // acu = header addr
+    try isa.pushReg(self, Reg.acu); // [sp] = header addr
+    try self.emitExpr(idx_expr); // acu = index (sp-neutral)
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = header
+    try class.emitWordLoadAtOffset(self, Reg.r1, len_ofs, Reg.r1); // r1 = len
+    try overflow.emitBoundsTrapReg(self, Reg.acu, Reg.r1); // trap idx >= len
+    try value_struct.scaleIndex(self, Reg.acu, ew); // acu = idx * ew
+    try isa.popReg(self, Reg.r1); // r1 = header addr
+    try class.emitWordLoadAtOffset(self, Reg.r1, ptr_ofs, Reg.r1); // r1 = buffer ptr
+    try isa.addRegToAcu(self, Reg.r1); // acu = ptr + idx*ew
+}
+
+/// `v[idx]` load — leaves the element value in `acu` (`at` / index-read).
+pub fn emitIndexLoad(self: *Emitter, recv: *const ast.Expr, idx: *const ast.Expr, elem: *const Type) error{OutOfMemory}!void {
+    try emitElemAddr(self, recv, idx, self.widthOfType(elem)); // acu = &elem
+    try loadElem(self, Reg.acu, elem);
+}
+
+/// `v[idx] = val` store (`set` / index-write).
+pub fn emitIndexStore(self: *Emitter, recv: *const ast.Expr, idx: *const ast.Expr, val: *const ast.Expr, elem: *const Type) error{OutOfMemory}!void {
+    const ew = self.widthOfType(elem);
+    try self.emitExpr(val); // acu = value
+    try isa.pushReg(self, Reg.acu); // [sp] = value
+    try emitElemAddr(self, recv, idx, ew); // acu = &elem (balances its own stack)
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = &elem
+    try isa.popReg(self, Reg.r2); // r2 = value
+    try storeElem(self, Reg.r1, ew, Reg.r2);
+}
+
+fn emitPush(self: *Emitter, recv: *const ast.Expr, val_expr: *const ast.Expr, ew: u16) error{OutOfMemory}!void {
+    try self.emitExpr(val_expr); // acu = value
+    try isa.pushReg(self, Reg.acu); // value → [sp+2] after the header push
+    try headerAddr(self, recv, Reg.acu);
+    try isa.pushReg(self, Reg.acu); // [sp] = header addr
+    // Grow when len == cap.
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = header
+    try class.emitWordLoadAtOffset(self, Reg.r1, len_ofs, Reg.r2); // r2 = len
+    try class.emitWordLoadAtOffset(self, Reg.r1, cap_ofs, Reg.r3); // r3 = cap
+    try isa.cmpRegReg(self, Reg.r2, Reg.r3);
+    const skip_grow = try isa.emitJumpPlaceholder(self, Op.jne_addr);
+    try emitGrow(self, ew); // header stays at [sp+0]; updates ptr + cap
+    try isa.patchJumpTo(self, skip_grow, try self.currentOffset());
+    // Store value at &buffer[len].
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = header
+    try class.emitWordLoadAtOffset(self, Reg.r1, len_ofs, Reg.acu); // acu = len
+    try value_struct.scaleIndex(self, Reg.acu, ew); // acu = len*ew
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = header (re-derive)
+    try class.emitWordLoadAtOffset(self, Reg.r1, ptr_ofs, Reg.r2); // r2 = ptr
+    try isa.addRegToAcu(self, Reg.r2); // acu = &slot
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = &slot
+    try isa.movRegOffsetToReg(self, Reg.sp, 2, Reg.r2); // r2 = value
+    try storeElem(self, Reg.r1, ew, Reg.r2);
+    // len += 1.
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1);
+    try class.emitWordLoadAtOffset(self, Reg.r1, len_ofs, Reg.r2);
+    try isa.addImmToReg(self, 1, Reg.r2);
+    try class.emitWordStoreAtOffset(self, Reg.r1, len_ofs, Reg.r2);
+    try isa.addImmToReg(self, 4, Reg.sp); // drop header + value
+}
+
+/// Grow the Vec whose header address is at `[sp + 0]`: new_cap =
+/// max(1, cap*2); alloc; copy `len*ew` bytes; write back ptr + cap. The
+/// header stays at `[sp + 0]` on exit (the temporaries are dropped).
+fn emitGrow(self: *Emitter, ew: u16) error{OutOfMemory}!void {
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = header
+    try class.emitWordLoadAtOffset(self, Reg.r1, cap_ofs, Reg.r2); // r2 = cap
+    // new_cap = cap == 0 ? 1 : cap*2.
+    try isa.cmpRegImm(self, Reg.r2, 0);
+    const nonzero = try isa.emitJumpPlaceholder(self, Op.jne_addr);
+    try isa.movImmToReg(self, 1, Reg.r2);
+    const have_cap = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    try isa.patchJumpTo(self, nonzero, try self.currentOffset());
+    try isa.shlRegImm(self, Reg.r2, 1); // cap * 2
+    try isa.patchJumpTo(self, have_cap, try self.currentOffset());
+    try isa.pushReg(self, Reg.r2); // [sp] = new_cap; header now [sp+2]
+    // Allocate new_cap * ew bytes.
+    try isa.movRegToReg(self, Reg.r2, Reg.acu);
+    try scaleBytes(self, Reg.acu, ew);
+    try emitAlloc(self, Reg.acu); // acu = new buffer
+    try isa.pushReg(self, Reg.acu); // [sp]=new_ptr; [sp+2]=new_cap; [sp+4]=header
+    // Copy len*ew bytes from old ptr to new ptr.
+    try isa.movRegOffsetToReg(self, Reg.sp, 4, Reg.r1); // r1 = header
+    try class.emitWordLoadAtOffset(self, Reg.r1, len_ofs, Reg.acu); // acu = len
+    try scaleBytes(self, Reg.acu, ew); // acu = len*ew
+    try isa.movRegToReg(self, Reg.acu, Reg.r3); // r3 = byte count
+    try isa.movRegOffsetToReg(self, Reg.sp, 4, Reg.r1); // r1 = header
+    try class.emitWordLoadAtOffset(self, Reg.r1, ptr_ofs, Reg.r2); // r2 = old ptr
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = new ptr
+    try isa.bcpy(self, Reg.r1, Reg.r2, Reg.r3); // dst, src, len
+    // header.ptr = new ptr; header.cap = new_cap.
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r2); // r2 = new ptr
+    try isa.movRegOffsetToReg(self, Reg.sp, 2, Reg.r3); // r3 = new_cap
+    try isa.movRegOffsetToReg(self, Reg.sp, 4, Reg.r1); // r1 = header
+    try class.emitWordStoreAtOffset(self, Reg.r1, ptr_ofs, Reg.r2);
+    try class.emitWordStoreAtOffset(self, Reg.r1, cap_ofs, Reg.r3);
+    try isa.addImmToReg(self, 4, Reg.sp); // drop new_ptr + new_cap
+}
+
+// ---- shared element load / store ----
+
+fn loadElem(self: *Emitter, addr_reg: u8, elem: *const Type) error{OutOfMemory}!void {
+    if (self.widthOfType(elem) == 1) {
+        try class.emitByteLoadAtOffset(self, addr_reg, 0, Reg.acu);
+        if (elem.* == .primitive and elem.primitive == .i8) try isa.signExtendByte(self, Reg.acu);
+    } else {
+        try class.emitWordLoadAtOffset(self, addr_reg, 0, Reg.acu);
+    }
+}
+
+fn storeElem(self: *Emitter, addr_reg: u8, ew: u16, src: u8) error{OutOfMemory}!void {
+    if (ew == 1) {
+        try class.emitByteStoreAtOffset(self, addr_reg, 0, src);
+    } else {
+        try class.emitWordStoreAtOffset(self, addr_reg, 0, src);
+    }
+}
+
+fn headerAddr(self: *Emitter, recv: *const ast.Expr, reg: u8) error{OutOfMemory}!void {
+    try self.emitExpr(recv); // acu = header base address (a Vec value is its address)
+    if (reg != Reg.acu) try isa.movRegToReg(self, Reg.acu, reg);
+}
+
+fn emitAlloc(self: *Emitter, size_reg: u8) error{OutOfMemory}!void {
+    if (size_reg != Reg.acu) try isa.movRegToReg(self, size_reg, Reg.acu);
+    try self.emitByte(Op.sys);
+    try self.emitByte(opcodes.Sys.alloc);
+}
+
+/// `reg = reg * ew` — an element count to a byte count (reuses the array
+/// index scaler).
+fn scaleBytes(self: *Emitter, reg: u8, ew: u16) error{OutOfMemory}!void {
+    try value_struct.scaleIndex(self, reg, ew);
+}
+
+fn frameAddr(self: *Emitter, ofs: i16, reg: u8) error{OutOfMemory}!void {
+    try isa.movRegToReg(self, Reg.fp, reg);
+    if (ofs < 0) {
+        try isa.subImmFromReg(self, @intCast(-ofs), reg);
+    } else if (ofs > 0) {
+        try isa.addImmToReg(self, @intCast(ofs), reg);
+    }
+}

--- a/src/lang/codegen/vec_builtin.zig
+++ b/src/lang/codegen/vec_builtin.zig
@@ -124,6 +124,101 @@ pub fn emitSliceInto(self: *Emitter, recv: *const ast.Expr, a: *const ast.Expr, 
     try isa.addImmToReg(self, 4, Reg.sp); // drop a, b
 }
 
+/// Materialize `recv.pop()` — a `T?` — into the frame slot at `dest_ofs`:
+/// when `len > 0`, `{present: 1, value: buf[len-1]}` and `len -= 1`; else
+/// `{present: 0, value: 0}`. Scalar element types only (the 4-byte tagged
+/// optional); pointer-element pop awaits the pointer-optional path.
+pub fn emitPopInto(self: *Emitter, recv: *const ast.Expr, elem: *const Type, dest_ofs: i16) error{OutOfMemory}!void {
+    const ew = self.widthOfType(elem);
+    try headerAddr(self, recv, Reg.acu);
+    try isa.pushReg(self, Reg.acu); // [sp] = vec header addr
+    try class.emitWordLoadAtOffset(self, Reg.acu, len_ofs, Reg.r2); // r2 = len
+    try isa.cmpRegImm(self, Reg.r2, 0);
+    const empty = try isa.emitJumpPlaceholder(self, Op.jeq_addr);
+    // Present: len -= 1; value = buf[len].
+    try isa.subImmFromReg(self, 1, Reg.r2); // r2 = len - 1 (the popped index + new len)
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = vec header
+    try class.emitWordStoreAtOffset(self, Reg.r1, len_ofs, Reg.r2); // len = len - 1
+    try isa.movRegToReg(self, Reg.r2, Reg.acu); // acu = index
+    try value_struct.scaleIndex(self, Reg.acu, ew); // acu = index * ew
+    try isa.movRegOffsetToReg(self, Reg.sp, 0, Reg.r1); // r1 = vec header
+    try class.emitWordLoadAtOffset(self, Reg.r1, ptr_ofs, Reg.r1); // r1 = buffer ptr
+    try isa.addRegToAcu(self, Reg.r1); // acu = &buf[index]
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = element addr
+    try loadElem(self, Reg.r1, elem); // acu = popped value
+    try storeOptional(self, dest_ofs, 1, Reg.acu);
+    const done = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    // Empty: {present: 0, value: 0}.
+    try isa.patchJumpTo(self, empty, try self.currentOffset());
+    try isa.movImmToReg(self, 0, Reg.acu);
+    try storeOptional(self, dest_ofs, 0, Reg.acu);
+    try isa.patchJumpTo(self, done, try self.currentOffset());
+    try isa.addImmToReg(self, 2, Reg.sp); // drop vec header addr
+}
+
+/// Materialize `recv.get(i)` — a `T?` — into `[fp + dest_ofs]`: when
+/// `i < len`, `{1, buf[i]}`; else `{0, 0}`. Scalar element types only.
+pub fn emitGetInto(self: *Emitter, recv: *const ast.Expr, idx: *const ast.Expr, elem: *const Type, dest_ofs: i16) error{OutOfMemory}!void {
+    const ew = self.widthOfType(elem);
+    try headerAddr(self, recv, Reg.acu);
+    try isa.pushReg(self, Reg.acu); // [sp] = vec header
+    try self.emitExpr(idx); // acu = index (sp-neutral)
+    try isa.pushReg(self, Reg.acu); // [sp] = index, [sp+2] = header
+    try isa.movRegOffsetToReg(self, Reg.sp, 2, Reg.r1); // r1 = header
+    try class.emitWordLoadAtOffset(self, Reg.r1, len_ofs, Reg.r2); // r2 = len
+    try isa.cmpRegReg(self, Reg.acu, Reg.r2); // index - len; C=0 ⇒ index >= len
+    const absent = try isa.emitJumpPlaceholder(self, Op.jcc_addr); // index >= len → None
+    // Present: value = buf[index].
+    try value_struct.scaleIndex(self, Reg.acu, ew); // acu = index*ew
+    try isa.movRegOffsetToReg(self, Reg.sp, 2, Reg.r1); // r1 = header
+    try class.emitWordLoadAtOffset(self, Reg.r1, ptr_ofs, Reg.r1); // r1 = buffer ptr
+    try isa.addRegToAcu(self, Reg.r1); // acu = &buf[index]
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try loadElem(self, Reg.r1, elem); // acu = value
+    try storeOptional(self, dest_ofs, 1, Reg.acu);
+    const done = try isa.emitJumpPlaceholder(self, Op.jmp_addr);
+    try isa.patchJumpTo(self, absent, try self.currentOffset());
+    try isa.movImmToReg(self, 0, Reg.acu);
+    try storeOptional(self, dest_ofs, 0, Reg.acu);
+    try isa.patchJumpTo(self, done, try self.currentOffset());
+    try isa.addImmToReg(self, 4, Reg.sp); // drop index + header
+}
+
+/// Materialize an optional-producing expression into the frame slot at
+/// `dest_ofs`: `v.pop()` / `v.get(i)` (the producers), `nil` (absent), or
+/// another optional value (byte-copied). `inner` is the element type.
+pub fn emitOptionalInto(self: *Emitter, src: *const ast.Expr, inner: *const Type, dest_ofs: i16) error{OutOfMemory}!void {
+    if (src.* == .method_call) {
+        const mc = src.method_call;
+        if (elemOf(self, mc.receiver) != null) {
+            const m = self.source[mc.method.start..mc.method.end];
+            if (std.mem.eql(u8, m, "pop")) return emitPopInto(self, mc.receiver, inner, dest_ofs);
+            if (std.mem.eql(u8, m, "get")) return emitGetInto(self, mc.receiver, mc.args[0], inner, dest_ofs);
+        }
+    }
+    if (src.* == .nil_lit) {
+        try isa.movImmToReg(self, 0, Reg.acu);
+        try storeOptional(self, dest_ofs, 0, Reg.acu);
+        return;
+    }
+    // Another optional value — byte-copy its header.
+    try self.emitExpr(src); // acu = source optional address
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try frameAddr(self, dest_ofs, Reg.r2);
+    const w: u16 = if (codegen.Emitter.isScalarOptional(inner)) codegen.Emitter.opt_scalar_size else 2;
+    try value_struct.copyBytes(self, Reg.r1, Reg.r2, w);
+}
+
+/// Store a scalar optional `{present, value}` into the 4-byte slot at
+/// `[fp + dest_ofs]` (`value` ignored when `present == 0`).
+fn storeOptional(self: *Emitter, dest_ofs: i16, present: u16, value_reg: u8) error{OutOfMemory}!void {
+    try isa.movRegToReg(self, value_reg, Reg.r2); // r2 = value (before frameAddr clobbers regs)
+    try frameAddr(self, dest_ofs, Reg.r1); // r1 = optional header addr
+    try isa.movImmToReg(self, present, Reg.acu);
+    try class.emitWordStoreAtOffset(self, Reg.r1, codegen.Emitter.opt_present_ofs, Reg.acu);
+    try class.emitWordStoreAtOffset(self, Reg.r1, codegen.Emitter.opt_value_ofs, Reg.r2);
+}
+
 // ---- instance methods — receiver evaluates to the header's base address ----
 
 /// Lower `recv.<method>(args)` for a Vec receiver of element type `elem`.

--- a/src/lang/expr.zig
+++ b/src/lang/expr.zig
@@ -335,7 +335,9 @@ fn parseFieldOrMethod(p: *Parser, receiver: *ast.Expr) ParserError!*ast.Expr {
             .span = .{ .start = receiver.span().start, .end = tok.end },
         } });
     }
-    const name_tok = try p.expect(.ident, "field or method name");
+    // A name after `.` is unambiguously a member — accept the `from`
+    // keyword (otherwise reserved for `use … from`) so `Vec.from(…)` parses.
+    const name_tok = if (p.accept(.kw_from)) |t| t else try p.expect(.ident, "field or method name");
     if (p.check(.lparen)) {
         p.pos += 1;
         p.skipNewlines();

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -137,6 +137,7 @@ pub fn typecheck(
 const mem_builtin = @import("typecheck/mem_builtin.zig");
 const stdlib = @import("typecheck/stdlib.zig");
 const match = @import("typecheck/match.zig");
+const vec_builtin = @import("typecheck/vec_builtin.zig");
 const predicates = @import("typecheck/predicates.zig");
 const annotations = @import("typecheck/annotations.zig");
 const relations = @import("typecheck/relations.zig");
@@ -1193,6 +1194,10 @@ pub const Checker = struct {
                     if (stdlib.isModule(recv_name)) {
                         return try stdlib.checkCall(self, recv_name, m.method, m.args, m.span);
                     }
+                    // `Vec.new` / `with_capacity` / `from` — Vec constructors.
+                    if (std.mem.eql(u8, recv_name, "Vec") and vec_builtin.isConstructor(self.lexeme(m.method))) {
+                        return try vec_builtin.checkConstructor(self, m, hint);
+                    }
                     // `Enum.Variant(args)` is indistinguishable from a
                     // method call at parse time — resolve it as a
                     // payload-variant constructor.
@@ -1202,6 +1207,10 @@ pub const Checker = struct {
                 }
                 const recv_ty = try self.inferExpr(m.receiver, null);
                 try self.checkNotNullableDeref(m.receiver, recv_ty, m.span);
+                // Vec instance method (`v.push` / `v.len` / `v.at` / …).
+                if (peelReference(recv_ty)) |peeled| if (peeled.* == .vec) {
+                    return try vec_builtin.checkMethod(self, m, peeled.vec);
+                };
                 return try fields.checkMethodCall(self, m, peelReference(recv_ty));
             },
             .field => |f| {
@@ -1271,6 +1280,9 @@ pub const Checker = struct {
                         }
                         return peeled.array.elem;
                     }
+                    // `v[i]` on a `Vec(T)` — element type (length is dynamic,
+                    // so no compile-time bounds check; debug-traps at runtime).
+                    if (peeled.* == .vec) return peeled.vec;
                 }
                 return null;
             },

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -940,6 +940,9 @@ pub const Checker = struct {
     /// — used by `if let` / `while let` and `match` arms so no binder is
     /// left `null`-typed (the strong-typing rule).
     pub fn registerBindingsFromType(self: *Checker, pat: *const ast.Pattern, ty: ?*const types.Type) WalkError!void {
+        // `if let` / `while let` unwrap an optional (§3.4.1) — bind the
+        // pattern against the inner (non-nil) type.
+        if (ty) |t| if (t.* == .optional) return self.registerBindingsFromType(pat, t.optional);
         switch (pat.*) {
             .ident => |i| try self.registerName(self.lexeme(i.name), .{
                 .kind = .let_binding,

--- a/src/lang/typecheck/type_resolve.zig
+++ b/src/lang/typecheck/type_resolve.zig
@@ -31,11 +31,11 @@ pub fn resolveType(self: *Checker, t: *const ast.TypeAnn) WalkError!*const types
         },
         .nullable => |n| {
             const inner = try resolveType(self, n.inner);
-            if (!isPointerLike(self, inner.*)) {
+            if (!isOptionalInner(self, inner.*)) {
                 const inner_s = try types.render(self.arena, inner.*);
                 const msg = try std.fmt.allocPrint(
                     self.arena,
-                    "type `{s}?` is invalid — `T?` only applies to pointer-like types (`str`, class, fn-pointer, references)",
+                    "type `{s}?` is invalid — `T?` applies to pointer-like types (`str`, class, fn-pointer, references) or scalars (`i8` / `u8` / `i16` / `u16` / `char` / `bool` / `fixed`)",
                     .{inner_s},
                 );
                 try self.emitSpan("E_NULL_NON_POINTER", n.span, msg);
@@ -92,6 +92,19 @@ pub fn resolveType(self: *Checker, t: *const ast.TypeAnn) WalkError!*const types
 /// Pointer-like types per §3.4.1 — `str`, references, function
 /// pointers, and class names. Struct / enum / numeric / bool /
 /// fixed are by-value and therefore not nullable-eligible.
+/// Whether `t` is a valid `T?` inner type — pointer-like (a single-word
+/// nullable pointer, `nil` = 0) or a scalar (a tagged `{present, value}`
+/// optional). Aggregates (array / tuple / `Vec` / struct) are rejected.
+pub fn isOptionalInner(self: *const Checker, t: types.Type) bool {
+    if (isPointerLike(self, t)) return true;
+    return t == .primitive and switch (t.primitive) {
+        .i8, .u8, .i16, .u16, .char, .bool_, .fixed => true,
+        .str, .nil_ => false, // `str` is pointer-like (handled above)
+    };
+}
+
+/// Whether `t` is a pointer-like type (`str`, class, fn-pointer, reference)
+/// — represented as a single nullable-pointer word (`nil` = 0).
 pub fn isPointerLike(self: *const Checker, t: types.Type) bool {
     return switch (t) {
         .primitive => |p| p == .str,

--- a/src/lang/typecheck/vec_builtin.zig
+++ b/src/lang/typecheck/vec_builtin.zig
@@ -1,0 +1,101 @@
+// Type-checking for the compiler-known `Vec(T)` surface (§3.4.3). Mirrors
+// `mem_builtin` — a fixed set of method signatures, generic over the
+// receiver's element type `T`. The non-optional surface; `pop` / `get`
+// (which return `T?`) await the scalar-optional model.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const types = @import("../types.zig");
+const typecheck = @import("../typecheck.zig");
+
+const Checker = typecheck.Checker;
+const WalkError = error{OutOfMemory};
+
+/// `true` when `name` is a `Vec.<name>(...)` constructor.
+pub fn isConstructor(name: []const u8) bool {
+    return std.mem.eql(u8, name, "new") or
+        std.mem.eql(u8, name, "with_capacity") or
+        std.mem.eql(u8, name, "from");
+}
+
+/// Type-check `Vec.<ctor>(args)`, returning the constructed `Vec(T)`. `T`
+/// comes from the annotation hint (`new` / `with_capacity`) or the array
+/// argument's element type (`from`).
+pub fn checkConstructor(self: *Checker, m: ast.MethodCallExpr, hint: ?*const types.Type) WalkError!?*const types.Type {
+    const method = self.lexeme(m.method);
+    if (std.mem.eql(u8, method, "from")) {
+        if (try expectArity(self, m, 1)) return null;
+        const arg_ty = try self.inferExpr(m.args[0], null);
+        if (arg_ty) |at| if (at.* == .array) return try types.mkVec(self.arena, at.array.elem);
+        try self.emitSpan("E_TYPE_MISMATCH", m.span, "`Vec.from` expects a fixed-array argument");
+        return null;
+    }
+    const vec_ty: *const types.Type = if (hint != null and hint.?.* == .vec)
+        hint.?
+    else {
+        try self.emitSpan("E_TYPE_AMBIGUOUS_INFER", m.span, "cannot infer `Vec` element type — annotate the binding (`let v: Vec(T) = …`)");
+        return null;
+    };
+    if (std.mem.eql(u8, method, "new")) {
+        if (try expectArity(self, m, 0)) return null;
+        return vec_ty;
+    }
+    // `with_capacity(n)` — `n: u16`.
+    if (try expectArity(self, m, 1)) return null;
+    _ = try self.inferExpr(m.args[0], try types.mkPrimitive(self.arena, .u16));
+    return vec_ty;
+}
+
+/// Type-check a Vec instance method `v.<method>(args)`; `elem` is the
+/// receiver's element type. Returns the method's result type.
+pub fn checkMethod(self: *Checker, m: ast.MethodCallExpr, elem: *const types.Type) WalkError!?*const types.Type {
+    const method = self.lexeme(m.method);
+    const u16_ty = try types.mkPrimitive(self.arena, .u16);
+    const nil_ty = try types.mkPrimitive(self.arena, .nil_);
+    if (std.mem.eql(u8, method, "len") or std.mem.eql(u8, method, "cap")) {
+        if (try expectArity(self, m, 0)) return null;
+        return u16_ty;
+    }
+    if (std.mem.eql(u8, method, "clear")) {
+        if (try expectArity(self, m, 0)) return null;
+        return nil_ty;
+    }
+    if (std.mem.eql(u8, method, "at")) {
+        if (try expectArity(self, m, 1)) return null;
+        _ = try self.inferExpr(m.args[0], u16_ty);
+        return elem;
+    }
+    if (std.mem.eql(u8, method, "set")) {
+        if (try expectArity(self, m, 2)) return null;
+        _ = try self.inferExpr(m.args[0], u16_ty);
+        _ = try self.inferExpr(m.args[1], elem);
+        return nil_ty;
+    }
+    if (std.mem.eql(u8, method, "push")) {
+        if (try expectArity(self, m, 1)) return null;
+        _ = try self.inferExpr(m.args[0], elem);
+        return nil_ty;
+    }
+    if (std.mem.eql(u8, method, "slice")) {
+        if (try expectArity(self, m, 2)) return null;
+        _ = try self.inferExpr(m.args[0], u16_ty);
+        _ = try self.inferExpr(m.args[1], u16_ty);
+        return try types.mkVec(self.arena, elem);
+    }
+    if (std.mem.eql(u8, method, "pop") or std.mem.eql(u8, method, "get")) {
+        try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.span, "`Vec.pop` / `Vec.get` return `T?` and await the scalar-optional model — use `len` / `at` for now");
+        return null;
+    }
+    const msg = try std.fmt.allocPrint(self.arena, "`Vec` has no method `{s}`", .{method});
+    try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
+    return null;
+}
+
+/// Emit `E_TYPE_ARG_COUNT` when `m` doesn't have exactly `n` args; returns
+/// `true` on mismatch (the caller bails).
+fn expectArity(self: *Checker, m: ast.MethodCallExpr, n: usize) WalkError!bool {
+    if (m.args.len == n) return false;
+    const msg = try std.fmt.allocPrint(self.arena, "`Vec.{s}` takes {d} argument(s), got {d}", .{ self.lexeme(m.method), n, m.args.len });
+    try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
+    return true;
+}

--- a/src/lang/typecheck/vec_builtin.zig
+++ b/src/lang/typecheck/vec_builtin.zig
@@ -82,9 +82,14 @@ pub fn checkMethod(self: *Checker, m: ast.MethodCallExpr, elem: *const types.Typ
         _ = try self.inferExpr(m.args[1], u16_ty);
         return try types.mkVec(self.arena, elem);
     }
-    if (std.mem.eql(u8, method, "pop") or std.mem.eql(u8, method, "get")) {
-        try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.span, "`Vec.pop` / `Vec.get` return `T?` and await the scalar-optional model — use `len` / `at` for now");
-        return null;
+    if (std.mem.eql(u8, method, "pop")) {
+        if (try expectArity(self, m, 0)) return null;
+        return try types.mkOptional(self.arena, elem);
+    }
+    if (std.mem.eql(u8, method, "get")) {
+        if (try expectArity(self, m, 1)) return null;
+        _ = try self.inferExpr(m.args[0], u16_ty);
+        return try types.mkOptional(self.arena, elem);
     }
     const msg = try std.fmt.allocPrint(self.arena, "`Vec` has no method `{s}`", .{method});
     try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -6483,3 +6483,89 @@ test "codegen/destructure: aggregate enum payload destructures in place" {
         \\end
     , "1\n2\n");
 }
+
+// ---------- Vec(T): growable dynamic array (#314) ----------
+
+test "codegen/vec: new + push grows + len + at" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.new()
+        \\  v.push(10)
+        \\  v.push(20)
+        \\  v.push(30)
+        \\  print v.len()
+        \\  print v.at(0)
+        \\  print v.at(2)
+        \\end
+    , "3\n10\n30\n");
+}
+
+test "codegen/vec: from + cap + index read/write + set" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([5, 6, 7])
+        \\  print v.len()
+        \\  print v.cap()
+        \\  print v[1]
+        \\  v.set(1, 99)
+        \\  print v[1]
+        \\  v[2] = 88
+        \\  print v.at(2)
+        \\end
+    , "3\n3\n6\n99\n88\n");
+}
+
+test "codegen/vec: with_capacity + clear keeps capacity" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.with_capacity(8)
+        \\  print v.cap()
+        \\  print v.len()
+        \\  v.push(1)
+        \\  v.push(2)
+        \\  print v.len()
+        \\  v.clear()
+        \\  print v.len()
+        \\  print v.cap()
+        \\end
+    , "8\n0\n2\n0\n8\n");
+}
+
+test "codegen/vec: slice is a borrowed view aliasing the parent" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([10, 20, 30, 40, 50])
+        \\  let s: Vec(i16) = v.slice(1, 4)
+        \\  print s.len()
+        \\  print s[0]
+        \\  print s[2]
+        \\  s[0] = 99
+        \\  print v[1]
+        \\end
+    , "3\n20\n40\n99\n");
+}
+
+test "codegen/vec: value binding copies the header" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([1, 2, 3])
+        \\  let v2: Vec(i16) = v
+        \\  print v2.len()
+        \\  print v2[0]
+        \\  print v2[2]
+        \\end
+    , "3\n1\n3\n");
+}
+
+test "codegen/vec: byte element type (u8)" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(u8) = Vec.new()
+        \\  v.push(200)
+        \\  v.push(5)
+        \\  print v.len()
+        \\  print v.at(0)
+        \\  print v[1]
+        \\end
+    , "2\n200\n5\n");
+}

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -6569,3 +6569,50 @@ test "codegen/vec: byte element type (u8)" {
         \\end
     , "2\n200\n5\n");
 }
+
+test "codegen/vec: pop returns the last element + shrinks; empty pops None" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([10, 20, 30])
+        \\  if let n = v.pop()
+        \\    print n
+        \\  end
+        \\  print v.len()
+        \\  v.clear()
+        \\  if let m = v.pop()
+        \\    print m
+        \\  else
+        \\    print 0
+        \\  end
+        \\end
+    , "30\n2\n0\n");
+}
+
+test "codegen/vec: get returns an in-bounds element, None past the end" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([7, 8, 9])
+        \\  if let a = v.get(1)
+        \\    print a
+        \\  end
+        \\  if let b = v.get(99)
+        \\    print b
+        \\  else
+        \\    print 0
+        \\  end
+        \\end
+    , "8\n0\n");
+}
+
+test "codegen/vec: scalar optional == nil / != nil tests the present tag" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.new()
+        \\  let x: i16? = v.pop()
+        \\  print x == nil
+        \\  v.push(5)
+        \\  let y: i16? = v.pop()
+        \\  print y != nil
+        \\end
+    , "1\n1\n");
+}

--- a/tests/lang/codegen/vec_builtin.test.zig
+++ b/tests/lang/codegen/vec_builtin.test.zig
@@ -1,0 +1,9 @@
+/// Smoke that the `vec_builtin` codegen module is reachable through the
+/// public barrel. End-to-end `Vec(T)` coverage (construct / push / grow /
+/// at / set / slice / value-copy) lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/vec_builtin: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.vec_builtin;
+}

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -849,22 +849,22 @@ test "typecheck: class? accepts" {
     );
 }
 
-test "typecheck: i16? errors with E_NULL_NON_POINTER" {
-    try expectCode(
+test "typecheck: i16? is a valid scalar optional" {
+    try expectClean(
         \\let x: i16? = nil
-    , "E_NULL_NON_POINTER");
+    );
 }
 
-test "typecheck: bool? errors with E_NULL_NON_POINTER" {
-    try expectCode(
+test "typecheck: bool? is a valid scalar optional" {
+    try expectClean(
         \\let x: bool? = nil
-    , "E_NULL_NON_POINTER");
+    );
 }
 
-test "typecheck: fixed? errors with E_NULL_NON_POINTER" {
-    try expectCode(
+test "typecheck: fixed? is a valid scalar optional" {
+    try expectClean(
         \\let x: fixed? = nil
-    , "E_NULL_NON_POINTER");
+    );
 }
 
 test "typecheck: struct? errors (structs are by-value)" {
@@ -2724,13 +2724,14 @@ test "typecheck/vec: `Vec.new` without an annotation can't infer T" {
     , "E_TYPE_AMBIGUOUS_INFER");
 }
 
-test "typecheck/vec: `pop` is deferred (returns T?, awaits scalar optionals)" {
-    try expectCode(
+test "typecheck/vec: `pop` / `get` return a scalar optional" {
+    try expectClean(
         \\def main()
-        \\  let v: Vec(i16) = Vec.new()
-        \\  let x = v.pop()
+        \\  let v: Vec(i16) = Vec.from([1, 2, 3])
+        \\  let x: i16? = v.pop()
+        \\  let y: i16? = v.get(0)
         \\end
-    , "E_TYPE_UNDEFINED_METHOD");
+    );
 }
 
 test "typecheck/vec: an unknown Vec method is rejected" {

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2701,3 +2701,43 @@ test "typecheck/destructure: an if-let payload binder is typed from the variant"
         \\end
     );
 }
+
+test "typecheck/vec: a fully-typed Vec program checks clean" {
+    try expectClean(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([1, 2, 3])
+        \\  v.push(4)
+        \\  print v.len()
+        \\  print v.at(0)
+        \\  v[1] = 9
+        \\  print v[1]
+        \\end
+    );
+}
+
+test "typecheck/vec: `Vec.new` without an annotation can't infer T" {
+    try expectCode(
+        \\def main()
+        \\  let v = Vec.new()
+        \\  print 1
+        \\end
+    , "E_TYPE_AMBIGUOUS_INFER");
+}
+
+test "typecheck/vec: `pop` is deferred (returns T?, awaits scalar optionals)" {
+    try expectCode(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.new()
+        \\  let x = v.pop()
+        \\end
+    , "E_TYPE_UNDEFINED_METHOD");
+}
+
+test "typecheck/vec: an unknown Vec method is rejected" {
+    try expectCode(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.new()
+        \\  v.frobnicate()
+        \\end
+    , "E_TYPE_UNDEFINED_METHOD");
+}

--- a/tests/lang/typecheck/vec_builtin.test.zig
+++ b/tests/lang/typecheck/vec_builtin.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `vec_builtin` typecheck dispatch is reachable through the
+/// public barrel. End-to-end `Vec(T)` type-checking coverage lives in
+/// `tests/lang/typecheck.test.zig` and the round-trip in
+/// `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "typecheck/vec_builtin: dispatch compiles through the barrel" {
+    _ = gero.lang.internal.typechecker.vec_builtin;
+}


### PR DESCRIPTION
Implements `Vec(T)` (§3.4.3) — the dynamic-array surface was spec'd; only the implementation was missing. The bump-allocator heap (`sys alloc`) already existed, so this is method lowering on the heap + the array machinery from #306.

## Vec surface

A `Vec(T)` value is a 6-byte `(ptr, len, cap)` header stored inline like a struct; the backing buffer is on the heap.

- **Constructors** — `Vec.new()`, `Vec.with_capacity(n)`, `Vec.from([a, b, c])`.
- **`push`** — doubles capacity when full (allocs a new buffer, `bcpy`-copies, rewrites the header).
- **`len` / `cap` / `at(i)` / `set(i, x)` / `v[i]` / `v[i] = x` / `clear`** — `at`/`v[i]` bounds-trapped to `$02` in debug; `clear` keeps the buffer.
- **`pop() -> T?`** (removes + returns last, None when empty) and **`get(i) -> T?`** (element or None past the end).
- **`slice(a, b)`** — a borrowed view aliasing the parent.
- Binding a Vec copies its header; element type `T` is scalar or aggregate.

## Scalar optionals (so `pop`/`get` work)

`pop`/`get` return `T?`, so `T?` now extends to scalars: a scalar `T?` (e.g. `i16?`) is a tagged 4-byte `{present, value}` value (pointer-like `T?` stays a single nullable word, `nil` = 0). Consumption:
- **`if let n = opt`** unwraps — binds `n` to the value when present, runs `else` when nil (extends the #308 matcher; a value of `0` is still `present`, the point of the tag vs a sentinel).
- **`opt == nil` / `!= nil`** test the present tag.

## How

New `vec_builtin` modules (codegen + typecheck) mirror `mem_builtin`; `Vec.from([..])` reuses the array-materialize machinery. Runtime-length primitives `isa.bcpy` + `overflow.emitBoundsTrapReg`. A name after `.` accepts the `from` keyword so `Vec.from` parses. `if let`/`while let` route optional scrutinees through the matcher to unwrap.

## Verification

Full `zig build ci` green (all release modes + cross-targets); 17 new tests. A 3-lane adversarial probe on the non-optional Vec surface returned **20 ok-notes / 0 real defects** (push/grow through 64 elements, slice aliasing, `Vec(u8)`, value-copy, bounds, mixed-frame locals); the optional path was verified incl. the `Some(0)` ≠ `None` tag edge, pop-to-empty/get-past-end → None, `== nil`, and pointer-optional unwrap.

Closes #314.