### PR TITLE
feat(lang): inline asm lowering + multi-file import fixes

### DIFF
--- a/.changeset/lang-imports-and-inline-asm.md
+++ b/.changeset/lang-imports-and-inline-asm.md
@@ -1,0 +1,32 @@
+---
+bump: minor
+---
+
+Inline assembly (`asm "<instruction>"`) now lowers (§4.11). A `{name}`
+operand resolves to the named local / parameter's stack slot, the
+single instruction is assembled through the asm layer, and its bytes
+are emitted in place. A form with no matching opcode is a compile
+error (`E_CODEGEN_INLINE_ASM`) instead of a silent `hlt`.
+
+Multi-file imports got three fixes:
+
+- **`use X as Y from "./mod"` renames now bind.** A quoted-path import
+  alias resolves to its real exported symbol for every kind — class,
+  `def`, `const`, `struct`, `enum` — across calls, `@static` calls,
+  constructors, type annotations, `match` arms, and `is` tests.
+- **A module imported from several `use` sites is fused once.** Two
+  selective imports from the same file no longer redefine its decls.
+- **Selectively-imported stdlib functions lower when called bare.**
+  `use rng from math` then `rng()` now compiles like `math.rng()`
+  (renames included), and resolves its return type at type-check.
+
+A real binding always shadows an import of the same name. New
+diagnostics: a `use` cycle is reported (not silently fused), an import
+alias bound to two different targets is an error
+(`E_USE_DUPLICATE_ALIAS`), and a selective import of a non-existent
+stdlib member is caught at the `use`. Tab-separated `use … from … as`
+directives and a `from`/`as` inside a trailing comment now parse
+correctly.
+
+A focused `docs/examples/modules.gr` (plus its `./io` stub) exercises
+these import forms end-to-end.

--- a/apps/gero-cli/check.zig
+++ b/apps/gero-cli/check.zig
@@ -342,7 +342,7 @@ fn checkOneGr(
     if (fused.hasErrors()) {
         return .{ .source = fused.source, .diagnostics = try includeErrorDiagnostics(arena, fused), .source_map = fused.source_map };
     }
-    return .{ .source = fused.source, .diagnostics = try collectGrDiagnostics(arena, fused.source, true), .source_map = fused.source_map };
+    return .{ .source = fused.source, .diagnostics = try collectGrDiagnostics(arena, fused.source, true, &fused.import_aliases), .source_map = fused.source_map };
 }
 
 /// Split a checked `.gr` file's diagnostics by their originating source
@@ -391,11 +391,13 @@ fn includeErrorDiagnostics(arena: std.mem.Allocator, fused: gero.lang.FusedSourc
             .cycle => "E_USE_CYCLE",
             .depth_exceeded => "E_USE_DEPTH",
             .not_found => "E_USE_NOT_FOUND",
+            .duplicate_alias => "E_USE_DUPLICATE_ALIAS",
         };
         const msg = switch (e.kind) {
             .cycle => try std.fmt.allocPrint(arena, "`use` cycle detected on `{s}`", .{e.requested}),
             .depth_exceeded => try std.fmt.allocPrint(arena, "`use` depth exceeds 32 on `{s}` — likely runaway recursion", .{e.requested}),
             .not_found => try std.fmt.allocPrint(arena, "`use` target file not found: `{s}`", .{e.requested}),
+            .duplicate_alias => try std.fmt.allocPrint(arena, "import alias `{s}` is bound to two different targets", .{e.requested}),
         };
         try out.append(arena, .{ .severity = .fatal, .code = code, .message = msg, .span = .{ .start = e.site_offset, .end = e.site_offset } });
     }
@@ -407,7 +409,12 @@ fn includeErrorDiagnostics(arena: std.mem.Allocator, fused: gero.lang.FusedSourc
 /// tests share it. Each diagnostic's `code` is the lexer/parser's
 /// stable `E_SYNTAX_*` code (see `docs/lang-diagnostics.md`), or
 /// `E_SYNTAX_GENERIC` when the emission site carries none.
-fn collectGrDiagnostics(arena: std.mem.Allocator, src: []const u8, validate_codegen: bool) ![]gero.lang.Diagnostic {
+fn collectGrDiagnostics(
+    arena: std.mem.Allocator,
+    src: []const u8,
+    validate_codegen: bool,
+    import_aliases: ?*const gero.lang.ImportAliases,
+) ![]gero.lang.Diagnostic {
     const stream = try gero.lang.tokenize(arena, src);
     var combined: std.ArrayList(gero.lang.Diagnostic) = .empty;
 
@@ -428,7 +435,7 @@ fn collectGrDiagnostics(arena: std.mem.Allocator, src: []const u8, validate_code
     // Only typecheck when parsing succeeded — otherwise the AST
     // shape can't carry semantic information.
     if (tree.errors.len == 0) {
-        var checked = try gero.lang.typecheck(arena, src, &tree.program);
+        var checked = try gero.lang.typecheckModule(arena, src, &tree.program, import_aliases);
         for (checked.diagnostics) |d| try combined.append(arena, d);
 
         // Codegen-validate so codegen-only errors surface at check time.
@@ -436,7 +443,7 @@ fn collectGrDiagnostics(arena: std.mem.Allocator, src: []const u8, validate_code
         // without a `main` (it's validation, not a runnable image). Only
         // when the type-check is clean — codegen consumes the typed AST.
         if (validate_codegen and !checked.hasErrors()) {
-            var compiled = gero.lang.compile(arena, src, &checked, .{ .require_entry = false }) catch |err| switch (err) {
+            var compiled = gero.lang.compile(arena, src, &checked, .{ .require_entry = false, .import_aliases = import_aliases }) catch |err| switch (err) {
                 error.OutOfMemory => return err,
                 // EntryNotFound can't fire (require_entry=false); any other
                 // codegen host failure leaves the type-check result standing.
@@ -564,7 +571,7 @@ fn writePhaseTimings(
 test "collectGrDiagnostics: clean source yields no diagnostics" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
-    const diags = try collectGrDiagnostics(arena_state.allocator(), "def add(x, y)\n  return x + y\nend\n", false);
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "def add(x, y)\n  return x + y\nend\n", false, null);
     try std.testing.expectEqual(@as(usize, 0), diags.len);
 }
 
@@ -573,7 +580,7 @@ test "collectGrDiagnostics: lexer diagnostic is not double-counted" {
     defer arena_state.deinit();
     // A lexer diagnostic (the `0x`-prefix error) surfaces exactly
     // once, not once per phase — `tree.errors` already includes it.
-    const diags = try collectGrDiagnostics(arena_state.allocator(), "let x = 0x1\n", false);
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "let x = 0x1\n", false, null);
     var hex_count: usize = 0;
     for (diags) |d| {
         if (std.mem.eql(u8, d.code, "E_SYNTAX_HEX_PREFIX")) hex_count += 1;
@@ -584,7 +591,7 @@ test "collectGrDiagnostics: lexer diagnostic is not double-counted" {
 test "collectGrDiagnostics: type error surfaces when parse succeeds" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
-    const diags = try collectGrDiagnostics(arena_state.allocator(), "def f()\n  return undefined_name\nend\n", false);
+    const diags = try collectGrDiagnostics(arena_state.allocator(), "def f()\n  return undefined_name\nend\n", false, null);
     try std.testing.expect(diags.len > 0);
 }
 
@@ -634,7 +641,7 @@ test "collectGrDiagnostics: codegen-validates a body even without a `main`" {
         \\end
         \\
     ;
-    const diags = try collectGrDiagnostics(arena_state.allocator(), src, true);
+    const diags = try collectGrDiagnostics(arena_state.allocator(), src, true, null);
     var found = false;
     for (diags) |d| {
         if (std.mem.eql(u8, d.code, "E_CODEGEN_FRAME_TOO_LARGE")) found = true;

--- a/apps/gero-cli/compile.zig
+++ b/apps/gero-cli/compile.zig
@@ -62,7 +62,7 @@ pub fn execute(
         return 3;
     }
 
-    var checked = gero.lang.typecheck(arena, fused.source, &tree.program) catch |err| {
+    var checked = gero.lang.typecheckModule(arena, fused.source, &tree.program, &fused.import_aliases) catch |err| {
         try term.err("gero compile: typecheck failure ({s})", .{@errorName(err)});
         return 1;
     };
@@ -76,6 +76,7 @@ pub fn execute(
 
     var compiled = gero.lang.compile(arena, fused.source, &checked, .{
         .optimize = mapOptimize(opts.optimize),
+        .import_aliases = &fused.import_aliases,
     }) catch |err| switch (err) {
         error.EntryNotFound => {
             try term.err("gero compile: no top-level `def main()` — every program needs an entry point", .{});
@@ -240,11 +241,13 @@ fn renderIncludeErrors(
             .cycle => "E_USE_CYCLE",
             .depth_exceeded => "E_USE_DEPTH",
             .not_found => "E_USE_NOT_FOUND",
+            .duplicate_alias => "E_USE_DUPLICATE_ALIAS",
         };
         const msg = switch (e.kind) {
             .cycle => try std.fmt.allocPrint(arena, "`use` cycle detected on `{s}`", .{e.requested}),
             .depth_exceeded => try std.fmt.allocPrint(arena, "`use` depth exceeds 32 on `{s}` — likely runaway recursion", .{e.requested}),
             .not_found => try std.fmt.allocPrint(arena, "`use` target file not found: `{s}`", .{e.requested}),
+            .duplicate_alias => try std.fmt.allocPrint(arena, "import alias `{s}` is bound to two different targets", .{e.requested}),
         };
         try diags_list.append(arena, .{
             .severity = .fatal,

--- a/docs/examples/io.gr
+++ b/docs/examples/io.gr
@@ -1,0 +1,19 @@
+-- io.gr — illustrative gtx-16 I/O façade for the syntax tour.
+--
+-- Stub bodies stand in for the device-backed console runtime; the
+-- shapes (a `display` blitter, an `input` gamepad reader) are enough
+-- for `gero check` to resolve and validate the tour end-to-end.
+-- The framebuffer blitter — clears and draws to the gtx-16 screen.
+class display
+  @static
+  def clear()
+  end
+end
+
+-- The gamepad reader — polls the gtx-16 controller ports.
+class input
+  @static
+  def button_pressed(button: i16) -> bool
+    return false
+  end
+end

--- a/docs/examples/modules.gr
+++ b/docs/examples/modules.gr
@@ -1,0 +1,19 @@
+-- modules.gr — a focused, fully-validating tour of gero's module
+-- system (§5). Unlike the broad `syntax_overview.gr`, this one passes
+-- `gero check` end-to-end: it exercises the import forms — a whole
+-- symbol, a selective import with a rename, and a selective stdlib
+-- pull — resolving against the shipped `./io` stub and the `math`
+-- stdlib.
+use display from "./io" -- import a class by name (§5.2)
+use input as keys from "./io" -- selective import + rename: `keys` IS `input`
+use rng from math -- selective stdlib import
+
+def main()
+  display.clear() -- @static call on an imported class
+  -- The rename binds the class, so a `@static` call resolves through it.
+  if keys.button_pressed(0)
+    print "pressed"
+  end
+  -- A bare `rng()` lowers like the qualified `math.rng()` would.
+  print rng() % 100
+end

--- a/docs/examples/syntax_overview.gr
+++ b/docs/examples/syntax_overview.gr
@@ -7,9 +7,11 @@
 -- Read this top-to-bottom to see every construct from the spec at
 -- least once. Annotations refer to spec section numbers.
 --
--- gero-example: fmt-only — imports an illustrative `./io` module that
--- isn't shipped, so `gero check` (which now resolves `use`) can't
--- validate it end-to-end; the formatting gate still applies.
+-- gero-example: fmt-only — this complete-syntax tour exercises
+-- constructs the codegen doesn't lower yet (`do`-as-expression §4.3,
+-- capturing closures §4.7.1), so `gero check` can't validate it
+-- end-to-end; the formatting gate still applies. The `./io` imports
+-- do resolve against the shipped stub (`docs/examples/io.gr`).
 ------------------------------------------------------------
 -- §5.2  Imports
 ------------------------------------------------------------
@@ -353,8 +355,10 @@ end
 -- §3.7.7  asm — last-resort inline asm
 ------------------------------------------------------------
 @inline
-def fast_swap(a: u16, b: u16)
-  asm "swap {a}, {b}"
+def load_acu(x: u16)
+  -- A `{name}` slot lowers to the local's stack address, so it
+  -- targets instructions that take a memory operand (here `mov`).
+  asm "mov {x}, acu"
 end
 
 ------------------------------------------------------------

--- a/docs/gero-lang.md
+++ b/docs/gero-lang.md
@@ -2225,19 +2225,21 @@ windows, hand-tuned hot loops, cycle-counted timing tricks, or
 direct manipulation of the VM's register / flag state.
 
 ```
-def fast_swap(a: u16, b: u16)
-  asm "swap {a}, {b}"
+def load_acu(x: i16)
+  asm "mov {x}, acu"
 end
 
-def fence()
-  asm "memfence"
+def begin_critical()
+  asm "cli"
 end
 ```
 
 **Substitution.** Operands inside `{name}` braces resolve to the
 gero-lang local with that name. The compiler validates that the
-local exists and emits the appropriate register / addressing
-reference at the asm slot.
+local exists and emits its stack-slot addressing reference at the
+asm slot — so `{name}` operands target instructions that accept a
+memory operand (e.g. `mov`); a register-only instruction needs an
+explicit register (`asm "swap r1, r2"`).
 
 **Constraints.**
 

--- a/docs/lang-diagnostics.md
+++ b/docs/lang-diagnostics.md
@@ -740,6 +740,7 @@ should have already enforced.
 |------|---------|
 | `E_CODEGEN_UNSUPPORTED` | A syntactically + type-valid construct the codegen doesn't lower yet (the catch-all — e.g. an ordering comparison on a struct or tuple, a `==` over an array / `Vec` / nullable field or a recursive enum, printing a value with no default rendering (array / `Vec` / class / reference) or a recursive type, storing into a tuple's aggregate element). |
 | `E_CODEGEN_FRAME_TOO_LARGE` | A function's locals or parameters exceed the 127-byte limit on `[fp + imm8]` fp-relative addressing (the ISA's only frame-offset mode). Reduce locals/params. |
+| `E_CODEGEN_INLINE_ASM` | An `asm "..."` statement (§4.11) couldn't lower — a `{name}` operand isn't a local / parameter, the instruction is malformed, or its operand types match no opcode form. |
 | `E_CODEGEN_UNDEFINED_FN` | A call's target isn't a known top-level `def` (an unresolved forward reference at patch time). |
 | `E_CODEGEN_UNKNOWN_CLASS` | A constructor / field / method targets a class with no computed layout. |
 | `E_CODEGEN_UNDEFINED_FIELD` | A `recv.field` names a field the class doesn't declare. |
@@ -850,6 +851,7 @@ Codes are stable. New ones append; old ones never change meaning.
 | `E_UNDEFINED_SYMBOL` | Name resolution | v0.3 |
 | `E_CODEGEN_UNSUPPORTED` | Codegen | v0.3 |
 | `E_CODEGEN_FRAME_TOO_LARGE` | Codegen | v0.3 |
+| `E_CODEGEN_INLINE_ASM` | Codegen | v0.3 |
 | `E_CODEGEN_UNDEFINED_FN` | Codegen | v0.3 |
 | `E_CODEGEN_UNKNOWN_CLASS` | Codegen | v0.3 |
 | `E_CODEGEN_UNDEFINED_FIELD` | Codegen | v0.3 |

--- a/src/asm.zig
+++ b/src/asm.zig
@@ -111,6 +111,10 @@ pub const Codegen = codegen_mod.Codegen;
 pub const CodegenOptions = codegen_mod.Options;
 /// Assemble a parsed program into a `.gx` byte image.
 pub const assemble = codegen_mod.assemble;
+/// Assemble one inline instruction to raw bytes (lang `asm "..."`).
+pub const assembleInstruction = codegen_mod.assembleInstruction;
+/// Bytes + diagnostics from `assembleInstruction`.
+pub const InlineAsm = codegen_mod.InlineAsm;
 /// Canonical-printer options (indent, etc.).
 pub const PrintOptions = printer_mod.PrintOptions;
 /// Default canonical-printer options.

--- a/src/asm/codegen.zig
+++ b/src/asm/codegen.zig
@@ -733,6 +733,83 @@ fn emitString(
     }
 }
 
+/// Bytes + diagnostics from assembling one inline instruction.
+/// `instruction_count` / `other_count` let the caller enforce the
+/// one-instruction-no-labels-or-directives rule (§4.11).
+pub const InlineAsm = struct {
+    bytes: []u8,
+    errors: []include.Diagnostic,
+    /// Number of `.instruction` statements parsed from the source.
+    instruction_count: usize,
+    /// Number of non-instruction statements (labels, directives).
+    other_count: usize,
+};
+
+/// Assemble a single inline-assembly instruction (no labels, banks, or
+/// directives) to its raw bytes — the lang `asm "..."` lowering (§4.11)
+/// emits these in place. Operand classification runs against empty const
+/// + symbol tables since an inline instruction references no symbols. The
+/// caller owns both returned slices. `bytes.len == 0` means the source
+/// held no instruction (a parse failure, reported in `errors`).
+pub fn assembleInstruction(allocator: std.mem.Allocator, source: []const u8) !InlineAsm {
+    var tree = try parser_mod.parse(allocator, source);
+    defer tree.deinit();
+
+    var errors: std.ArrayList(include.Diagnostic) = .empty;
+    errdefer errors.deinit(allocator);
+    for (tree.errors) |e| try errors.append(allocator, e);
+
+    var inst: ?ast.Instruction = null;
+    var instruction_count: usize = 0;
+    var other_count: usize = 0;
+    for (tree.program.statements) |s| switch (s) {
+        .instruction => |i| {
+            inst = i;
+            instruction_count += 1;
+        },
+        else => other_count += 1,
+    };
+
+    var image: std.ArrayList(u8) = .empty;
+    errdefer image.deinit(allocator);
+    if (inst) |i| {
+        var consts = expr.ConstantTable.init(allocator);
+        defer consts.deinit();
+        var symbols = symtab.SymbolTable.init(allocator);
+        defer symbols.deinit();
+        // Validate the opcode resolves — `emitInstruction` silently emits
+        // a 0xFF (`hlt`) fallback on failure, expecting the layout pass
+        // (which we skip for one instruction) to have raised the error.
+        const mnem = source[i.mnemonic.start..i.mnemonic.end];
+        if (!isBankPseudo(mnem)) {
+            var kinds: [3]opres.Kind = undefined;
+            for (i.operands, 0..) |op, idx| kinds[idx] = classifyForEmit(op, source, symbols, null, allocator);
+            if (opres.resolve(mnem, kinds[0..i.operands.len]) == null) {
+                const known = opres.isKnownMnemonic(mnem);
+                try errors.append(allocator, .{
+                    .code = if (known) .operand_type_mismatch else .unknown_mnemonic,
+                    .parse_error = core.parseError(
+                        "codegen",
+                        i.mnemonic.start,
+                        if (known) "operand type mismatch" else "unknown mnemonic",
+                        .{ .expected = "valid instruction shape", .actual = mnem, .kind = .semantic },
+                    ),
+                });
+            }
+        }
+        if (errors.items.len == 0) {
+            try emitInstruction(allocator, &image, &errors, source, i, consts, &symbols, null);
+        }
+    }
+
+    return .{
+        .bytes = try image.toOwnedSlice(allocator),
+        .errors = try errors.toOwnedSlice(allocator),
+        .instruction_count = instruction_count,
+        .other_count = other_count,
+    };
+}
+
 fn emitInstruction(
     allocator: std.mem.Allocator,
     image: *std.ArrayList(u8),

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -43,6 +43,7 @@ const cg_destructure = @import("lang/codegen/destructure.zig");
 const cg_vec_builtin = @import("lang/codegen/vec_builtin.zig");
 const cg_str_builtin = @import("lang/codegen/str_builtin.zig");
 const cg_variadic = @import("lang/codegen/variadic.zig");
+const cg_inline_asm = @import("lang/codegen/inline_asm.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 const cg_class = @import("lang/codegen/class.zig");
@@ -82,6 +83,8 @@ pub const print = print_mod.print;
 
 /// Fused-source output from `resolveUseImports`.
 pub const FusedSource = include_mod.FusedSource;
+/// `use X as Y from "./mod"` alias table (`Y` → `X`).
+pub const ImportAliases = include_mod.ImportAliases;
 /// Fused offset → (file, file_offset) resolver.
 pub const SourceMap = include_mod.SourceMap;
 /// One file's metadata in the include graph.
@@ -108,6 +111,9 @@ pub const scope = scope_mod;
 pub const CheckedProgram = typecheck_mod.CheckedProgram;
 /// Type-check an `ast.Program`.
 pub const typecheck = typecheck_mod.typecheck;
+/// Type-check a fused multi-file program, resolving `use X as Y`
+/// quoted-path aliases (`Y` → `X`).
+pub const typecheckModule = typecheck_mod.typecheckModule;
 /// `mem.*` stdlib builtin signature.
 pub const MemBuiltinSig = tc_mem_builtin.MemBuiltinSig;
 /// Look up a `mem.X` builtin by name.
@@ -234,6 +240,8 @@ pub const internal = struct {
         pub const str_builtin = cg_str_builtin;
         /// Variadic `def` monomorphization (`name$N` specializations).
         pub const variadic = cg_variadic;
+        /// Inline-assembly statement lowering (`asm "..."`).
+        pub const inline_asm = cg_inline_asm;
         /// Expression lowering.
         pub const expr_emit = cg_expr_emit;
         /// Control-flow lowering (if / while / for / match / break / continue / defer).

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -23,6 +23,13 @@ const statements = @import("codegen/statements.zig");
 const isa = @import("codegen/isa.zig");
 const vec_builtin = @import("codegen/vec_builtin.zig");
 const variadic = @import("codegen/variadic.zig");
+const inline_asm = @import("codegen/inline_asm.zig");
+const stdlib = @import("codegen/stdlib.zig");
+
+/// The asm assembler, re-exported here (one level up from
+/// `codegen/`) so `codegen/inline_asm.zig` can lower an
+/// `asm "<instr>"` statement without a deep cross-layer import.
+pub const assembleInstruction = @import("../asm.zig").assembleInstruction;
 const bake_mod = @import("bake.zig");
 
 const Diagnostic = diag_mod.Diagnostic;
@@ -140,7 +147,14 @@ pub const Options = struct {
     /// `false` for validation-only (e.g. `gero check`), where a library
     /// file with no `main` still has its bodies lowered + checked.
     require_entry: bool = true,
+    /// `use X as Y from "./mod"` quoted-path aliases (`Y` → `X`) from
+    /// the fuser, or `null` for a single-file build.
+    import_aliases: ?*const std.StringHashMapUnmanaged([]const u8) = null,
 };
+
+/// A stdlib function pulled into scope by a selective `use` —
+/// `use rng from math` records `rng → (math, rng)`.
+pub const StdlibImport = struct { module: []const u8, name: []const u8 };
 
 /// Errors `compile` can return. Semantic errors land in
 /// `Compiled.diagnostics`; only host failures propagate here.
@@ -225,6 +239,8 @@ pub fn compile(
         .enum_decls = .{},
         .struct_decls = .{},
         .class_decls = .{},
+        .import_aliases = opts.import_aliases,
+        .selective_stdlib = .{},
         .class_layouts = .{},
         .current_class_name = null,
         .current_variadic = null,
@@ -665,6 +681,13 @@ pub const Emitter = struct {
     /// `class` decls by name. Used by constructor detection,
     /// vtable lookup, and field / method access.
     class_decls: std.StringHashMapUnmanaged(*const ast.ClassDecl),
+    /// `use X as Y from "./mod"` aliases (`Y` → `X`), or `null` for a
+    /// single-file build. Resolved before a top-level name lookup so
+    /// an alias lowers like its target.
+    import_aliases: ?*const std.StringHashMapUnmanaged([]const u8),
+    /// Selectively-imported stdlib functions (`use rng from math`):
+    /// local name → `(module, real_name)`. Built in the pre-pass.
+    selective_stdlib: std.StringHashMapUnmanaged(StdlibImport),
     /// Per-class layout: instance size, field offsets, vtable
     /// slots, vtable address (set by `class.emitVtables`).
     class_layouts: std.StringHashMapUnmanaged(class.ClassLayout),
@@ -1326,6 +1349,9 @@ pub const Emitter = struct {
         // Pre-pass 0c: collect `bake def`s so global-init
         // resolution can call them at codegen time.
         try self.collectBakeDefs(program);
+        // Pre-pass 0d: index selectively-imported stdlib functions
+        // so a bare call lowers like its qualified form.
+        try self.collectSelectiveStdlib(program);
         // Pre-pass 1: register globals (top-level let/const).
         try self.registerGlobals(program);
         // Pre-pass 2: collect each def's bank so `emitCall` can
@@ -1466,6 +1492,30 @@ pub const Emitter = struct {
                 const name = self.source[sd.name.start..sd.name.end];
                 const dup = try self.arena.dupe(u8, name);
                 try self.struct_decls.put(self.arena, dup, &stmt.struct_decl);
+            },
+            else => {},
+        };
+    }
+
+    /// Pre-pass: record selectively-imported stdlib functions
+    /// (`use rng [as r] from math`) keyed by local name → its
+    /// `(module, real_name)`, so a bare call routes to the module's
+    /// inline emitter like the qualified `math.rng()` form.
+    fn collectSelectiveStdlib(self: *Emitter, program: *const ast.Program) !void {
+        for (program.statements) |stmt| switch (stmt) {
+            .use_decl => |d| {
+                if (d.items.len == 0) continue;
+                const module = self.source[d.module.start..d.module.end];
+                if (!stdlib.isModule(module)) continue;
+                const mod_dup = try self.arena.dupe(u8, module);
+                for (d.items) |it| {
+                    const orig = self.source[it.name.start..it.name.end];
+                    const local = if (it.alias) |a| self.source[a.start..a.end] else orig;
+                    try self.selective_stdlib.put(self.arena, try self.arena.dupe(u8, local), .{
+                        .module = mod_dup,
+                        .name = try self.arena.dupe(u8, orig),
+                    });
+                }
             },
             else => {},
         };
@@ -1787,7 +1837,7 @@ pub const Emitter = struct {
     pub fn widthOfTypeAnn(self: *const Emitter, t: ast.TypeAnn) u16 {
         return switch (t) {
             .named => |n| blk: {
-                const name = self.source[n.name.start..n.name.end];
+                const name = self.resolveImportAlias(self.source[n.name.start..n.name.end]);
                 if (std.mem.eql(u8, name, "i8") or
                     std.mem.eql(u8, name, "u8") or
                     std.mem.eql(u8, name, "bool") or
@@ -1875,6 +1925,7 @@ pub const Emitter = struct {
             .break_stmt => |bs| try self.emitLoopJump(bs, .break_),
             .continue_stmt => |cs| try self.emitLoopJump(cs, .continue_),
             .defer_stmt => |ds| try self.emitDeferStmt(ds),
+            .asm_stmt => |as_| try inline_asm.emitInlineAsm(self, as_),
             else => try self.unsupported(stmt.span(), "this statement form"),
         }
     }
@@ -1957,6 +2008,13 @@ pub const Emitter = struct {
         return name;
     }
 
+    /// Resolve a quoted-path import alias to its real exported name;
+    /// identity when `name` isn't an alias.
+    pub fn resolveImportAlias(self: *const Emitter, name: []const u8) []const u8 {
+        const aliases = self.import_aliases orelse return name;
+        return aliases.get(name) orelse name;
+    }
+
     /// Struct name when `e`'s type is a registered struct (auto-deref
     /// through a `&T` reference). Structs are inline value aggregates,
     /// so a struct-typed expression evaluates to its base address.
@@ -1999,7 +2057,7 @@ pub const Emitter = struct {
     /// Struct name if `t` names a registered struct, else `null`.
     pub fn structNameOfTypeAnn(self: *const Emitter, t: ast.TypeAnn) ?[]const u8 {
         if (t != .named) return null;
-        const name = self.source[t.named.name.start..t.named.name.end];
+        const name = self.resolveImportAlias(self.source[t.named.name.start..t.named.name.end]);
         return if (self.struct_decls.contains(name)) name else null;
     }
 

--- a/src/lang/codegen/destructure.zig
+++ b/src/lang/codegen/destructure.zig
@@ -129,7 +129,7 @@ fn matchVariant(self: *Emitter, vp: ast.VariantPattern, ofs: i8, ty: ?*const Typ
         try self.diagFatal(vp.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: variant pattern must be `EnumName.Variant`");
         return;
     };
-    const enum_name = path[0..dot];
+    const enum_name = self.resolveImportAlias(path[0..dot]);
     const variant_name = path[dot + 1 ..];
     const ed = self.enum_decls.get(enum_name) orelse {
         try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum in variant pattern");

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -90,7 +90,10 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
                 try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
                 return;
             }
-            if (self.globals.get(name)) |g| {
+            // Module-level names (globals / consts) resolve through an
+            // import alias; frame-local lookups above stay on the raw
+            // name, since a same-named local shadows the alias.
+            if (self.globals.get(self.resolveImportAlias(name))) |g| {
                 try self.emitGlobalLoad(g);
                 return;
             }
@@ -220,7 +223,7 @@ pub fn emitFieldExpr(self: *Emitter, f: ast.FieldExpr, e: *const ast.Expr) !void
         return;
     }
     if (f.receiver.* == .ident) {
-        const recv_name = self.source[f.receiver.ident.span.start..f.receiver.ident.span.end];
+        const recv_name = self.resolveImportAlias(self.source[f.receiver.ident.span.start..f.receiver.ident.span.end]);
         if (self.enum_decls.get(recv_name)) |ed| {
             const variant_name = self.source[f.field.start..f.field.end];
             const tag = self.variantTag(recv_name, variant_name) orelse {
@@ -343,7 +346,7 @@ pub fn emitIsTest(self: *Emitter, it: ast.IsTestExpr) !void {
                 try self.diagFatal(it.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: `is` rhs must be `EnumName.Variant`");
                 return;
             };
-            const enum_name = path[0..dot];
+            const enum_name = self.resolveImportAlias(path[0..dot]);
             const variant_name = path[dot + 1 ..];
             const tag = self.variantTag(enum_name, variant_name) orelse {
                 try self.diagFatal(it.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in `is` test");
@@ -895,15 +898,19 @@ pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr)
     }
     if (m.receiver.* == .ident) {
         const recv = self.source[m.receiver.ident.span.start..m.receiver.ident.span.end];
+        // A quoted-path import alias resolves to the real exported name;
+        // the shadowing test stays on `recv`, since a same-named local
+        // value shadows the alias just as it would the original.
+        const resolved = self.resolveImportAlias(recv);
         // `ClassName.method(args)` — `@static` call: the receiver is a
         // class NAME, not an instance, so no `self` is pushed (§3.7). A
         // same-named value binding shadows the class, so skip when `recv`
         // names a local / param / capture / global value.
         const shadowed = self.locals.contains(recv) or self.params.contains(recv) or
             self.captures.contains(recv) or self.globals.contains(recv);
-        if (!shadowed and self.class_decls.contains(recv)) {
+        if (!shadowed and self.class_decls.contains(resolved)) {
             const mname = self.source[m.method.start..m.method.end];
-            if (class.resolveMethodOwner(self, recv, mname)) |res| {
+            if (class.resolveMethodOwner(self, resolved, mname)) |res| {
                 const is_var = variadic.isVariadicDef(res.method.*);
                 const arity = if (is_var) class.variadicMethodArity(self, res.method, m.args.len) else 0;
                 try class.emitStaticMethodCall(self, res.owner, mname, m.args, m.span, is_var, arity);
@@ -912,9 +919,9 @@ pub fn emitMethodCall(self: *Emitter, m: ast.MethodCallExpr, e: *const ast.Expr)
         }
         // Payload-variant constructor — `Enum.Variant(args)` parses as
         // a method call on the enum name.
-        if (self.enum_decls.get(recv)) |ed| {
+        if (self.enum_decls.get(resolved)) |ed| {
             const variant_name = self.source[m.method.start..m.method.end];
-            if (self.variantTag(recv, variant_name)) |tag| {
+            if (self.variantTag(resolved, variant_name)) |tag| {
                 for (ed.variants) |v| {
                     if (!std.mem.eql(u8, self.source[v.name.start..v.name.end], variant_name)) continue;
                     try emitEnumConstruct(self, ed, v, tag, m.args);
@@ -991,23 +998,31 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
             try diverge_builtin.emitDivergeCall(self, c, callee_name);
             return;
         }
-        if (class.isClassName(self, callee_name)) {
-            try class.emitConstructor(self, callee_name, c);
-            return;
-        }
         // Closure call — `f(args)` where `f` is a let-binding
         // initialized from a lambda OR a binding whose inferred
-        // type is a function (covers `let c = make_counter()`
-        // where make_counter returns a closure). Dispatch through
-        // the tuple's fn_ptr instead of the free-fn path.
+        // type is a function. Checked FIRST so a local binding shadows
+        // a same-named import / class / stdlib function below.
         if (lambda.isClosureBinding(self, callee_name) or lambda.isClosureByType(self, c.callee)) {
             try lambda.emitClosureCall(self, c.callee, c);
+            return;
+        }
+        // A selectively-imported stdlib function called bare
+        // (`use rng from math` then `rng()`) lowers to its module's
+        // inline emitter, like the qualified `math.rng()` form.
+        if (self.selective_stdlib.get(callee_name)) |si| {
+            try stdlib.emitCallName(self, si.module, si.name, c);
+            return;
+        }
+        // A quoted-path import alias resolves to its real exported name.
+        const resolved = self.resolveImportAlias(callee_name);
+        if (class.isClassName(self, resolved)) {
+            try class.emitConstructor(self, resolved, c);
             return;
         }
         // `@inline` call — splice the callee body in place rather
         // than emit a `call addr`. No standalone def emits for
         // the callee (see `emitProgram`).
-        if (self.inline_defs.get(callee_name)) |callee_decl| {
+        if (self.inline_defs.get(resolved)) |callee_decl| {
             try self.emitInlineCall(callee_decl, c);
             return;
         }
@@ -1025,9 +1040,10 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
                 return;
             }
             // Payload-variant constructor — `Enum.Variant(args)`.
-            if (self.enum_decls.get(recv)) |ed| {
+            const resolved = self.resolveImportAlias(recv);
+            if (self.enum_decls.get(resolved)) |ed| {
                 const variant_name = self.source[fe.field.start..fe.field.end];
-                if (self.variantTag(recv, variant_name)) |tag| {
+                if (self.variantTag(resolved, variant_name)) |tag| {
                     for (ed.variants) |v| {
                         if (!std.mem.eql(u8, self.source[v.name.start..v.name.end], variant_name)) continue;
                         try emitEnumConstruct(self, ed, v, tag, c.args);
@@ -1041,7 +1057,7 @@ pub fn emitCall(self: *Emitter, c: ast.CallExpr) !void {
         try self.unsupported(c.span, "non-ident callee");
         return;
     }
-    const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+    const callee_name = self.resolveImportAlias(self.source[c.callee.ident.span.start..c.callee.ident.span.end]);
     // A variadic call targets the `name$N` specialization for this
     // site's arity; metadata (bank, return shape) stays keyed by the
     // bare name, shared across specializations (§4.6.2).

--- a/src/lang/codegen/globals.zig
+++ b/src/lang/codegen/globals.zig
@@ -90,7 +90,7 @@ fn evalConstIfBake(self: *Emitter, d: *const ast.ConstDecl) !?bake_mod.BakeValue
         },
         .call => |c| {
             if (c.callee.* != .ident) return null;
-            const callee_name = self.source[c.callee.ident.span.start..c.callee.ident.span.end];
+            const callee_name = self.resolveImportAlias(self.source[c.callee.ident.span.start..c.callee.ident.span.end]);
             const decl = self.bake_defs.get(callee_name) orelse return null;
             // Top-level entry call — args must be literal / const-foldable.
             const args = try self.arena.alloc(bake_mod.BakeValue, c.args.len);

--- a/src/lang/codegen/inline_asm.zig
+++ b/src/lang/codegen/inline_asm.zig
@@ -1,0 +1,79 @@
+// Inline-assembly lowering (§4.11). An `asm "<instruction>"` statement
+// emits one bytecode instruction directly. Each `{name}` operand resolves
+// to the named local / parameter's `[fp ± ofs]` slot; the substituted
+// instruction is assembled through the asm layer and its bytes emitted in
+// place. No labels, banks, or control flow — one instruction, full stop.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+
+const Emitter = codegen.Emitter;
+
+/// Lower `asm "<instruction>"`: substitute `{name}` operands, assemble the
+/// single instruction, and emit its bytes. Any failure (unknown operand,
+/// malformed instruction, no matching opcode form) is a fatal
+/// `E_CODEGEN_INLINE_ASM` pointing at the statement.
+pub fn emitInlineAsm(self: *Emitter, stmt: ast.AsmStmt) error{OutOfMemory}!void {
+    // `body` spans the string literal including its quotes — strip them.
+    const raw = self.source[stmt.body.start..stmt.body.end];
+    const body = if (raw.len >= 2 and raw[0] == '"') raw[1 .. raw.len - 1] else raw;
+
+    var sub: std.ArrayList(u8) = .empty;
+    defer sub.deinit(self.allocator);
+    var i: usize = 0;
+    while (i < body.len) {
+        if (body[i] != '{') {
+            try sub.append(self.allocator, body[i]);
+            i += 1;
+            continue;
+        }
+        const close = std.mem.indexOfScalarPos(u8, body, i + 1, '}') orelse
+            return self.diagFatal(stmt.span, "E_CODEGEN_INLINE_ASM", "inline `asm` has an unclosed `{` operand reference");
+        const name = body[i + 1 .. close];
+        const ofs = localOffset(self, name) orelse {
+            const msg = try std.fmt.allocPrint(self.diag_arena, "inline `asm` references `{s}`, which isn't a local or parameter in scope (§4.11)", .{name});
+            return self.diagFatal(stmt.span, "E_CODEGEN_INLINE_ASM", msg);
+        };
+        // `[fp + $N]` / `[fp - $N]` — the slot holding the named value.
+        // Asm offsets are `$`-prefixed hex (§asm spec).
+        const op = if (ofs >= 0) blk: {
+            // safety: a non-negative fp-offset fits u8.
+            const slot: u8 = @intCast(ofs);
+            break :blk try std.fmt.allocPrint(self.allocator, "[fp + ${x}]", .{slot});
+        } else blk: {
+            // safety: negating the i16-widened offset gives 1..128, fits u8.
+            const wide: i16 = ofs;
+            const slot: u8 = @intCast(-wide);
+            break :blk try std.fmt.allocPrint(self.allocator, "[fp - ${x}]", .{slot});
+        };
+        defer self.allocator.free(op);
+        try sub.appendSlice(self.allocator, op);
+        i = close + 1;
+    }
+    // The asm parser is line-oriented — terminate the instruction.
+    try sub.append(self.allocator, '\n');
+
+    const result = try codegen.assembleInstruction(self.allocator, sub.items);
+    defer self.allocator.free(result.bytes);
+    defer self.allocator.free(result.errors);
+
+    if (result.errors.len > 0) {
+        const msg = try std.fmt.allocPrint(self.diag_arena, "inline `asm` did not assemble: {s} (§4.11)", .{result.errors[0].parse_error.message});
+        return self.diagFatal(stmt.span, "E_CODEGEN_INLINE_ASM", msg);
+    }
+    // §4.11: exactly one instruction, no labels or directives — a
+    // multi-instruction or label-bearing body would otherwise emit only
+    // the last instruction and silently drop the rest.
+    if (result.instruction_count != 1 or result.other_count != 0)
+        return self.diagFatal(stmt.span, "E_CODEGEN_INLINE_ASM", "inline `asm` must be exactly one instruction — no labels, directives, or multiple instructions (§4.11)");
+
+    for (result.bytes) |b| try self.emitByte(b);
+}
+
+/// fp-relative offset of `name` — a local first, then a parameter.
+fn localOffset(self: *const Emitter, name: []const u8) ?i8 {
+    if (self.locals.get(name)) |o| return o;
+    if (self.params.get(name)) |o| return o;
+    return null;
+}

--- a/src/lang/codegen/pattern.zig
+++ b/src/lang/codegen/pattern.zig
@@ -39,7 +39,7 @@ pub fn emitPatternTest(
                 try self.diagFatal(vp.span, "E_CODEGEN_BAD_VARIANT_PATH", "codegen: variant pattern must be `EnumName.Variant`");
                 return;
             };
-            const enum_name = path[0..dot];
+            const enum_name = self.resolveImportAlias(path[0..dot]);
             const variant_name = path[dot + 1 ..];
             const tag = self.variantTag(enum_name, variant_name) orelse {
                 try self.diagFatal(vp.span, "E_CODEGEN_UNDEFINED_VARIANT", "codegen: unknown enum variant in match pattern");

--- a/src/lang/codegen/stdlib.zig
+++ b/src/lang/codegen/stdlib.zig
@@ -22,7 +22,13 @@ pub fn isModule(name: []const u8) bool {
 
 /// Lower a `recv.name(args)` stdlib call. `recv` is gated by `isModule`.
 pub fn emitCall(self: *Emitter, recv: []const u8, fe: ast.FieldExpr, c: ast.CallExpr) !void {
-    const name = self.source[fe.field.start..fe.field.end];
+    return emitCallName(self, recv, self.source[fe.field.start..fe.field.end], c);
+}
+
+/// `emitCall` resolved by an explicit function `name` — used when a
+/// selectively-imported (and possibly renamed) stdlib function is
+/// called bare (`use rng as random from math` then `random()`).
+pub fn emitCallName(self: *Emitter, recv: []const u8, name: []const u8, c: ast.CallExpr) !void {
     if (std.mem.eql(u8, recv, "bank")) return bank_builtin.emitBankCall(self, name, c);
     if (std.mem.eql(u8, recv, "test")) return test_builtin.emitTestCall(self, name, c);
     return math_builtin.emitMathCall(self, name, c);

--- a/src/lang/include.zig
+++ b/src/lang/include.zig
@@ -6,6 +6,13 @@ const Dir = Io.Dir;
 const max_include_depth: u8 = 32;
 const max_file_size: usize = 16 * 1024 * 1024;
 
+/// `use X as Y from "./mod"` bindings collected while fusing: the
+/// alias `Y` mapped to the real exported name `X`. A quoted-path
+/// import inlines the module's source flat, so the alias has no
+/// declaration of its own — front-ends resolve `Y` to `X` through
+/// this table. Keys/values borrow the fused source buffer.
+pub const ImportAliases = std.StringHashMapUnmanaged([]const u8);
+
 /// One source file's metadata. Files dedupe by canonical path
 /// inside `SourceMap`; a module referenced multiple times shares
 /// one entry, several `Region`s pointing into it.
@@ -104,6 +111,9 @@ pub const IncludeErrorKind = enum {
     cycle,
     depth_exceeded,
     not_found,
+    /// `use X as Y` and `use Z as Y` bind the same alias `Y` to two
+    /// different targets.
+    duplicate_alias,
 };
 
 /// One error from the include-resolution phase. Carries the
@@ -126,6 +136,8 @@ pub const FusedSource = struct {
     source: []const u8,
     source_map: SourceMap,
     errors: []IncludeError,
+    /// `use X as Y from "./mod"` alias bindings (`Y` → `X`).
+    import_aliases: ImportAliases,
     allocator: std.mem.Allocator,
 
     /// Release the fused buffer, source map, and errors list.
@@ -134,6 +146,8 @@ pub const FusedSource = struct {
         self.source_map.deinit();
         for (self.errors) |e| self.allocator.free(e.requested);
         self.allocator.free(self.errors);
+        // Keys/values borrow the source buffers — only free the table.
+        self.import_aliases.deinit(self.allocator);
     }
 
     /// `true` when at least one include-phase error was recorded.
@@ -154,6 +168,13 @@ const Context = struct {
     source_map: *SourceMap,
     errors: *std.ArrayList(IncludeError),
     in_progress: *std.ArrayList([]const u8),
+    /// Canonical paths already fused. A file's symbols enter the
+    /// program once no matter how many `use` sites reach it — a
+    /// second emission would re-declare its top-level decls.
+    emitted: *std.ArrayList([]const u8),
+    /// `use X as Y from "./mod"` aliases, collected as each import
+    /// directive is elided (the alias has no inlined declaration).
+    import_aliases: *ImportAliases,
 };
 
 /// Resolve every `use "./path"` reachable from `root_path` into
@@ -185,6 +206,12 @@ pub fn resolveUseImports(
     var in_progress: std.ArrayList([]const u8) = .empty;
     defer in_progress.deinit(allocator);
 
+    var emitted: std.ArrayList([]const u8) = .empty;
+    defer emitted.deinit(allocator);
+
+    var import_aliases: ImportAliases = .{};
+    errdefer import_aliases.deinit(allocator);
+
     var ctx = Context{
         .io = io,
         .allocator = allocator,
@@ -192,6 +219,8 @@ pub fn resolveUseImports(
         .source_map = &source_map,
         .errors = &errors,
         .in_progress = &in_progress,
+        .emitted = &emitted,
+        .import_aliases = &import_aliases,
     };
 
     try resolveOne(&ctx, root_path, null, 0, 0);
@@ -200,6 +229,7 @@ pub fn resolveUseImports(
         .source = try fused.toOwnedSlice(allocator),
         .source_map = source_map,
         .errors = try errors.toOwnedSlice(allocator),
+        .import_aliases = import_aliases,
         .allocator = allocator,
     };
 }
@@ -244,9 +274,23 @@ fn resolveOne(
         else => return err,
     };
 
+    // Cycle check first — a file in `emitted` is also in `in_progress`
+    // mid-recursion, so a cyclic re-entry must be caught here before the
+    // include-once short-circuit below masks it.
     for (ctx.in_progress.items) |p| {
         if (std.mem.eql(u8, p, canonical)) {
             try recordError(ctx, .cycle, site_offset, requested);
+            ctx.allocator.free(canonical);
+            return;
+        }
+    }
+
+    // Include-once: already fused via an earlier `use` — its decls are
+    // in scope, so a second emission would redefine them. The
+    // directive's sentinel region (appended by the caller) still
+    // anchors any diagnostic.
+    for (ctx.emitted.items) |p| {
+        if (std.mem.eql(u8, p, canonical)) {
             ctx.allocator.free(canonical);
             return;
         }
@@ -264,6 +308,10 @@ fn resolveOne(
     };
 
     const file = ctx.source_map.files.items[file_id];
+
+    // Mark before recursing so a diamond (two paths to one file)
+    // emits it once; `in_progress` still catches true cycles.
+    try ctx.emitted.append(ctx.allocator, file.path);
 
     try ctx.in_progress.append(ctx.allocator, file.path);
     defer _ = ctx.in_progress.pop();
@@ -289,6 +337,7 @@ fn processSource(
     while (i < content.len) {
         const line_start = i;
         var in_string = false;
+        var comment_at: ?usize = null;
         while (i < content.len and content[i] != '\n') : (i += 1) {
             const b = content[i];
             if (in_string) {
@@ -303,14 +352,25 @@ fn processSource(
                 in_string = true;
             } else if (b == '-' and i + 1 < content.len and content[i + 1] == '-') {
                 // gero-lang line comment — skip the rest of the line.
+                comment_at = i;
                 while (i < content.len and content[i] != '\n') : (i += 1) {}
                 break;
             }
         }
         const line_end = i;
         const line = content[line_start..line_end];
+        // `use` detection + alias capture run on the code portion only,
+        // so a `from` / `as` inside a trailing comment isn't parsed as
+        // part of the directive.
+        const code = content[line_start .. comment_at orelse line_end];
 
-        if (matchUseQuotedLine(line)) |target| {
+        if (matchUseQuotedLine(code)) |target| {
+            // The directive is about to be elided; capture any `as`
+            // aliases first, since the inlined module carries no
+            // declaration for them. The fused length here equals the
+            // sentinel offset appended below, so a duplicate-alias
+            // diagnostic maps back to this `use` line.
+            try collectAliases(ctx, code, @intCast(ctx.fused.items.len));
             const seg_file_end: u32 = @intCast(line_start);
             if (seg_file_end > seg_file_start) {
                 try ctx.source_map.appendRegion(
@@ -376,6 +436,22 @@ fn recordError(
 /// imports (`use a, b from "./bar"`) DO match — we strip
 /// everything up to `from` first and apply the same quoted-path
 /// rule on the right.
+/// Index of a whitespace-delimited keyword `kw` (`from` / `as`) in
+/// `s`, or null. Unlike a `" kw "` substring search this matches tab-
+/// as well as space-separated tokens, and won't fire inside a longer
+/// word (`class`, `fromage`).
+fn findKeyword(s: []const u8, kw: []const u8) ?usize {
+    var i: usize = 0;
+    while (i + kw.len <= s.len) : (i += 1) {
+        if (!std.mem.eql(u8, s[i .. i + kw.len], kw)) continue;
+        const before_ws = i == 0 or s[i - 1] == ' ' or s[i - 1] == '\t';
+        const after = i + kw.len;
+        const after_ws = after >= s.len or s[after] == ' ' or s[after] == '\t';
+        if (before_ws and after_ws) return i;
+    }
+    return null;
+}
+
 fn matchUseQuotedLine(line: []const u8) ?[]const u8 {
     var i: usize = 0;
     while (i < line.len and (line[i] == ' ' or line[i] == '\t')) i += 1;
@@ -385,9 +461,9 @@ fn matchUseQuotedLine(line: []const u8) ?[]const u8 {
     i += kw.len;
     if (i >= line.len or (line[i] != ' ' and line[i] != '\t')) return null;
     while (i < line.len and (line[i] == ' ' or line[i] == '\t')) i += 1;
-    // Skip past `<items> from ` if a selective import is present.
-    if (std.mem.indexOf(u8, line[i..], " from ")) |from_off| {
-        i += from_off + " from ".len;
+    // Skip past `<items> from` if a selective import is present.
+    if (findKeyword(line[i..], "from")) |from_off| {
+        i += from_off + "from".len;
         while (i < line.len and (line[i] == ' ' or line[i] == '\t')) i += 1;
     }
     if (i >= line.len or line[i] != '"') return null;
@@ -401,6 +477,39 @@ fn matchUseQuotedLine(line: []const u8) ?[]const u8 {
     // Trailing content allowed only if it's a comment.
     if (k < line.len and !(k + 1 < line.len and line[k] == '-' and line[k + 1] == '-')) return null;
     return line[path_start..path_end];
+}
+
+/// Record `Y → X` for every `X as Y` item in a selective directive
+/// `use <items> from "path"`. The whole-module form `use "path"` has
+/// no items, so nothing is recorded. Name/alias slices borrow `line`
+/// (interned source, stable for the fuse). A repeated alias key takes
+/// the last binding.
+fn collectAliases(ctx: *Context, line: []const u8, site_offset: u32) ResolveError!void {
+    var i: usize = 0;
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) i += 1;
+    const kw = "use";
+    if (i + kw.len > line.len or !std.mem.eql(u8, line[i .. i + kw.len], kw)) return;
+    i += kw.len;
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) i += 1;
+    // Aliases only appear in the selective form, ahead of `from`.
+    const from_off = findKeyword(line[i..], "from") orelse return;
+    const items = line[i .. i + from_off];
+
+    var it = std.mem.splitScalar(u8, items, ',');
+    while (it.next()) |raw| {
+        const item = std.mem.trim(u8, raw, " \t");
+        const as_off = findKeyword(item, "as") orelse continue;
+        const name = std.mem.trim(u8, item[0..as_off], " \t");
+        const alias = std.mem.trim(u8, item[as_off + "as".len ..], " \t");
+        if (name.len == 0 or alias.len == 0) continue;
+        const gop = try ctx.import_aliases.getOrPut(ctx.allocator, alias);
+        // Re-binding the same alias to the same target is a harmless
+        // repeat; to a different one is an ambiguous import.
+        if (gop.found_existing and !std.mem.eql(u8, gop.value_ptr.*, name)) {
+            try recordError(ctx, .duplicate_alias, site_offset, alias);
+        }
+        gop.value_ptr.* = name;
+    }
 }
 
 // ---------- tests ----------

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -66,6 +66,18 @@ pub fn typecheck(
     source: []const u8,
     program: *const ast.Program,
 ) !CheckedProgram {
+    return typecheckModule(allocator, source, program, null);
+}
+
+/// Type-check a fused multi-file `program`, resolving `use X as Y`
+/// quoted-path aliases through `import_aliases` (`Y` → `X`). The
+/// single-file `typecheck` is this with no aliases.
+pub fn typecheckModule(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    program: *const ast.Program,
+    import_aliases: ?*const std.StringHashMapUnmanaged([]const u8),
+) !CheckedProgram {
     var arena = std.heap.ArenaAllocator.init(allocator);
     errdefer arena.deinit();
     const a = arena.allocator();
@@ -106,6 +118,8 @@ pub fn typecheck(
         .in_no_capture = false,
         .lambda_locals = null,
         .expr_types = &expr_types,
+        .import_aliases = import_aliases,
+        .selective_stdlib = .{},
     };
 
     // Pre-pass: index enum / struct / class / def decls and the
@@ -279,6 +293,32 @@ pub const Checker = struct {
     /// Inferred type per AST expression pointer. Owned by the
     /// caller; survives `Checker` for the codegen to read.
     expr_types: *std.AutoHashMapUnmanaged(*const ast.Expr, *const types.Type),
+    /// `use X as Y from "./mod"` aliases (`Y` → `X`) from the fuser,
+    /// or `null` for a single-file check. A top-level name lookup
+    /// resolves through this first so an alias binds like its target.
+    import_aliases: ?*const std.StringHashMapUnmanaged([]const u8),
+    /// Selectively-imported stdlib function (`use rng from math`):
+    /// the local name (alias or original) → its `(module, real_name)`.
+    /// Lets a bare call lower to the stdlib signature.
+    selective_stdlib: std.StringHashMapUnmanaged(StdlibImport),
+
+    /// A stdlib function pulled into scope by a selective `use`.
+    pub const StdlibImport = struct { module: []const u8, name: []const u8 };
+
+    /// Resolve a quoted-path import alias to the real exported name;
+    /// identity when `name` isn't an alias.
+    pub fn resolveImportAlias(self: *const Checker, name: []const u8) []const u8 {
+        const aliases = self.import_aliases orelse return name;
+        return aliases.get(name) orelse name;
+    }
+
+    /// Like `resolveImportAlias`, but in value position: a real binding
+    /// (local / param / global) of the same name shadows the alias, so
+    /// the alias applies only when `raw` isn't already in scope.
+    pub fn resolveValueAlias(self: *const Checker, raw: []const u8) []const u8 {
+        if (self.current_scope.lookup(raw) != null) return raw;
+        return self.resolveImportAlias(raw);
+    }
 
     /// Explicit error set for the mutually-recursive walker fns.
     const WalkError = error{OutOfMemory};
@@ -1149,7 +1189,7 @@ pub const Checker = struct {
     fn registerVariantBindings(self: *Checker, vp: ast.VariantPattern, ty: ?*const types.Type) WalkError!void {
         const ed: ?*const ast.EnumDecl = blk: {
             if (ty) |it| if (self.enumDeclForType(it.*)) |e| break :blk e;
-            const head = match.splitPath(self.lexeme(vp.path)).head;
+            const head = self.resolveImportAlias(match.splitPath(self.lexeme(vp.path)).head);
             break :blk if (head.len > 0) self.enum_registry.get(head) else null;
         };
         if (ed) |e| {
@@ -1186,7 +1226,7 @@ pub const Checker = struct {
                 return false;
             },
             .variant_pattern => |vp| {
-                const head = match.splitPath(self.lexeme(vp.path)).head;
+                const head = self.resolveImportAlias(match.splitPath(self.lexeme(vp.path)).head);
                 const ed = if (head.len > 0) self.enum_registry.get(head) else null;
                 // A variant of a multi-variant (or unknown) enum is refutable.
                 if (ed == null or ed.?.variants.len != 1) return true;
@@ -1287,8 +1327,22 @@ pub const Checker = struct {
                 return try self.primitive(.str);
             },
             .ident => |i| {
-                const name = self.lexeme(i.span);
-                if (self.current_scope.lookup(name)) |info| {
+                const raw = self.lexeme(i.span);
+                // A binding for `raw` in the current scope wins — locals
+                // shadow imports. Otherwise `raw` may be a quoted-path
+                // import alias: its target is a module-level export,
+                // looked up at module scope so a local named like the
+                // target can't capture it.
+                var name = raw;
+                var info_opt = self.current_scope.lookup(raw);
+                if (info_opt == null) {
+                    const target = self.resolveImportAlias(raw);
+                    if (!std.mem.eql(u8, target, raw)) {
+                        name = target;
+                        info_opt = self.module_scope.lookup(target);
+                    }
+                }
+                if (info_opt) |info| {
                     // Bake context cannot touch MMIO-bound globals.
                     if (self.in_bake and self.mmio_names.contains(name)) {
                         const msg = try std.fmt.allocPrint(
@@ -1353,7 +1407,8 @@ pub const Checker = struct {
                 // synthetic `mem` module — dispatch through the
                 // stdlib resolver rather than the class-method path.
                 if (m.receiver.* == .ident) {
-                    const recv_name = self.lexeme(m.receiver.ident.span);
+                    const raw_recv = self.lexeme(m.receiver.ident.span);
+                    const recv_name = self.resolveValueAlias(raw_recv);
                     if (std.mem.eql(u8, recv_name, "mem")) {
                         return try fields.checkMemMethodCall(self, m);
                     }
@@ -1379,7 +1434,10 @@ pub const Checker = struct {
                     // binding of the same name shadows the class, so only
                     // route here when the name still resolves to the class.
                     if (self.class_registry.get(recv_name)) |cd| {
-                        const is_class_ref = if (self.current_scope.lookup(recv_name)) |info| info.kind == .class else true;
+                        // Shadowing is judged on the RAW receiver — a local
+                        // named like the alias *target* must not mask the
+                        // class the alias points at.
+                        const is_class_ref = if (self.current_scope.lookup(raw_recv)) |info| info.kind == .class else true;
                         if (is_class_ref) return try fields.checkStaticMethodCall(self, m, cd, recv_name);
                     }
                 }
@@ -1402,7 +1460,7 @@ pub const Checker = struct {
                 //   - `EnumName.Variant` — variant constructor.
                 //   - `mem.func`         — stdlib builtin.
                 if (f.receiver.* == .ident) {
-                    const recv_name = self.lexeme(f.receiver.ident.span);
+                    const recv_name = self.resolveValueAlias(self.lexeme(f.receiver.ident.span));
                     if (self.enum_registry.get(recv_name)) |ed| {
                         return try fields.resolveEnumVariant(self, ed, recv_name, f);
                     }
@@ -1618,7 +1676,7 @@ pub const Checker = struct {
         switch (it.kind) {
             .variant => return bool_ty,
             .class_type => |probe| {
-                const class_name = self.lexeme(probe.class_name);
+                const class_name = self.resolveImportAlias(self.lexeme(probe.class_name));
                 if (!self.class_registry.contains(class_name)) {
                     const msg = try std.fmt.allocPrint(self.arena, "undefined class `{s}`", .{class_name});
                     try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED", probe.class_name, msg, try self.suggestTypeName(class_name));

--- a/src/lang/typecheck/calls.zig
+++ b/src/lang/typecheck/calls.zig
@@ -44,10 +44,24 @@ pub fn checkCall(self: *Checker, c: ast.CallExpr, hint: ?*const types.Type) Walk
             }
         }
     }
+    // A selectively-imported stdlib function called bare — `use rng
+    // from math` then `rng()` — resolves to its module's checker, the
+    // same as the qualified `math.rng()` form (renames bind too). A
+    // same-named local binding shadows the import (its scope entry is
+    // no longer `.imported`), so skip the route then.
+    if (c.callee.* == .ident) {
+        const callee_name = self.lexeme(c.callee.ident.span);
+        const still_import = if (self.current_scope.lookup(callee_name)) |info| info.kind == .imported else false;
+        if (still_import) {
+            if (self.selective_stdlib.get(callee_name)) |si| {
+                return try stdlib.checkCallName(self, si.module, si.name, c.callee.ident.span, c.args, c.span);
+            }
+        }
+    }
     // Abstract-class instantiation: `ClassName(args)` where
     // `ClassName` is abstract is rejected.
     if (c.callee.* == .ident) {
-        const callee_name = self.lexeme(c.callee.ident.span);
+        const callee_name = self.resolveValueAlias(self.lexeme(c.callee.ident.span));
         if (self.class_registry.get(callee_name)) |cd| {
             if (annotations.classIsAbstract(self, cd)) {
                 const msg = try std.fmt.allocPrint(
@@ -489,14 +503,16 @@ pub fn checkBakeAnnotationConflicts(self: *Checker, anns: []const ast.Annotation
 /// wrapped in `paren`). Used by call-site rules that need to find
 /// the underlying decl (bake-call check, variadic detection).
 fn directCalleeName(c: *const Checker, callee: *const ast.Expr) ?[]const u8 {
-    return flow.identName(c, callee);
+    const raw = flow.identName(c, callee) orelse return null;
+    return c.resolveValueAlias(raw);
 }
 
 /// When `callee` resolves to a `def` decl whose last param is
 /// variadic, return that decl. Returns `null` otherwise — callers
 /// fall back to the regular fixed-arity path.
 fn variadicCalleeDecl(c: *const Checker, callee: *const ast.Expr) ?*const ast.DefDecl {
-    const name = flow.identName(c, callee) orelse return null;
+    const raw = flow.identName(c, callee) orelse return null;
+    const name = c.resolveValueAlias(raw);
     const decl = c.def_registry.get(name) orelse return null;
     if (decl.params.len == 0) return null;
     if (!decl.params[decl.params.len - 1].variadic) return null;

--- a/src/lang/typecheck/decls.zig
+++ b/src/lang/typecheck/decls.zig
@@ -4,6 +4,7 @@ const types = @import("../types.zig");
 const scope_mod = @import("../scope.zig");
 const typecheck = @import("../typecheck.zig");
 const type_resolve = @import("type_resolve.zig");
+const stdlib = @import("stdlib.zig");
 
 const Checker = typecheck.Checker;
 const WalkError = error{OutOfMemory};
@@ -82,13 +83,28 @@ fn registerUseDecl(self: *Checker, d: ast.UseDecl) WalkError!void {
     if (d.items.len > 0) {
         // `use a [as al], b [as bl] from module` — each item
         // becomes its own imported symbol.
+        const module = self.lexeme(d.module);
+        const from_stdlib = stdlib.isModule(module);
         for (d.items) |it| {
-            const name = if (it.alias) |a| self.lexeme(a) else self.lexeme(it.name);
+            const orig = self.lexeme(it.name);
+            const name = if (it.alias) |a| self.lexeme(a) else orig;
             try registerName(self, name, .{
                 .kind = .imported,
                 .decl_span = it.name,
                 .ty = null,
             });
+            // A stdlib selective import records its origin so a bare
+            // call (`rng()` after `use rng from math`) lowers like the
+            // qualified `math.rng()` form — and the member must exist,
+            // surfaced here rather than only at a call site.
+            if (from_stdlib) {
+                if (stdlib.isMember(module, orig)) {
+                    try self.selective_stdlib.put(self.arena, name, .{ .module = module, .name = orig });
+                } else {
+                    const msg = try std.fmt.allocPrint(self.arena, "stdlib module `{s}` has no member `{s}`", .{ module, orig });
+                    try self.emitSpan("E_TYPE_UNDEFINED_METHOD", it.name, msg);
+                }
+            }
         }
     } else {
         // Whole-module import — register the alias (or the

--- a/src/lang/typecheck/fields.zig
+++ b/src/lang/typecheck/fields.zig
@@ -406,7 +406,7 @@ pub fn checkStaticMethodCall(
 /// unknown / missing / mistyped fields and returns the named
 /// type so the surrounding expression continues to type-check.
 pub fn checkStructLit(self: *Checker, sl: ast.StructLit) WalkError!?*const types.Type {
-    const type_name = self.lexeme(sl.type_name);
+    const type_name = self.resolveImportAlias(self.lexeme(sl.type_name));
     const named_ty = try types.mkNamed(self.arena, type_name, sl.type_name);
 
     // Struct literals can be used to construct classes too

--- a/src/lang/typecheck/match.zig
+++ b/src/lang/typecheck/match.zig
@@ -112,8 +112,10 @@ fn walkArmPattern(
         .variant_pattern => |vp| {
             const split = splitPath(self.lexeme(vp.path));
             // Verify the head matches the enum name (skip when
-            // it doesn't — pattern targets a different enum).
-            if (split.head.len > 0 and !std.mem.eql(u8, split.head, self.lexeme(ed.name))) return;
+            // it doesn't — pattern targets a different enum). An
+            // import alias resolves to the real enum name first.
+            const head = self.resolveImportAlias(split.head);
+            if (head.len > 0 and !std.mem.eql(u8, head, self.lexeme(ed.name))) return;
             // Verify variant exists on this enum.
             if (!variantExists(self, ed, split.tail)) return;
             if (covered.contains(split.tail)) {
@@ -259,7 +261,7 @@ fn resolveMatchEnum(self: *Checker, ms: ast.MatchStmt, scrut_ty: ?*const types.T
     if (scrut_ty) |st| if (enumDeclForType(self, st.*)) |ed| return ed;
     for (ms.arms) |arm| {
         if (arm.pattern.* != .variant_pattern) continue;
-        const head = splitPath(self.lexeme(arm.pattern.variant_pattern.path)).head;
+        const head = self.resolveImportAlias(splitPath(self.lexeme(arm.pattern.variant_pattern.path)).head);
         if (head.len > 0) if (self.enum_registry.get(head)) |ed| return ed;
     }
     return null;

--- a/src/lang/typecheck/stdlib.zig
+++ b/src/lang/typecheck/stdlib.zig
@@ -77,6 +77,13 @@ fn lookup(recv: []const u8, name: []const u8) ?Sig {
     return null;
 }
 
+/// `true` when `name` is a function of stdlib module `recv` (gated by
+/// `isModule`). Lets `use <name> from <module>` validate the member at
+/// registration rather than only at the call site.
+pub fn isMember(recv: []const u8, name: []const u8) bool {
+    return lookup(recv, name) != null;
+}
+
 fn suggest(recv: []const u8, name: []const u8) ?[]const u8 {
     const sigs = sigsFor(recv);
     var pool: [16][]const u8 = undefined;
@@ -118,10 +125,24 @@ pub fn checkCall(
     args: []const *ast.Expr,
     call_span: ast.Span,
 ) WalkError!?*const types.Type {
-    const name = self.lexeme(name_span);
+    return checkCallName(self, recv, self.lexeme(name_span), name_span, args, call_span);
+}
+
+/// `checkCall` resolved by an explicit function `name` rather than its
+/// source span — used when a selectively-imported (and possibly
+/// renamed) stdlib function is called bare (`use rng as random from
+/// math` then `random()`). `diag_span` anchors any error.
+pub fn checkCallName(
+    self: *Checker,
+    recv: []const u8,
+    name: []const u8,
+    diag_span: ast.Span,
+    args: []const *ast.Expr,
+    call_span: ast.Span,
+) WalkError!?*const types.Type {
     const sig = lookup(recv, name) orelse {
         const msg = try std.fmt.allocPrint(self.arena, "stdlib module `{s}` has no member `{s}`", .{ recv, name });
-        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", name_span, msg, suggest(recv, name));
+        try self.emitSpanWithSuggestion("E_TYPE_UNDEFINED_METHOD", diag_span, msg, suggest(recv, name));
         for (args) |a| _ = try self.inferExpr(a, null);
         return null;
     };

--- a/src/lang/typecheck/type_resolve.zig
+++ b/src/lang/typecheck/type_resolve.zig
@@ -14,7 +14,7 @@ const WalkError = error{OutOfMemory};
 pub fn resolveType(self: *Checker, t: *const ast.TypeAnn) WalkError!*const types.Type {
     switch (t.*) {
         .named => |n| {
-            const name = self.lexeme(n.name);
+            const name = self.resolveImportAlias(self.lexeme(n.name));
             if (types.primitiveFromName(name)) |p| {
                 return try self.primitive(p);
             }

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -871,6 +871,233 @@ fn runAndExpect(source: []const u8, expected: []const u8) !void {
     try std.testing.expectEqualStrings(expected, writer.written());
 }
 
+/// Like `runAndExpect`, but threads a `use X as Y from "./mod"` alias
+/// table (`Y` → `X`) through both the typechecker and codegen — the
+/// post-fuse view of a quoted-path import whose alias has no inlined
+/// declaration. Each pair is `.{ alias, real_name }`.
+fn runWithAliasesAndExpect(source: []const u8, pairs: []const [2][]const u8, expected: []const u8) !void {
+    var stream = try gero.lang.tokenize(alloc, source);
+    defer stream.deinit();
+    var tree = try gero.lang.parse(alloc, source, stream);
+    defer tree.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tree.errors.len);
+
+    var aliases: gero.lang.ImportAliases = .{};
+    defer aliases.deinit(alloc);
+    for (pairs) |p| try aliases.put(alloc, p[0], p[1]);
+
+    var checked = try gero.lang.typecheckModule(alloc, source, &tree.program, &aliases);
+    defer checked.deinit();
+    if (checked.diagnostics.len > 0) {
+        for (checked.diagnostics) |d| std.debug.print("  - {s}: {s}\n", .{ d.code, d.message });
+    }
+    try std.testing.expectEqual(@as(usize, 0), checked.diagnostics.len);
+
+    var compiled = try gero.lang.compile(alloc, source, &checked, .{ .import_aliases = &aliases });
+    defer compiled.deinit();
+    try std.testing.expect(!compiled.hasErrors());
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var writer = std.Io.Writer.Allocating.fromArrayList(alloc, &buf);
+    defer writer.deinit();
+    var vm = try runWith(compiled.image, &writer);
+    defer vm.deinit();
+
+    try std.testing.expectEqualStrings(expected, writer.written());
+}
+
+test "codegen: import alias resolves a `@static` class call" {
+    // `keys` is `input` under another name — `keys.flag()` static-
+    // dispatches to the emitted `input.flag`.
+    try runWithAliasesAndExpect(
+        \\class input
+        \\  @static
+        \\  def flag() -> i16
+        \\    return 7
+        \\  end
+        \\end
+        \\def main()
+        \\  print keys.flag()
+        \\end
+    , &.{.{ "keys", "input" }}, "7\n");
+}
+
+test "codegen: import alias resolves a free `def` call" {
+    try runWithAliasesAndExpect(
+        \\def helper(x: i16) -> i16
+        \\  return x + 1
+        \\end
+        \\def main()
+        \\  print h(41)
+        \\end
+    , &.{.{ "h", "helper" }}, "42\n");
+}
+
+test "codegen: import alias resolves a module-level const" {
+    try runWithAliasesAndExpect(
+        \\const MAX = 100
+        \\def main()
+        \\  print M
+        \\end
+    , &.{.{ "M", "MAX" }}, "100\n");
+}
+
+test "codegen: import alias resolves a struct type + literal" {
+    try runWithAliasesAndExpect(
+        \\struct Point
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let p: P = P { x: 3, y: 4 }
+        \\  print p.y
+        \\end
+    , &.{.{ "P", "Point" }}, "4\n");
+}
+
+test "codegen: import alias resolves an enum in a `match`" {
+    try runWithAliasesAndExpect(
+        \\enum Color
+        \\  case Red
+        \\  case Green
+        \\  case Blue
+        \\end
+        \\def main()
+        \\  let c: C = C.Blue
+        \\  match c
+        \\    case C.Red => print 1
+        \\    case C.Green => print 2
+        \\    case C.Blue => print 3
+        \\  end
+        \\end
+    , &.{.{ "C", "Color" }}, "3\n");
+}
+
+test "codegen: a local binding shadows an import alias of the same name" {
+    // `h` is both an alias for `helper` and a local — the local wins,
+    // so `h` reads `5`, not a call to `helper`.
+    try runWithAliasesAndExpect(
+        \\def helper() -> i16
+        \\  return 99
+        \\end
+        \\def main()
+        \\  let h: i16 = 5
+        \\  print h
+        \\end
+    , &.{.{ "h", "helper" }}, "5\n");
+}
+
+test "codegen: a selectively-imported stdlib function lowers when called bare" {
+    try runAndExpect(
+        \\use max from math
+        \\def main()
+        \\  print max(3, 7)
+        \\end
+    , "7\n");
+}
+
+test "codegen: a renamed selective stdlib import lowers when called bare" {
+    try runAndExpect(
+        \\use max as biggest from math
+        \\def main()
+        \\  print biggest(3, 7)
+        \\end
+    , "7\n");
+}
+
+test "codegen: a param shadows an import alias of the same name" {
+    // `helper` is both an alias for `real_thing` and a param — the
+    // param wins, so `f(5)` returns 5, not a call to `real_thing`.
+    try runWithAliasesAndExpect(
+        \\def real_thing() -> i16
+        \\  return 100
+        \\end
+        \\def f(helper: i16) -> i16
+        \\  return helper
+        \\end
+        \\def main()
+        \\  print f(5)
+        \\end
+    , &.{.{ "helper", "real_thing" }}, "5\n");
+}
+
+test "codegen: a local named like an alias target doesn't capture the alias" {
+    // `h` aliases the import `helper`; a local also *named* `helper`
+    // must not capture `h` — the alias resolves to the module-level
+    // export, so `h()` calls it (11), not the local.
+    try runWithAliasesAndExpect(
+        \\def helper() -> i16
+        \\  return 11
+        \\end
+        \\def main()
+        \\  let helper: i16 = 777
+        \\  print h()
+        \\end
+    , &.{.{ "h", "helper" }}, "11\n");
+}
+
+test "codegen: a local closure shadows a selective stdlib import" {
+    // `math.max(2, 9)` is 9; the local closure `a + b` is 11 — the
+    // local must win.
+    try runAndExpect(
+        \\use max from math
+        \\def main()
+        \\  let max = |a: i16, b: i16| -> i16 a + b
+        \\  print max(2, 9)
+        \\end
+    , "11\n");
+}
+
+test "codegen: a local closure shadows a same-named class constructor" {
+    try runAndExpect(
+        \\class Widget
+        \\  let v: i16
+        \\  def init(self)
+        \\    self.v = 1
+        \\  end
+        \\end
+        \\def main()
+        \\  let Widget = |x: i16| -> i16 x * 2
+        \\  print Widget(21)
+        \\end
+    , "42\n");
+}
+
+test "codegen: an aliased `bake def` is evaluated in a const initializer" {
+    // The const init calls the bake def through its alias — it must
+    // still be folded at compile time, not silently skipped.
+    try runWithAliasesAndExpect(
+        \\bake def origin() -> i16
+        \\  return 1234
+        \\end
+        \\const C = make()
+        \\def main()
+        \\  print C
+        \\end
+    , &.{.{ "make", "origin" }}, "1234\n");
+}
+
+test "codegen: an aliased variadic `def` is called variadically" {
+    try runWithAliasesAndExpect(
+        \\def pick(first: i16, rest: ...) -> i16
+        \\  return first
+        \\end
+        \\def main()
+        \\  print choose(10, 20, 30, 40)
+        \\end
+    , &.{.{ "choose", "pick" }}, "10\n");
+}
+
+test "codegen: an `asm` body with multiple instructions is rejected" {
+    try expectCodegenError(
+        \\def main()
+        \\  asm "nop
+        \\nop"
+        \\end
+    , "E_CODEGEN_INLINE_ASM");
+}
+
 test "codegen: if-then with truthy cond runs the body" {
     try runAndExpect(
         \\def main()
@@ -1904,6 +2131,59 @@ test "codegen: a value binding shadows a same-named class in receiver position" 
         \\  print M
         \\end
     , "5\n");
+}
+
+test "codegen: an `asm` statement with no operands emits its instruction" {
+    try runAndExpect(
+        \\def main()
+        \\  asm "nop"
+        \\  print 7
+        \\end
+    , "7\n");
+}
+
+test "codegen: `asm` `{name}` operands resolve to the local's slot" {
+    // gero asm is AT&T order (src, dest): load `a` into acu, add `b`
+    // (via r1), store acu back into `r` — all through inline asm.
+    try runAndExpect(
+        \\def main()
+        \\  let a: i16 = 20
+        \\  let b: i16 = 22
+        \\  let r: i16 = 0
+        \\  asm "mov {a}, acu"
+        \\  asm "mov {b}, r1"
+        \\  asm "add r1, acu"
+        \\  asm "mov acu, {r}"
+        \\  print r
+        \\end
+    , "42\n");
+}
+
+test "codegen: `asm` with an unknown `{name}` operand is rejected" {
+    try expectCodegenError(
+        \\def main()
+        \\  asm "mov {nope}, acu"
+        \\end
+    , "E_CODEGEN_INLINE_ASM");
+}
+
+test "codegen: `asm` with no matching opcode form is rejected, not silently `hlt`" {
+    // `add [mem], acu` has no opcode form — the assembler must surface it,
+    // not emit the 0xFF fallback that would halt the program.
+    try expectCodegenError(
+        \\def main()
+        \\  let b: i16 = 1
+        \\  asm "add {b}, acu"
+        \\end
+    , "E_CODEGEN_INLINE_ASM");
+}
+
+test "codegen: `asm` with an unknown mnemonic is rejected" {
+    try expectCodegenError(
+        \\def main()
+        \\  asm "bogusmnemonic"
+        \\end
+    , "E_CODEGEN_INLINE_ASM");
 }
 
 test "codegen: print of a string literal goes through sys print_str + emits `hi`" {

--- a/tests/lang/codegen/inline_asm.test.zig
+++ b/tests/lang/codegen/inline_asm.test.zig
@@ -1,0 +1,9 @@
+/// Smoke that the `inline_asm` codegen module is reachable through the
+/// public barrel. End-to-end `asm "..."` lowering coverage (operand
+/// substitution, opcode validation) lives in `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/inline_asm: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.inline_asm;
+}

--- a/tests/lang/include.test.zig
+++ b/tests/lang/include.test.zig
@@ -1,13 +1,210 @@
 //! Mirror file for `src/lang/include.zig`.
 //! Unit tests for `matchUseQuotedLine` live alongside the source;
-//! end-to-end include-resolution coverage lives in the
-//! `gero compile` integration tests.
+//! `use`-resolution behavior (fusing, include-once) is covered here
+//! against real temp files, and end-to-end through the `gero check`
+//! / `compile` integration tests.
 
 const std = @import("std");
 const gero = @import("gero");
+
+const alloc = std.testing.allocator;
+
+const Fixture = struct {
+    tmp: std.testing.TmpDir,
+
+    fn init() Fixture {
+        return .{ .tmp = std.testing.tmpDir(.{}) };
+    }
+
+    fn deinit(self: *Fixture) void {
+        self.tmp.cleanup();
+    }
+
+    fn write(self: *Fixture, name: []const u8, body: []const u8) !void {
+        try self.tmp.dir.writeFile(std.testing.io, .{ .sub_path = name, .data = body });
+    }
+
+    fn pathOf(self: *Fixture, name: []const u8) ![:0]u8 {
+        return self.tmp.dir.realPathFileAlloc(std.testing.io, name, alloc);
+    }
+};
+
+/// Count non-overlapping occurrences of `needle` in `haystack`.
+fn occurrences(haystack: []const u8, needle: []const u8) usize {
+    var count: usize = 0;
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) {
+        if (std.mem.eql(u8, haystack[i .. i + needle.len], needle)) {
+            count += 1;
+            i += needle.len;
+        } else {
+            i += 1;
+        }
+    }
+    return count;
+}
 
 test "include: module reachable through the barrel" {
     _ = gero.lang.resolveUseImports;
     _ = gero.lang.FusedSource;
     _ = gero.lang.SourceMap;
+}
+
+test "resolveUseImports: a file reached by two `use` sites fuses once" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("io.gr",
+        \\class display
+        \\  @static
+        \\  def clear()
+        \\  end
+        \\end
+        \\class input
+        \\  @static
+        \\  def pressed() -> bool
+        \\    return false
+        \\  end
+        \\end
+        \\
+    );
+    try fx.write("main.gr",
+        \\use display from "./io"
+        \\use input from "./io"
+        \\def main()
+        \\  display.clear()
+        \\end
+        \\
+    );
+
+    const main_path = try fx.pathOf("main.gr");
+    defer alloc.free(main_path);
+
+    var fused = try gero.lang.resolveUseImports(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    // The shared file's bodies are spliced once, not once per `use`
+    // site — a second splice would redefine its top-level decls.
+    try std.testing.expectEqual(@as(usize, 1), occurrences(fused.source, "class display"));
+    try std.testing.expectEqual(@as(usize, 1), occurrences(fused.source, "class input"));
+}
+
+test "resolveUseImports: a `use X as Y from` rename is captured as an alias" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("io.gr",
+        \\class input
+        \\  @static
+        \\  def pressed() -> bool
+        \\    return false
+        \\  end
+        \\end
+        \\
+    );
+    try fx.write("main.gr",
+        \\use input as keys from "./io"
+        \\def main()
+        \\  print 0
+        \\end
+        \\
+    );
+
+    const main_path = try fx.pathOf("main.gr");
+    defer alloc.free(main_path);
+
+    var fused = try gero.lang.resolveUseImports(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    // The directive is elided from the fused source, but its `as keys`
+    // rename survives in the alias table for the front-ends to apply.
+    const real = fused.import_aliases.get("keys");
+    try std.testing.expect(real != null);
+    try std.testing.expectEqualStrings("input", real.?);
+}
+
+/// First include-error of `kind` in `fused`, or null.
+fn firstError(fused: gero.lang.FusedSource, kind: gero.lang.IncludeErrorKind) ?gero.lang.IncludeError {
+    for (fused.errors) |e| if (e.kind == kind) return e;
+    return null;
+}
+
+test "resolveUseImports: a `use` cycle is reported, not silently fused" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("a.gr", "use \"./b\"\ndef fa() -> i16\n  return 1\nend\n");
+    try fx.write("b.gr", "use \"./a\"\ndef fb() -> i16\n  return 2\nend\n");
+    try fx.write("main.gr", "use \"./a\"\ndef main()\n  print 0\nend\n");
+
+    const main_path = try fx.pathOf("main.gr");
+    defer alloc.free(main_path);
+
+    var fused = try gero.lang.resolveUseImports(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(firstError(fused, .cycle) != null);
+}
+
+test "resolveUseImports: `from` inside a trailing comment isn't parsed as a directive" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("io.gr", "class display\n  @static\n  def clear()\n  end\nend\n");
+    try fx.write("main.gr",
+        \\use display from "./io" -- borrowed from the runtime
+        \\def main()
+        \\  display.clear()
+        \\end
+        \\
+    );
+
+    const main_path = try fx.pathOf("main.gr");
+    defer alloc.free(main_path);
+
+    var fused = try gero.lang.resolveUseImports(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    // The module resolved despite the comment's `from`.
+    try std.testing.expectEqual(@as(usize, 1), occurrences(fused.source, "class display"));
+}
+
+test "resolveUseImports: a tab-delimited `use ... from` resolves" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("io.gr", "class display\n  @static\n  def clear()\n  end\nend\n");
+    try fx.write("main.gr", "use display\tfrom\t\"./io\"\ndef main()\n  display.clear()\nend\n");
+
+    const main_path = try fx.pathOf("main.gr");
+    defer alloc.free(main_path);
+
+    var fused = try gero.lang.resolveUseImports(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    try std.testing.expect(!fused.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), occurrences(fused.source, "class display"));
+}
+
+test "resolveUseImports: one alias bound to two different targets errors" {
+    var fx = Fixture.init();
+    defer fx.deinit();
+    try fx.write("m1.gr", "def one() -> i16\n  return 1\nend\n");
+    try fx.write("m2.gr", "def two() -> i16\n  return 2\nend\n");
+    try fx.write("main.gr",
+        \\use one as h from "./m1"
+        \\use two as h from "./m2"
+        \\def main()
+        \\  print h()
+        \\end
+        \\
+    );
+
+    const main_path = try fx.pathOf("main.gr");
+    defer alloc.free(main_path);
+
+    var fused = try gero.lang.resolveUseImports(std.testing.io, alloc, main_path);
+    defer fused.deinit();
+
+    const dup = firstError(fused, .duplicate_alias);
+    try std.testing.expect(dup != null);
+    try std.testing.expectEqualStrings("h", dup.?.requested);
 }

--- a/tests/lang/typecheck.test.zig
+++ b/tests/lang/typecheck.test.zig
@@ -691,6 +691,29 @@ test "typecheck: selective import registers each item" {
     );
 }
 
+test "typecheck: a selectively-imported stdlib fn resolves its return type when called bare" {
+    // `max(3, 7)` binds to `math.max`'s signature, so `m` is `i16` —
+    // not an untyped import.
+    try expectClean(
+        \\use max from math
+        \\def main()
+        \\  let m: i16 = max(3, 7)
+        \\  print m
+        \\end
+    );
+}
+
+test "typecheck: a selective import of a non-existent stdlib member errors at the import" {
+    // Even unused — the bad member is caught at the `use`, not only at
+    // a call site.
+    try expectCode(
+        \\use bogus from math
+        \\def main()
+        \\  print 1
+        \\end
+    , "E_TYPE_UNDEFINED_METHOD");
+}
+
 // ---------- slice 3: bidirectional integer-literal inference ----------
 
 test "typecheck: let x: u8 = 0 pins the literal to u8" {


### PR DESCRIPTION
## Summary

Lowers the inline-assembly statement (§4.11) and fixes the multi-file
import system the example tours need.

### Inline asm
`asm "<instruction>"` now lowers: a `{name}` operand resolves to the
named local / parameter's stack slot; the single instruction is
assembled through a new asm-layer `assembleInstruction` and emitted in
place. Anything that isn't exactly one valid instruction — a bad
opcode form, a label/directive, or multiple instructions — is
`E_CODEGEN_INLINE_ASM`, never a silent `hlt`.

### Multi-file imports
Surfaced while shipping the `./io` stub the tours import:

- **`use X as Y from "./mod"` renames bind** for every symbol kind
  (class / def / const / struct / enum) across calls, `@static`
  calls, constructors, type annotations, `match` arms, and `is`
  tests. A real binding always shadows an import of the same name.
- **Include-once:** a module reached from several `use` sites is fused
  once (it was redefining its decls). Cycles report `E_USE_CYCLE`; a
  duplicate alias is `E_USE_DUPLICATE_ALIAS`.
- **Selective stdlib calls:** `use rng from math` then `rng()` lowers
  like `math.rng()` (renames included), return type resolved at
  type-check; a non-existent member is caught at the `use`.

### Examples
New fully-validating `docs/examples/modules.gr` (+ `io.gr` stub)
exercising the import forms end-to-end. `syntax_overview.gr`'s invalid
`asm "swap {a}, {b}"` is fixed (swap is register-only) and its
`fmt-only` marker corrected to cite the real codegen gaps it tours
(`do`-as-expression, capturing closures) rather than the now-resolved
`./io` import.

## Testing
`zig build ci` green (4 release modes × 5 cross-targets + examples).
Two rounds of adversarial review found and fixed 13 defects (shadowing
order across alias/import sites, alias coverage for every symbol kind,
cycle detection, single-instruction enforcement, an alias→target
module-scope soundness hole); all regression-tested.

Closes #311.
