### PR TITLE
feat(lang): variadic methods + @static calls + gero check hardening

### DIFF
--- a/.changeset/cli-check-codegen-validate.md
+++ b/.changeset/cli-check-codegen-validate.md
@@ -1,0 +1,13 @@
+---
+bump: minor
+---
+
+`gero check` now validates every `.gr` file end-to-end, not just ones
+with a `main`. It resolves `use` imports and runs codegen in a new
+validation mode (`compile` gained `require_entry`), so a library file
+with no entry point still has its bodies lowered and its codegen-only
+errors surfaced at check time instead of only at `gero compile`.
+
+A `use` that can't be resolved (missing / cyclic file) is now a check
+diagnostic too. The `docs/examples` tours that import an illustrative,
+unshipped `./io` module are marked `gero-example: fmt-only` accordingly.

--- a/.changeset/cli-check-codegen-validate.md
+++ b/.changeset/cli-check-codegen-validate.md
@@ -11,3 +11,8 @@ errors surfaced at check time instead of only at `gero compile`.
 A `use` that can't be resolved (missing / cyclic file) is now a check
 diagnostic too. The `docs/examples` tours that import an illustrative,
 unshipped `./io` module are marked `gero-example: fmt-only` accordingly.
+
+For a multi-file check, each diagnostic is attributed back to the
+original source file (via the fused source map) — an error inside an
+imported file renders against *that* file's path, line, and excerpt,
+not the fused buffer's.

--- a/.changeset/lang-check-codegen-divergence.md
+++ b/.changeset/lang-check-codegen-divergence.md
@@ -1,0 +1,18 @@
+---
+bump: patch
+---
+
+Three `gero check` / typecheck soundness fixes:
+
+- `gero check <missing-path>` now prints a clean file-not-found
+  diagnostic and exits 1, instead of laundering the error into
+  `error.OutOfMemory` and dumping an internal Zig stack trace.
+- An ordering comparison (`<` `<=` `>` `>=`) on an aggregate (struct /
+  tuple / array / `Vec`) is now a type error (`E_TYPE_NOT_ORDERED`) at
+  check time rather than a codegen-only `E_CODEGEN_UNSUPPORTED`.
+  Aggregates still compare with `==` / `!=`; scalars (incl. `char`,
+  `bool`, `str`) still order.
+- A method call on a receiver with no methods — a scalar, `struct`,
+  `enum`, tuple, or array value — is now `E_TYPE_UNDEFINED_METHOD` at
+  check time rather than slipping through to a codegen failure. (A
+  nullable class receiver narrowed to non-nil still resolves.)

--- a/.changeset/lang-static-method-calls.md
+++ b/.changeset/lang-static-method-calls.md
@@ -1,0 +1,31 @@
+---
+bump: minor
+---
+
+`@static` method calls now lower (§3.7) — `ClassName.method(args)` is
+compiled as a direct call with no receiver, and previously only
+type-checked-by-accident (it produced no diagnostic *and* no code). The
+call is now fully type-checked (arguments, return type, variadic arity)
+and emitted, including struct / tuple (sret) returns and variadic
+`@static` methods.
+
+Call-form and scope mismatches that used to slip through are now caught:
+
+- An instance method invoked as `ClassName.method(...)` →
+  `E_INSTANCE_AS_STATIC`; a `@static` method invoked on an instance →
+  `E_STATIC_ON_INSTANCE` (it previously leaked the receiver into the
+  first parameter).
+- `self` / `super` referenced in a `@static` body → `E_STATIC_SELF`
+  (previously passed `gero check` and only failed at compile).
+- A value binding that shadows a class name (`let M = …`) is now honored
+  in receiver position instead of being silently bypassed.
+
+Adversarial review also surfaced pre-existing gaps in the shared method-
+call ABI, fixed here (they affect instance and variadic methods too):
+
+- A tuple passed by value to any method was pushed as only its base
+  address — now copied by value, like struct / array / `Vec` args.
+- A tuple- (and, latently, struct-) returning method didn't always pass
+  its hidden sret destination pointer — the returns-sret test now
+  includes tuple returns and resolves through the inheritance chain
+  rather than the vtable layout (which omits non-virtual methods).

--- a/.changeset/lang-variadic-methods.md
+++ b/.changeset/lang-variadic-methods.md
@@ -1,0 +1,31 @@
+---
+bump: minor
+---
+
+Class methods can now be variadic (`def m(self, …, args: ...)`, §4.6.2).
+A variadic method type-checks once against `args: (T, …, T)` and
+monomorphizes per call-site arity — `args.N` indexing and
+`str.format(fmt, args)` forwarding work in a method body, on direct,
+`self`, `super`, and reference receivers, including inherited methods.
+
+A variadic method is **non-virtual**: per-arity specialization needs a
+distinct address per arity, which a single vtable slot can't hold, so it
+is statically dispatched to its declaring class and gets no vtable entry.
+It therefore can't be `@override` / `@abstract` (new `E_VAR_VIRTUAL`),
+and a class can't redefine an ancestor method with a variadic one or
+vice versa (new `E_VAR_OVERRIDE`).
+
+Adversarial review surfaced four soundness holes (some pre-existing on
+the free-`def` variadic path), all now closed:
+
+- An inline-aggregate variadic element — struct / tuple / array / `Vec`,
+  or a scalar `T?` — was accepted then miscompiled (pushed by value,
+  read back as one word). It's now rejected with `E_VAR_AGGREGATE`; pass
+  aggregate data through an explicit parameter or by reference.
+- A variadic body called only with zero varargs skipped all of its body
+  type-checking while still emitting an arity-0 specialization; the body
+  is now checked against an empty `args` tuple.
+- A non-`@static` method declared without `self` was accepted but the
+  receiver aliased its first parameter (silent corruption, and a
+  compiler panic on the variadic path). Such a method is now rejected
+  with `E_METHOD_NO_SELF`.

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -45,7 +45,13 @@ pub fn execute(
         }
     } else {
         for (positionals) |path| {
-            try collectSourceFiles(io, arena, term, path, &files);
+            // A missing / unreadable path already printed a clean
+            // diagnostic; map its sentinel to exit 1 rather than letting
+            // it escape as an internal error + stack trace.
+            collectSourceFiles(io, arena, term, path, &files) catch |err| switch (err) {
+                error.SourceCollectFailed => return 1,
+                else => |e| return e,
+            };
         }
     }
 
@@ -431,12 +437,12 @@ fn collectSourceFiles(
 ) !void {
     const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch |err| {
         try term.err("gero check: cannot stat {s} ({s})", .{ path, @errorName(err) });
-        return error.OutOfMemory;
+        return error.SourceCollectFailed;
     };
     if (stat.kind == .directory) {
         var dir = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch |err| {
             try term.err("gero check: cannot open dir {s} ({s})", .{ path, @errorName(err) });
-            return error.OutOfMemory;
+            return error.SourceCollectFailed;
         };
         defer dir.close(io);
         var walker = try dir.walk(arena);
@@ -452,7 +458,7 @@ fn collectSourceFiles(
         try out.append(arena, try arena.dupe(u8, path));
     } else {
         try term.err("gero check: {s} is neither a file nor a directory", .{path});
-        return error.OutOfMemory;
+        return error.SourceCollectFailed;
     }
 }
 

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -103,7 +103,7 @@ pub fn execute(
             // it. Always render the diagnostics so the user sees
             // the warnings either way.
             const is_failure = isFailure(res.diagnostics, opts.werror);
-            try gr_files.append(arena, .{ .path = path, .source = res.source, .diagnostics = res.diagnostics, .is_failure = is_failure });
+            try gr_files.append(arena, .{ .path = path, .source = res.source, .diagnostics = res.diagnostics, .source_map = res.source_map, .is_failure = is_failure });
             if (!is_failure) {
                 pass += 1;
                 if (!opts.quiet and !json_mode) try printPassGr(stdout, style, path, single);
@@ -186,11 +186,7 @@ pub fn execute(
         // only files so editors render the squiggles regardless.
         if (gr_files.items.len > 0) {
             var lang_files: std.ArrayList(gero.lang.render.FileDiagnostics) = .empty;
-            for (gr_files.items) |gf| try lang_files.append(arena, .{
-                .path = gf.path,
-                .source = gf.source,
-                .diagnostics = gf.diagnostics,
-            });
+            for (gr_files.items) |gf| try appendAttributed(arena, &lang_files, gf);
             try gero.lang.render.json(stdout, lang_files.items);
         }
         return if (fail > 0) 4 else 0;
@@ -218,11 +214,7 @@ pub fn execute(
     if (gr_files.items.len > 0) {
         if (!single and !opts.quiet and (pass > 0 or failures.items.len > 0)) try stdout.writeByte('\n');
         var lang_files: std.ArrayList(gero.lang.render.FileDiagnostics) = .empty;
-        for (gr_files.items) |gf| try lang_files.append(arena, .{
-            .path = gf.path,
-            .source = gf.source,
-            .diagnostics = gf.diagnostics,
-        });
+        for (gr_files.items) |gf| try appendAttributed(arena, &lang_files, gf);
         const lang_style: gero.lang.render.Style = if (term.color) .ansi else .none;
         try gero.lang.render.pretty(stdout, lang_files.items, lang_style);
     }
@@ -262,6 +254,9 @@ const GrFile = struct {
     path: []const u8,
     source: []const u8,
     diagnostics: []gero.lang.Diagnostic,
+    /// Maps fused offsets back to their originating file, so a
+    /// diagnostic in an imported file renders against the right source.
+    source_map: gero.lang.SourceMap,
     is_failure: bool,
 };
 
@@ -319,11 +314,14 @@ test "isFailure: only notes → not a failure (notes are informational)" {
     try std.testing.expect(!isFailure(&diags, true));
 }
 
-/// Result of running parse + typecheck on one `.gr` source.
+/// Result of validating one `.gr` source (with its `use` imports).
 const GrCheckResult = struct {
     source: []const u8,
     parse_errors: []const u8 = "",
     diagnostics: []gero.lang.Diagnostic,
+    /// Fused → original-file map for diagnostic attribution. Empty for a
+    /// read error (no file was fused).
+    source_map: gero.lang.SourceMap,
     read_error: bool = false,
 };
 
@@ -339,12 +337,49 @@ fn checkOneGr(
     // Resolve `use` imports so the validated program is whole — a `use`
     // failure (missing / cyclic file) is itself a check diagnostic.
     var fused = gero.lang.resolveUseImports(io, arena, path) catch {
-        return .{ .source = "", .diagnostics = &.{}, .read_error = true };
+        return .{ .source = "", .diagnostics = &.{}, .source_map = .{ .files = .empty, .regions = .empty, .allocator = arena }, .read_error = true };
     };
     if (fused.hasErrors()) {
-        return .{ .source = fused.source, .diagnostics = try includeErrorDiagnostics(arena, fused) };
+        return .{ .source = fused.source, .diagnostics = try includeErrorDiagnostics(arena, fused), .source_map = fused.source_map };
     }
-    return .{ .source = fused.source, .diagnostics = try collectGrDiagnostics(arena, fused.source, true) };
+    return .{ .source = fused.source, .diagnostics = try collectGrDiagnostics(arena, fused.source, true), .source_map = fused.source_map };
+}
+
+/// Split a checked `.gr` file's diagnostics by their originating source
+/// file (resolved through the fused source map) and append one
+/// `FileDiagnostics` per file, with each span remapped to that file's
+/// offsets. A single-file check collapses to one entry (identity map);
+/// a multi-file check attributes each diagnostic to the right import.
+fn appendAttributed(
+    arena: std.mem.Allocator,
+    out: *std.ArrayList(gero.lang.render.FileDiagnostics),
+    gf: GrFile,
+) !void {
+    // Insertion-ordered so the root file's diagnostics render first.
+    var by_file: std.StringArrayHashMapUnmanaged(std.ArrayListUnmanaged(gero.lang.Diagnostic)) = .{};
+    var content: std.StringHashMapUnmanaged([]const u8) = .{};
+    for (gf.diagnostics) |d| {
+        const loc = gf.source_map.lookup(d.span.start);
+        const fpath: []const u8 = if (loc) |l| l.file.path else gf.path;
+        const fsrc: []const u8 = if (loc) |l| l.file.content else gf.source;
+        const start: u32 = if (loc) |l| l.file_offset else d.span.start;
+        const remapped: gero.lang.Diagnostic = .{
+            .severity = d.severity,
+            .code = d.code,
+            .message = d.message,
+            .span = .{ .start = start, .end = start + (d.span.end - d.span.start) },
+        };
+        const gop = try by_file.getOrPut(arena, fpath);
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+        try gop.value_ptr.append(arena, remapped);
+        try content.put(arena, fpath, fsrc);
+    }
+    var it = by_file.iterator();
+    while (it.next()) |e| try out.append(arena, .{
+        .path = e.key_ptr.*,
+        .source = content.get(e.key_ptr.*).?,
+        .diagnostics = try e.value_ptr.toOwnedSlice(arena),
+    });
 }
 
 /// Convert `use`-resolution failures into check diagnostics (mirrors the
@@ -551,6 +586,38 @@ test "collectGrDiagnostics: type error surfaces when parse succeeds" {
     defer arena_state.deinit();
     const diags = try collectGrDiagnostics(arena_state.allocator(), "def f()\n  return undefined_name\nend\n", false);
     try std.testing.expect(diags.len > 0);
+}
+
+test "appendAttributed: maps a diagnostic in an imported region to its file" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // Fused = "ROOT--" (file 0, [0,6)) ++ "IMPORTED" (file 1, [6,14)).
+    var files: std.ArrayList(gero.lang.FileInfo) = .empty;
+    try files.append(arena, .{ .path = "root.gr", .content = "ROOT--" });
+    try files.append(arena, .{ .path = "import.gr", .content = "IMPORTED" });
+    var regions: std.ArrayList(gero.lang.Region) = .empty;
+    try regions.append(arena, .{ .fused_start = 0, .fused_end = 6, .file_id = 0, .file_offset = 0 });
+    try regions.append(arena, .{ .fused_start = 6, .fused_end = 14, .file_id = 1, .file_offset = 0 });
+    const sm: gero.lang.SourceMap = .{ .files = files, .regions = regions, .allocator = arena };
+
+    // One diagnostic in the root region, one at fused offset 8 (= import + 2).
+    var diags: std.ArrayList(gero.lang.Diagnostic) = .empty;
+    try diags.append(arena, .{ .severity = .fatal, .code = "E_A", .message = "a", .span = .{ .start = 1, .end = 3 } });
+    try diags.append(arena, .{ .severity = .fatal, .code = "E_B", .message = "b", .span = .{ .start = 8, .end = 10 } });
+
+    var out: std.ArrayList(gero.lang.render.FileDiagnostics) = .empty;
+    try appendAttributed(arena, &out, .{ .path = "root.gr", .source = "ROOT--IMPORTED", .diagnostics = diags.items, .source_map = sm, .is_failure = true });
+
+    try std.testing.expectEqual(@as(usize, 2), out.items.len);
+    // Root file first (insertion order), with the original span.
+    try std.testing.expectEqualStrings("root.gr", out.items[0].path);
+    try std.testing.expectEqual(@as(u32, 1), out.items[0].diagnostics[0].span.start);
+    // Imported file, span remapped to its own offset (8 - 6 = 2).
+    try std.testing.expectEqualStrings("import.gr", out.items[1].path);
+    try std.testing.expectEqual(@as(u32, 2), out.items[1].diagnostics[0].span.start);
+    try std.testing.expectEqual(@as(u32, 4), out.items[1].diagnostics[0].span.end);
 }
 
 test "collectGrDiagnostics: codegen-validates a body even without a `main`" {

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -336,10 +336,35 @@ fn checkOneGr(
     arena: std.mem.Allocator,
     path: []const u8,
 ) !GrCheckResult {
-    const src = std.Io.Dir.cwd().readFileAlloc(io, path, arena, .unlimited) catch {
+    // Resolve `use` imports so the validated program is whole — a `use`
+    // failure (missing / cyclic file) is itself a check diagnostic.
+    var fused = gero.lang.resolveUseImports(io, arena, path) catch {
         return .{ .source = "", .diagnostics = &.{}, .read_error = true };
     };
-    return .{ .source = src, .diagnostics = try collectGrDiagnostics(arena, src) };
+    if (fused.hasErrors()) {
+        return .{ .source = fused.source, .diagnostics = try includeErrorDiagnostics(arena, fused) };
+    }
+    return .{ .source = fused.source, .diagnostics = try collectGrDiagnostics(arena, fused.source, true) };
+}
+
+/// Convert `use`-resolution failures into check diagnostics (mirrors the
+/// compile path's include-error rendering).
+fn includeErrorDiagnostics(arena: std.mem.Allocator, fused: gero.lang.FusedSource) ![]gero.lang.Diagnostic {
+    var out: std.ArrayList(gero.lang.Diagnostic) = .empty;
+    for (fused.errors) |e| {
+        const code: []const u8 = switch (e.kind) {
+            .cycle => "E_USE_CYCLE",
+            .depth_exceeded => "E_USE_DEPTH",
+            .not_found => "E_USE_NOT_FOUND",
+        };
+        const msg = switch (e.kind) {
+            .cycle => try std.fmt.allocPrint(arena, "`use` cycle detected on `{s}`", .{e.requested}),
+            .depth_exceeded => try std.fmt.allocPrint(arena, "`use` depth exceeds 32 on `{s}` — likely runaway recursion", .{e.requested}),
+            .not_found => try std.fmt.allocPrint(arena, "`use` target file not found: `{s}`", .{e.requested}),
+        };
+        try out.append(arena, .{ .severity = .fatal, .code = code, .message = msg, .span = .{ .start = e.site_offset, .end = e.site_offset } });
+    }
+    return out.toOwnedSlice(arena);
 }
 
 /// Tokenize + parse + typecheck a gero-lang source into one flat
@@ -347,7 +372,7 @@ fn checkOneGr(
 /// tests share it. Each diagnostic's `code` is the lexer/parser's
 /// stable `E_SYNTAX_*` code (see `docs/lang-diagnostics.md`), or
 /// `E_SYNTAX_GENERIC` when the emission site carries none.
-fn collectGrDiagnostics(arena: std.mem.Allocator, src: []const u8) ![]gero.lang.Diagnostic {
+fn collectGrDiagnostics(arena: std.mem.Allocator, src: []const u8, validate_codegen: bool) ![]gero.lang.Diagnostic {
     const stream = try gero.lang.tokenize(arena, src);
     var combined: std.ArrayList(gero.lang.Diagnostic) = .empty;
 
@@ -368,8 +393,30 @@ fn collectGrDiagnostics(arena: std.mem.Allocator, src: []const u8) ![]gero.lang.
     // Only typecheck when parsing succeeded — otherwise the AST
     // shape can't carry semantic information.
     if (tree.errors.len == 0) {
-        const checked = try gero.lang.typecheck(arena, src, &tree.program);
+        var checked = try gero.lang.typecheck(arena, src, &tree.program);
         for (checked.diagnostics) |d| try combined.append(arena, d);
+
+        // Codegen-validate so codegen-only errors surface at check time.
+        // `require_entry = false` lowers a library file's bodies even
+        // without a `main` (it's validation, not a runnable image). Only
+        // when the type-check is clean — codegen consumes the typed AST.
+        if (validate_codegen and !checked.hasErrors()) {
+            var compiled = gero.lang.compile(arena, src, &checked, .{ .require_entry = false }) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                // EntryNotFound can't fire (require_entry=false); any other
+                // codegen host failure leaves the type-check result standing.
+                else => null,
+            };
+            if (compiled) |*c| {
+                defer c.deinit();
+                for (c.diagnostics) |d| try combined.append(arena, .{
+                    .severity = d.severity,
+                    .code = d.code,
+                    .message = try arena.dupe(u8, d.message),
+                    .span = d.span,
+                });
+            }
+        }
     }
 
     return combined.toOwnedSlice(arena);
@@ -482,7 +529,7 @@ fn writePhaseTimings(
 test "collectGrDiagnostics: clean source yields no diagnostics" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
-    const diags = try collectGrDiagnostics(arena_state.allocator(), "def add(x, y)\n  return x + y\nend\n");
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "def add(x, y)\n  return x + y\nend\n", false);
     try std.testing.expectEqual(@as(usize, 0), diags.len);
 }
 
@@ -491,7 +538,7 @@ test "collectGrDiagnostics: lexer diagnostic is not double-counted" {
     defer arena_state.deinit();
     // A lexer diagnostic (the `0x`-prefix error) surfaces exactly
     // once, not once per phase — `tree.errors` already includes it.
-    const diags = try collectGrDiagnostics(arena_state.allocator(), "let x = 0x1\n");
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "let x = 0x1\n", false);
     var hex_count: usize = 0;
     for (diags) |d| {
         if (std.mem.eql(u8, d.code, "E_SYNTAX_HEX_PREFIX")) hex_count += 1;
@@ -502,6 +549,28 @@ test "collectGrDiagnostics: lexer diagnostic is not double-counted" {
 test "collectGrDiagnostics: type error surfaces when parse succeeds" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
-    const diags = try collectGrDiagnostics(arena_state.allocator(), "def f()\n  return undefined_name\nend\n");
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "def f()\n  return undefined_name\nend\n", false);
     try std.testing.expect(diags.len > 0);
+}
+
+test "collectGrDiagnostics: codegen-validates a body even without a `main`" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    // A frame-too-large body type-checks clean but is a codegen-only
+    // error; with no `main` in the file, surfacing it proves codegen runs
+    // in validation mode.
+    const src =
+        \\def hog() -> i16
+        \\  let a: [i16; 40] = [0; 40]
+        \\  let b: [i16; 40] = [0; 40]
+        \\  return a[0] + b[0]
+        \\end
+        \\
+    ;
+    const diags = try collectGrDiagnostics(arena_state.allocator(), src, true);
+    var found = false;
+    for (diags) |d| {
+        if (std.mem.eql(u8, d.code, "E_CODEGEN_FRAME_TOO_LARGE")) found = true;
+    }
+    try std.testing.expect(found);
 }

--- a/docs/examples/syntax_overview.gr
+++ b/docs/examples/syntax_overview.gr
@@ -6,6 +6,10 @@
 --
 -- Read this top-to-bottom to see every construct from the spec at
 -- least once. Annotations refer to spec section numbers.
+--
+-- gero-example: fmt-only — imports an illustrative `./io` module that
+-- isn't shipped, so `gero check` (which now resolves `use`) can't
+-- validate it end-to-end; the formatting gate still applies.
 ------------------------------------------------------------
 -- §5.2  Imports
 ------------------------------------------------------------

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -1793,6 +1793,17 @@ The format-spec language (§3.2.2) understands varargs: `format(fmt,
 args)` forwards a varargs tuple positionally. User-defined helpers
 follow the same convention.
 
+A **method** may be variadic too (`def m(self, …, args: ...)`), with
+one consequence: a variadic method is **non-virtual** — it is
+statically dispatched to its declaring class. Per-call specialization
+needs a distinct address per arity, which a single vtable slot can't
+hold, so a variadic method gets no vtable entry; the call resolves to
+the owning class's specialization at compile time (the same body even
+through a base-class reference). It therefore cannot be `@override` or
+`@abstract`, and a class cannot redefine an ancestor's method with a
+variadic one (or vice versa). When a method needs to be polymorphic,
+take a tuple or `Vec` parameter instead of varargs.
+
 Restrictions:
 
 - Only the **last** parameter may be variadic.
@@ -1801,6 +1812,8 @@ Restrictions:
 - All variadic args must be **the same statically-known type** (or
   satisfy a common annotation). Mixed-type varargs aren't supported;
   for heterogeneous data, pass a tuple or struct explicitly.
+- A variadic **method** is non-virtual: not `@override` / `@abstract`,
+  and not overridable.
 
 #### 4.6.3 Method calls and chaining
 
@@ -2484,6 +2497,12 @@ class Player
   end
 end
 ```
+
+Every instance method takes `self` as its first parameter (the
+receiver). A non-`@static` method without `self` is a compile error
+(`E_METHOD_NO_SELF`) — the receiver occupies the first parameter slot,
+so omitting `self` would alias it. Class-level helpers that take no
+receiver are spelled `@static` and called as `ClassName.method(...)`.
 
 Instantiation:
 

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -235,6 +235,7 @@ Raised by the typechecker after parsing succeeds.
 | `E_TYPE_RECURSIVE_STRUCT` | A struct contains itself by value (directly or transitively, through a struct / array / tuple field) — infinite size, no layout. Use `Vec(T)` or `&T` for a recursive shape. |
 | `E_TYPE_NOT_A_TUPLE` | `.N` element access on a non-tuple value. |
 | `E_TYPE_TUPLE_INDEX_OOR` | Tuple element index `.N` is past the tuple's arity. |
+| `E_TYPE_NOT_ORDERED` | Ordering comparison (`<` `<=` `>` `>=`) on an aggregate (struct / tuple / array / `Vec`) — only `==` / `!=` apply. |
 | `E_TYPE_INDEX_OOR` | A constant array index `arr[N]` is negative or past the array's length. |
 | `E_TYPE_REFUTABLE_LET` | A `let` binding uses a refutable pattern (a literal / range / or-pattern, or a multi-variant enum) that can fail to match — use `if let` / `match` instead (§4.2). |
 | `E_TYPE_TUPLE_TOO_MANY` | A tuple has more than 4 elements (§3.4) — use a struct instead. |
@@ -779,6 +780,7 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_TYPE_RECURSIVE_STRUCT` | Typechecker | v0.3 |
 | `E_TYPE_NOT_A_TUPLE` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_INDEX_OOR` | Typechecker | v0.3 |
+| `E_TYPE_NOT_ORDERED` | Typechecker | v0.3 |
 | `E_TYPE_INDEX_OOR` | Typechecker | v0.3 |
 | `E_TYPE_REFUTABLE_LET` | Typechecker | v0.3 |
 | `E_TYPE_TUPLE_TOO_MANY` | Typechecker | v0.3 |

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -455,6 +455,9 @@ Annotation semantics and conflicts. Per spec §3.7.
 | `E_PRIVATE_ACCESS` | Access to a `@private` field / method from outside the declaring class. |
 | `E_STATIC_HAS_SELF` | `@static` method declares a `self` parameter. |
 | `E_METHOD_NO_SELF` | Non-`@static` method doesn't declare `self` as its first parameter (the receiver would alias the first param). |
+| `E_INSTANCE_AS_STATIC` | An instance method called as `ClassName.method(...)` — call it on an instance. |
+| `E_STATIC_ON_INSTANCE` | A `@static` method called on an instance — call it as `ClassName.method(...)`. |
+| `E_STATIC_SELF` | `self` / `super` referenced inside a `@static` method body (no receiver). |
 
 **Mockup — `@inline` too large:**
 
@@ -815,6 +818,9 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_PRIVATE_ACCESS` | Annotations | v0.3 |
 | `E_STATIC_HAS_SELF` | Annotations | v0.3 |
 | `E_METHOD_NO_SELF` | Annotations | v0.3 |
+| `E_INSTANCE_AS_STATIC` | Annotations | v0.3 |
+| `E_STATIC_ON_INSTANCE` | Annotations | v0.3 |
+| `E_STATIC_SELF` | Annotations | v0.3 |
 | `E_BAKE_MMIO_ACCESS` | Bake | v0.3 |
 | `E_BAKE_NON_BAKEABLE_VALUE` | Bake | v0.3 |
 | `E_BAKE_ASM_INSIDE` | Bake | v0.3 |

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -454,6 +454,7 @@ Annotation semantics and conflicts. Per spec §3.7.
 | `E_ABSTRACT_NOT_IMPLEMENTED` | Concrete subclass doesn't override an inherited `@abstract` method. |
 | `E_PRIVATE_ACCESS` | Access to a `@private` field / method from outside the declaring class. |
 | `E_STATIC_HAS_SELF` | `@static` method declares a `self` parameter. |
+| `E_METHOD_NO_SELF` | Non-`@static` method doesn't declare `self` as its first parameter (the receiver would alias the first param). |
 
 **Mockup — `@inline` too large:**
 
@@ -576,7 +577,10 @@ help: simplify the computation, or precompute the table with a
 | `E_VAR_NOT_LAST` | Variadic parameter isn't the last in the list (parse-time). |
 | `E_VAR_HETEROGENEOUS` | Call site mixes types in the variadic slot. |
 | `E_VAR_INCONSISTENT_TYPE` | Two call sites pass different element types — a variadic function has one element type `T` across the whole program (§4.6.2). |
+| `E_VAR_AGGREGATE` | A variadic argument is an inline aggregate (struct / tuple / array / `Vec`). Varargs are word-strided scalars; pass aggregate data through an explicit parameter or by reference (§4.6.2). |
 | `E_VAR_INLINE` | A variadic `def` is marked `@inline` — it already specializes per call-site arity, so the two are mutually exclusive (§4.6.2). |
+| `E_VAR_VIRTUAL` | A variadic method is `@override` or `@abstract` — variadic methods are non-virtual (statically dispatched per arity), so they can't be virtual (§4.6.2). |
+| `E_VAR_OVERRIDE` | A method collides with an ancestor method where one side is variadic — a variadic method can't participate in overriding (§4.6.2). |
 | `E_VAR_NO_DEFAULT` | Variadic parameter declared with a default value. |
 
 **Mockup — heterogeneous call:**
@@ -810,6 +814,7 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_ABSTRACT_NOT_IMPLEMENTED` | Annotations | v0.3 |
 | `E_PRIVATE_ACCESS` | Annotations | v0.3 |
 | `E_STATIC_HAS_SELF` | Annotations | v0.3 |
+| `E_METHOD_NO_SELF` | Annotations | v0.3 |
 | `E_BAKE_MMIO_ACCESS` | Bake | v0.3 |
 | `E_BAKE_NON_BAKEABLE_VALUE` | Bake | v0.3 |
 | `E_BAKE_ASM_INSIDE` | Bake | v0.3 |
@@ -818,7 +823,10 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_VAR_NOT_LAST` | Variadic | v0.3 |
 | `E_VAR_HETEROGENEOUS` | Variadic | v0.3 |
 | `E_VAR_INCONSISTENT_TYPE` | Variadic | v0.3 |
+| `E_VAR_AGGREGATE` | Variadic | v0.3 |
 | `E_VAR_INLINE` | Variadic | v0.3 |
+| `E_VAR_VIRTUAL` | Variadic | v0.3 |
+| `E_VAR_OVERRIDE` | Variadic | v0.3 |
 | `E_VAR_NO_DEFAULT` | Variadic | v0.3 |
 | `E_CAST_INVALID` | Casts | v0.3 |
 | `E_CAST_PRECISION_LOSS` | Casts | v0.3 |

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -86,6 +86,8 @@ pub const FusedSource = include_mod.FusedSource;
 pub const SourceMap = include_mod.SourceMap;
 /// One file's metadata in the include graph.
 pub const FileInfo = include_mod.FileInfo;
+/// One fused-offset → original-file mapping in a `SourceMap`.
+pub const Region = include_mod.Region;
 /// Result of `SourceMap.lookup`.
 pub const Located = include_mod.Located;
 /// One error from include resolution (cycle / depth / not-found).

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -136,6 +136,10 @@ pub const Options = struct {
     /// Build mode. Controls `debug_assert` elision (§5.3) and
     /// overflow trap insertion (§4.2.1).
     optimize: Optimize = .debug,
+    /// Require a top-level entry `def`. `true` for a runnable image;
+    /// `false` for validation-only (e.g. `gero check`), where a library
+    /// file with no `main` still has its bodies lowered + checked.
+    require_entry: bool = true,
 };
 
 /// Errors `compile` can return. Semantic errors land in
@@ -173,7 +177,7 @@ pub fn compile(
     var diag_arena = std.heap.ArenaAllocator.init(allocator);
     errdefer diag_arena.deinit();
 
-    if (findEntryDef(source, checked.program, opts.entry_name) == null) return error.EntryNotFound;
+    if (opts.require_entry and findEntryDef(source, checked.program, opts.entry_name) == null) return error.EntryNotFound;
 
     var emitter: Emitter = .{
         .allocator = allocator,
@@ -1329,8 +1333,11 @@ pub const Emitter = struct {
         // target's address yet.
         try self.collectDefBanks(program);
 
-        const entry = findEntryDef(self.source, program, entry_name).?;
-        try self.emitDef(entry, .entry);
+        // Validation-only builds (no entry) still lower every def / method
+        // body below so codegen errors surface; only the entry prologue
+        // (IVT init, global seeding, `hlt`) is skipped.
+        const entry = findEntryDef(self.source, program, entry_name);
+        if (entry) |e| try self.emitDef(e, .entry);
         // Two-pass over top-level defs: hot first (source order),
         // then `@cold`-marked defs (still source order within the
         // group) — deterministic layout across compiler versions.
@@ -1340,12 +1347,12 @@ pub const Emitter = struct {
         // arity. `emitSpecializations` emits one `name$N` per call-site
         // arity below, sharing the body (§4.6.2).
         for (program.statements) |*stmt| switch (stmt.*) {
-            .def_decl => |*dd| if (dd != entry and !defHasFlagAnnotation(self.source, dd, "cold") and !defHasFlagAnnotation(self.source, dd, "inline") and !variadic.isVariadicDef(dd.*))
+            .def_decl => |*dd| if ((entry == null or dd != entry.?) and !defHasFlagAnnotation(self.source, dd, "cold") and !defHasFlagAnnotation(self.source, dd, "inline") and !variadic.isVariadicDef(dd.*))
                 try self.emitDef(dd, .regular),
             else => {},
         };
         for (program.statements) |*stmt| switch (stmt.*) {
-            .def_decl => |*dd| if (dd != entry and defHasFlagAnnotation(self.source, dd, "cold") and !defHasFlagAnnotation(self.source, dd, "inline") and !variadic.isVariadicDef(dd.*))
+            .def_decl => |*dd| if ((entry == null or dd != entry.?) and defHasFlagAnnotation(self.source, dd, "cold") and !defHasFlagAnnotation(self.source, dd, "inline") and !variadic.isVariadicDef(dd.*))
                 try self.emitDef(dd, .regular),
             else => {},
         };

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -8,6 +8,7 @@ const value_struct = @import("value_struct.zig");
 const vec_builtin = @import("vec_builtin.zig");
 const variadic = @import("variadic.zig");
 const def_emit = @import("def.zig");
+const archive = @import("archive.zig");
 
 const Emitter = codegen_mod.Emitter;
 const Type = types.Type;
@@ -166,12 +167,15 @@ fn computeLayout(self: *Emitter, class_name: []const u8) !void {
         }
     }
 
-    // A struct- or scalar-`T?`-returning method needs the same sret scratch
-    // buffer as a free fn — size the per-frame scratch to the widest return.
+    // A struct- / tuple- / scalar-`T?`-returning method needs the same sret
+    // scratch buffer as a free fn — size the per-frame scratch to the widest.
     for (cd.methods) |method| {
         const rt = method.ret_type orelse continue;
         if (self.structNameOfTypeAnn(rt.*)) |sname| {
             const w = self.structSlotWidth(sname);
+            if (w > self.global_sret_scratch) self.global_sret_scratch = w;
+        } else if (rt.* == .tuple) {
+            const w = archive.alignUpU16(self.widthOfTypeAnn(rt.*), 2);
             if (w > self.global_sret_scratch) self.global_sret_scratch = w;
         } else if (try self.scalarOptReturnInner(rt.*)) |_| {
             if (Emitter.opt_scalar_size > self.global_sret_scratch) self.global_sret_scratch = Emitter.opt_scalar_size;
@@ -286,50 +290,52 @@ pub fn patchVtableSlots(self: *Emitter) !void {
     }
 }
 
-/// Struct return-type name of `class_name`.`method_name` (resolving
-/// the owner up the inheritance chain), or `null` when it returns a
-/// scalar. Drives the sret convention at the call site.
+/// Return-type annotation of `class_name`.`method_name`, resolving the
+/// owner up the inheritance chain. Uses `resolveMethodOwner` (not the
+/// vtable layout) so it also covers variadic / `@static` methods, which
+/// have no vtable slot. `null` when the method / class is unknown or has
+/// no return annotation.
+fn methodRetTypeAnn(self: *Emitter, class_name: []const u8, method_name: []const u8) ?*const ast.TypeAnn {
+    const res = resolveMethodOwner(self, class_name, method_name) orelse return null;
+    return if (res.method.ret_type) |rt| rt else null;
+}
+
+/// Struct return-type name of `class_name`.`method_name`, or `null` when
+/// it doesn't return a struct. Drives the sret convention at the call site.
 fn methodRetStruct(self: *Emitter, class_name: []const u8, method_name: []const u8) ?[]const u8 {
-    const layout = self.class_layouts.get(class_name) orelse return null;
-    const owner = layout.method_owners.get(method_name) orelse return null;
-    const cd = self.class_decls.get(owner) orelse return null;
-    for (cd.methods) |m| {
-        if (std.mem.eql(u8, self.source[m.name.start..m.name.end], method_name)) {
-            return if (m.ret_type) |rt| self.structNameOfTypeAnn(rt.*) else null;
-        }
-    }
-    return null;
+    const rt = methodRetTypeAnn(self, class_name, method_name) orelse return null;
+    return self.structNameOfTypeAnn(rt.*);
+}
+
+/// `true` when `class_name`.`method_name` returns a tuple by value (rides
+/// the same sret convention as a struct).
+fn methodRetTuple(self: *Emitter, class_name: []const u8, method_name: []const u8) bool {
+    const rt = methodRetTypeAnn(self, class_name, method_name) orelse return false;
+    return rt.* == .tuple;
+}
+
+/// `true` when `class_name`.`method_name` returns a scalar `T?` (the
+/// 4-byte `{present, value}` rides the sret convention like a struct).
+fn methodRetScalarOpt(self: *Emitter, class_name: []const u8, method_name: []const u8) error{OutOfMemory}!bool {
+    const rt = methodRetTypeAnn(self, class_name, method_name) orelse return false;
+    return (try self.scalarOptReturnInner(rt.*)) != null;
+}
+
+/// `true` when a call to `class_name`.`method_name` must pass a hidden
+/// sret destination pointer — i.e. the method returns a struct, tuple,
+/// or scalar `T?` by value.
+fn methodReturnsSret(self: *Emitter, class_name: []const u8, method_name: []const u8) error{OutOfMemory}!bool {
+    return methodRetStruct(self, class_name, method_name) != null or
+        methodRetTuple(self, class_name, method_name) or
+        try methodRetScalarOpt(self, class_name, method_name);
 }
 
 /// Resolved return type of `class_name`.`method_name` (walking the
 /// inheritance chain to the owner), or `null` when the method has no
 /// return annotation or the class / method is unknown.
 pub fn methodReturnType(self: *Emitter, class_name: []const u8, method_name: []const u8) error{OutOfMemory}!?*const Type {
-    const layout = self.class_layouts.get(class_name) orelse return null;
-    const owner = layout.method_owners.get(method_name) orelse return null;
-    const cd = self.class_decls.get(owner) orelse return null;
-    for (cd.methods) |m| {
-        if (std.mem.eql(u8, self.source[m.name.start..m.name.end], method_name)) {
-            const rt = m.ret_type orelse return null;
-            return try self.typeAnnToType(rt.*);
-        }
-    }
-    return null;
-}
-
-/// `true` when `class_name`.`method_name` returns a scalar `T?` (the
-/// 4-byte `{present, value}` rides the sret convention like a struct).
-fn methodRetScalarOpt(self: *Emitter, class_name: []const u8, method_name: []const u8) error{OutOfMemory}!bool {
-    const layout = self.class_layouts.get(class_name) orelse return false;
-    const owner = layout.method_owners.get(method_name) orelse return false;
-    const cd = self.class_decls.get(owner) orelse return false;
-    for (cd.methods) |m| {
-        if (std.mem.eql(u8, self.source[m.name.start..m.name.end], method_name)) {
-            const rt = m.ret_type orelse return false;
-            return (try self.scalarOptReturnInner(rt.*)) != null;
-        }
-    }
-    return false;
+    const rt = methodRetTypeAnn(self, class_name, method_name) orelse return null;
+    return try self.typeAnnToType(rt.*);
 }
 
 /// Push an optional sret destination pointer (this frame's scratch
@@ -354,6 +360,11 @@ fn pushSretAndArgs(self: *Emitter, args: []const *const ast.Expr, sret: bool) !u
             if (self.argStructName(args[i])) |sname| {
                 try value_struct.pushArg(self, args[i], sname);
                 total += self.structSlotWidth(sname);
+                continue;
+            }
+            if (self.tupleElemsOf(args[i])) |elems| {
+                try value_struct.pushTupleArg(self, args[i], elems);
+                total += self.tupleSlotWidth(elems);
                 continue;
             }
             if (self.arrayInfoOf(args[i])) |info| {
@@ -634,8 +645,7 @@ pub fn emitMethodDispatchOnInstance(
     try isa.pushReg(self, Reg.acu);
 
     // 2. Push the optional sret destination + args (sret-aware).
-    const returns_sret = methodRetStruct(self, class_name, method_name) != null or
-        try methodRetScalarOpt(self, class_name, method_name);
+    const returns_sret = try methodReturnsSret(self, class_name, method_name);
     const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
 
     // 3. Reload the instance pointer (spilled at `sp + arg_bytes`),
@@ -705,8 +715,7 @@ pub fn emitVariadicMethodCall(
     try emitInstancePtr(self, recv); // acu = instance pointer
     try isa.pushReg(self, Reg.acu); // spill above args
 
-    const returns_sret = methodRetStruct(self, owner, method_name) != null or
-        try methodRetScalarOpt(self, owner, method_name);
+    const returns_sret = try methodReturnsSret(self, owner, method_name);
     const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
 
     // Reload the spilled instance pointer, push it last so self lands
@@ -718,6 +727,28 @@ pub fn emitVariadicMethodCall(
 
     // Drop self + args + the spilled instance pointer.
     try isa.addImmToReg(self, 2 + arg_bytes + 2, Reg.sp);
+}
+
+/// Lower `ClassName.method(args)` — a `@static` method call (§3.7). No
+/// receiver, so no `self` is pushed: just the optional sret pointer + the
+/// args, then a direct call to `Owner.method` (or `Owner.method$N` for a
+/// variadic `@static` method). `arity` is ignored unless `variadic`.
+pub fn emitStaticMethodCall(
+    self: *Emitter,
+    owner: []const u8,
+    method_name: []const u8,
+    args: []const *const ast.Expr,
+    span: ast.Span,
+    variadic_call: bool,
+    arity: u16,
+) !void {
+    const returns_sret = try methodReturnsSret(self, owner, method_name);
+    const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
+    const base = try methodLabel(self, owner, method_name);
+    const label = if (variadic_call) try variadic.label(self, base, arity) else base;
+    try emitDirectCall(self, label, span);
+    // Drop sret + args — no `self` to clean up.
+    if (arg_bytes > 0) try isa.addImmToReg(self, arg_bytes, Reg.sp);
 }
 
 /// Lower `super.method(args)` — direct call to the named method
@@ -753,8 +784,7 @@ pub fn emitSuperMethodCall(
 
     // Push the optional sret destination + args (sret-aware), then
     // reload self and push it last so it lands at fp+4.
-    const returns_sret = methodRetStruct(self, owner, method_name) != null or
-        try methodRetScalarOpt(self, owner, method_name);
+    const returns_sret = try methodReturnsSret(self, owner, method_name);
     const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
     try isa.movRegOffsetToReg(self, Reg.fp, self_ofs, Reg.r1);
     try isa.pushReg(self, Reg.r1);
@@ -781,8 +811,7 @@ pub fn emitSuperVariadicMethodCall(
         try self.diagFatal(span, "E_CODEGEN_NO_SELF", "codegen: `super.method` used outside a method body");
         return;
     };
-    const returns_sret = methodRetStruct(self, owner, method_name) != null or
-        try methodRetScalarOpt(self, owner, method_name);
+    const returns_sret = try methodReturnsSret(self, owner, method_name);
     const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
     try isa.movRegOffsetToReg(self, Reg.fp, self_ofs, Reg.r1);
     try isa.pushReg(self, Reg.r1);

--- a/src/lang/codegen/class.zig
+++ b/src/lang/codegen/class.zig
@@ -6,6 +6,8 @@ const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
 const value_struct = @import("value_struct.zig");
 const vec_builtin = @import("vec_builtin.zig");
+const variadic = @import("variadic.zig");
+const def_emit = @import("def.zig");
 
 const Emitter = codegen_mod.Emitter;
 const Type = types.Type;
@@ -143,9 +145,13 @@ fn computeLayout(self: *Emitter, class_name: []const u8) !void {
     }
 
     // Own methods — overrides reuse the parent's slot (same name
-    // already in `method_slots`); brand-new methods append.
+    // already in `method_slots`); brand-new methods append. A variadic
+    // method is non-virtual (§4.6.2): it monomorphizes per arity and
+    // gets no vtable slot — it's reached only by static `Class.method$N`
+    // dispatch, never through the vtable.
     const dup_class = try self.arena.dupe(u8, class_name);
     for (cd.methods) |method| {
+        if (variadic.isVariadicDef(method)) continue;
         const mname = self.source[method.name.start..method.name.end];
         const dup_m = try self.arena.dupe(u8, mname);
         if (layout.method_slots.get(mname) != null) {
@@ -192,12 +198,37 @@ pub fn emitClassMethods(self: *Emitter, program: *const ast.Program) !void {
             const cname = self.source[cd.name.start..cd.name.end];
             for (cd.methods) |*method| {
                 const mname = self.source[method.name.start..method.name.end];
-                const label = try methodLabel(self, cname, mname);
-                try self.emitMethodAsDef(method, cname, label);
+                const base = try methodLabel(self, cname, mname);
+                if (variadic.isVariadicDef(method.*)) {
+                    try emitVariadicMethod(self, method, cname, base);
+                } else {
+                    try self.emitMethodAsDef(method, cname, base);
+                }
             }
         },
         else => {},
     };
+}
+
+/// Emit a variadic method's per-arity specializations under
+/// `Class.method$N` (§4.6.2) — the method analog of
+/// `variadic.emitSpecializations`, routed through `emitMethodAsDef` so
+/// each specialization keeps its class context (`self`, `super`).
+/// `base` is the `Class.method` label; the whole-program facts are keyed
+/// by it. An arity-0 specialization still emits when no `T` is pinned.
+fn emitVariadicMethod(self: *Emitter, method: *const ast.DefDecl, cname: []const u8, base: []const u8) !void {
+    const elem = self.checked.variadicElem(base);
+    const last = method.params[method.params.len - 1];
+    const param_name = self.source[last.name.start..last.name.end];
+    for (self.checked.variadicArities(base)) |arity| {
+        // @as: a call-site arity is frame-bounded well under u16.
+        const n: u16 = @intCast(arity);
+        if (n > 0 and elem == null) continue;
+        const saved = self.current_variadic;
+        self.current_variadic = .{ .param = param_name, .elem = elem, .arity = n };
+        defer self.current_variadic = saved;
+        try self.emitMethodAsDef(method, cname, try variadic.label(self, base, n));
+    }
 }
 
 /// Emit per-class vtables after all method addresses are known.
@@ -625,6 +656,70 @@ pub fn emitMethodDispatchOnInstance(
     try isa.addImmToReg(self, 2 + arg_bytes + 2, Reg.sp);
 }
 
+/// The owning class + decl of `method_name` resolved up `class_name`'s
+/// inheritance chain (codegen analog of `lookupClassMethodOwner`).
+pub const MethodResolution = struct { owner: []const u8, method: *const ast.DefDecl };
+
+/// Walk `class_name`'s ancestor chain for a method named `method_name`,
+/// returning the owning class name + its decl, or `null`.
+pub fn resolveMethodOwner(self: *Emitter, class_name: []const u8, method_name: []const u8) ?MethodResolution {
+    var cname = class_name;
+    while (true) {
+        const cd = self.class_decls.get(cname) orelse return null;
+        for (cd.methods) |*m| {
+            if (std.mem.eql(u8, self.source[m.name.start..m.name.end], method_name)) {
+                return .{ .owner = cname, .method = m };
+            }
+        }
+        cname = if (cd.extends) |ext| self.source[ext.start..ext.end] else return null;
+    }
+}
+
+/// Vararg count at a variadic method call site: `n_args` minus the
+/// fixed params (excluding `self` when present + the variadic slot).
+/// Underflow-safe — a `self`-less method (`has_self == false`) would
+/// otherwise wrap `params.len - 2`.
+pub fn variadicMethodArity(self: *Emitter, method: *const ast.DefDecl, n_args: usize) u16 {
+    const params = method.params;
+    const has_self = params.len > 0 and std.mem.eql(u8, self.source[params[0].name.start..params[0].name.end], "self");
+    const skip: usize = if (has_self) 1 else 0;
+    const fixed: usize = if (params.len > skip) params.len - skip - 1 else 0;
+    // @as: arity is frame-bounded; clamp to keep the narrowing safe.
+    return @intCast(if (n_args > fixed) n_args - fixed else 0);
+}
+
+/// Static-dispatch a variadic method call to `Owner.method$arity`
+/// (§4.6.2). A variadic method is non-virtual, so there's no vtable
+/// slot — this mirrors the instance dispatch (spill receiver, push
+/// sret + args, reload + push self) but ends in a direct call to the
+/// arity specialization rather than a vtable-indexed `call_reg`.
+pub fn emitVariadicMethodCall(
+    self: *Emitter,
+    recv: *const ast.Expr,
+    owner: []const u8,
+    method_name: []const u8,
+    arity: u16,
+    args: []const *const ast.Expr,
+    span: ast.Span,
+) !void {
+    try emitInstancePtr(self, recv); // acu = instance pointer
+    try isa.pushReg(self, Reg.acu); // spill above args
+
+    const returns_sret = methodRetStruct(self, owner, method_name) != null or
+        try methodRetScalarOpt(self, owner, method_name);
+    const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
+
+    // Reload the spilled instance pointer, push it last so self lands
+    // at fp+4, then direct-call the per-arity specialization.
+    try loadFromStack(self, arg_bytes, Reg.r1);
+    try isa.pushReg(self, Reg.r1);
+    const base = try methodLabel(self, owner, method_name);
+    try emitDirectCall(self, try variadic.label(self, base, arity), span);
+
+    // Drop self + args + the spilled instance pointer.
+    try isa.addImmToReg(self, 2 + arg_bytes + 2, Reg.sp);
+}
+
 /// Lower `super.method(args)` — direct call to the named method
 /// on the parent of the enclosing method's class. Bypasses vtable
 /// lookup entirely (the dispatch is static at compile time).
@@ -668,6 +763,31 @@ pub fn emitSuperMethodCall(
     try emitDirectCall(self, label, span);
 
     // Drop self + args. The method's result survives in `acu`.
+    try isa.addImmToReg(self, 2 + arg_bytes, Reg.sp);
+}
+
+/// Static-dispatch `super.method(args)` for a variadic method (§4.6.2)
+/// to `Owner.method$arity`. Mirrors `emitSuperMethodCall` (self is the
+/// stable `fp+4` param, no spill) but targets the arity specialization.
+pub fn emitSuperVariadicMethodCall(
+    self: *Emitter,
+    owner: []const u8,
+    method_name: []const u8,
+    arity: u16,
+    args: []const *const ast.Expr,
+    span: ast.Span,
+) !void {
+    const self_ofs = self.params.get("self") orelse {
+        try self.diagFatal(span, "E_CODEGEN_NO_SELF", "codegen: `super.method` used outside a method body");
+        return;
+    };
+    const returns_sret = methodRetStruct(self, owner, method_name) != null or
+        try methodRetScalarOpt(self, owner, method_name);
+    const arg_bytes = try pushSretAndArgs(self, args, returns_sret);
+    try isa.movRegOffsetToReg(self, Reg.fp, self_ofs, Reg.r1);
+    try isa.pushReg(self, Reg.r1);
+    const base = try methodLabel(self, owner, method_name);
+    try emitDirectCall(self, try variadic.label(self, base, arity), span);
     try isa.addImmToReg(self, 2 + arg_bytes, Reg.sp);
 }
 

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -895,6 +895,21 @@ pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr)
     }
     if (m.receiver.* == .ident) {
         const recv = self.source[m.receiver.ident.span.start..m.receiver.ident.span.end];
+        // `ClassName.method(args)` — `@static` call: the receiver is a
+        // class NAME, not an instance, so no `self` is pushed (§3.7). A
+        // same-named value binding shadows the class, so skip when `recv`
+        // names a local / param / capture / global value.
+        const shadowed = self.locals.contains(recv) or self.params.contains(recv) or
+            self.captures.contains(recv) or self.globals.contains(recv);
+        if (!shadowed and self.class_decls.contains(recv)) {
+            const mname = self.source[m.method.start..m.method.end];
+            if (class.resolveMethodOwner(self, recv, mname)) |res| {
+                const is_var = variadic.isVariadicDef(res.method.*);
+                const arity = if (is_var) class.variadicMethodArity(self, res.method, m.args.len) else 0;
+                try class.emitStaticMethodCall(self, res.owner, mname, m.args, m.span, is_var, arity);
+                return;
+            }
+        }
         // Payload-variant constructor — `Enum.Variant(args)` parses as
         // a method call on the enum name.
         if (self.enum_decls.get(recv)) |ed| {

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -849,15 +849,35 @@ pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr)
     if (m.receiver.* == .super_expr) {
         if (self.current_class_name) |cname| {
             const mname = self.source[m.method.start..m.method.end];
+            // A variadic ancestor method is non-virtual — static-dispatch
+            // to its `Owner.method$N` (§4.6.2). `resolveMethodOwner` skips
+            // `cname` (which can't redeclare a variadic method) to the
+            // ancestor that owns it, matching `super` semantics.
+            if (class.resolveMethodOwner(self, cname, mname)) |res| {
+                if (variadic.isVariadicDef(res.method.*)) {
+                    const arity = class.variadicMethodArity(self, res.method, m.args.len);
+                    try class.emitSuperVariadicMethodCall(self, res.owner, mname, arity, m.args, m.span);
+                    return;
+                }
+            }
             try class.emitSuperMethodCall(self, cname, mname, m.args, m.span);
             return;
         }
         try self.unsupported(m.span, "`super.method` used outside a method body");
         return;
     }
-    // Class-typed receiver — vtable dispatch.
+    // Class-typed receiver. A variadic method is non-virtual (§4.6.2):
+    // resolve its owner + this site's arity and static-dispatch to the
+    // `Owner.method$N` specialization. Everything else is vtable dispatch.
     if (self.classNameOf(m.receiver)) |cname| {
         const mname = self.source[m.method.start..m.method.end];
+        if (class.resolveMethodOwner(self, cname, mname)) |res| {
+            if (variadic.isVariadicDef(res.method.*)) {
+                const arity = class.variadicMethodArity(self, res.method, m.args.len);
+                try class.emitVariadicMethodCall(self, m.receiver, res.owner, mname, arity, m.args, m.span);
+                return;
+            }
+        }
         try class.emitMethodDispatch(self, m.receiver, cname, mname, m.args, m.span);
         return;
     }

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -97,6 +97,7 @@ pub fn typecheck(
         .def_registry = .{},
         .variadic_info = .{},
         .deferred_variadic = .empty,
+        .deferred_variadic_methods = .empty,
         .mmio_names = .{},
         .fn_locals = null,
         .tuple_correlations = .{},
@@ -193,6 +194,14 @@ pub const VariadicInfo = struct {
     arities: std.ArrayListUnmanaged(u32) = .empty,
 };
 
+/// A variadic method whose body is deferred until call sites pin its
+/// `T` + arity (§4.6.2). Carries the declaring class so the deferred
+/// walk can re-establish the method's scope (`self`, fields, `super`).
+pub const DeferredMethod = struct {
+    class: *const ast.ClassDecl,
+    method: *const ast.DefDecl,
+};
+
 /// Stateful walker that runs resolution + inference + checking.
 /// Sub-modules under `typecheck/` take a `*Checker` and call back
 /// into its public methods.
@@ -241,6 +250,10 @@ pub const Checker = struct {
     /// Variadic defs whose bodies are deferred until `variadic_info` is
     /// fully populated (the element type comes from call sites).
     deferred_variadic: std.ArrayListUnmanaged(*const ast.DefDecl),
+    /// Variadic methods whose bodies are deferred — same rule as
+    /// `deferred_variadic`, but each carries its declaring class so the
+    /// deferred walk restores the method scope.
+    deferred_variadic_methods: std.ArrayListUnmanaged(DeferredMethod),
     /// Module-level `let`s annotated `@addr`. Accessing from a
     /// bake context emits `E_BAKE_MMIO_ACCESS`.
     mmio_names: std.StringHashMapUnmanaged(void),

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -88,6 +88,7 @@ pub fn typecheck(
         .current_scope = &module_scope,
         .current_ret_ty = null,
         .current_variadic_param = null,
+        .in_static_method = false,
         .current_class_extends = null,
         .current_class_name = null,
         .non_nil = .{},
@@ -225,6 +226,9 @@ pub const Checker = struct {
     /// body, else `null`. Lets an out-of-range `args.N` report against
     /// the call-site minimum arity rather than a bare tuple width.
     current_variadic_param: ?[]const u8,
+    /// `true` while checking a `@static` method body — `self` / `super`
+    /// are unavailable there (no receiver), so referencing either errors.
+    in_static_method: bool,
     /// `extends Parent` span when inside a class method. `null`
     /// elsewhere. Drives `super` resolution.
     current_class_extends: ?ast.Span,
@@ -1314,6 +1318,10 @@ pub const Checker = struct {
                 return null;
             },
             .self_expr => |se| {
+                if (self.in_static_method) {
+                    try self.emitSpan("E_STATIC_SELF", se.span, "`self` is not available in a `@static` method — it has no receiver");
+                    return null;
+                }
                 if (self.current_class_name) |cn| {
                     // `self` is a value of the enclosing class type.
                     return try types.mkNamed(self.arena, cn, se.span);
@@ -1321,6 +1329,10 @@ pub const Checker = struct {
                 return null;
             },
             .super_expr => |se| {
+                if (self.in_static_method) {
+                    try self.emitSpan("E_STATIC_SELF", se.span, "`super` is not available in a `@static` method — it has no receiver");
+                    return null;
+                }
                 if (self.current_class_extends) |ext| {
                     return try types.mkNamed(self.arena, self.lexeme(ext), ext);
                 }
@@ -1361,6 +1373,14 @@ pub const Checker = struct {
                     // payload-variant constructor.
                     if (self.enum_registry.get(recv_name)) |ed| {
                         return try fields.checkEnumVariantConstruct(self, m, ed, recv_name);
+                    }
+                    // `ClassName.method(args)` — a `@static` call (the
+                    // receiver is a class name, not an instance). A value
+                    // binding of the same name shadows the class, so only
+                    // route here when the name still resolves to the class.
+                    if (self.class_registry.get(recv_name)) |cd| {
+                        const is_class_ref = if (self.current_scope.lookup(recv_name)) |info| info.kind == .class else true;
+                        if (is_class_ref) return try fields.checkStaticMethodCall(self, m, cd, recv_name);
                     }
                 }
                 const recv_ty = try self.inferExpr(m.receiver, null);

--- a/src/lang/typecheck/calls.zig
+++ b/src/lang/typecheck/calls.zig
@@ -7,6 +7,7 @@ const relations = @import("relations.zig");
 const annotations = @import("annotations.zig");
 const flow = @import("flow.zig");
 const stdlib = @import("stdlib.zig");
+const type_resolve = @import("type_resolve.zig");
 
 const Checker = typecheck.Checker;
 const WalkError = error{OutOfMemory};
@@ -270,8 +271,24 @@ pub fn checkVariadicCall(
         }
     }
     // Variadic slot: all trailing args must share a type.
+    const pivot = try checkVariadicSlot(self, c.args[fixed_count..]);
+    // Fold this call's element type + arity into the callee's
+    // whole-program variadic facts (§4.6.2) so the body can be
+    // type-checked once against `args: (T, …, T)` of the max arity.
+    if (directCalleeName(self, c.callee)) |name| {
+        const arity: u32 = @intCast(c.args.len - fixed_count);
+        try recordVariadic(self, name, pivot, arity, c.span);
+    }
+    return f.ret;
+}
+
+/// Type-check the trailing variadic args for homogeneity (§4.6.2):
+/// every arg must share the first inferred element type. Returns that
+/// pivot type (`null` when no arg pins one). A divergent arg is
+/// `E_VAR_HETEROGENEOUS`.
+fn checkVariadicSlot(self: *Checker, varargs: []const *ast.Expr) WalkError!?*const types.Type {
     var pivot: ?*const types.Type = null;
-    for (c.args[fixed_count..]) |arg| {
+    for (varargs) |arg| {
         const arg_ty = try self.inferExpr(arg, pivot);
         const at = arg_ty orelse continue;
         if (pivot) |p| {
@@ -289,14 +306,103 @@ pub fn checkVariadicCall(
             pivot = at;
         }
     }
-    // Fold this call's element type + arity into the callee's
-    // whole-program variadic facts (§4.6.2) so the body can be
-    // type-checked once against `args: (T, …, T)` of the max arity.
-    if (directCalleeName(self, c.callee)) |name| {
-        const arity: u32 = @intCast(c.args.len - fixed_count);
-        try recordVariadic(self, name, pivot, arity, c.span);
+    // Varargs are word-strided (each pushed as a full word); an inline
+    // aggregate element doesn't fit that ABI. Reject it — the spec's
+    // remedy for aggregate data is an explicit tuple / struct / `Vec`
+    // parameter, not a variadic element (§4.6.2).
+    if (pivot) |p| {
+        if (varargs.len > 0 and isAggregateElem(self, p)) {
+            const s = try types.render(self.arena, p.*);
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "variadic argument can't be the aggregate type `{s}` — varargs are scalar; pass it through an explicit tuple, struct, array, or `Vec` parameter (or by reference, `&{s}`) instead",
+                .{ s, s },
+            );
+            try self.emitSpan("E_VAR_AGGREGATE", varargs[0].span(), msg);
+        }
     }
-    return f.ret;
+    return pivot;
+}
+
+/// `true` when `t` is an inline aggregate pushed by value at multi-word
+/// width — a struct / tuple / array / `Vec`. It can't be a variadic
+/// element: the caller pushes the whole value while `args.N` reads a
+/// single word, so field / element access would deref garbage. Scalars
+/// and pointer-like types (`str`, `&T`, class, enum) are one word.
+fn isAggregateElem(self: *const Checker, t: *const types.Type) bool {
+    return switch (t.*) {
+        .array, .vec, .tuple => true,
+        .named => |n| self.struct_registry.contains(n.name),
+        // A scalar `T?` is a 4-byte `{present, value}` inline value (§3.4.1)
+        // — multi-word, like a struct. A pointer-like `T?` (`str?`, `&T?`,
+        // class) is a single nullable word, so it stays a legal element.
+        .optional => |inner| inner.* == .primitive and switch (inner.primitive) {
+            .i8, .u8, .i16, .u16, .char, .bool_, .fixed => true,
+            else => false,
+        },
+        else => false,
+    };
+}
+
+/// Whole-program key for a variadic method's facts: `Owner.method`,
+/// matching the codegen method label so emission + call routing read
+/// the same arity set. `.` can't appear in a source identifier, so a
+/// method key never collides with a free-def key.
+pub fn methodKey(self: *Checker, owner_name: []const u8, method_name: []const u8) WalkError![]const u8 {
+    return std.fmt.allocPrint(self.arena, "{s}.{s}", .{ owner_name, method_name });
+}
+
+/// Type-check a variadic METHOD call `recv.m(args)` (§4.6.2). Mirrors
+/// `checkVariadicCall` but skips the implicit `self` param when matching
+/// fixed args, and records facts under the owner-qualified key so the
+/// body + codegen monomorphize per arity. A variadic method is
+/// statically dispatched (non-virtual), so the owner is unique.
+pub fn checkVariadicMethodCall(
+    self: *Checker,
+    m: ast.MethodCallExpr,
+    method: *const ast.DefDecl,
+    owner_name: []const u8,
+) WalkError!?*const types.Type {
+    const has_self = method.params.len > 0 and std.mem.eql(u8, self.lexeme(method.params[0].name), "self");
+    const skip: usize = if (has_self) 1 else 0;
+    // params = [self?, fixed…, args]; fixed_count excludes both. Guarded
+    // against underflow for a degenerate `self`-only / variadic-`self` list.
+    const fixed_count: usize = if (method.params.len > skip) method.params.len - skip - 1 else 0;
+    if (m.args.len < fixed_count) {
+        const suffix: []const u8 = if (fixed_count == 1) "" else "s";
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "variadic method requires at least {d} fixed argument{s}, called with {d}",
+            .{ fixed_count, suffix, m.args.len },
+        );
+        try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return try methodReturnType(self, method);
+    }
+    // Fixed params (skip `self`): standard per-arg type check.
+    for (m.args[0..fixed_count], 0..) |arg, i| {
+        const p = method.params[skip + i];
+        const param_ty: ?*const types.Type = if (p.type_ann) |t|
+            try type_resolve.resolveType(self, t)
+        else
+            null;
+        const skip_arg = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
+        const arg_ty = try self.inferExpr(arg, if (skip_arg) null else param_ty);
+        if (!skip_arg and param_ty != null and arg_ty != null) {
+            try self.checkStoreCompat(arg.span(), param_ty.?, arg_ty.?);
+        }
+    }
+    const pivot = try checkVariadicSlot(self, m.args[fixed_count..]);
+    const key = try methodKey(self, owner_name, self.lexeme(method.name));
+    const arity: u32 = @intCast(m.args.len - fixed_count);
+    try recordVariadic(self, key, pivot, arity, m.span);
+    return try methodReturnType(self, method);
+}
+
+/// Resolve a method's declared return type, or `nil` when implicit.
+fn methodReturnType(self: *Checker, method: *const ast.DefDecl) WalkError!?*const types.Type {
+    if (method.ret_type) |r| return try type_resolve.resolveType(self, r);
+    return try self.primitive(.nil_);
 }
 
 /// Fold one call site's `(elem, arity)` into the callee's whole-program

--- a/src/lang/typecheck/class_check.zig
+++ b/src/lang/typecheck/class_check.zig
@@ -96,6 +96,12 @@ pub fn walkDefBody(
     self.current_scope = &fn_scope;
     defer self.current_scope = saved_scope;
 
+    // A `@static` method body has no receiver — `self` / `super` are
+    // unavailable. Set inside a class only (a free def isn't `@static`).
+    const saved_static = self.in_static_method;
+    self.in_static_method = self.current_class_name != null and annotations.hasAnnotation(self, d.annotations, "static");
+    defer self.in_static_method = saved_static;
+
     // Fresh `fn_locals` per fn — params and inner `let`s land
     // here; nested `def`s push their own frame too so an inner
     // fn doesn't inherit outer-fn locals.

--- a/src/lang/typecheck/class_check.zig
+++ b/src/lang/typecheck/class_check.zig
@@ -56,12 +56,19 @@ pub fn checkDefDecl(self: *Checker, d: ast.DefDecl) WalkError!void {
     }
 
     if (isVariadicDef(d)) {
-        // A top-level variadic def is monomorphized: defer its body until
-        // call sites pin `T` + the arity (the registry holds the stable
-        // decl pointer the deferred walk replays from). A variadic method
-        // isn't monomorphized — the method-call path carries no variadic
-        // arity — so its body is checked here with an untyped `args` slot.
-        if (self.def_registry.get(self.lexeme(d.name))) |ptr| {
+        // A variadic def/method is monomorphized: defer its body until
+        // call sites pin `T` + the arity. Inside a class it's a method —
+        // carry the declaring class so the deferred walk restores `self`
+        // / fields / `super`; at top level it's a free def. The registries
+        // hold the stable decl pointer the deferred walk replays from.
+        if (self.current_class_name) |cn| {
+            if (self.class_registry.get(cn)) |class| {
+                if (stableMethod(self, class, self.lexeme(d.name))) |method| {
+                    try self.deferred_variadic_methods.append(self.arena, .{ .class = class, .method = method });
+                    return;
+                }
+            }
+        } else if (self.def_registry.get(self.lexeme(d.name))) |ptr| {
             try self.deferred_variadic.append(self.arena, ptr);
             return;
         }
@@ -144,12 +151,15 @@ pub fn walkDefBody(
 /// variadic def, so discover those calls with diagnostics muted until
 /// the facts stabilize, then commit one checked walk per body.
 pub fn resolveDeferredVariadics(self: *Checker) WalkError!void {
-    if (self.deferred_variadic.items.len == 0) return;
+    const total = self.deferred_variadic.items.len + self.deferred_variadic_methods.items.len;
+    if (total == 0) return;
 
-    // Discovery converges in at most one round per deferred def: each
-    // round can only extend the chain by one variadic callee.
+    // Discovery converges in at most one round per deferred body: each
+    // round can only extend the chain by one variadic callee. Free defs
+    // and methods share the loop so a method calling a free variadic def
+    // (or vice versa) contributes its arity before either commits.
     var rounds: usize = 0;
-    while (rounds <= self.deferred_variadic.items.len) : (rounds += 1) {
+    while (rounds <= total) : (rounds += 1) {
         const before = variadicProgress(self);
         try walkDeferredVariadics(self, true);
         if (variadicProgress(self) == before) break;
@@ -157,10 +167,10 @@ pub fn resolveDeferredVariadics(self: *Checker) WalkError!void {
     try walkDeferredVariadics(self, false);
 }
 
-/// Walk every deferred variadic body once, binding `args` to the
-/// current whole-program tuple. When `mute`, diagnostics are routed to
-/// a scratch list and dropped — the walk exists only to surface nested
-/// variadic calls into `variadic_info`.
+/// Walk every deferred variadic body (free defs + methods) once, binding
+/// `args` to the current whole-program tuple. When `mute`, diagnostics
+/// are routed to a scratch list and dropped — the walk exists only to
+/// surface nested variadic calls into `variadic_info`.
 fn walkDeferredVariadics(self: *Checker, mute: bool) WalkError!void {
     const saved = self.diagnostics;
     defer self.diagnostics = saved;
@@ -170,12 +180,74 @@ fn walkDeferredVariadics(self: *Checker, mute: bool) WalkError!void {
 
     for (self.deferred_variadic.items) |decl| {
         const info = self.variadic_info.get(self.lexeme(decl.name)) orelse continue;
-        // No call site pinned `T`: the def is uninstantiable, so there
-        // is nothing to monomorphize and no element type to check against.
-        const elem = info.elem orelse continue;
-        const args_ty = try variadicArgsTuple(self, elem, info.min_arity orelse 0);
+        const args_ty = try deferredArgsTuple(self, info) orelse continue;
         try walkDefBody(self, decl.*, args_ty);
     }
+    for (self.deferred_variadic_methods.items) |dm| {
+        const key = try calls.methodKey(self, self.lexeme(dm.class.name), self.lexeme(dm.method.name));
+        const info = self.variadic_info.get(key) orelse continue;
+        const args_ty = try deferredArgsTuple(self, info) orelse continue;
+        try walkMethodBody(self, dm.class, dm.method, args_ty);
+    }
+}
+
+/// The `args: (T, …, T)` tuple a deferred variadic body checks against,
+/// or `null` when it's uninstantiable (an arity ≥ 1 was seen but no `T`
+/// pinned — an inference failure already reported elsewhere). An entry
+/// called only with zero varargs has `elem == null` and `min_arity == 0`:
+/// the tuple is empty, so the body still type-checks (and its codegen
+/// `$0` specialization stays sound) — the placeholder element is never
+/// read.
+fn deferredArgsTuple(self: *Checker, info: typecheck.VariadicInfo) WalkError!?*const types.Type {
+    const min = info.min_arity orelse 0;
+    if (info.elem == null and min > 0) return null;
+    const elem = info.elem orelse try self.primitive(.nil_);
+    return try variadicArgsTuple(self, elem, min);
+}
+
+/// Walk a variadic method body in its class scope: restore the
+/// `current_class_*` context + register fields (mirrors `checkClassDecl`'s
+/// method setup, minus the per-method signature checks already done in the
+/// main walk), then walk the body with `args` bound to the pinned tuple.
+fn walkMethodBody(
+    self: *Checker,
+    class: *const ast.ClassDecl,
+    method: *const ast.DefDecl,
+    args_ty: *const types.Type,
+) WalkError!void {
+    const saved_name = self.current_class_name;
+    self.current_class_name = self.lexeme(class.name);
+    defer self.current_class_name = saved_name;
+
+    const saved_extends = self.current_class_extends;
+    self.current_class_extends = class.extends;
+    defer self.current_class_extends = saved_extends;
+
+    const saved_scope = self.current_scope;
+    var class_scope: Scope = .init(self.arena, saved_scope);
+    self.current_scope = &class_scope;
+    defer self.current_scope = saved_scope;
+
+    for (class.fields) |f| {
+        const ty: ?*const types.Type = if (f.type_ann) |t|
+            try type_resolve.resolveType(self, t)
+        else
+            null;
+        try self.registerName(self.lexeme(f.name), .{
+            .kind = .let_binding,
+            .decl_span = f.name,
+            .ty = ty,
+        });
+    }
+
+    try walkDefBody(self, method.*, args_ty);
+}
+
+/// First method named `name` declared directly on `class` — a stable
+/// AST pointer for deferral, or `null` when the class doesn't declare it.
+fn stableMethod(self: *const Checker, class: *const ast.ClassDecl, name: []const u8) ?*const ast.DefDecl {
+    for (class.methods) |*m| if (std.mem.eql(u8, self.lexeme(m.name), name)) return m;
+    return null;
 }
 
 /// Change metric for the discovery fixpoint: a rolling combine over
@@ -268,6 +340,7 @@ pub fn checkClassDecl(self: *Checker, d: ast.ClassDecl) WalkError!void {
 /// - `@override` without a parent method → `E_OVERRIDE_NO_PARENT`.
 /// - Overriding a `@final` method → `E_METHOD_FINAL_OVERRIDE`.
 /// - `@static` with a `self` first param → `E_STATIC_HAS_SELF`.
+/// - non-`@static` without a `self` first param → `E_METHOD_NO_SELF`.
 fn checkMethodAnnotations(
     self: *Checker,
     cd: *const ast.ClassDecl,
@@ -277,14 +350,40 @@ fn checkMethodAnnotations(
     const is_override = annotations.hasAnnotation(self, m.annotations, "override");
     const is_static = annotations.hasAnnotation(self, m.annotations, "static");
 
-    if (is_static and m.params.len > 0) {
-        const first = self.lexeme(m.params[0].name);
-        if (std.mem.eql(u8, first, "self")) {
+    const has_self = m.params.len > 0 and std.mem.eql(u8, self.lexeme(m.params[0].name), "self");
+    if (is_static) {
+        if (has_self) {
             try self.emitSpan(
                 "E_STATIC_HAS_SELF",
                 m.params[0].name,
                 "`@static` method must not take a `self` parameter — it's called as `ClassName.method(...)`",
             );
+        }
+    } else if (!has_self) {
+        // An instance method's receiver is always pushed at fp+4; without
+        // a `self` param to claim that slot, the first declared param
+        // would alias the receiver pointer. Require `self` (or `@static`).
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "method `{s}` must take `self` as its first parameter (or be `@static`)",
+            .{m_name},
+        );
+        try self.emitSpan("E_METHOD_NO_SELF", m.name, msg);
+    }
+
+    // A variadic method is non-virtual — it monomorphizes per call-site
+    // arity (§4.6.2) and a single vtable slot can't hold its N
+    // specializations. So it can't be `@override`/`@abstract`, and it
+    // can't share a name with an ancestor method (which would override).
+    const is_variadic = isVariadicDef(m);
+    if (is_variadic) {
+        if (is_override or annotations.hasAnnotation(self, m.annotations, "abstract")) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "variadic method `{s}` can't be `@override` or `@abstract` — it is non-virtual (statically dispatched per arity)",
+                .{m_name},
+            );
+            try self.emitSpan("E_VAR_VIRTUAL", m.name, msg);
         }
     }
 
@@ -300,6 +399,14 @@ fn checkMethodAnnotations(
         }
     }
     if (parent_method) |pm| {
+        if (is_variadic or isVariadicDef(pm.*)) {
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "method `{s}` collides with an ancestor method, but a variadic method is non-virtual and can't participate in overriding (§4.6.2)",
+                .{m_name},
+            );
+            try self.emitSpan("E_VAR_OVERRIDE", m.name, msg);
+        }
         if (annotations.hasAnnotation(self, pm.annotations, "final")) {
             const msg = try std.fmt.allocPrint(
                 self.arena,

--- a/src/lang/typecheck/fields.zig
+++ b/src/lang/typecheck/fields.zig
@@ -8,6 +8,8 @@ const annotations = @import("annotations.zig");
 const flow = @import("flow.zig");
 const predicates = @import("predicates.zig");
 const mem_builtin = @import("mem_builtin.zig");
+const calls = @import("calls.zig");
+const class_check = @import("class_check.zig");
 
 const Checker = typecheck.Checker;
 const WalkError = error{OutOfMemory};
@@ -273,6 +275,13 @@ pub fn checkMethodCall(
             try self.emitSpan("E_PRIVATE_ACCESS", m.method, msg);
         }
     }
+    // A variadic method pivots to the homogeneous-args / arity rules
+    // (§4.6.2) — it's statically dispatched to its owner, so route here
+    // before the fixed-arity check below.
+    if (class_check.isVariadicDef(method.*)) {
+        return try calls.checkVariadicMethodCall(self, m, method, self.lexeme(hit.owner.name));
+    }
+
     // Build the method signature on the fly. Skip the `self`
     // param when matching args.
     var has_self = false;

--- a/src/lang/typecheck/fields.zig
+++ b/src/lang/typecheck/fields.zig
@@ -263,6 +263,17 @@ pub fn checkMethodCall(
         return null;
     };
     const method = hit.method;
+    if (annotations.hasAnnotation(self, method.annotations, "static")) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "`{s}.{s}` is `@static` — call it as `{s}.{s}(...)`, not on an instance",
+            .{ named_name, method_name, named_name, method_name },
+        );
+        try self.emitSpan("E_STATIC_ON_INSTANCE", m.method, msg);
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        if (method.ret_type) |r| return try type_resolve.resolveType(self, r);
+        return try self.primitive(.nil_);
+    }
     if (annotations.hasAnnotation(self, method.annotations, "private")) {
         const owner_name = self.lexeme(hit.owner.name);
         const visible = if (self.current_class_name) |cn| std.mem.eql(u8, cn, owner_name) else false;
@@ -303,6 +314,69 @@ pub fn checkMethodCall(
                 try type_resolve.resolveType(self, t)
             else
                 null;
+            const skip = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
+            const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
+            if (!skip and param_ty != null and arg_ty != null) {
+                try self.checkStoreCompat(arg.span(), param_ty.?, arg_ty.?);
+            }
+        }
+    }
+    if (method.ret_type) |r| return try type_resolve.resolveType(self, r);
+    return try self.primitive(.nil_);
+}
+
+/// Type-check a `@static` method call `ClassName.method(args)` (§3.7) —
+/// the receiver is a class *name*, not an instance, so there's no `self`.
+/// Resolves the method, requires it be `@static`, checks the args, and
+/// (for a variadic `@static` method) records its per-arity facts. Returns
+/// the method's return type.
+pub fn checkStaticMethodCall(
+    self: *Checker,
+    m: ast.MethodCallExpr,
+    cd: *const ast.ClassDecl,
+    class_name: []const u8,
+) WalkError!?*const types.Type {
+    const method_name = self.lexeme(m.method);
+    const hit = lookupClassMethodOwner(self, cd, method_name) orelse {
+        const msg = try std.fmt.allocPrint(self.arena, "class `{s}` has no method `{s}`", .{ class_name, method_name });
+        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", m.method, msg, try self.suggestClassMethod(cd, method_name));
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    };
+    const method = hit.method;
+    if (!annotations.hasAnnotation(self, method.annotations, "static")) {
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "`{s}.{s}` is an instance method — call it on an instance, not on the class name",
+            .{ class_name, method_name },
+        );
+        try self.emitSpan("E_INSTANCE_AS_STATIC", m.method, msg);
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+        return null;
+    }
+    // A variadic `@static` method records + monomorphizes like any other
+    // (it has no `self`, which `checkVariadicMethodCall` already handles).
+    if (class_check.isVariadicDef(method.*)) {
+        return try calls.checkVariadicMethodCall(self, m, method, self.lexeme(hit.owner.name));
+    }
+    // Fixed-arity: every param is a user arg. A `@static` method takes no
+    // `self` (E_STATIC_HAS_SELF flags it at the decl); skip an illegal one
+    // here so the count reflects user args rather than cascading.
+    const has_self = method.params.len > 0 and std.mem.eql(u8, self.lexeme(method.params[0].name), "self");
+    const skip_count: usize = if (has_self) 1 else 0;
+    const sig_params = method.params[skip_count..];
+    if (m.args.len != sig_params.len) {
+        const suffix: []const u8 = if (sig_params.len == 1) "" else "s";
+        const msg = try std.fmt.allocPrint(
+            self.arena,
+            "`{s}.{s}` takes {d} argument{s}, called with {d}",
+            .{ class_name, method_name, sig_params.len, suffix, m.args.len },
+        );
+        try self.emitSpan("E_TYPE_ARG_COUNT", m.span, msg);
+        for (m.args) |a| _ = try self.inferExpr(a, null);
+    } else {
+        for (m.args, sig_params) |arg, p| {
+            const param_ty: ?*const types.Type = if (p.type_ann) |t| try type_resolve.resolveType(self, t) else null;
             const skip = if (param_ty) |pt| predicates.isNilType(pt.*) else true;
             const arg_ty = try self.inferExpr(arg, if (skip) null else param_ty);
             if (!skip and param_ty != null and arg_ty != null) {

--- a/src/lang/typecheck/fields.zig
+++ b/src/lang/typecheck/fields.zig
@@ -239,15 +239,29 @@ pub fn checkMethodCall(
     m: ast.MethodCallExpr,
     recv_ty: ?*const types.Type,
 ) WalkError!?*const types.Type {
-    const rt = recv_ty orelse {
+    const rt0 = recv_ty orelse {
         for (m.args) |a| _ = try self.inferExpr(a, null);
         return null;
     };
+    // Peel a nullable receiver (`Player?`) to its inner type — the
+    // nil-deref was already gated by `checkNotNullableDeref` at the call
+    // arm, so a method call here means the value is statically non-nil.
+    const rt = if (rt0.* == .optional) rt0.optional else rt0;
+    // The receiver isn't a named type (scalar / tuple / array / `Vec`) —
+    // Vec / str / stdlib receivers were already routed away, so this type
+    // has no methods. Reject here, not as a codegen-only failure.
     const named_name = flow.namedNameOf(rt.*) orelse {
+        const ty_s = try types.render(self.arena, rt.*);
+        const msg = try std.fmt.allocPrint(self.arena, "type `{s}` has no method `{s}`", .{ ty_s, self.lexeme(m.method) });
+        try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
         for (m.args) |a| _ = try self.inferExpr(a, null);
         return null;
     };
+    // A named type that isn't a class — a `struct` or `enum`. Only
+    // classes carry methods (§6).
     const cd = self.class_registry.get(named_name) orelse {
+        const msg = try std.fmt.allocPrint(self.arena, "`{s}` is not a class — it has no method `{s}`", .{ named_name, self.lexeme(m.method) });
+        try self.emitSpan("E_TYPE_UNDEFINED_METHOD", m.method, msg);
         for (m.args) |a| _ = try self.inferExpr(a, null);
         return null;
     };

--- a/src/lang/typecheck/operators.zig
+++ b/src/lang/typecheck/operators.zig
@@ -127,8 +127,35 @@ fn checkComparison(self: *Checker, b: ast.BinaryExpr) WalkError!?*const types.Ty
         if (!either_is_nil and !lhs_ty.?.eql(rhs_ty.?.*)) {
             try self.emitMismatch(b.rhs.span(), lhs_ty.?, rhs_ty.?);
         }
+        // Ordering (`<` `<=` `>` `>=`) needs a scalar — an inline
+        // aggregate has no defined order; only `==` / `!=` compare them
+        // (by identity). Reject here so it isn't a codegen-only failure.
+        const ordering = switch (b.op) {
+            .lt, .lte, .gt, .gte => true,
+            else => false,
+        };
+        if (ordering and !isOrderableType(self, lhs_ty.?.*)) {
+            const ty_s = try types.render(self.arena, lhs_ty.?.*);
+            const msg = try std.fmt.allocPrint(
+                self.arena,
+                "operator {s} needs an ordered scalar, found `{s}` — aggregates compare only with `==` / `!=`",
+                .{ predicates.opLexeme(b.op), ty_s },
+            );
+            try self.emitSpan("E_TYPE_NOT_ORDERED", b.span, msg);
+        }
     }
     return try self.primitive(.bool_);
+}
+
+/// `true` when `t` has a defined `<` order at the bytecode level — every
+/// scalar / pointer-like type. Inline aggregates (struct / tuple / array
+/// / `Vec`) don't: only identity `==` / `!=` apply to them.
+fn isOrderableType(self: *const Checker, t: types.Type) bool {
+    return switch (t) {
+        .tuple, .array, .vec => false,
+        .named => |n| !self.struct_registry.contains(n.name),
+        else => true,
+    };
 }
 
 fn checkLogical(self: *Checker, b: ast.BinaryExpr) WalkError!?*const types.Type {

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -5520,14 +5520,6 @@ test "codegen/tuple: `==` recurses into a struct element (str by content)" {
     , "1\n0\n");
 }
 
-test "codegen/tuple: ordering comparison is a clean error" {
-    try expectCodegenError(
-        \\def main()
-        \\  print (1, 2) < (1, 3)
-        \\end
-    , "E_CODEGEN_UNSUPPORTED");
-}
-
 test "codegen/tuple: whole-tuple `print` renders `(v0, v1, …)`" {
     try runAndExpect(
         \\enum E
@@ -6017,21 +6009,6 @@ test "codegen/struct: equality of two struct-returning calls (distinct buffers)"
         \\  print mk(5) == mk(6)
         \\end
     , "1\n0\n");
-}
-
-test "codegen/struct: ordering comparison on structs is rejected" {
-    try expectCodegenError(
-        \\struct P
-        \\  x: i16
-        \\end
-        \\def main()
-        \\  let a = P { x: 1 }
-        \\  let b = P { x: 2 }
-        \\  if a < b
-        \\    print 1
-        \\  end
-        \\end
-    , "E_CODEGEN_UNSUPPORTED");
 }
 
 test "codegen/str: `+` concatenates into a fresh buffer (§3.2.1)" {

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1732,6 +1732,83 @@ test "codegen: a plain tuple value forwards to `str.format` positionally" {
     , "7/8\n");
 }
 
+test "codegen: a variadic method monomorphizes per arity (index + forward)" {
+    try runAndExpect(
+        \\class Logger
+        \\  def fmt(self, f: str, args: ...) -> str
+        \\    return str.format(f, args)
+        \\  end
+        \\  def first(self, args: ...) -> i16
+        \\    return args.0
+        \\  end
+        \\end
+        \\def main()
+        \\  let l = Logger()
+        \\  print l.fmt("a={0} b={1}", 1, 2)
+        \\  print l.fmt("just {0}", 9)
+        \\  print l.first(100, 200, 300)
+        \\end
+    , "a=1 b=2\njust 9\n100\n");
+}
+
+test "codegen: a variadic method reads `self` fields alongside its args" {
+    try runAndExpect(
+        \\class Counter
+        \\  let base: i16
+        \\  def init(self, b: i16)
+        \\    self.base = b
+        \\  end
+        \\  def add(self, args: ...) -> i16
+        \\    return self.base + args.0 + args.1
+        \\  end
+        \\end
+        \\def main()
+        \\  let c = Counter(100)
+        \\  print c.add(10, 20)
+        \\end
+    , "130\n");
+}
+
+test "codegen: an inherited variadic method dispatches to its declaring class" {
+    try runAndExpect(
+        \\class Base
+        \\  def tag(self, args: ...) -> i16
+        \\    return args.0 + args.1
+        \\  end
+        \\end
+        \\class Derived extends Base
+        \\  def go(self) -> i16
+        \\    return super.tag(3, 4)
+        \\  end
+        \\end
+        \\def main()
+        \\  let d = Derived()
+        \\  print d.tag(5, 6)
+        \\  print d.go()
+        \\end
+    , "11\n7\n");
+}
+
+test "codegen: a struct-returning variadic method rides the sret ABI" {
+    try runAndExpect(
+        \\struct Point
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\class Maker
+        \\  def mk(self, args: ...) -> Point
+        \\    return Point { x: args.0, y: args.1 }
+        \\  end
+        \\end
+        \\def main()
+        \\  let m = Maker()
+        \\  let p = m.mk(11, 22)
+        \\  print p.x
+        \\  print p.y
+        \\end
+    , "11\n22\n");
+}
+
 test "codegen: print of a string literal goes through sys print_str + emits `hi`" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -1809,6 +1809,103 @@ test "codegen: a struct-returning variadic method rides the sret ABI" {
     , "11\n22\n");
 }
 
+test "codegen: a `@static` method is called as `ClassName.method` with no self" {
+    try runAndExpect(
+        \\class Box
+        \\  @static
+        \\  def make(a: i16, b: i16) -> i16
+        \\    return a + b
+        \\  end
+        \\end
+        \\def main()
+        \\  print Box.make(10, 5)
+        \\end
+    , "15\n");
+}
+
+test "codegen: a `@static` method can return a struct via the sret ABI" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\class Mk
+        \\  @static
+        \\  def origin() -> P
+        \\    return P { x: 0, y: 7 }
+        \\  end
+        \\end
+        \\def main()
+        \\  let p = Mk.origin()
+        \\  print p.y
+        \\end
+    , "7\n");
+}
+
+test "codegen: a variadic `@static` method monomorphizes per arity" {
+    try runAndExpect(
+        \\class Box
+        \\  @static
+        \\  def fmt(f: str, args: ...) -> str
+        \\    return str.format(f, args)
+        \\  end
+        \\end
+        \\def main()
+        \\  print Box.fmt("{0}/{1}", 3, 4)
+        \\  print Box.fmt("one {0}", 9)
+        \\end
+    , "3/4\none 9\n");
+}
+
+test "codegen: a tuple argument passes by value through a method call" {
+    // pushSretAndArgs must copy the tuple's bytes, not just its base
+    // address — exercised here through a `@static` method.
+    try runAndExpect(
+        \\class Math
+        \\  @static
+        \\  def sum_pair(p: (i16, i16)) -> i16
+        \\    return p.0 + p.1
+        \\  end
+        \\end
+        \\def main()
+        \\  let t = (10, 32)
+        \\  print Math.sum_pair(t)
+        \\end
+    , "42\n");
+}
+
+test "codegen: a tuple-returning method rides the sret ABI" {
+    // The returns-sret test must include tuple returns, or the callee
+    // writes its result through an un-pushed destination pointer.
+    try runAndExpect(
+        \\class Maker
+        \\  @static
+        \\  def pair() -> (i16, i16)
+        \\    return (40, 2)
+        \\  end
+        \\end
+        \\def main()
+        \\  let t = Maker.pair()
+        \\  print t.0 + t.1
+        \\end
+    , "42\n");
+}
+
+test "codegen: a value binding shadows a same-named class in receiver position" {
+    try runAndExpect(
+        \\class M
+        \\  @static
+        \\  def id(x: i16) -> i16
+        \\    return x + 1
+        \\  end
+        \\end
+        \\def main()
+        \\  let M = 5
+        \\  print M
+        \\end
+    , "5\n");
+}
+
 test "codegen: print of a string literal goes through sys print_str + emits `hi`" {
     try runAndExpect(
         \\def main()

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2399,6 +2399,63 @@ test "typecheck: a scalar optional (multi-word) variadic element is rejected" {
     , "E_VAR_AGGREGATE");
 }
 
+test "typecheck: a `@static` method call validates its arguments" {
+    try expectCode(
+        \\class Box
+        \\  @static
+        \\  def make(a: i16) -> i16
+        \\    return a
+        \\  end
+        \\end
+        \\def main()
+        \\  print Box.make("not an int")
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
+test "typecheck: an instance method called as `ClassName.method` errors" {
+    try expectCode(
+        \\class Box
+        \\  def make(self, a: i16) -> i16
+        \\    return a
+        \\  end
+        \\end
+        \\def main()
+        \\  print Box.make(10)
+        \\end
+    , "E_INSTANCE_AS_STATIC");
+}
+
+test "typecheck: a `@static` method called on an instance errors" {
+    try expectCode(
+        \\class Box
+        \\  @static
+        \\  def make(a: i16) -> i16
+        \\    return a
+        \\  end
+        \\end
+        \\def main()
+        \\  let b = Box()
+        \\  print b.make(10)
+        \\end
+    , "E_STATIC_ON_INSTANCE");
+}
+
+test "typecheck: `self` in a `@static` method body errors" {
+    try expectCode(
+        \\class Box
+        \\  let v: i16
+        \\  @static
+        \\  def make(x: i16) -> i16
+        \\    return self.v + x
+        \\  end
+        \\end
+        \\def main()
+        \\  print Box.make(1)
+        \\end
+    , "E_STATIC_SELF");
+}
+
 test "typecheck: a non-`@static` method must declare `self`" {
     // Without `self`, the call-site receiver (always at fp+4) would alias
     // the first declared param. Applies to variadic + plain methods.

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2456,6 +2456,52 @@ test "typecheck: `self` in a `@static` method body errors" {
     , "E_STATIC_SELF");
 }
 
+test "typecheck: ordering comparison on a struct is rejected" {
+    try expectCode(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def main()
+        \\  let a = P { x: 1 }
+        \\  let b = P { x: 2 }
+        \\  if a < b
+        \\    print 1
+        \\  end
+        \\end
+    , "E_TYPE_NOT_ORDERED");
+}
+
+test "typecheck: ordering comparison on a tuple is rejected" {
+    try expectCode(
+        \\def main()
+        \\  if (1, 2) < (1, 3)
+        \\    print 1
+        \\  end
+        \\end
+    , "E_TYPE_NOT_ORDERED");
+}
+
+test "typecheck: a method call on a scalar receiver is rejected" {
+    try expectCode(
+        \\def main()
+        \\  let x: i16 = 5
+        \\  print x.nope(10)
+        \\end
+    , "E_TYPE_UNDEFINED_METHOD");
+}
+
+test "typecheck: a method call on a struct value is rejected" {
+    try expectCode(
+        \\struct P
+        \\  x: i16
+        \\end
+        \\def main()
+        \\  let p = P { x: 1 }
+        \\  print p.nope()
+        \\end
+    , "E_TYPE_UNDEFINED_METHOD");
+}
+
 test "typecheck: a non-`@static` method must declare `self`" {
     // Without `self`, the call-site receiver (always at fp+4) would alias
     // the first declared param. Applies to variadic + plain methods.

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -2289,6 +2289,150 @@ test "typecheck: a variadic `def` cannot be `@inline`" {
     , "E_VAR_INLINE");
 }
 
+test "typecheck: a variadic method accepts a multi-arg call + types `args.N`" {
+    try expectClean(
+        \\class Logger
+        \\  def fmt(self, f: str, args: ...) -> str
+        \\    return str.format(f, args)
+        \\  end
+        \\  def sum(self, args: ...) -> i16
+        \\    return args.0 + args.1
+        \\  end
+        \\end
+        \\def main()
+        \\  let l = Logger()
+        \\  print l.fmt("{0}/{1}", 3, 4)
+        \\  print l.sum(10, 20)
+        \\end
+    );
+}
+
+test "typecheck: `args.N` past the smallest call's arity errors in a method" {
+    try expectCode(
+        \\class C
+        \\  def pick(self, args: ...) -> i16
+        \\    return args.2
+        \\  end
+        \\end
+        \\def main()
+        \\  let c = C()
+        \\  print c.pick(1, 2)
+        \\end
+    , "E_TYPE_TUPLE_INDEX_OOR");
+}
+
+test "typecheck: a variadic method cannot be `@override`" {
+    try expectCode(
+        \\class Base
+        \\  def log(self, args: ...) -> i16
+        \\    return args.0
+        \\  end
+        \\end
+        \\class Sub extends Base
+        \\  @override
+        \\  def log(self, args: ...) -> i16
+        \\    return args.0
+        \\  end
+        \\end
+    , "E_VAR_VIRTUAL");
+}
+
+test "typecheck: a method cannot override a variadic ancestor method" {
+    try expectCode(
+        \\class Base
+        \\  def log(self, args: ...) -> i16
+        \\    return args.0
+        \\  end
+        \\end
+        \\class Sub extends Base
+        \\  def log(self, x: i16) -> i16
+        \\    return x
+        \\  end
+        \\end
+    , "E_VAR_OVERRIDE");
+}
+
+test "typecheck: a struct (aggregate) variadic element type is rejected" {
+    // Varargs are word-strided scalars; an inline aggregate would push by
+    // value but read back as a single word, so it's a clean error here
+    // rather than a silent miscompile.
+    try expectCode(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def take(args: ...) -> i16
+        \\  return args.0.x
+        \\end
+        \\def main()
+        \\  let p = P { x: 1, y: 2 }
+        \\  print take(p)
+        \\end
+    , "E_VAR_AGGREGATE");
+}
+
+test "typecheck: an array (aggregate) variadic element type is rejected" {
+    try expectCode(
+        \\def take(args: ...) -> i16
+        \\  return 0
+        \\end
+        \\def main()
+        \\  let a: [i16; 2] = [1, 2]
+        \\  print take(a)
+        \\end
+    , "E_VAR_AGGREGATE");
+}
+
+test "typecheck: a scalar optional (multi-word) variadic element is rejected" {
+    // A scalar `T?` is a 4-byte `{present, value}` value — multi-word like
+    // a struct, so it can't be a (word-strided) variadic element. A
+    // pointer-like `str?` would stay legal.
+    try expectCode(
+        \\def take(args: ...) -> i16
+        \\  return 0
+        \\end
+        \\def main()
+        \\  let a: i16? = 1
+        \\  let b: i16? = 2
+        \\  take(a, b)
+        \\end
+    , "E_VAR_AGGREGATE");
+}
+
+test "typecheck: a non-`@static` method must declare `self`" {
+    // Without `self`, the call-site receiver (always at fp+4) would alias
+    // the first declared param. Applies to variadic + plain methods.
+    try expectCode(
+        \\class Box
+        \\  def make(first: i16, args: ...) -> i16
+        \\    return first + args.0
+        \\  end
+        \\end
+        \\def main()
+        \\  let b = Box()
+        \\  print b.make(10, 5)
+        \\end
+    , "E_METHOD_NO_SELF");
+}
+
+test "typecheck: a body called only with zero varargs is still checked" {
+    // The deferred body must type-check even when no call pins `T` — its
+    // arity-0 codegen specialization still runs, so a body type error
+    // can't be allowed to escape.
+    try expectCode(
+        \\class Box
+        \\  def each(self, args: ...) -> u16
+        \\    let z: u16 = "not a u16"
+        \\    return z
+        \\  end
+        \\end
+        \\def main()
+        \\  let b = Box()
+        \\  print b.each()
+        \\end
+    , "E_TYPE_MISMATCH");
+}
+
 // ---------- CheckedProgram surface ----------
 
 test "typecheck: CheckedProgram retains program pointer" {

--- a/tests/lang/typecheck/annotations.test.zig
+++ b/tests/lang/typecheck/annotations.test.zig
@@ -235,7 +235,7 @@ test "typecheck/annotations: @final + @override conflict errors with E_ANN_CONFL
         \\class A
         \\  @final
         \\  @override
-        \\  def m()
+        \\  def m(self)
         \\  end
         \\end
     , "E_ANN_CONFLICT");
@@ -246,7 +246,7 @@ test "typecheck/annotations: @abstract + @static conflict errors with E_ANN_CONF
         \\class A
         \\  @abstract
         \\  @static
-        \\  def m()
+        \\  def m(self)
         \\  end
         \\end
     , "E_ANN_CONFLICT");
@@ -257,7 +257,7 @@ test "typecheck/annotations: @final alone on a def accepts" {
     try expectClean(
         \\class A
         \\  @final
-        \\  def m()
+        \\  def m(self)
         \\  end
         \\end
     );


### PR DESCRIPTION
Implements variadic methods (#341), and — folded in by direction as each was surfaced by review — `@static` method calls plus a round of `gero check` hardening. The commits are clean-sliced if a reviewer wants to read them in order.

## Variadic methods (#341)

A class method can be variadic (`def m(self, …, args: ...)`, §4.6.2). It type-checks once against `args: (T, …, T)` of the minimum call-site arity and monomorphizes per distinct arity — `args.N` indexing and `str.format(fmt, args)` forwarding work in method bodies on direct, `self`, `super`, and `&`-reference receivers, inherited methods included.

A variadic method is **non-virtual**: per-arity specialization needs a distinct `Class.method$N` address per arity, which a single vtable slot can't hold, so it's statically dispatched to its declaring class and gets no vtable entry. It can't be `@override`/`@abstract` (`E_VAR_VIRTUAL`) or collide with an ancestor method where either side is variadic (`E_VAR_OVERRIDE`).

## `@static` method calls

`ClassName.method(args)` (§3.7) previously neither type-checked (no diagnostic) nor lowered (`E_CODEGEN_UNSUPPORTED`). It's now fully checked + emitted (no `self` pushed), including struct/tuple (sret) returns and variadic `@static` methods. Call-form mismatches are caught: instance method as `ClassName.method` → `E_INSTANCE_AS_STATIC`; `@static` on an instance → `E_STATIC_ON_INSTANCE`; `self`/`super` in a `@static` body → `E_STATIC_SELF`; a non-`@static` method without `self` → `E_METHOD_NO_SELF`; a value shadowing a class name is honored in receiver position.

## `gero check` hardening

- Ordering (`<` `<=` `>` `>=`) on an aggregate → `E_TYPE_NOT_ORDERED`, and a method call on a non-class receiver → `E_TYPE_UNDEFINED_METHOD`, both at check time (were codegen-only).
- `gero check <missing-path>` returns a clean diagnostic instead of an internal `OutOfMemory` stack trace.
- **Check validates every file, `main` or not.** `compile` gained `require_entry`; `gero check` resolves `use` imports and codegen-validates in this mode, so library files (no entry) have their bodies lowered and codegen-only errors surface at check. Multi-file diagnostics are attributed back to their originating file via the source map.

## Folded soundness fixes (pre-existing, surfaced by review)

Aggregate variadic element types (struct/tuple/array/`Vec`/scalar-`T?`) miscompiled → now `E_VAR_AGGREGATE`. Zero-vararg-only bodies skipped type-checking → now checked. Tuple args/returns to *any* method mis-passed the ABI (a struct-returning variadic method's sret only worked by luck) → `pushSretAndArgs` + `methodReturnsSret` corrected to resolve through the inheritance chain.

## Verification

- 3 adversarial review rounds (18 confirmed bugs found + fixed, each re-verified via disassembly) + targeted probes.
- `zig build ci` green — 4 release modes × 5 cross-targets + asm/`.gr` example gates; 2030 tests.
- 9 new diagnostics documented in `docs/lang-diagnostics.md`; spec edits in `docs/gero-lang.md` (§4.6.2 variadic-methods non-virtual, §6 `self` requirement); four changesets.

## Out of scope

The `docs/examples` tours that `use` an unshipped illustrative `./io` module are marked `gero-example: fmt-only` (check now resolves `use`).

Closes #341
