### PR TITLE
feat(lang/codegen): for over arrays, Vecs, strings, and iterators

### DIFF
--- a/.changeset/lang-for-over-iterables.md
+++ b/.changeset/lang-for-over-iterables.md
@@ -12,7 +12,8 @@ ranges. The loop variable is typed from the iterable's element type
   element buffer (the array's base address, or the Vec's
   snapshotted heap pointer + length). Scalar elements load their
   value; aggregate elements (struct / array / tuple) bind by value,
-  address-valued like any inline-aggregate binding.
+  address-valued like any inline-aggregate binding. A `&[T; N]` /
+  `&Vec(T)` reference iterates the pointed-to aggregate.
 - `str` — a null-terminated byte walk; the loop variable is `char`.
 - A class with `next(self) -> T?` — the iterator protocol (§4.5.3):
   the iterable is evaluated once into a hidden slot (iteration is
@@ -35,6 +36,15 @@ accumulator. This fixes `if let x = call()` / `let x: T? = call()`
 for any optional-returning method or function (previously only
 `Vec.pop` / `Vec.get` materialized correctly), and a present inner
 value now implicitly wraps (`let x: i16? = 5`).
+
+**Zero-length arrays**
+
+An empty array literal types from its `[T; N]` annotation
+(`let a: [i16; 0] = []`), materializing a zero-byte slot — a
+degenerate but valid no-op (iterating it runs the body zero times).
+A bare `[]` with no annotation stays a type error (no inferable
+element type), and a count-mismatched `[i16; 2] = []` is
+`E_TYPE_MISMATCH`.
 
 **Diagnostics**
 

--- a/.changeset/lang-for-over-iterables.md
+++ b/.changeset/lang-for-over-iterables.md
@@ -1,0 +1,42 @@
+---
+bump: minor
+---
+
+`for x in <iterable>` now lowers over every iterable shape, not just
+ranges. The loop variable is typed from the iterable's element type
+(strong-typing: it's never left untyped).
+
+**Iterables**
+
+- `[T; N]` / `Vec(T)` — a direct `0..count` index loop over the
+  element buffer (the array's base address, or the Vec's
+  snapshotted heap pointer + length). Scalar elements load their
+  value; aggregate elements (struct / array / tuple) bind by value,
+  address-valued like any inline-aggregate binding.
+- `str` — a null-terminated byte walk; the loop variable is `char`.
+- A class with `next(self) -> T?` — the iterator protocol (§4.5.3):
+  the iterable is evaluated once into a hidden slot (iteration is
+  destructive — the instance's own cursor advances), then each pass
+  calls `it.next()`, binds the loop variable to a present value, and
+  exits on `nil`.
+
+`break` / `continue` / `:label` work across all of them. The loop
+variable's type flows into the body, so misusing it (e.g. binding an
+`i16` element where `str` is expected) is a type error.
+
+**Scalar-optional return ABI**
+
+Optional-returning calls now materialize correctly. A scalar `T?`
+(the 4-byte `{present, value}`) rides the sret convention like a
+struct — methods and free functions reserve a per-frame scratch
+buffer, `return` materializes the optional there, and the call site
+reads it back. A pointer-like `T?` returns its nullable word in the
+accumulator. This fixes `if let x = call()` / `let x: T? = call()`
+for any optional-returning method or function (previously only
+`Vec.pop` / `Vec.get` materialized correctly), and a present inner
+value now implicitly wraps (`let x: i16? = 5`).
+
+**Diagnostics**
+
+- `E_TYPE_NOT_ITERABLE` — `for x in e` where `e` isn't a range,
+  `[T; N]`, `Vec(T)`, `str`, or a class with `next(self) -> T?`.

--- a/.changeset/lang-ref-value-aggregates.md
+++ b/.changeset/lang-ref-value-aggregates.md
@@ -2,24 +2,25 @@
 bump: patch
 ---
 
-Fix `&T` references to value-type aggregates (`struct` / `[T; N]` /
-`Vec(T)` / tuple). Such a reference was passed **by value** — the
-argument was copied onto the stack while the parameter slot held only a
-2-byte pointer — so mutation through the reference never reached the
-caller and field / index / method access was mis-based (it read the
-pointer's own bytes). `&class` was unaffected (a class instance is
-already a heap pointer).
+Fix passing value-type aggregates (`struct` / `[T; N]` / `Vec(T)` /
+tuple) across function and method call boundaries — both by reference
+and by value.
 
-Two coordinated changes restore the §3.4.4 contract (a `&T` is a 2-byte
-pointer; mutation through it is visible to the caller; it auto-derefs at
-field access, indexing, and method calls):
+**`&T` references.** A reference to a value-type aggregate was passed
+*by value* (the argument copied onto the stack while the parameter slot
+held only a 2-byte pointer), so mutation through the reference never
+reached the caller and field / index / method access read the pointer's
+own bytes. Now a reference argument is pushed as the pointer (never
+copied) in both free-function calls and method dispatch, and a
+reference-typed aggregate binding dereferences once at access time —
+restoring the §3.4.4 contract (mutation through a `&T` is visible to the
+caller; it auto-derefs at field access, indexing, and method calls).
+`&class` was unaffected (a class instance is already a heap pointer).
 
-- A reference-typed argument is pushed as the pointer, never copied by
-  value — in both free-function calls and method dispatch.
-- A reference-typed aggregate binding dereferences once at access time
-  (loading the pointer value as the base), mirroring what class
-  receivers already did.
-
-Now `def bump(p: &P) p.x = p.x + 1 end`, `a[i] = v` through a
-`&[T; N]`, and `v.push(x)` through a `&Vec(T)` all mutate the caller's
-value. Passing a struct / tuple **by value** still copies (unchanged).
+**By value.** A `[T; N]` or `Vec(T)` parameter was sized as a 2-byte
+slot and the argument pushed as an address, so the callee read garbage
+instead of a copy. Both now pass by value like a struct / tuple — a
+fixed array is copied (§3.4 value semantics: callee mutations stay
+local), a `Vec` moves its 6-byte header (§3.4.3). This covers array /
+Vec literal arguments, arguments alongside scalars / other aggregates /
+references, and method arguments.

--- a/.changeset/lang-ref-value-aggregates.md
+++ b/.changeset/lang-ref-value-aggregates.md
@@ -1,0 +1,25 @@
+---
+bump: patch
+---
+
+Fix `&T` references to value-type aggregates (`struct` / `[T; N]` /
+`Vec(T)` / tuple). Such a reference was passed **by value** — the
+argument was copied onto the stack while the parameter slot held only a
+2-byte pointer — so mutation through the reference never reached the
+caller and field / index / method access was mis-based (it read the
+pointer's own bytes). `&class` was unaffected (a class instance is
+already a heap pointer).
+
+Two coordinated changes restore the §3.4.4 contract (a `&T` is a 2-byte
+pointer; mutation through it is visible to the caller; it auto-derefs at
+field access, indexing, and method calls):
+
+- A reference-typed argument is pushed as the pointer, never copied by
+  value — in both free-function calls and method dispatch.
+- A reference-typed aggregate binding dereferences once at access time
+  (loading the pointer value as the base), mirroring what class
+  receivers already did.
+
+Now `def bump(p: &P) p.x = p.x + 1 end`, `a[i] = v` through a
+`&[T; N]`, and `v.push(x)` through a `&Vec(T)` all mutate the caller's
+value. Passing a struct / tuple **by value** still copies (unchanged).

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -244,6 +244,7 @@ Raised by the typechecker after parsing succeeds.
 | `E_TYPE_AMBIGUOUS_INFER` | Inference can't pin a single type. |
 | `E_TYPE_RECURSIVE_NO_RET` | Recursive fn missing return annotation. |
 | `E_TYPE_INVALID_CAST` | `as T` between incompatible types. |
+| `E_TYPE_NOT_ITERABLE` | `for x in e` where `e` isn't a range, `[T; N]`, `Vec(T)`, `str`, or a class with `next(self) -> T?` (§4.5.3). |
 
 **Mockup — type mismatch in let init:**
 
@@ -777,6 +778,7 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_TYPE_AMBIGUOUS_INFER` | Typechecker | v0.3 |
 | `E_TYPE_RECURSIVE_NO_RET` | Typechecker | v0.3 |
 | `E_TYPE_INVALID_CAST` | Typechecker | v0.3 |
+| `E_TYPE_NOT_ITERABLE` | Typechecker | v0.3 |
 | `E_NULL_DEREF` | Nullable | v0.3 |
 | `E_NULL_NON_POINTER` | Nullable | v0.3 |
 | `E_NULL_NIL_TO_NONNULL` | Nullable | v0.3 |

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -188,6 +188,7 @@ pub fn compile(
         .is_isr = false,
         .current_ret_struct = null,
         .current_ret_is_tuple = false,
+        .current_ret_scalar_opt = null,
         .sret_param_ofs = 0,
         .sret_scratch_ofs = null,
         .inline_ret_struct = null,
@@ -199,6 +200,7 @@ pub fn compile(
         .noreturn_defs = .{},
         .fn_ret_struct = .{},
         .fn_ret_tuple = .{},
+        .fn_ret_scalar_opt = .{},
         .global_sret_scratch = 0,
         .inline_defs = .{},
         .interrupt_defs = .empty,
@@ -546,10 +548,16 @@ pub const Emitter = struct {
     /// `current_ret_struct`; the element layout comes from the return
     /// expression's inferred type).
     current_ret_is_tuple: bool,
+    /// Element type of a scalar `T?` return for the def currently being
+    /// emitted, or `null`. A scalar optional is a 4-byte `{present, value}`
+    /// that rides the sret convention like a struct; `return` materializes
+    /// it into the caller's sret buffer. A pointer-like `T?` returns its
+    /// nullable word in `acu`, so it stays `null` here.
+    current_ret_scalar_opt: ?*const Type,
     /// fp-offset of the hidden sret destination pointer in the current
     /// frame (`4 + Σ user-param widths` — it sits just above the last
-    /// user param). Valid while `current_ret_struct` is set or
-    /// `current_ret_is_tuple` is true.
+    /// user param). Valid while `current_ret_struct` is set,
+    /// `current_ret_is_tuple` is true, or `current_ret_scalar_opt` is set.
     sret_param_ofs: i16,
     /// fp-offset of this frame's sret scratch buffer (a returned
     /// struct's holding space), or `null` when the program returns no
@@ -587,10 +595,14 @@ pub const Emitter = struct {
     /// convention as `fn_ret_struct` (a set: the element layout is read
     /// from the call/return expression's inferred type).
     fn_ret_tuple: std.StringHashMapUnmanaged(void),
-    /// Largest (2-aligned) struct return width across the program — the
+    /// `def` names that return a scalar `T?` by value — the 4-byte
+    /// `{present, value}` rides the same sret convention as a struct
+    /// (a set: the element type is read from the call/return expression).
+    fn_ret_scalar_opt: std.StringHashMapUnmanaged(void),
+    /// Largest (2-aligned) aggregate return width across the program — the
     /// size of the per-frame sret scratch buffer that holds a returned
-    /// struct until its consumer copies it out. 0 when no def returns a
-    /// struct.
+    /// struct / tuple / scalar-optional until its consumer copies it out.
+    /// 0 when no def returns by sret.
     global_sret_scratch: u16,
     /// `def` names carrying `@inline`. `emitCall` inlines the
     /// body rather than emitting `call addr`.
@@ -849,6 +861,16 @@ pub const Emitter = struct {
         return if (isScalarOptional(inner.optional)) inner.optional else null;
     }
 
+    /// Element type of a scalar `T?` return annotation (`-> T?` with a
+    /// scalar `T`), or `null` for any other return shape. A scalar optional
+    /// rides the sret convention; a pointer-like `T?` returns its nullable
+    /// word in `acu`, so it stays `null` here.
+    pub fn scalarOptReturnInner(self: *const Emitter, rt: ast.TypeAnn) error{OutOfMemory}!?*const Type {
+        if (rt != .nullable) return null;
+        const inner = (try self.typeAnnToType(rt.nullable.inner.*)) orelse return null;
+        return if (isScalarOptional(inner)) inner else null;
+    }
+
     /// Resolve a surface `TypeAnn` to an arena `types.Type` so the
     /// destructuring matcher can thread one type representation (struct
     /// field / enum payload types come from AST `TypeAnn`s, tuple slots
@@ -954,9 +976,7 @@ pub const Emitter = struct {
                 n += self.countFrameBytesDepth(ws.body, depth);
                 break :blk n;
             },
-            // Range-based `for` reserves 1 hidden slot for the `end`
-            // bound (the iteration variable uses its own slot).
-            .for_stmt => |fs| 2 + 2 + self.countFrameBytesDepth(fs.body, depth),
+            .for_stmt => |fs| self.forFrameBytes(fs) + self.countFrameBytesDepth(fs.body, depth),
             .repeat_stmt => |rs| self.countFrameBytesDepth(rs.body, depth),
             .match_stmt => |ms| blk: {
                 // The scrutinee is materialized into a slot once (full width
@@ -979,6 +999,47 @@ pub const Emitter = struct {
         // ...plus the inline frames in the statement's own expressions
         // (sub-bodies are covered by the recursion above).
         return own + self.stmtInlineFrameBytes(stmt, depth);
+    }
+
+    /// Frame bytes a `for x in iter` loop reserves for its hidden slots +
+    /// loop variable, by iterable kind — mirrors the codegen dispatch in
+    /// `control_flow.emitForStmt`. The body's own locals are counted by the
+    /// caller's recursion. An over-estimate is harmless (a larger reserve);
+    /// an under-estimate corrupts the frame, so this must be an upper bound.
+    fn forFrameBytes(self: *const Emitter, fs: ast.ForStmt) usize {
+        // Range: iteration variable + a hidden `end` bound.
+        if (fs.iter.* == .range) return 2 + 2;
+        const it_ty = self.typeOf(fs.iter) orelse return 2 + 2;
+        return switch (it_ty.*) {
+            // base + count + index hidden slots, plus the loop variable.
+            // An array-literal iterable also materializes into a temp slot.
+            .array => |a| blk: {
+                var n: usize = 6 + self.loopVarBytes(a.elem);
+                if (fs.iter.* == .list_lit or fs.iter.* == .list_repeat) {
+                    // @as: array byte width is bounded by the i8 frame cap.
+                    const w: u16 = @intCast(@as(usize, self.widthOfType(a.elem)) * a.len);
+                    n += alignUpU16(w, 2);
+                }
+                break :blk n;
+            },
+            .vec => |elem| 6 + self.loopVarBytes(elem),
+            // `str`: a byte cursor + the `char` loop variable.
+            .primitive => |p| if (p == .str) 2 + 2 else 0,
+            // Iterator: the hidden instance pointer + the `T?` result slot
+            // (the loop variable aliases that slot's value region).
+            .named => 2 + opt_scalar_size,
+            else => 0,
+        };
+    }
+
+    /// Frame bytes a loop variable of element type `elem` occupies — a word
+    /// for a scalar / pointer element, the full (2-aligned) inline width for
+    /// an aggregate element (struct / array / tuple).
+    fn loopVarBytes(self: *const Emitter, elem: *const Type) usize {
+        return switch (self.arrayElemKindOf(elem)) {
+            .scalar => 2,
+            else => alignUpU16(self.widthOfType(elem), 2),
+        };
     }
 
     /// Inline-expansion bytes reachable from a statement's own
@@ -1504,6 +1565,11 @@ pub const Emitter = struct {
                     try self.fn_ret_tuple.put(self.arena, dup, {});
                     const w = alignUpU16(self.widthOfTypeAnn(rt.*), 2);
                     if (w > self.global_sret_scratch) self.global_sret_scratch = w;
+                };
+                // A scalar-`T?`-returning def shares the sret scratch too.
+                if (dd.ret_type) |rt| if (try self.scalarOptReturnInner(rt.*)) |_| {
+                    try self.fn_ret_scalar_opt.put(self.arena, dup, {});
+                    if (opt_scalar_size > self.global_sret_scratch) self.global_sret_scratch = opt_scalar_size;
                 };
                 if (noreturn_marked) try self.noreturn_defs.put(self.arena, dup, {});
                 if (inline_marked) try self.inline_defs.put(self.arena, dup, dd);

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -2023,7 +2023,11 @@ pub const Emitter = struct {
         if (self.structNameOfTypeAnn(t.*)) |sname| {
             return self.structSlotWidth(sname);
         }
-        if (t.* == .tuple) return alignUpU16(self.widthOfTypeAnn(t.*), 2);
+        // A struct / tuple / fixed-array / `Vec` param is passed by value —
+        // its full (2-aligned) width (a `Vec` moves its 6-byte header,
+        // §3.4.3). A `&T` reference is `.reference`, not the aggregate, so it
+        // stays a 2-byte pointer.
+        if (t.* == .tuple or t.* == .array or t.* == .vec) return alignUpU16(self.widthOfTypeAnn(t.*), 2);
         return 2;
     }
 
@@ -2047,6 +2051,13 @@ pub const Emitter = struct {
     /// size for inline-value frame, param, and arg layout.
     pub fn tupleSlotWidth(self: *const Emitter, elems: []const *const Type) u16 {
         return alignUpU16(self.tupleWidth(elems), 2);
+    }
+
+    /// 2-aligned stack footprint of a `[T; N]` value — `N` element widths
+    /// byte-packed, rounded up so word access stays aligned.
+    pub fn arraySlotWidth(self: *const Emitter, elem: *const Type, count: u32) u16 {
+        // @as: total array width ≤ the i8 frame cap.
+        return alignUpU16(@intCast(@as(u32, self.widthOfType(elem)) * count), 2);
     }
 
     /// Layout of one tuple element: byte offset (sum of prior element

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -1010,7 +1010,9 @@ pub const Emitter = struct {
         // Range: iteration variable + a hidden `end` bound.
         if (fs.iter.* == .range) return 2 + 2;
         const it_ty = self.typeOf(fs.iter) orelse return 2 + 2;
-        return switch (it_ty.*) {
+        // A `&T` reference iterates the pointed-to aggregate (§3.4.4).
+        const peeled = if (it_ty.* == .reference) it_ty.reference else it_ty;
+        return switch (peeled.*) {
             // base + count + index hidden slots, plus the loop variable.
             // An array-literal iterable also materializes into a temp slot.
             .array => |a| blk: {
@@ -2001,6 +2003,15 @@ pub const Emitter = struct {
             return if (self.struct_decls.contains(name)) name else null;
         }
         return self.structNameOf(arg);
+    }
+
+    /// `true` when `arg` has reference type `&T` — a 2-byte pointer that
+    /// must be pushed as a scalar, never copied by value (the aggregate
+    /// classifiers peel the reference, so a bare `&Struct` / `&[T;N]` /
+    /// `&Vec` would otherwise be mistaken for a by-value aggregate).
+    pub fn isReferenceArg(self: *const Emitter, arg: *const ast.Expr) bool {
+        const t = self.typeOf(arg) orelse return false;
+        return t.* == .reference;
     }
 
     /// Stack footprint of a parameter: a struct or tuple param occupies

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -1,11 +1,13 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
+const types = @import("../types.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
 const value_struct = @import("value_struct.zig");
 
 const Emitter = codegen_mod.Emitter;
+const Type = types.Type;
 const Op = opcodes.Op;
 const Reg = opcodes.Reg;
 const Sys = opcodes.Sys;
@@ -157,13 +159,16 @@ fn computeLayout(self: *Emitter, class_name: []const u8) !void {
         }
     }
 
-    // A struct-returning method needs the same sret scratch buffer as
-    // a free fn — size the per-frame scratch to the widest return.
+    // A struct- or scalar-`T?`-returning method needs the same sret scratch
+    // buffer as a free fn — size the per-frame scratch to the widest return.
     for (cd.methods) |method| {
-        if (method.ret_type) |rt| if (self.structNameOfTypeAnn(rt.*)) |sname| {
+        const rt = method.ret_type orelse continue;
+        if (self.structNameOfTypeAnn(rt.*)) |sname| {
             const w = self.structSlotWidth(sname);
             if (w > self.global_sret_scratch) self.global_sret_scratch = w;
-        };
+        } else if (try self.scalarOptReturnInner(rt.*)) |_| {
+            if (Emitter.opt_scalar_size > self.global_sret_scratch) self.global_sret_scratch = Emitter.opt_scalar_size;
+        }
     }
 
     try self.class_layouts.put(self.arena, dup_class, layout);
@@ -262,6 +267,37 @@ fn methodRetStruct(self: *Emitter, class_name: []const u8, method_name: []const 
         }
     }
     return null;
+}
+
+/// Resolved return type of `class_name`.`method_name` (walking the
+/// inheritance chain to the owner), or `null` when the method has no
+/// return annotation or the class / method is unknown.
+pub fn methodReturnType(self: *Emitter, class_name: []const u8, method_name: []const u8) error{OutOfMemory}!?*const Type {
+    const layout = self.class_layouts.get(class_name) orelse return null;
+    const owner = layout.method_owners.get(method_name) orelse return null;
+    const cd = self.class_decls.get(owner) orelse return null;
+    for (cd.methods) |m| {
+        if (std.mem.eql(u8, self.source[m.name.start..m.name.end], method_name)) {
+            const rt = m.ret_type orelse return null;
+            return try self.typeAnnToType(rt.*);
+        }
+    }
+    return null;
+}
+
+/// `true` when `class_name`.`method_name` returns a scalar `T?` (the
+/// 4-byte `{present, value}` rides the sret convention like a struct).
+fn methodRetScalarOpt(self: *Emitter, class_name: []const u8, method_name: []const u8) error{OutOfMemory}!bool {
+    const layout = self.class_layouts.get(class_name) orelse return false;
+    const owner = layout.method_owners.get(method_name) orelse return false;
+    const cd = self.class_decls.get(owner) orelse return false;
+    for (cd.methods) |m| {
+        if (std.mem.eql(u8, self.source[m.name.start..m.name.end], method_name)) {
+            const rt = m.ret_type orelse return false;
+            return (try self.scalarOptReturnInner(rt.*)) != null;
+        }
+    }
+    return false;
 }
 
 /// Push an optional sret destination pointer (this frame's scratch
@@ -419,7 +455,7 @@ fn findInheritedField(
 /// `&c` produces the address of `c`'s slot, so reaching the heap-
 /// allocated instance needs one extra word load through that
 /// address.
-fn emitInstancePtr(self: *Emitter, recv: *const ast.Expr) !void {
+pub fn emitInstancePtr(self: *Emitter, recv: *const ast.Expr) !void {
     try self.emitExpr(recv);
     const ty = self.typeOf(recv) orelse return;
     if (ty.* == .reference) {
@@ -522,6 +558,22 @@ pub fn emitMethodDispatch(
     args: []const *const ast.Expr,
     span: ast.Span,
 ) !void {
+    // Evaluate the receiver (auto-deref if `&T`) → acu = instance pointer,
+    // then dispatch on it.
+    try emitInstancePtr(self, recv);
+    try emitMethodDispatchOnInstance(self, class_name, method_name, args, span);
+}
+
+/// Vtable dispatch on the instance pointer already in `acu` (the receiver
+/// has been evaluated). Drives the iterator protocol's hidden `__it.next()`
+/// — where the instance lives in a frame slot, not a source expression.
+pub fn emitMethodDispatchOnInstance(
+    self: *Emitter,
+    class_name: []const u8,
+    method_name: []const u8,
+    args: []const *const ast.Expr,
+    span: ast.Span,
+) !void {
     const layout = self.class_layouts.get(class_name) orelse {
         try self.diagFatal(span, "E_CODEGEN_UNKNOWN_CLASS", "codegen: method call on unknown class");
         return;
@@ -531,15 +583,15 @@ pub fn emitMethodDispatch(
         return;
     };
 
-    // 1. Evaluate receiver (auto-deref if `&T`) and spill the instance
-    //    pointer above the args — a struct arg's by-value push moves
-    //    `sp`, so the pointer can't ride a register across arg eval.
-    try emitInstancePtr(self, recv);
+    // 1. Spill the instance pointer above the args — a struct arg's
+    //    by-value push moves `sp`, so the pointer can't ride a register
+    //    across arg eval.
     try isa.pushReg(self, Reg.acu);
 
-    // 2. Push the optional sret destination + args (struct-aware).
-    const returns_struct = methodRetStruct(self, class_name, method_name) != null;
-    const arg_bytes = try pushSretAndArgs(self, args, returns_struct);
+    // 2. Push the optional sret destination + args (sret-aware).
+    const returns_sret = methodRetStruct(self, class_name, method_name) != null or
+        try methodRetScalarOpt(self, class_name, method_name);
+    const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
 
     // 3. Reload the instance pointer (spilled at `sp + arg_bytes`),
     //    then resolve the method address through its vtable slot.
@@ -590,10 +642,11 @@ pub fn emitSuperMethodCall(
         return;
     };
 
-    // Push the optional sret destination + args (struct-aware), then
+    // Push the optional sret destination + args (sret-aware), then
     // reload self and push it last so it lands at fp+4.
-    const returns_struct = methodRetStruct(self, owner, method_name) != null;
-    const arg_bytes = try pushSretAndArgs(self, args, returns_struct);
+    const returns_sret = methodRetStruct(self, owner, method_name) != null or
+        try methodRetScalarOpt(self, owner, method_name);
+    const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
     try isa.movRegOffsetToReg(self, Reg.fp, self_ofs, Reg.r1);
     try isa.pushReg(self, Reg.r1);
 

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -5,6 +5,7 @@ const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
 const value_struct = @import("value_struct.zig");
+const vec_builtin = @import("vec_builtin.zig");
 
 const Emitter = codegen_mod.Emitter;
 const Type = types.Type;
@@ -322,6 +323,16 @@ fn pushSretAndArgs(self: *Emitter, args: []const *const ast.Expr, sret: bool) !u
             if (self.argStructName(args[i])) |sname| {
                 try value_struct.pushArg(self, args[i], sname);
                 total += self.structSlotWidth(sname);
+                continue;
+            }
+            if (self.arrayInfoOf(args[i])) |info| {
+                try value_struct.pushArrayArg(self, args[i], info.elem, info.count);
+                total += self.arraySlotWidth(info.elem, info.count);
+                continue;
+            }
+            if (vec_builtin.elemOf(self, args[i]) != null) {
+                try vec_builtin.pushVecArg(self, args[i]);
+                total += vec_builtin.header_size;
                 continue;
             }
         }

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -317,14 +317,17 @@ fn pushSretAndArgs(self: *Emitter, args: []const *const ast.Expr, sret: bool) !u
     var i = args.len;
     while (i > 0) {
         i -= 1;
-        if (self.argStructName(args[i])) |sname| {
-            try value_struct.pushArg(self, args[i], sname);
-            total += self.structSlotWidth(sname);
-        } else {
-            try self.emitExpr(args[i]);
-            try isa.pushReg(self, Reg.acu);
-            total += 2;
+        // A `&T` reference arg is a 2-byte pointer, not a by-value copy.
+        if (!self.isReferenceArg(args[i])) {
+            if (self.argStructName(args[i])) |sname| {
+                try value_struct.pushArg(self, args[i], sname);
+                total += self.structSlotWidth(sname);
+                continue;
+            }
         }
+        try self.emitExpr(args[i]);
+        try isa.pushReg(self, Reg.acu);
+        total += 2;
     }
     return total;
 }

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -394,7 +394,10 @@ pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
         try self.unsupported(fs.span, "`for` over a value of unknown type");
         return;
     };
-    switch (it_ty.*) {
+    // A `&T` reference iterates the pointed-to aggregate (the access helpers
+    // deref it transparently, §3.4.4).
+    const peeled = if (it_ty.* == .reference) it_ty.reference else it_ty;
+    switch (peeled.*) {
         .array => try emitForArray(self, fs),
         .vec => |elem| try emitForVec(self, fs, elem),
         .primitive => |p| if (p == .str)

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -1,15 +1,19 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
+const types = @import("../types.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const pattern = @import("pattern.zig");
 const destructure = @import("destructure.zig");
 const class = @import("class.zig");
+const value_struct = @import("value_struct.zig");
+const vec_builtin = @import("vec_builtin.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
 const Reg = opcodes.Reg;
+const Type = types.Type;
 const LoopFrame = codegen.LoopFrame;
 
 /// Walk `body` inside a fresh block scope. The common helper for
@@ -344,34 +348,12 @@ pub fn emitRepeatStmt(self: *Emitter, rs: ast.RepeatStmt) !void {
     frame.continue_patches.deinit(self.allocator);
 }
 
-/// Lower `for x in start..end [step S] body end` — the range
-/// special case per spec §4.5.3. User-defined iterables
-/// (`next(self) -> T?`) are not yet supported.
-pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
-    if (fs.iter.* != .range) {
-        try self.unsupported(fs.span, "`for` over non-range iterables");
-        return;
-    }
-    const range = fs.iter.range;
-    const inclusive = range.inclusive;
-    const step_expr = fs.step;
-    const binding_name = self.source[fs.binding.start..fs.binding.end];
-
-    // Allocate slots: the loop variable + a hidden `end` slot.
-    const dup_name = try self.arena.dupe(u8, binding_name);
-    const var_ofs = try self.allocLocal(dup_name);
-    const end_ofs = try self.allocLocal(try self.arena.dupe(u8, "\x00__for_end"));
-
-    try self.emitExpr(range.start);
-    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, var_ofs);
-    try self.emitExpr(range.end);
-    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, end_ofs);
-
-    const label_str: ?[]const u8 = if (fs.label) |s|
+/// Push a loop's block scope + loop frame (shared by the `for` family).
+fn enterLoop(self: *Emitter, label_span: ?ast.Span) !void {
+    const label_str: ?[]const u8 = if (label_span) |s|
         try self.arena.dupe(u8, self.source[s.start..s.end])
     else
         null;
-
     try pushBlock(self);
     const body_block_idx = self.block_stack.items.len - 1;
     try self.loop_stack.append(self.allocator, .{
@@ -380,9 +362,69 @@ pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
         .break_patches = .empty,
         .continue_patches = .empty,
     });
+}
 
-    // Top-of-loop: load `current`, load `end`, compare. Exit
-    // when current > end (inclusive) or current >= end (exclusive).
+/// Pop the innermost loop frame, resolving its `break` jumps to
+/// `exit_offset` and `continue` jumps to `continue_offset`.
+fn exitLoop(self: *Emitter, exit_offset: usize, continue_offset: usize) !void {
+    var frame = self.loop_stack.pop().?;
+    for (frame.break_patches.items) |p| try isa.patchJumpTo(self, p, exit_offset);
+    for (frame.continue_patches.items) |p| try isa.patchJumpTo(self, p, continue_offset);
+    frame.break_patches.deinit(self.allocator);
+    frame.continue_patches.deinit(self.allocator);
+}
+
+/// `reg = fp + ofs` — the address of a frame slot.
+fn frameAddr(self: *Emitter, ofs: i8, reg: u8) !void {
+    try isa.movRegToReg(self, Reg.fp, reg);
+    if (ofs < 0) {
+        // @as: |ofs| ≤ 127 fits u16.
+        try isa.subImmFromReg(self, @intCast(-@as(i16, ofs)), reg);
+    } else if (ofs > 0) {
+        try isa.addImmToReg(self, @intCast(ofs), reg);
+    }
+}
+
+/// Lower `for x in <iterable> body end` (§4.5.3). Ranges + the built-in
+/// iterables (`[T; N]` / `Vec(T)` / `str`) emit direct memory loops; a
+/// class with `next(self) -> T?` desugars to the iterator protocol.
+pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
+    if (fs.iter.* == .range) return emitForRange(self, fs);
+    const it_ty = self.typeOf(fs.iter) orelse {
+        try self.unsupported(fs.span, "`for` over a value of unknown type");
+        return;
+    };
+    switch (it_ty.*) {
+        .array => try emitForArray(self, fs),
+        .vec => |elem| try emitForVec(self, fs, elem),
+        .primitive => |p| if (p == .str)
+            try emitForStr(self, fs)
+        else
+            try self.unsupported(fs.span, "`for` over this value"),
+        .named => |n| try emitForIterator(self, fs, n.name),
+        else => try self.unsupported(fs.span, "`for` over this value"),
+    }
+}
+
+/// `for x in start..end [step S]` — the range special case (§4.5.1). No
+/// allocation, no iterator object: a hidden `end` slot bounds the
+/// iteration variable, which steps by `S` (default 1) each pass.
+fn emitForRange(self: *Emitter, fs: ast.ForStmt) !void {
+    const range = fs.iter.range;
+    const inclusive = range.inclusive;
+    const dup_name = try self.arena.dupe(u8, self.source[fs.binding.start..fs.binding.end]);
+    const var_ofs = try self.allocLocal(dup_name);
+    const end_ofs = try self.allocLocal("\x00__for_end");
+
+    try self.emitExpr(range.start);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, var_ofs);
+    try self.emitExpr(range.end);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, end_ofs);
+
+    try enterLoop(self, fs.label);
+
+    // Top-of-loop: load `current`, load `end`, compare. Exit when current
+    // > end (inclusive) or current >= end (exclusive).
     const test_offset = try self.currentOffset();
     try isa.movRegOffsetToReg(self, Reg.fp, var_ofs, Reg.acu);
     try isa.movRegOffsetToReg(self, Reg.fp, end_ofs, Reg.r1);
@@ -398,7 +440,7 @@ pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
     // `continue` target — the step-and-back-edge.
     const continue_offset = try self.currentOffset();
     try isa.movRegOffsetToReg(self, Reg.fp, var_ofs, Reg.acu);
-    if (step_expr) |se| {
+    if (fs.step) |se| {
         if (se.* == .int_lit) {
             // @as: parser stores int_lit as i32; range steps fit i16 per spec §4.5.1.
             const step_i16: i16 = @truncate(se.int_lit.value);
@@ -420,12 +462,193 @@ pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
 
     const exit_offset = try self.currentOffset();
     try isa.patchJumpTo(self, exit_patch, exit_offset);
+    try exitLoop(self, exit_offset, continue_offset);
+}
 
-    var frame = self.loop_stack.pop().?;
-    for (frame.break_patches.items) |p| try isa.patchJumpTo(self, p, exit_offset);
-    for (frame.continue_patches.items) |p| try isa.patchJumpTo(self, p, continue_offset);
-    frame.break_patches.deinit(self.allocator);
-    frame.continue_patches.deinit(self.allocator);
+/// `for x in arr` (`[T; N]`) — snapshot the base address + the comptime
+/// element count into hidden slots, then index `0..count`. An array
+/// literal is an rvalue, so it's materialized into a temp slot first; an
+/// addressable array (ident / field) yields its base address directly.
+fn emitForArray(self: *Emitter, fs: ast.ForStmt) !void {
+    const info = self.arrayInfoOf(fs.iter) orelse {
+        try self.unsupported(fs.span, "`for` over a non-array value");
+        return;
+    };
+    const base_ofs = try self.allocLocal("\x00__for_base");
+    const cnt_ofs = try self.allocLocal("\x00__for_cnt");
+    if (fs.iter.* == .list_lit or fs.iter.* == .list_repeat) {
+        // @as: array width is bounded by the i8 frame cap.
+        const width: u16 = @intCast(@as(u32, info.elem_width) * info.count);
+        const arr_ofs = try self.allocLocalSized("\x00__for_lit", width);
+        try value_struct.emitArrayInto(self, fs.iter, info.elem, info.count, arr_ofs);
+        try frameAddr(self, arr_ofs, Reg.acu);
+    } else {
+        try self.emitExpr(fs.iter); // an array value is its base address
+    }
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, base_ofs);
+    // @as: array count ≤ the i8 frame cap.
+    try isa.movImmToReg(self, @intCast(info.count), Reg.acu);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, cnt_ofs);
+    try emitIndexedBody(self, fs, base_ofs, cnt_ofs, info.elem);
+}
+
+/// `for x in v` (`Vec(T)`) — snapshot the heap buffer pointer + length
+/// once, then index `0..len`. Mutating the Vec inside the body doesn't
+/// reshape the iteration (the bounds are sampled up front).
+fn emitForVec(self: *Emitter, fs: ast.ForStmt, elem: *const Type) !void {
+    const base_ofs = try self.allocLocal("\x00__for_base");
+    const cnt_ofs = try self.allocLocal("\x00__for_cnt");
+    try self.emitExpr(fs.iter); // a Vec value is its header address
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try class.emitWordLoadAtOffset(self, Reg.r1, vec_builtin.ptr_ofs, Reg.acu);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, base_ofs);
+    try class.emitWordLoadAtOffset(self, Reg.r1, vec_builtin.len_ofs, Reg.acu);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, cnt_ofs);
+    try emitIndexedBody(self, fs, base_ofs, cnt_ofs, elem);
+}
+
+/// The shared `0..count` index loop for `[T; N]` / `Vec(T)`: `base_ofs`
+/// holds the element buffer base, `cnt_ofs` the element count. Each pass
+/// loads `base[i]` into the loop var, then steps `i`.
+fn emitIndexedBody(self: *Emitter, fs: ast.ForStmt, base_ofs: i8, cnt_ofs: i8, elem: *const Type) !void {
+    const ew = self.widthOfType(elem);
+    const scalar = switch (self.arrayElemKindOf(elem)) {
+        .scalar => true,
+        else => false,
+    };
+    const idx_ofs = try self.allocLocal("\x00__for_i");
+    const dup = try self.arena.dupe(u8, self.source[fs.binding.start..fs.binding.end]);
+    const x_ofs = if (scalar) try self.allocLocal(dup) else try self.allocLocalSized(dup, self.widthOfType(elem));
+
+    try isa.movImmToReg(self, 0, Reg.acu);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, idx_ofs);
+
+    try enterLoop(self, fs.label);
+    const test_offset = try self.currentOffset();
+    // Exit when `i >= count` (unsigned: counts span the full u16 range).
+    try isa.movRegOffsetToReg(self, Reg.fp, idx_ofs, Reg.acu);
+    try isa.movRegOffsetToReg(self, Reg.fp, cnt_ofs, Reg.r1);
+    try isa.cmpRegReg(self, Reg.acu, Reg.r1);
+    const exit_patch = try isa.emitJumpPlaceholder(self, Op.jcc_addr);
+
+    try emitElementInto(self, base_ofs, idx_ofs, ew, elem, scalar, x_ofs);
+
+    for (fs.body) |s| try self.emitStatement(s);
+    try popBlockWithDefers(self);
+
+    const continue_offset = try self.currentOffset();
+    try isa.movRegOffsetToReg(self, Reg.fp, idx_ofs, Reg.acu);
+    try isa.addImmToReg(self, 1, Reg.acu);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, idx_ofs);
+    try isa.emitJumpBack(self, test_offset);
+
+    const exit_offset = try self.currentOffset();
+    try isa.patchJumpTo(self, exit_patch, exit_offset);
+    try exitLoop(self, exit_offset, continue_offset);
+}
+
+/// Load element `base[idx]` (width `ew`) into the loop var slot `x_ofs`.
+/// A scalar element loads its value (sign-extending `i8`); an aggregate
+/// element copies its bytes — the loop var is then address-valued, like
+/// any inline-aggregate binding.
+fn emitElementInto(self: *Emitter, base_ofs: i8, idx_ofs: i8, ew: u16, elem: *const Type, scalar: bool, x_ofs: i8) !void {
+    try isa.movRegOffsetToReg(self, Reg.fp, idx_ofs, Reg.acu);
+    try value_struct.scaleIndex(self, Reg.acu, ew); // acu = idx * ew
+    try isa.movRegOffsetToReg(self, Reg.fp, base_ofs, Reg.r1);
+    try isa.addRegToAcu(self, Reg.r1); // acu = &base[idx]
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = element address
+    if (scalar) {
+        if (ew == 1) {
+            try class.emitByteLoadAtOffset(self, Reg.r1, 0, Reg.acu);
+            if (elem.* == .primitive and elem.primitive == .i8) try isa.signExtendByte(self, Reg.acu);
+        } else {
+            try class.emitWordLoadAtOffset(self, Reg.r1, 0, Reg.acu);
+        }
+        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, x_ofs);
+    } else {
+        try frameAddr(self, x_ofs, Reg.r2);
+        try value_struct.copyBytes(self, Reg.r1, Reg.r2, self.widthOfType(elem));
+    }
+}
+
+/// `for c in s` (`str`) — walk the null-terminated byte buffer: load
+/// `[cursor]` into the `char` loop var, stop at the terminator, advance.
+fn emitForStr(self: *Emitter, fs: ast.ForStmt) !void {
+    const cursor_ofs = try self.allocLocal("\x00__for_cursor");
+    const dup = try self.arena.dupe(u8, self.source[fs.binding.start..fs.binding.end]);
+    const x_ofs = try self.allocLocal(dup); // the `char` loop var (a word slot)
+    try self.emitExpr(fs.iter); // a str value is a pointer to its first byte
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, cursor_ofs);
+
+    try enterLoop(self, fs.label);
+    const test_offset = try self.currentOffset();
+    try isa.movRegOffsetToReg(self, Reg.fp, cursor_ofs, Reg.r1);
+    try class.emitByteLoadAtOffset(self, Reg.r1, 0, Reg.acu); // acu = [cursor] (zero-extended)
+    try isa.cmpRegImm(self, Reg.acu, 0);
+    const exit_patch = try isa.emitJumpPlaceholder(self, Op.jeq_addr); // null terminator → exit
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, x_ofs);
+
+    for (fs.body) |s| try self.emitStatement(s);
+    try popBlockWithDefers(self);
+
+    const continue_offset = try self.currentOffset();
+    try isa.movRegOffsetToReg(self, Reg.fp, cursor_ofs, Reg.acu);
+    try isa.addImmToReg(self, 1, Reg.acu);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, cursor_ofs);
+    try isa.emitJumpBack(self, test_offset);
+
+    const exit_offset = try self.currentOffset();
+    try isa.patchJumpTo(self, exit_patch, exit_offset);
+    try exitLoop(self, exit_offset, continue_offset);
+}
+
+/// `for x in it` (a class with `next(self) -> T?`) — the iterator protocol
+/// (§4.5.3). Evaluates the iterable once into a hidden slot (iteration is
+/// destructive — the instance's own cursor advances), then each pass calls
+/// `it.next()`, binds `x` to a present value, and exits on `nil`.
+fn emitForIterator(self: *Emitter, fs: ast.ForStmt, class_name: []const u8) !void {
+    const ret = (try class.methodReturnType(self, class_name, "next")) orelse {
+        try self.unsupported(fs.span, "`for` over a class without a `next(self) -> T?` method");
+        return;
+    };
+    if (ret.* != .optional) {
+        try self.unsupported(fs.span, "iterator `next` must return `T?`");
+        return;
+    }
+    const inner = ret.optional;
+    const it_ofs = try self.allocLocal("\x00__for_it");
+    const v_ofs = try self.allocLocalSized("\x00__for_v", self.widthOfType(ret));
+    try class.emitInstancePtr(self, fs.iter);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, it_ofs);
+
+    try enterLoop(self, fs.label);
+    // The `continue` target re-calls `next()`, so the test sits at the top.
+    const test_offset = try self.currentOffset();
+    try isa.movRegOffsetToReg(self, Reg.fp, it_ofs, Reg.acu); // acu = instance ptr
+    try class.emitMethodDispatchOnInstance(self, class_name, "next", &.{}, fs.span);
+    if (Emitter.isScalarOptional(inner)) {
+        // acu = sret buffer address — copy the 4-byte {present, value}.
+        try isa.movRegToReg(self, Reg.acu, Reg.r1);
+        try frameAddr(self, v_ofs, Reg.r2);
+        try value_struct.copyBytes(self, Reg.r1, Reg.r2, Emitter.opt_scalar_size);
+    } else {
+        // acu = the nullable pointer (nil = 0) — store the word.
+        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, v_ofs);
+    }
+    // Unwrap: bind the loop var to a present value; any `nil` skips to exit.
+    var skip: std.ArrayList(usize) = .empty;
+    defer skip.deinit(self.allocator);
+    const x_pat: ast.Pattern = .{ .ident = .{ .name = fs.binding, .span = fs.binding } };
+    try destructure.emitMatchPattern(self, &x_pat, v_ofs, ret, &skip);
+
+    for (fs.body) |s| try self.emitStatement(s);
+    try popBlockWithDefers(self);
+
+    try isa.emitJumpBack(self, test_offset);
+
+    const exit_offset = try self.currentOffset();
+    for (skip.items) |p| try isa.patchJumpTo(self, p, exit_offset);
+    try exitLoop(self, exit_offset, test_offset);
 }
 
 // ---------- break / continue ----------

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -56,6 +56,7 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     const saved_isr = self.is_isr;
     const saved_bank = self.current_bank;
     const saved_ret_struct = self.current_ret_struct;
+    const saved_ret_scalar_opt = self.current_ret_scalar_opt;
     const saved_sret_param = self.sret_param_ofs;
     const saved_sret_scratch = self.sret_scratch_ofs;
     self.locals = .{};
@@ -75,6 +76,7 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
         self.is_isr = saved_isr;
         self.current_bank = saved_bank;
         self.current_ret_struct = saved_ret_struct;
+        self.current_ret_scalar_opt = saved_ret_scalar_opt;
         self.sret_param_ofs = saved_sret_param;
         self.sret_scratch_ofs = saved_sret_scratch;
     }
@@ -108,6 +110,7 @@ fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, labe
     // `return` copies the result there instead of into `acu`.
     self.current_ret_struct = if (def.ret_type) |rt| self.structNameOfTypeAnn(rt.*) else null;
     self.current_ret_is_tuple = if (def.ret_type) |rt| rt.* == .tuple else false;
+    self.current_ret_scalar_opt = if (def.ret_type) |rt| try self.scalarOptReturnInner(rt.*) else null;
     // A param list overrunning the fp range already set `frame_overflow`
     // above, so this clamped value is unused; the clamp only keeps the
     // narrowing from panicking on a pathologically long param list.

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -1021,6 +1021,14 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
                 try value_struct.pushTupleArg(self, arg, elems);
                 continue;
             }
+            if (self.arrayInfoOf(arg)) |info| {
+                try value_struct.pushArrayArg(self, arg, info.elem, info.count);
+                continue;
+            }
+            if (vec_builtin.elemOf(self, arg) != null) {
+                try vec_builtin.pushVecArg(self, arg);
+                continue;
+            }
         }
         try emitExpr(self, arg);
         try isa.pushReg(self, Reg.acu);

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -989,10 +989,11 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     // returns the pointer in `acu`.
     const returns_struct = self.fn_ret_struct.contains(callee_name);
     const returns_tuple = self.fn_ret_tuple.contains(callee_name);
-    if (returns_struct or returns_tuple) {
+    const returns_scalar_opt = self.fn_ret_scalar_opt.contains(callee_name);
+    if (returns_struct or returns_tuple or returns_scalar_opt) {
         // Invariant: an aggregate-returning callee implies the program
-        // reserved an sret scratch slot in every frame (struct + tuple
-        // returns share it).
+        // reserved an sret scratch slot in every frame (struct / tuple /
+        // scalar-optional returns share it).
         const sofs = self.sret_scratch_ofs.?;
         try isa.movRegToReg(self, Reg.fp, Reg.acu);
         if (sofs < 0) try isa.subImmFromReg(self, @intCast(-sofs), Reg.acu);

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -54,10 +54,14 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
             // A struct- / tuple- / array- / Vec- / scalar-optional-typed
             // binding evaluates to its base address — inline aggregates
             // (incl. the 6-byte Vec header + the 4-byte `{present, value}`
-            // optional) are addressed in place, not loaded as a word.
-            if (self.structNameOf(e) != null or self.tupleElemsOf(e) != null or
+            // optional) are addressed in place, not loaded as a word. But a
+            // `&T` reference to such an aggregate holds a POINTER to it: its
+            // base is the pointer VALUE in the slot, so fall through to the
+            // word-load tail (one deref, mirroring `class.emitInstancePtr`).
+            const is_reference = if (self.typeOf(e)) |t| t.* == .reference else false;
+            if (!is_reference and (self.structNameOf(e) != null or self.tupleElemsOf(e) != null or
                 self.arrayInfoOf(e) != null or vec_builtin.elemOf(self, e) != null or
-                self.scalarOptionalElemOf(e) != null)
+                self.scalarOptionalElemOf(e) != null))
             {
                 try self.emitAddrOf(e);
                 return;
@@ -1001,18 +1005,25 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
     }
 
     // Push args right-to-left (caller-cleans-up). A struct or tuple arg
-    // is passed by value — its (2-aligned) width copied onto the stack.
+    // is passed by value — its (2-aligned) width copied onto the stack. A
+    // `&T` reference arg is a 2-byte pointer (the `*Of` helpers peel the
+    // reference, so it must be excluded from the by-value paths).
     var i: usize = c.args.len;
     while (i > 0) {
         i -= 1;
-        if (self.argStructName(c.args[i])) |sname| {
-            try value_struct.pushArg(self, c.args[i], sname);
-        } else if (self.tupleElemsOf(c.args[i])) |elems| {
-            try value_struct.pushTupleArg(self, c.args[i], elems);
-        } else {
-            try emitExpr(self, c.args[i]);
-            try isa.pushReg(self, Reg.acu);
+        const arg = c.args[i];
+        if (!self.isReferenceArg(arg)) {
+            if (self.argStructName(arg)) |sname| {
+                try value_struct.pushArg(self, arg, sname);
+                continue;
+            }
+            if (self.tupleElemsOf(arg)) |elems| {
+                try value_struct.pushTupleArg(self, arg, elems);
+                continue;
+            }
         }
+        try emitExpr(self, arg);
+        try isa.pushReg(self, Reg.acu);
     }
 
     if (cross_bank) {

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -490,6 +490,14 @@ pub fn emitReturnStmt(self: *Emitter, r: ast.ReturnStmt) !void {
                 if (self.sret_param_ofs > 0) try isa.addImmToReg(self, @intCast(self.sret_param_ofs), Reg.acu);
                 try isa.movRegOffsetToReg(self, Reg.acu, 0, Reg.acu);
             } else try self.unsupported(r.span, "tuple return from a non-tuple value");
+        } else if (self.current_ret_scalar_opt) |inner| {
+            // Scalar `T?` return: materialize {present, value} into the
+            // caller's sret buffer, then leave that buffer's address in acu
+            // (the 4-byte optional *is* an address, like a struct return).
+            try vec_builtin.emitScalarOptIntoSret(self, v, inner, self.sret_param_ofs);
+            try isa.movRegToReg(self, Reg.fp, Reg.acu);
+            if (self.sret_param_ofs > 0) try isa.addImmToReg(self, @intCast(self.sret_param_ofs), Reg.acu);
+            try isa.movRegOffsetToReg(self, Reg.acu, 0, Reg.acu);
         } else {
             try self.emitExpr(v);
         }

--- a/src/lang/codegen/value_struct.zig
+++ b/src/lang/codegen/value_struct.zig
@@ -130,6 +130,13 @@ pub fn pushTupleArg(self: *Emitter, arg: *const ast.Expr, elems: []const *const 
     try emitTupleIntoDest(self, arg, elems, .{ .sp = 0 });
 }
 
+/// Pass a fixed-array argument by value (§3.4): reserve its (2-aligned)
+/// width on the stack and materialize a copy there.
+pub fn pushArrayArg(self: *Emitter, arg: *const ast.Expr, elem: *const types.Type, count: u32) error{OutOfMemory}!void {
+    try isa.subImmFromReg(self, self.arraySlotWidth(elem, count), Reg.sp);
+    try emitArrayIntoDest(self, arg, elem, count, .{ .sp = 0 });
+}
+
 /// Materialize a returned tuple into the caller's sret buffer.
 pub fn emitTupleIntoSret(self: *Emitter, src: *const ast.Expr, elems: []const *const types.Type, ptr_ofs: i16) error{OutOfMemory}!void {
     try emitTupleIntoDest(self, src, elems, .{ .indirect = .{ .ptr_ofs = ptr_ofs, .delta = 0 } });

--- a/src/lang/codegen/vec_builtin.zig
+++ b/src/lang/codegen/vec_builtin.zig
@@ -1,9 +1,9 @@
 // `Vec(T)` lowering (§3.4.3) — a growable dynamic array. The value is a
 // 6-byte `(ptr, len, cap)` header stored inline (like a struct); the
 // backing buffer lives on the heap (`sys alloc`, a bump allocator — growth
-// allocates a new buffer and copies, leaking the old one). This covers the
-// non-optional surface; `pop` / `get` (which return `T?`) await the scalar-
-// optional model.
+// allocates a new buffer and copies, leaking the old one). Also hosts the
+// optional-materialization helpers (`pop` / `get` return `T?`; scalar `T?`
+// rides the sret convention) shared by `if let` / `while let` / `for`.
 
 const std = @import("std");
 const ast = @import("../ast.zig");
@@ -22,8 +22,10 @@ const Type = types.Type;
 
 /// Byte size of a `Vec` value's inline header.
 pub const header_size: u16 = 6;
-const ptr_ofs: u16 = 0;
-const len_ofs: u16 = 2;
+/// Byte offset of the buffer pointer within a `Vec` header.
+pub const ptr_ofs: u16 = 0;
+/// Byte offset of the length within a `Vec` header.
+pub const len_ofs: u16 = 2;
 const cap_ofs: u16 = 4;
 
 /// Element type of a Vec-typed expression (peeling a reference), or `null`.
@@ -185,8 +187,9 @@ pub fn emitGetInto(self: *Emitter, recv: *const ast.Expr, idx: *const ast.Expr, 
 }
 
 /// Materialize an optional-producing expression into the frame slot at
-/// `dest_ofs`: `v.pop()` / `v.get(i)` (the producers), `nil` (absent), or
-/// another optional value (byte-copied). `inner` is the element type.
+/// `dest_ofs`: `v.pop()` / `v.get(i)` (the producers), `nil` (absent), a
+/// present inner value (wrapped), or another optional value (copied).
+/// `inner` is the optional's element type.
 pub fn emitOptionalInto(self: *Emitter, src: *const ast.Expr, inner: *const Type, dest_ofs: i16) error{OutOfMemory}!void {
     if (src.* == .method_call) {
         const mc = src.method_call;
@@ -198,15 +201,50 @@ pub fn emitOptionalInto(self: *Emitter, src: *const ast.Expr, inner: *const Type
     }
     if (src.* == .nil_lit) {
         try isa.movImmToReg(self, 0, Reg.acu);
-        try storeOptional(self, dest_ofs, 0, Reg.acu);
+        if (codegen.Emitter.isScalarOptional(inner)) {
+            try storeOptional(self, dest_ofs, 0, Reg.acu);
+        } else {
+            try frameAddr(self, dest_ofs, Reg.r1);
+            try class.emitWordStoreAtOffset(self, Reg.r1, 0, Reg.acu);
+        }
         return;
     }
-    // Another optional value — byte-copy its header.
-    try self.emitExpr(src); // acu = source optional address
-    try isa.movRegToReg(self, Reg.acu, Reg.r1);
-    try frameAddr(self, dest_ofs, Reg.r2);
-    const w: u16 = if (codegen.Emitter.isScalarOptional(inner)) codegen.Emitter.opt_scalar_size else 2;
-    try value_struct.copyBytes(self, Reg.r1, Reg.r2, w);
+    // A pointer-like `T?` is the nullable pointer word itself (`nil` = 0),
+    // whether produced as a present value or copied from another optional —
+    // a call return or an ident load both leave the word in `acu`.
+    if (!codegen.Emitter.isScalarOptional(inner)) {
+        try self.emitExpr(src); // acu = pointer value (nil = 0)
+        try frameAddr(self, dest_ofs, Reg.r1);
+        try class.emitWordStoreAtOffset(self, Reg.r1, 0, Reg.acu);
+        return;
+    }
+    // A scalar `T?`. An already-optional source byte-copies its 4-byte
+    // `{present, value}` from the address it evaluates to; a present inner
+    // value wraps to `{present: 1, value}`.
+    const src_ty = self.typeOf(src);
+    if (src_ty != null and src_ty.?.* == .optional) {
+        try self.emitExpr(src); // acu = source optional address
+        try isa.movRegToReg(self, Reg.acu, Reg.r1);
+        try frameAddr(self, dest_ofs, Reg.r2);
+        try value_struct.copyBytes(self, Reg.r1, Reg.r2, codegen.Emitter.opt_scalar_size);
+    } else {
+        try self.emitExpr(src); // acu = present inner value
+        try storeOptional(self, dest_ofs, 1, Reg.acu);
+    }
+}
+
+/// Materialize a scalar `T?` return value into the caller's sret buffer
+/// (its pointer sits at `[fp + ptr_ofs]`): build the `{present, value}` in
+/// a temp slot, then copy it through the sret pointer. `inner` is the
+/// optional's element type. Caller leaves the buffer address in `acu`.
+pub fn emitScalarOptIntoSret(self: *Emitter, src: *const ast.Expr, inner: *const Type, sret_ptr_ofs: i16) error{OutOfMemory}!void {
+    const tmp = try self.allocLocalSized("\x00__retopt", codegen.Emitter.opt_scalar_size);
+    try emitOptionalInto(self, src, inner, tmp);
+    try isa.movRegToReg(self, Reg.fp, Reg.r2);
+    if (sret_ptr_ofs > 0) try isa.addImmToReg(self, @intCast(sret_ptr_ofs), Reg.r2);
+    try isa.movRegOffsetToReg(self, Reg.r2, 0, Reg.r2); // r2 = sret dest pointer
+    try frameAddr(self, tmp, Reg.r1); // r1 = &temp
+    try value_struct.copyBytes(self, Reg.r1, Reg.r2, codegen.Emitter.opt_scalar_size);
 }
 
 /// Store a scalar optional `{present, value}` into the 4-byte slot at

--- a/src/lang/codegen/vec_builtin.zig
+++ b/src/lang/codegen/vec_builtin.zig
@@ -35,6 +35,17 @@ pub fn elemOf(self: *const Emitter, e: *const ast.Expr) ?*const Type {
     return if (inner.* == .vec) inner.vec else null;
 }
 
+/// Pass a `Vec(T)` argument by value (§3.4.3 — moves the 6-byte header;
+/// the backing buffer is shared): reserve the header width on the stack
+/// and byte-copy it there.
+pub fn pushVecArg(self: *Emitter, arg: *const ast.Expr) error{OutOfMemory}!void {
+    try isa.subImmFromReg(self, header_size, Reg.sp);
+    try self.emitExpr(arg); // acu = source header address (a Vec value is its address)
+    try isa.movRegToReg(self, Reg.acu, Reg.r1);
+    try isa.movRegToReg(self, Reg.sp, Reg.r2);
+    try value_struct.copyBytes(self, Reg.r1, Reg.r2, header_size);
+}
+
 /// `true` when `name` is a `Vec.<name>(...)` constructor.
 pub fn isConstructor(name: []const u8) bool {
     return std.mem.eql(u8, name, "new") or

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -785,9 +785,11 @@ pub const Checker = struct {
             return start_ty orelse try self.primitive(.i16);
         }
         const it_ty = (try self.inferExpr(fs.iter, null)) orelse return null;
-        switch (it_ty.*) {
-            .array => return it_ty.array.elem,
-            .vec => return it_ty.vec,
+        // A `&T` reference iterates the pointed-to aggregate (§3.4.4).
+        const peeled = if (it_ty.* == .reference) it_ty.reference else it_ty;
+        switch (peeled.*) {
+            .array => return peeled.array.elem,
+            .vec => return peeled.vec,
             .primitive => |p| if (p == .str) return try self.primitive(.char),
             .named => |n| {
                 if (self.class_registry.get(n.name)) |cd| {
@@ -1615,6 +1617,14 @@ pub const Checker = struct {
             .vec => |v| v,
             else => null,
         } else null;
+        // An empty literal has no element to infer from — recover the type
+        // from a `[T; N]` annotation (the literal's own count is 0). A bare
+        // `[]` with no array hint stays untyped: ambiguous, a type error at
+        // the use site.
+        if (ll.elems.len == 0) {
+            if (hint) |h| if (h.* == .array) return try types.mkArray(self.arena, h.array.elem, 0);
+            return null;
+        }
         var first_ty: ?*const types.Type = null;
         for (ll.elems) |x| {
             const t = try self.inferExpr(x, elem_hint);

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -759,7 +759,7 @@ pub const Checker = struct {
     }
 
     fn checkFor(self: *Checker, fs: ast.ForStmt) WalkError!void {
-        _ = try self.inferExpr(fs.iter, null);
+        const elem_ty = try self.forElementType(fs);
         if (fs.step) |st| _ = try self.inferExpr(st, null);
         const saved = self.current_scope;
         var child: Scope = .init(self.arena, saved);
@@ -768,9 +768,47 @@ pub const Checker = struct {
         try self.registerName(self.lexeme(fs.binding), .{
             .kind = .let_binding,
             .decl_span = fs.binding,
-            .ty = null,
+            .ty = elem_ty,
         });
         try self.walkStatementSequence(fs.body);
+    }
+
+    /// Resolve the loop variable's type from the iterable's element type
+    /// (§4.5.3): a range yields its bound type; `[T; N]` / `Vec(T)` yield
+    /// `T`; `str` yields `char`; a class with `next(self) -> T?` yields `T`.
+    /// A non-iterable operand is `E_TYPE_NOT_ITERABLE` and binds no type.
+    fn forElementType(self: *Checker, fs: ast.ForStmt) WalkError!?*const types.Type {
+        if (fs.iter.* == .range) {
+            // The loop variable takes the range bound's type (`0u8..` → u8).
+            const start_ty = try self.inferExpr(fs.iter.range.start, null);
+            _ = try self.inferExpr(fs.iter.range.end, null);
+            return start_ty orelse try self.primitive(.i16);
+        }
+        const it_ty = (try self.inferExpr(fs.iter, null)) orelse return null;
+        switch (it_ty.*) {
+            .array => return it_ty.array.elem,
+            .vec => return it_ty.vec,
+            .primitive => |p| if (p == .str) return try self.primitive(.char),
+            .named => |n| {
+                if (self.class_registry.get(n.name)) |cd| {
+                    if (fields.lookupClassMethod(self, cd, "next")) |m| {
+                        if (m.ret_type) |rt| {
+                            const ret = try type_resolve.resolveType(self, rt);
+                            if (ret.* == .optional) return ret.optional;
+                        }
+                    }
+                }
+            },
+            else => {},
+        }
+        const rendered = try types.render(self.arena, it_ty.*);
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "type `{s}` is not iterable — `for x in …` needs a range, `[T; N]`, `Vec(T)`, `str`, or a class with `next(self) -> T?`",
+            .{rendered},
+        );
+        try self.emitSpan("E_TYPE_NOT_ITERABLE", fs.iter.span(), msg);
+        return null;
     }
 
     fn checkRepeat(self: *Checker, rs: ast.RepeatStmt) WalkError!void {

--- a/src/lang/typecheck/vec_builtin.zig
+++ b/src/lang/typecheck/vec_builtin.zig
@@ -1,7 +1,6 @@
 // Type-checking for the compiler-known `Vec(T)` surface (§3.4.3). Mirrors
 // `mem_builtin` — a fixed set of method signatures, generic over the
-// receiver's element type `T`. The non-optional surface; `pop` / `get`
-// (which return `T?`) await the scalar-optional model.
+// receiver's element type `T`. Includes `pop` / `get`, which return `T?`.
 
 const std = @import("std");
 const ast = @import("../ast.zig");

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1290,6 +1290,99 @@ test "codegen: a method returning a scalar `T?` unwraps through `if let`" {
     , "0\n");
 }
 
+test "codegen: mutation through a `&struct` param propagates to the caller" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def setx(p: &P)
+        \\  p.x = 99
+        \\end
+        \\def main()
+        \\  let pt: P = P { x: 7, y: 42 }
+        \\  setx(&pt)
+        \\  print pt.x
+        \\  print pt.y
+        \\end
+    , "99\n42\n");
+}
+
+test "codegen: index read + write through a `&[T; N]` param hits the caller's array" {
+    try runAndExpect(
+        \\def zero1(a: &[i16; 3])
+        \\  a[1] = 0
+        \\end
+        \\def main()
+        \\  let arr: [i16; 3] = [4, 5, 6]
+        \\  zero1(&arr)
+        \\  print arr[0]
+        \\  print arr[1]
+        \\  print arr[2]
+        \\end
+    , "4\n0\n6\n");
+}
+
+test "codegen: mutating a `&Vec(T)` param is visible to the caller" {
+    try runAndExpect(
+        \\def app(v: &Vec(i16))
+        \\  v.push(30)
+        \\end
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([10, 20])
+        \\  app(&v)
+        \\  print v.len()
+        \\  print v.at(2)
+        \\end
+    , "3\n30\n");
+}
+
+test "codegen: a `&T` reference arg reaches a method through dispatch" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\class Bumper
+        \\  def init(self) end
+        \\  def bump(self, p: &P)
+        \\    p.x = p.x + 1
+        \\  end
+        \\end
+        \\def main()
+        \\  let pt: P = P { x: 5 }
+        \\  let b = Bumper()
+        \\  b.bump(&pt)
+        \\  print pt.x
+        \\end
+    , "6\n");
+}
+
+test "codegen: for over a `&[T; N]` iterates the referenced array" {
+    try runAndExpect(
+        \\def each(a: &[i16; 3])
+        \\  for x in a
+        \\    print x
+        \\  end
+        \\end
+        \\def main()
+        \\  let arr: [i16; 3] = [4, 5, 6]
+        \\  each(&arr)
+        \\end
+    , "4\n5\n6\n");
+}
+
+test "codegen: a zero-length array binding is a no-op (empty for-loop body)" {
+    try runAndExpect(
+        \\def main()
+        \\  let a: [i16; 0] = []
+        \\  for x in a
+        \\    print x
+        \\  end
+        \\  print 100
+        \\end
+    , "100\n");
+}
+
 test "codegen: repeat-until runs body at least once then exits when cond is true" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1371,6 +1371,60 @@ test "codegen: for over a `&[T; N]` iterates the referenced array" {
     , "4\n5\n6\n");
 }
 
+test "codegen: a `[T; N]` param is passed by value — callee mutation stays local" {
+    try runAndExpect(
+        \\def clobber(a: [i16; 3]) -> i16
+        \\  a[0] = 999
+        \\  return a[0]
+        \\end
+        \\def main()
+        \\  let arr: [i16; 3] = [4, 5, 6]
+        \\  print clobber(arr)
+        \\  print arr[0]
+        \\end
+    , "999\n4\n");
+}
+
+test "codegen: a `[T; N]` param reads its copied elements among scalar args" {
+    try runAndExpect(
+        \\def pick(n: i16, a: [i16; 3], m: i16) -> i16
+        \\  return n + a[1] + m
+        \\end
+        \\def main()
+        \\  let arr: [i16; 3] = [4, 5, 6]
+        \\  print pick(10, arr, 20)
+        \\end
+    , "35\n");
+}
+
+test "codegen: a `Vec(T)` param is passed by value (the moved header)" {
+    try runAndExpect(
+        \\def total(v: Vec(i16)) -> i16
+        \\  return v.at(0) + v.at(1)
+        \\end
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([6, 7])
+        \\  print total(v)
+        \\end
+    , "13\n");
+}
+
+test "codegen: a `Vec(T)` argument reaches a method by value" {
+    try runAndExpect(
+        \\class Adder
+        \\  def init(self) end
+        \\  def sum(self, v: Vec(i16)) -> i16
+        \\    return v.at(0) + v.at(1) + v.at(2)
+        \\  end
+        \\end
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([10, 20, 30])
+        \\  let a = Adder()
+        \\  print a.sum(v)
+        \\end
+    , "60\n");
+}
+
 test "codegen: a zero-length array binding is a no-op (empty for-loop body)" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1065,6 +1065,231 @@ test "codegen: for-range respects break" {
     , "0\n1\n2\n3\n");
 }
 
+test "codegen: for over a fixed array iterates its scalar elements" {
+    try runAndExpect(
+        \\def main()
+        \\  let arr: [i16; 3] = [11, 22, 33]
+        \\  for a in arr
+        \\    print a
+        \\  end
+        \\end
+    , "11\n22\n33\n");
+}
+
+test "codegen: for over an array literal iterates the materialized elements" {
+    try runAndExpect(
+        \\def main()
+        \\  for x in [1, 2, 3]
+        \\    print x
+        \\  end
+        \\  for y in [7; 3]
+        \\    print y
+        \\  end
+        \\end
+    , "1\n2\n3\n7\n7\n7\n");
+}
+
+test "codegen: for over an array honors continue + break" {
+    try runAndExpect(
+        \\def main()
+        \\  let arr: [i16; 5] = [1, 2, 3, 4, 5]
+        \\  for a in arr
+        \\    if a == 2
+        \\      continue
+        \\    end
+        \\    if a == 4
+        \\      break
+        \\    end
+        \\    print a
+        \\  end
+        \\end
+    , "1\n3\n");
+}
+
+test "codegen: for over a `Vec(T)` iterates its elements" {
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.from([7, 8, 9])
+        \\  for x in v
+        \\    print x
+        \\  end
+        \\end
+    , "7\n8\n9\n");
+}
+
+test "codegen: for over a `str` yields each char until the terminator" {
+    try runAndExpect(
+        \\def main()
+        \\  for c in "AB"
+        \\    print c
+        \\  end
+        \\end
+    , "A\nB\n");
+}
+
+test "codegen: for over an array of aggregates binds each element by value" {
+    try runAndExpect(
+        \\struct Pt
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let pts: [Pt; 2] = [Pt { x: 1, y: 2 }, Pt { x: 3, y: 4 }]
+        \\  for p in pts
+        \\    print p.x + p.y
+        \\  end
+        \\end
+    , "3\n7\n");
+}
+
+test "codegen: for over a class iterator (`next -> T?`) drains scalar values" {
+    try runAndExpect(
+        \\class Counter
+        \\  let n: i16
+        \\  def init(self)
+        \\    self.n = 0
+        \\  end
+        \\  def next(self) -> i16?
+        \\    if self.n >= 3
+        \\      return nil
+        \\    end
+        \\    let v = self.n
+        \\    self.n = self.n + 1
+        \\    return v * 10
+        \\  end
+        \\end
+        \\def main()
+        \\  let c = Counter()
+        \\  for n in c
+        \\    print n
+        \\  end
+        \\end
+    , "0\n10\n20\n");
+}
+
+test "codegen: for over a class iterator yielding class instances" {
+    try runAndExpect(
+        \\class Item
+        \\  let v: i16
+        \\  def init(self, x: i16)
+        \\    self.v = x
+        \\  end
+        \\end
+        \\class Bag
+        \\  let cur: i16
+        \\  def init(self)
+        \\    self.cur = 0
+        \\  end
+        \\  def next(self) -> Item?
+        \\    if self.cur >= 2
+        \\      return nil
+        \\    end
+        \\    self.cur = self.cur + 1
+        \\    return Item(self.cur * 100)
+        \\  end
+        \\end
+        \\def main()
+        \\  let b = Bag()
+        \\  for item in b
+        \\    print item.v
+        \\  end
+        \\end
+    , "100\n200\n");
+}
+
+test "codegen: nested for over array + Vec multiplies the passes" {
+    try runAndExpect(
+        \\def main()
+        \\  let arr: [i16; 2] = [1, 2]
+        \\  let v: Vec(i16) = Vec.from([10, 20])
+        \\  for a in arr
+        \\    for b in v
+        \\      print a + b
+        \\    end
+        \\  end
+        \\end
+    , "11\n21\n12\n22\n");
+}
+
+test "codegen: labeled break exits an outer for-over-iterable" {
+    try runAndExpect(
+        \\def main()
+        \\  let arr: [i16; 3] = [1, 2, 3]
+        \\  for a in arr :outer
+        \\    for c in "xy"
+        \\      if a == 2
+        \\        break :outer
+        \\      end
+        \\      print a
+        \\    end
+        \\  end
+        \\end
+    , "1\n1\n");
+}
+
+test "codegen: a present `let x: T? = v` unwraps through `if let`" {
+    try runAndExpect(
+        \\def main()
+        \\  let a: i16? = 5
+        \\  if let v = a
+        \\    print v
+        \\  end
+        \\  let b: i16? = nil
+        \\  if let w = b
+        \\    print w
+        \\  else
+        \\    print 99
+        \\  end
+        \\end
+    , "5\n99\n");
+}
+
+test "codegen: a fn returning a scalar `T?` round-trips present + nil" {
+    try runAndExpect(
+        \\def find(t: i16) -> i16?
+        \\  if t == 7
+        \\    return nil
+        \\  end
+        \\  return t + 100
+        \\end
+        \\def main()
+        \\  if let r = find(3)
+        \\    print r
+        \\  end
+        \\  if let r2 = find(7)
+        \\    print r2
+        \\  else
+        \\    print 999
+        \\  end
+        \\end
+    , "103\n999\n");
+}
+
+test "codegen: a method returning a scalar `T?` unwraps through `if let`" {
+    try runAndExpect(
+        \\class Counter
+        \\  let n: i16
+        \\  def init(self)
+        \\    self.n = 0
+        \\  end
+        \\  def next(self) -> i16?
+        \\    if self.n >= 3
+        \\      return nil
+        \\    end
+        \\    let v = self.n
+        \\    self.n = self.n + 1
+        \\    return v
+        \\  end
+        \\end
+        \\def main()
+        \\  let c = Counter()
+        \\  if let n = c.next()
+        \\    print n
+        \\  end
+        \\end
+    , "0\n");
+}
+
 test "codegen: repeat-until runs body at least once then exits when cond is true" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -282,6 +282,73 @@ test "typecheck: while let binds the pattern in the loop body" {
     );
 }
 
+test "typecheck: for binds the loop variable to the array's element type" {
+    // `x` is typed `i16` (the element type), so assigning it where `str`
+    // is expected is a mismatch — the binder isn't left untyped.
+    try expectCode(
+        \\def main()
+        \\  let arr: [i16; 2] = [1, 2]
+        \\  for x in arr
+        \\    let s: str = x
+        \\  end
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: for over a `str` binds the loop variable as `char`" {
+    try expectCode(
+        \\def main()
+        \\  for c in "hi"
+        \\    let s: str = c
+        \\  end
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: a range loop variable is typed from its bound" {
+    try expectClean(
+        \\def takes(n: i16) -> i16
+        \\  return n
+        \\end
+        \\def main()
+        \\  for i in 0..3
+        \\    print takes(i)
+        \\  end
+        \\end
+    );
+}
+
+test "typecheck: an iterator loop variable carries the `next` element type" {
+    try expectClean(
+        \\class Item
+        \\  let v: i16
+        \\  def init(self)
+        \\    self.v = 0
+        \\  end
+        \\  def next(self) -> Item?
+        \\    return nil
+        \\  end
+        \\end
+        \\def main()
+        \\  let it = Item()
+        \\  for x in it
+        \\    print x.v
+        \\  end
+        \\end
+    );
+}
+
+test "typecheck: for over a non-iterable value is rejected" {
+    try expectCode(
+        \\def main()
+        \\  let n: i16 = 5
+        \\  for x in n
+        \\    print x
+        \\  end
+        \\end
+    , "E_TYPE_NOT_ITERABLE");
+}
+
 test "typecheck: match payload binder carries the variant's field type" {
     // `n` binds the `i16` payload, so returning it where `str` is
     // expected is a mismatch (the binder isn't left untyped).

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -338,6 +338,40 @@ test "typecheck: an iterator loop variable carries the `next` element type" {
     );
 }
 
+test "typecheck: a zero-length array binding types from its annotation" {
+    try expectClean(
+        \\def main()
+        \\  let a: [i16; 0] = []
+        \\  for x in a
+        \\    print x
+        \\  end
+        \\end
+    );
+}
+
+test "typecheck: an empty literal whose count differs from the annotation is rejected" {
+    try expectCode(
+        \\def main()
+        \\  let a: [i16; 2] = []
+        \\  print 0
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: for over a `&[T; N]` types the loop variable from the element" {
+    try expectCode(
+        \\def each(a: &[i16; 3])
+        \\  for x in a
+        \\    let s: str = x
+        \\  end
+        \\end
+        \\def main()
+        \\  let arr: [i16; 3] = [1, 2, 3]
+        \\  each(&arr)
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
 test "typecheck: for over a non-iterable value is rejected" {
     try expectCode(
         \\def main()


### PR DESCRIPTION
## What

`for x in <iterable>` now lowers over every iterable shape (§4.5.3), not just ranges, and types the loop variable from the element type — never left untyped (strong-typing guarantee).

- **`[T; N]`** — direct `0..count` index loop. Array ident/field, literal `[1, 2, 3]` / repeat `[v; n]`, `&[T; N]` reference, and zero-length `[i16; 0]` (no-op). Scalar elements load their value; aggregate elements bind by value.
- **`Vec(T)`** / **`&Vec(T)`** — index loop over the heap buffer (snapshotting pointer + length).
- **`str`** — null-terminated byte walk; loop variable is `char`.
- **iterator protocol** — a class with `next(self) -> T?`: evaluated once into a hidden slot (destructive iteration), each pass calls `it.next()`, binds a present value, exits on `nil`.

`break` / `continue` / `:label` across all kinds. Misusing the loop variable is a type error; a non-iterable operand raises the new `E_TYPE_NOT_ITERABLE`.

## Scalar-optional return ABI (folded prerequisite)

The iterator's `next()` is an optional-returning call, and those didn't materialize before (only `Vec.pop`/`get` did). A scalar `T?` now rides the sret convention like a struct; a pointer-like `T?` returns its nullable word. Side benefit: `if let x = call()` / `let x: T? = call()` work for any optional-returning callee, and a present inner value implicitly wraps (`let x: i16? = 5`).

## Aggregate calling-convention fixes (folded — per maintainer)

Investigating the originally-scoped-out `&array` case uncovered a family of calling-convention defects in how value-type aggregates (`struct` / `[T; N]` / `Vec(T)` / tuple) cross call boundaries. All now correct and adversarially verified (struct/tuple were already correct):

| pass mode | `struct` | tuple | `[T; N]` | `Vec(T)` |
|---|---|---|---|---|
| **by value** | ✓ | ✓ | ✓ fixed | ✓ fixed |
| **`&T` reference** | ✓ fixed | ✓ fixed | ✓ fixed | ✓ fixed |

- **`&T` references** were passed *by value* (reference ignored) → mutation never propagated, access mis-based. Now reference args push a 2-byte pointer; reference-typed aggregate access dereferences once (mirroring class receivers).
- **`[T; N]` / `Vec(T)` by value** were sized as a 2-byte slot + pushed as an address → callee read garbage. Now sized + copied like a struct (array copies, §3.4; Vec moves its 6-byte header, §3.4.3).

Verified across ~30 shapes — field/index/Vec/tuple read+write, nested aggregates, i8/u8 fields, literal args, multiple + mixed by-value/reference args, method dispatch, copy-isolation — with the by-value-copy and struct-return baselines intact.

## Zero-length arrays

`let a: [i16; 0] = []` types from its annotation (zero-byte no-op); a bare `[]` stays a type error (no inferable element type); `[i16; 2] = []` is `E_TYPE_MISMATCH`.

## Tests

23 codegen round-trips + 8 typecheck tests. `zig build ci` green across all release modes + cross-targets.

Closes #309.