### PR TITLE
feat(lang/codegen): do-as-expression (§4.3) + capturing closures (§4.7.1–4.7.2)

### DIFF
--- a/.changeset/lang-do-expression-and-closure-interp.md
+++ b/.changeset/lang-do-expression-and-closure-interp.md
@@ -1,0 +1,34 @@
+---
+bump: minor
+---
+
+`do … end` now lowers as an **expression** (§4.3): `let x = do … end`
+runs the block's scoped statements and evaluates to its last
+expression — for any result type, including tuples, structs, and
+arrays. The block's inner locals are reserved in the enclosing frame,
+and its defers fire without clobbering the value.
+
+Closure **capture analysis is reworked** to be scope-correct and to
+cover the cases the previous flat walker missed:
+
+- Variables used inside `$(…)` string interpolation (and the other
+  sub-expression shapes the free-variable walker had skipped) are now
+  captured, so `|| -> str "score: $(score)"` resolves `score`.
+- A capture shadowed by a block / loop / `match`-arm local is scoped
+  out at the inner scope's end, so the outer binding resolves again
+  afterward.
+- A free function, class, enum, or struct named in a lambda body is no
+  longer mistaken for a capture — the body addresses it directly.
+- A captured parameter that escapes its function is kept alive, reading
+  and writing its current value.
+
+Closures can now capture **`self`** (a method-defined lambda reads the
+receiver from its env) and **inline aggregates** — structs, arrays,
+tuples, `Vec`, and scalar optionals. Following §4.7.2: a read-only
+aggregate is copied at construction (value semantics, escape-safe); an
+aggregate the closure mutates becomes a shared heap upvalue, so writes
+are visible to the enclosing scope and to every closure over it.
+
+Together these let `docs/examples/syntax_overview.gr` — the
+complete-syntax tour — type-check and lower end-to-end; it is no
+longer `fmt-only`.

--- a/docs/examples/syntax_overview.gr
+++ b/docs/examples/syntax_overview.gr
@@ -5,13 +5,9 @@
 -- most language features in one cohesive program.
 --
 -- Read this top-to-bottom to see every construct from the spec at
--- least once. Annotations refer to spec section numbers.
---
--- gero-example: fmt-only — this complete-syntax tour exercises
--- constructs the codegen doesn't lower yet (`do`-as-expression §4.3,
--- capturing closures §4.7.1), so `gero check` can't validate it
--- end-to-end; the formatting gate still applies. The `./io` imports
--- do resolve against the shipped stub (`docs/examples/io.gr`).
+-- least once. Annotations refer to spec section numbers. The `./io`
+-- imports resolve against the shipped stub (`docs/examples/io.gr`);
+-- the whole tour type-checks and lowers under `gero check`.
 ------------------------------------------------------------
 -- §5.2  Imports
 ------------------------------------------------------------

--- a/src/lang.zig
+++ b/src/lang.zig
@@ -44,6 +44,7 @@ const cg_vec_builtin = @import("lang/codegen/vec_builtin.zig");
 const cg_str_builtin = @import("lang/codegen/str_builtin.zig");
 const cg_variadic = @import("lang/codegen/variadic.zig");
 const cg_inline_asm = @import("lang/codegen/inline_asm.zig");
+const cg_do_expr = @import("lang/codegen/do_expr.zig");
 const cg_expr_emit = @import("lang/codegen/expr.zig");
 const cg_control_flow = @import("lang/codegen/control_flow.zig");
 const cg_class = @import("lang/codegen/class.zig");
@@ -242,6 +243,8 @@ pub const internal = struct {
         pub const variadic = cg_variadic;
         /// Inline-assembly statement lowering (`asm "..."`).
         pub const inline_asm = cg_inline_asm;
+        /// `do … end` value-block lowering (§4.3).
+        pub const do_expr = cg_do_expr;
         /// Expression lowering.
         pub const expr_emit = cg_expr_emit;
         /// Control-flow lowering (if / while / for / match / break / continue / defer).

--- a/src/lang/codegen.zig
+++ b/src/lang/codegen.zig
@@ -1140,10 +1140,12 @@ pub const Emitter = struct {
     fn countExprInlineBytes(self: *const Emitter, e: *const ast.Expr, depth: u8) usize {
         return switch (e.*) {
             .int_lit, .fixed_lit, .bool_lit, .nil_lit, .char_lit, .ident, .self_expr, .super_expr, .sizeof => 0,
-            // `if` / `do` expressions and lambda bodies don't splice an
-            // inline frame into THIS frame (unsupported at value position
-            // / compile-time-only / a separate def with its own prologue).
-            .if_expr, .do_expr, .lambda => 0,
+            // A lambda body is a separate def with its own prologue; an
+            // `if` expression isn't lowered at value position. A `do …
+            // end` value block (§4.3) reserves its inner locals in THIS
+            // frame, so count its body.
+            .if_expr, .lambda => 0,
+            .do_expr => |de| self.countFrameBytesDepth(de.body, depth),
             .str_lit => |s| blk: {
                 var n: usize = 0;
                 var has_aggregate = false;

--- a/src/lang/codegen/control_flow.zig
+++ b/src/lang/codegen/control_flow.zig
@@ -20,6 +20,13 @@ const LoopFrame = codegen.LoopFrame;
 /// any statement-list with its own defer lifetime (do-blocks, if
 /// arm bodies, loop bodies, match-arm bodies).
 pub fn emitScopedBody(self: *Emitter, body: []const ast.Statement) error{OutOfMemory}!void {
+    // Block-locals are name-scoped: snapshot the name→slot map so a
+    // `let` inside the block (even one shadowing an enclosing binding /
+    // capture) is forgotten at block end, and the outer name resolves
+    // again afterward. Frame slots stay reserved up front; only the
+    // name mapping is restored.
+    const saved_locals = try self.locals.clone(self.arena);
+    defer self.locals = saved_locals;
     try pushBlock(self);
     for (body) |s| try self.emitStatement(s);
     try popBlockWithDefers(self);
@@ -249,6 +256,11 @@ fn emitLetPatternTest(self: *Emitter, pat: *const ast.Pattern, expr: *const ast.
 /// byte after the back-edge. `while let` is supported for the
 /// ident-binder form per spec §4.5.2.
 pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
+    // The loop var (`while let`) and body `let`s are scoped to the loop;
+    // restore the name→slot map afterward so an enclosing binding they
+    // shadow resolves again. Frame slots stay reserved up front.
+    const saved_locals = try self.locals.clone(self.arena);
+    defer self.locals = saved_locals;
     const cond_offset = try self.currentOffset();
     const label_str: ?[]const u8 = if (ws.label) |s|
         try self.arena.dupe(u8, self.source[s.start..s.end])
@@ -313,6 +325,8 @@ pub fn emitWhileStmt(self: *Emitter, ws: ast.WhileStmt) !void {
 /// runs at least once; `cond` is tested after the body and the
 /// loop exits when `cond` is truthy.
 pub fn emitRepeatStmt(self: *Emitter, rs: ast.RepeatStmt) !void {
+    const saved_locals = try self.locals.clone(self.arena);
+    defer self.locals = saved_locals;
     const top_offset = try self.currentOffset();
     const label_str: ?[]const u8 = if (rs.label) |s|
         try self.arena.dupe(u8, self.source[s.start..s.end])
@@ -389,6 +403,10 @@ fn frameAddr(self: *Emitter, ofs: i8, reg: u8) !void {
 /// iterables (`[T; N]` / `Vec(T)` / `str`) emit direct memory loops; a
 /// class with `next(self) -> T?` desugars to the iterator protocol.
 pub fn emitForStmt(self: *Emitter, fs: ast.ForStmt) !void {
+    // The loop var + body `let`s are scoped to the loop; restore the
+    // name→slot map afterward (frame slots stay reserved up front).
+    const saved_locals = try self.locals.clone(self.arena);
+    defer self.locals = saved_locals;
     if (fs.iter.* == .range) return emitForRange(self, fs);
     const it_ty = self.typeOf(fs.iter) orelse {
         try self.unsupported(fs.span, "`for` over a value of unknown type");

--- a/src/lang/codegen/def.zig
+++ b/src/lang/codegen/def.zig
@@ -158,6 +158,22 @@ pub fn emitDefWithLabel(self: *Emitter, def: *const ast.DefDecl, kind: DefKind, 
     try lambda.analyzeFn(self, def);
     defer lambda.resetFnInfo(self);
 
+    // A captured-and-promoted param arrives by value in its slot; seed a
+    // shared upvalue so the body / closures reach it through one pointer
+    // (a heap cell for a scalar, a heap buffer for an inline aggregate).
+    for (def.params) |p| {
+        const pname = self.source[p.name.start..p.name.end];
+        if (!lambda.isPromoted(self, pname)) continue;
+        const slot = self.params.get(pname).?;
+        if (lambda.capturedType(self, pname)) |ty| {
+            if (lambda.isInlineAggregateType(self, ty)) {
+                try lambda.emitPromoteAggregate(self, slot, self.widthOfType(ty));
+                continue;
+            }
+        }
+        try lambda.emitPromoteParam(self, slot);
+    }
+
     // Entry-def prologue: write every `@interrupt N` handler address into
     // its IVT slot before the body runs — boot leaves `flg.I = 0`, so an
     // interrupt could otherwise fire against an uninitialized vector.

--- a/src/lang/codegen/do_expr.zig
+++ b/src/lang/codegen/do_expr.zig
@@ -1,0 +1,79 @@
+// `do … end` in expression position (§4.3). The block opens a fresh
+// lexical scope, runs its statements, and evaluates to its LAST
+// expression (or `nil` if the last item is a statement). A trailing
+// bare `do … end` is itself a value-producing block, so the walk
+// descends through it, opening a scope per level. `popBlock`'s defer
+// cleanup preserves `acu`, so a scalar value survives any of the
+// blocks' defers; an aggregate value lands in a dest slot the defers
+// don't touch.
+
+const std = @import("std");
+const ast = @import("../ast.zig");
+const codegen = @import("../codegen.zig");
+const control_flow = @import("control_flow.zig");
+const isa = @import("isa.zig");
+const opcodes = @import("opcodes.zig");
+
+const Emitter = codegen.Emitter;
+const Reg = opcodes.Reg;
+
+/// The result of opening a do-block's scope(s) and emitting its prefix:
+/// the innermost tail value expression (or `null` when the innermost
+/// block ends in a statement), how many scopes were opened, and the
+/// name→slot map snapshot to restore at `emitSuffix` (so the block's
+/// `let`s — incl. ones shadowing an enclosing binding — are scoped out).
+pub const Prefix = struct {
+    tail: ?*const ast.Expr,
+    scopes: u8,
+    saved_locals: std.StringHashMapUnmanaged(i8),
+};
+
+fn emitBodyPrefix(self: *Emitter, body: []const ast.Statement, scopes: *u8) error{OutOfMemory}!?*const ast.Expr {
+    try control_flow.pushBlock(self);
+    scopes.* += 1;
+    if (body.len == 0) return null;
+    for (body[0 .. body.len - 1]) |s| try self.emitStatement(s);
+    return switch (body[body.len - 1]) {
+        .expr_stmt => |es| es.expr,
+        // A trailing `do … end` parses as a block statement; it is the
+        // value-producing tail, so descend (opening its own scope).
+        .block => |b| try emitBodyPrefix(self, b.body, scopes),
+        else => blk: {
+            try self.emitStatement(body[body.len - 1]);
+            break :blk null;
+        },
+    };
+}
+
+/// Open the do-block scope(s) and emit the statements before the tail.
+/// Pair with `emitSuffix(p.scopes)`; between them the caller emits /
+/// materializes `p.tail` (still inside the innermost scope).
+pub fn emitPrefix(self: *Emitter, de: ast.DoExpr) error{OutOfMemory}!Prefix {
+    const saved_locals = try self.locals.clone(self.arena);
+    var scopes: u8 = 0;
+    const tail = try emitBodyPrefix(self, de.body, &scopes);
+    return .{ .tail = tail, .scopes = scopes, .saved_locals = saved_locals };
+}
+
+/// Close the do-block scope(s), firing their defers (which preserve
+/// `acu`) and restoring the name→slot map.
+pub fn emitSuffix(self: *Emitter, prefix: Prefix) error{OutOfMemory}!void {
+    var i: u8 = 0;
+    while (i < prefix.scopes) : (i += 1) try control_flow.popBlockWithDefers(self);
+    self.locals = prefix.saved_locals;
+}
+
+/// Lower a `do … end` used as a value expression whose result is a
+/// scalar (or an aggregate addressed by reference) — the tail's value
+/// lands in `acu`. Aggregate-literal tails are materialized by the
+/// value-aggregate path (`value_struct`), which intercepts `do_expr`
+/// sources and recurses through `emitPrefix` / `emitSuffix`.
+pub fn emitScalar(self: *Emitter, de: ast.DoExpr) error{OutOfMemory}!void {
+    const p = try emitPrefix(self, de);
+    if (p.tail) |t| {
+        try self.emitExpr(t);
+    } else {
+        try isa.movImmToReg(self, 0, Reg.acu);
+    }
+    try emitSuffix(self, p);
+}

--- a/src/lang/codegen/expr.zig
+++ b/src/lang/codegen/expr.zig
@@ -9,6 +9,7 @@ const diverge_builtin = @import("diverge.zig");
 const stdlib = @import("stdlib.zig");
 const class = @import("class.zig");
 const value_struct = @import("value_struct.zig");
+const do_expr = @import("do_expr.zig");
 const vec_builtin = @import("vec_builtin.zig");
 const str_builtin = @import("str_builtin.zig");
 const variadic = @import("variadic.zig");
@@ -69,13 +70,11 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
                 return;
             }
             const name = self.source[i.span.start..i.span.end];
-            // Lookup order: captures (lambda body) → locals → params
-            // → globals. Captures take precedence so they shadow any
-            // same-named local that might also exist in the body.
-            if (self.captures.get(name)) |slot| {
-                try lambda.emitCaptureLoad(self, slot);
-                return;
-            }
+            // Lookup order: locals → params → captures → globals. An
+            // inner-scope local (e.g. a `do`-block / loop-body `let`)
+            // shadows an enclosing capture of the same name (standard
+            // lexical scoping); block-locals are scoped out at block end,
+            // so after the block the capture resolves again.
             if (self.locals.get(name)) |ofs| {
                 // Promoted bindings live as heap cells — the slot
                 // holds the cell pointer; deref to get the value.
@@ -87,7 +86,17 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
                 return;
             }
             if (self.params.get(name)) |ofs| {
+                // A param captured-and-promoted holds a cell pointer in
+                // its slot (seeded at entry); deref like a promoted local.
+                if (lambda.isPromoted(self, name)) {
+                    try lambda.emitPromotedIdentLoad(self, ofs);
+                    return;
+                }
                 try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
+                return;
+            }
+            if (self.captures.get(name)) |slot| {
+                try lambda.emitCaptureLoad(self, slot);
                 return;
             }
             // Module-level names (globals / consts) resolve through an
@@ -107,10 +116,13 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .tuple_index => |ti| try emitTupleIndexExpr(self, ti),
         .index => |ix| try emitIndexExpr(self, ix),
         .self_expr => |se| {
-            // `self` inside a method body lives at fp+4 (the first
-            // implicit param). Outside a method it's a typecheck
-            // error — the codegen falls through to "unsupported".
-            if (self.params.get("self")) |ofs| {
+            // Inside a method-defined lambda body `self` is a capture
+            // (read from the env); inside the method itself it lives at
+            // fp+4 (the first implicit param). Outside a method it's a
+            // typecheck error — the codegen falls through to "unsupported".
+            if (self.captures.get("self")) |slot| {
+                try lambda.emitCaptureLoad(self, slot);
+            } else if (self.params.get("self")) |ofs| {
                 try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
             } else {
                 try self.unsupported(se.span, "`self` used outside a method body");
@@ -127,6 +139,7 @@ pub fn emitExpr(self: *Emitter, e: *const ast.Expr) EmitError!void {
         .ref_of => |r| try self.emitAddrOf(r.inner),
         .cast => |c| try emitExpr(self, c.inner), // same-width primitives share a bit pattern, so the cast is a no-op
         .sizeof => |s| try isa.movImmToReg(self, self.widthOfTypeAnn(s.type_ann.*), Reg.acu),
+        .do_expr => |de| try do_expr.emitScalar(self, de),
         else => try self.unsupported(e.span(), "this expression form"),
     }
 }

--- a/src/lang/codegen/lambda.zig
+++ b/src/lang/codegen/lambda.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
+const types = @import("../types.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
 const codegen_mod = @import("../codegen.zig");
@@ -8,6 +9,28 @@ const Emitter = codegen_mod.Emitter;
 const Op = opcodes.Op;
 const Reg = opcodes.Reg;
 const Sys = opcodes.Sys;
+const Type = types.Type;
+
+/// Per-capture type, keyed by capture name — recorded at the
+/// free-variable's reference site so the closure-creation site knows
+/// whether a capture is an inline aggregate (struct / array / tuple /
+/// Vec / scalar optional) that must be captured by pointer rather than
+/// by word value.
+const CaptureTypes = std.StringHashMapUnmanaged(*const Type);
+
+/// `true` when `ty` is an inline aggregate — it lives as contiguous
+/// bytes in its owner's frame and an expression of this type evaluates
+/// to a base address (so a capture must propagate that address, not a
+/// word). A class / enum / pointer-optional is word-sized and captured
+/// by value like a scalar.
+pub fn isInlineAggregateType(self: *const Emitter, ty: *const Type) bool {
+    return switch (ty.*) {
+        .named => |n| self.struct_decls.contains(n.name),
+        .array, .tuple, .vec => true,
+        .optional => |inner| codegen_mod.Emitter.isScalarOptional(inner),
+        else => false,
+    };
+}
 
 /// Per-fn analysis result. Built by `analyzeFn` before the body
 /// emits; consulted by `emitLetDecl` / `emitIdent` / `emitAssign`
@@ -51,6 +74,9 @@ pub const LambdaInfo = struct {
     /// Captured binding names in slot order. Slot index N maps to
     /// tuple offset `2 + N*2` (offset 0 is fn_ptr).
     captures: std.ArrayListUnmanaged([]const u8),
+    /// Type of each capture, keyed by name — drives by-pointer capture
+    /// of inline aggregates (a name absent here is a word-sized value).
+    capture_types: CaptureTypes,
     /// Bindings declared inside THIS lambda's body that need a
     /// heap cell — captured-by-some-inner-lambda AND
     /// (mutated OR captured by an escaping inner lambda).
@@ -96,6 +122,19 @@ pub fn analyzeFn(self: *Emitter, def: *const ast.DefDecl) !void {
     // Find every lambda in the body + its captures.
     for (def.body) |stmt| try findLambdasInStatement(self, stmt, def, &info);
 
+    // Drop captures that name a module-level callable / type. The free-var
+    // walk flags any out-of-scope ident, but a free function / class / enum
+    // / struct is globally addressable — the lambda body resolves it
+    // directly, so it must not consume an env slot.
+    for (info.lambdas.items) |*li| {
+        var kept: std.ArrayListUnmanaged([]const u8) = .empty;
+        for (li.captures.items) |cap| {
+            if (isModuleName(self, cap)) continue;
+            try kept.append(self.arena, cap);
+        }
+        li.captures = kept;
+    }
+
     const no_capture = codegen_mod.defHasFlagAnnotation(self.source, def, "no_capture");
     if (!no_capture) {
         // Decide promotion. A binding is promoted if it's captured
@@ -110,7 +149,12 @@ pub fn analyzeFn(self: *Emitter, def: *const ast.DefDecl) !void {
         for (info.lambdas.items) |li| {
             for (li.captures.items) |cap| {
                 if (!local_bindings.contains(cap)) continue;
-                if (mutated.contains(cap) or escaping_captures.contains(cap)) {
+                // `self` is immutable and points to a heap object that
+                // outlives the frame, so a by-value pointer copy is always
+                // correct — never promote it (an escaping method closure
+                // would otherwise heap-cell a stable pointer).
+                if (std.mem.eql(u8, cap, "self")) continue;
+                if (shouldPromote(self, li, cap, &mutated, &escaping_captures)) {
                     try info.promoted.put(self.arena, cap, {});
                 }
             }
@@ -118,6 +162,23 @@ pub fn analyzeFn(self: *Emitter, def: *const ast.DefDecl) !void {
     }
 
     self.fn_closure_info = info;
+}
+
+/// Whether a captured binding needs a heap upvalue (§4.7.2). A scalar
+/// promotes when mutated OR captured by an escaping closure (the value
+/// must outlive the frame). An inline aggregate promotes ONLY when
+/// mutated — a read-only aggregate is heap-copied at capture, which is
+/// already escape-safe, so escape alone keeps it by-copy.
+fn shouldPromote(
+    self: *const Emitter,
+    li: LambdaInfo,
+    cap: []const u8,
+    mutated: *const std.StringHashMapUnmanaged(void),
+    escaping: *const std.StringHashMapUnmanaged(void),
+) bool {
+    if (mutated.contains(cap)) return true;
+    const is_agg = if (li.capture_types.get(cap)) |ty| isInlineAggregateType(self, ty) else false;
+    return !is_agg and escaping.contains(cap);
 }
 
 /// Reset the per-fn analysis between defs.
@@ -186,6 +247,45 @@ pub fn emitPromotedLetInit(
         try isa.popReg(self, Reg.r1);
         try cellStore(self, Reg.r1, Reg.acu);
     }
+}
+
+/// Promote a captured param to a heap cell at fn entry. A param
+/// arrives in its frame slot by value (no `let`), so the slot has no
+/// cell yet — allocate one, seed it with the incoming value, and store
+/// the cell pointer back into the slot. Afterward every promotion-aware
+/// path (ident load / assign / capture source) treats the param exactly
+/// like a promoted local.
+pub fn emitPromoteParam(self: *Emitter, slot_ofs: i8) !void {
+    // Save the incoming value before the alloc clobbers acu.
+    try isa.movRegOffsetToReg(self, Reg.fp, slot_ofs, Reg.r1);
+    try isa.pushReg(self, Reg.r1);
+    try isa.movImmToReg(self, 2, Reg.acu);
+    try self.emitByte(Op.sys);
+    try self.emitByte(Sys.alloc);
+    // acu = cell pointer; store it in the param slot.
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, slot_ofs);
+    // Seed the cell with the saved value.
+    try isa.movRegToReg(self, Reg.acu, Reg.r1); // r1 = cell ptr
+    try isa.popReg(self, Reg.r2); // r2 = incoming value
+    try cellStore(self, Reg.r1, Reg.r2);
+}
+
+/// Promote an inline aggregate binding to a shared heap upvalue: move
+/// its just-materialized inline bytes at `[fp+slot]` to the heap and
+/// park the pointer in the slot's first word. Shared by the promoted
+/// aggregate `let` and the captured-aggregate param entry.
+pub fn emitPromoteAggregate(self: *Emitter, slot: i8, width: u16) !void {
+    try emitHeapCopyFromFrame(self, slot, width);
+    try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, slot);
+}
+
+/// Type recorded for a captured binding (from any lambda in this fn that
+/// captures it), or null when the name isn't captured / wasn't typed.
+pub fn capturedType(self: *const Emitter, name: []const u8) ?*const Type {
+    for (self.fn_closure_info.lambdas.items) |li| {
+        if (li.capture_types.get(name)) |ty| return ty;
+    }
+    return null;
 }
 
 /// Read a promoted local: load cell pointer from slot, then deref.
@@ -258,7 +358,7 @@ pub fn emitLambdaExpr(self: *Emitter, lambda: ast.LambdaExpr, expr: *const ast.E
         // @as: idx fits u16 — capture count caps below 32k.
         const slot_offset: u16 = 2 + @as(u16, @intCast(idx)) * 2;
         try isa.pushReg(self, Reg.r1); // preserve tuple ptr
-        try emitCaptureSource(self, cap);
+        try emitCaptureSource(self, cap, li.capture_types.get(cap));
         try isa.popReg(self, Reg.r1);
         // acu = capture value (cell ptr if promoted, value otherwise)
         try emitWordStoreAtOffset(self, Reg.r1, slot_offset, Reg.acu);
@@ -273,20 +373,30 @@ pub fn emitLambdaExpr(self: *Emitter, lambda: ast.LambdaExpr, expr: *const ast.E
 /// promoted binding that's the cell pointer (so the inner
 /// closure shares state with the parent), for a non-promoted
 /// binding that's the value (re-copied into the new closure).
-/// The lookup order — captures → locals → params → globals —
-/// lets nested closures chain: a closure created INSIDE another
-/// lambda's body reads its captures from the enclosing env
-/// rather than a stack slot that doesn't exist at this scope.
-fn emitCaptureSource(self: *Emitter, name: []const u8) !void {
+/// An inline aggregate captured read-only is heap-copied here so the
+/// env holds a private base pointer (value semantics, escape-safe); a
+/// promoted aggregate's slot already holds its shared heap pointer, so
+/// the raw read propagates it. The lookup order — captures → locals →
+/// params → globals — lets nested closures chain: a closure created
+/// INSIDE another lambda's body reads its captures from the enclosing
+/// env rather than a stack slot that doesn't exist at this scope.
+fn emitCaptureSource(self: *Emitter, name: []const u8, cap_ty: ?*const Type) !void {
     if (self.captures.get(name)) |slot| {
         // Inside an enclosing lambda — re-read this slot raw
         // from our own env to populate the inner closure's slot.
         // For promoted (cell-pointer) captures the pointer
-        // propagates as-is (shared state); for by-value captures
-        // the value re-copies.
+        // propagates as-is (shared state); for an aggregate the
+        // slot holds the base pointer, also propagated as-is.
         try loadEnvPtr(self, Reg.r1);
         try emitWordLoadAtOffset(self, Reg.r1, slot.env_offset, Reg.acu);
         return;
+    }
+    // A read-only inline aggregate (not promoted) lives as bytes in the
+    // frame — heap-copy it so the closure owns a private base pointer.
+    const is_agg = if (cap_ty) |ty| isInlineAggregateType(self, ty) else false;
+    if (is_agg and !self.fn_closure_info.promoted.contains(name)) {
+        if (self.locals.get(name)) |ofs| return emitHeapCopyFromFrame(self, ofs, self.widthOfType(cap_ty.?));
+        if (self.params.get(name)) |ofs| return emitHeapCopyFromFrame(self, ofs, self.widthOfType(cap_ty.?));
     }
     if (self.locals.get(name)) |ofs| {
         try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
@@ -303,6 +413,36 @@ fn emitCaptureSource(self: *Emitter, name: []const u8) !void {
     // Unbound at this point — analyzeFn shouldn't have recorded
     // it as a capture. Defensive fault.
     try self.diagFatal(.{ .start = 0, .end = 0 }, "E_CODEGEN_UNBOUND_CAPTURE", "codegen: lambda captures a name with no current binding");
+}
+
+/// Heap-copy a `width`-byte inline aggregate at `[fp + base_ofs]` into a
+/// fresh heap block; leave the block pointer in `acu`. Word-strided over
+/// the (2-aligned) slot, so no byte ops are needed.
+fn emitHeapCopyFromFrame(self: *Emitter, base_ofs: i8, width: u16) !void {
+    const aligned: u16 = width + (width & 1); // round up to a whole word
+    try isa.movImmToReg(self, aligned, Reg.acu);
+    try self.emitByte(Op.sys);
+    try self.emitByte(Sys.alloc); // acu = dest pointer
+    try isa.pushReg(self, Reg.acu); // save the result pointer across the copy
+    try isa.movRegToReg(self, Reg.acu, Reg.r2); // r2 = dest cursor
+    try isa.movRegToReg(self, Reg.fp, Reg.r1);
+    if (base_ofs < 0) {
+        // @as: widen i8 → i16 so the negate is safe at the i8 minimum.
+        const w: i16 = base_ofs;
+        // @as: |base_ofs| ≤ 128 → fits u16.
+        try isa.subImmFromReg(self, @intCast(-w), Reg.r1);
+    } else if (base_ofs > 0) {
+        // @as: positive i8 → u16.
+        try isa.addImmToReg(self, @intCast(base_ofs), Reg.r1);
+    }
+    var remaining = aligned;
+    while (remaining >= 2) : (remaining -= 2) {
+        try isa.movRegOffsetToReg(self, Reg.r1, 0, Reg.acu);
+        try isa.movRegToRegOffset(self, Reg.acu, Reg.r2, 0);
+        try isa.addImmToReg(self, 2, Reg.r1);
+        try isa.addImmToReg(self, 2, Reg.r2);
+    }
+    try isa.popReg(self, Reg.acu); // acu = dest pointer (the result)
 }
 
 // ---------- lambda body emission ----------
@@ -406,9 +546,14 @@ fn emitOneLambdaBody(self: *Emitter, li: LambdaInfo) !void {
         // pre-swap `saved_promoted` since that's the enclosing
         // scope's promotion set, not this lambda's own.
         const promoted_in_parent = saved_promoted.contains(cap);
+        // An inline aggregate is captured by pointer (the env slot holds
+        // its base), so the body loads the pointer directly — never the
+        // cell double-deref a promoted scalar needs.
+        const is_aggregate = if (li.capture_types.get(cap)) |ty| isInlineAggregateType(self, ty) else false;
         try captures_map.put(self.arena, cap, .{
             .env_offset = offset,
-            .is_cell = promoted_in_parent,
+            .is_cell = promoted_in_parent and !is_aggregate,
+            .is_aggregate = is_aggregate,
         });
     }
     const saved_captures = self.captures;
@@ -450,6 +595,11 @@ pub const CaptureSlot = struct {
     /// cell. Reads in the lambda body need an extra deref; writes
     /// store back to the cell (visible to other closures + parent).
     is_cell: bool,
+    /// `true` when the capture is an inline aggregate. The env slot
+    /// holds the aggregate's base pointer (a heap copy for a read-only
+    /// capture, the shared promoted buffer for a mutated one), so the
+    /// body reads the pointer directly — one load, never a cell deref.
+    is_aggregate: bool,
 };
 
 /// Load env_ptr from `[fp + 4]` into `dst` — used by capture
@@ -615,10 +765,21 @@ fn findLambdasInStatement(
             if (ws.let_guard) |lg| try findLambdasInExpr(self, lg, def, info);
             for (ws.body) |inner| try findLambdasInStatement(self, inner, def, info);
         },
-        .for_stmt => |fs| for (fs.body) |inner| try findLambdasInStatement(self, inner, def, info),
+        .for_stmt => |fs| {
+            try findLambdasInExpr(self, fs.iter, def, info);
+            if (fs.step) |step_e| try findLambdasInExpr(self, step_e, def, info);
+            for (fs.body) |inner| try findLambdasInStatement(self, inner, def, info);
+        },
         .repeat_stmt => |rs| {
             for (rs.body) |inner| try findLambdasInStatement(self, inner, def, info);
             try findLambdasInExpr(self, rs.cond, def, info);
+        },
+        .match_stmt => |ms| {
+            try findLambdasInExpr(self, ms.scrutinee, def, info);
+            for (ms.arms) |arm| {
+                if (arm.guard) |g| try findLambdasInExpr(self, g, def, info);
+                for (arm.body) |inner| try findLambdasInStatement(self, inner, def, info);
+            }
         },
         else => {},
     }
@@ -637,7 +798,8 @@ fn findLambdasInExpr(
             const fn_name = self.source[def.name.start..def.name.end];
             const label = try std.fmt.allocPrint(self.arena, "__lambda_{s}_{d}", .{ fn_name, idx });
             var captures: std.ArrayListUnmanaged([]const u8) = .empty;
-            try collectFreeVars(self, &l, &captures, def);
+            var cap_types: CaptureTypes = .{};
+            try collectFreeVars(self, &l, &captures, &cap_types, def);
             // Per-lambda scope analysis: this lambda's own locals,
             // which subset of them get initialized with a nested
             // lambda, and which subset needs a heap cell. Computed
@@ -670,6 +832,7 @@ fn findLambdasInExpr(
                 .ast_node = &e.lambda,
                 .label = label,
                 .captures = captures,
+                .capture_types = cap_types,
                 .promoted = promoted,
                 .closure_bindings = scope_closure_bindings,
             });
@@ -689,9 +852,39 @@ fn findLambdasInExpr(
             for (m.args) |a| try findLambdasInExpr(self, a, def, info);
         },
         .field => |f| try findLambdasInExpr(self, f.receiver, def, info),
+        .tuple_index => |ti| try findLambdasInExpr(self, ti.receiver, def, info),
+        .index => |ix| {
+            try findLambdasInExpr(self, ix.receiver, def, info);
+            try findLambdasInExpr(self, ix.index, def, info);
+        },
+        .range => |r| {
+            try findLambdasInExpr(self, r.start, def, info);
+            try findLambdasInExpr(self, r.end, def, info);
+        },
         .is_test => |it| try findLambdasInExpr(self, it.lhs, def, info),
         .ref_of => |r| try findLambdasInExpr(self, r.inner, def, info),
         .cast => |c| try findLambdasInExpr(self, c.inner, def, info),
+        .str_lit => |sl| for (sl.parts) |part| switch (part) {
+            .interp => |ip| try findLambdasInExpr(self, ip.expr, def, info),
+            .lit => {},
+        },
+        .list_lit => |ll| for (ll.elems) |el| try findLambdasInExpr(self, el, def, info),
+        .list_repeat => |lr| {
+            try findLambdasInExpr(self, lr.value, def, info);
+            try findLambdasInExpr(self, lr.count, def, info);
+        },
+        .struct_lit => |stl| for (stl.fields) |f| try findLambdasInExpr(self, f.value, def, info),
+        .tuple_lit => |tl| for (tl.elems) |el| try findLambdasInExpr(self, el, def, info),
+        .do_expr => |de| for (de.body) |inner| try findLambdasInStatement(self, inner, def, info),
+        .if_expr => |ie| {
+            for (ie.arms) |arm| {
+                if (arm.cond) |c| try findLambdasInExpr(self, c, def, info);
+                if (arm.let_expr) |le| try findLambdasInExpr(self, le, def, info);
+                if (arm.let_guard) |lg| try findLambdasInExpr(self, lg, def, info);
+                for (arm.body) |inner| try findLambdasInStatement(self, inner, def, info);
+            }
+            if (ie.else_body) |eb| for (eb) |inner| try findLambdasInStatement(self, inner, def, info);
+        },
         else => {},
     }
 }
@@ -768,161 +961,238 @@ fn collectScopeStatementBindings(
 /// names used but not declared as a lambda param / local. The
 /// caller filters against actual parent bindings; this function
 /// just returns the candidate names.
+const Scope = std.StringHashMapUnmanaged(void);
+const CollectError = error{OutOfMemory};
+
+/// Free variables of `lambda` — names its body reads that resolve to an
+/// ENCLOSING binding (captures). A single scoped pass: the lambda's own
+/// params seed a base scope; statements add their bindings as they're
+/// walked (so a `let` is invisible to its own init and to earlier
+/// statements), and each nested block (do / for / if / while / match /
+/// repeat) walks in a CHILD scope so its locals shadow correctly and
+/// don't leak. An ident not bound in the active scope is a capture.
 fn collectFreeVars(
     self: *Emitter,
     lambda: *const ast.LambdaExpr,
     captures: *std.ArrayListUnmanaged([]const u8),
+    cap_types: *CaptureTypes,
     def: *const ast.DefDecl,
-) !void {
-    var lambda_locals: std.StringHashMapUnmanaged(void) = .{};
-    for (lambda.params) |p| {
-        const name = self.source[p.name.start..p.name.end];
-        try lambda_locals.put(self.arena, name, {});
-    }
-    for (lambda.body) |stmt| try collectLambdaLocalsInStatement(self, stmt, &lambda_locals);
-    for (lambda.body) |stmt| try collectIdentsInStatement(self, stmt, &lambda_locals, captures, def);
+) CollectError!void {
+    var scope: Scope = .{};
+    for (lambda.params) |p| try scope.put(self.arena, self.source[p.name.start..p.name.end], {});
+    try captureWalkBody(self, lambda.body, &scope, captures, cap_types, def);
 }
 
-fn collectLambdaLocalsInStatement(
-    self: *Emitter,
-    s: ast.Statement,
-    locals: *std.StringHashMapUnmanaged(void),
-) !void {
+fn cloneScope(self: *Emitter, scope: *const Scope) CollectError!Scope {
+    var c: Scope = .{};
+    var it = scope.iterator();
+    while (it.next()) |e| try c.put(self.arena, e.key_ptr.*, {});
+    return c;
+}
+
+/// Add every name a pattern binds (`let`-binder, `match` / `if let` arm)
+/// into `scope`.
+fn capturePatternBinders(self: *Emitter, p: *const ast.Pattern, scope: *Scope) CollectError!void {
+    switch (p.*) {
+        .ident => |i| try scope.put(self.arena, self.source[i.name.start..i.name.end], {}),
+        .tuple_pattern => |t| for (t.elems) |e| try capturePatternBinders(self, e, scope),
+        .variant_pattern => |v| for (v.args) |a| try capturePatternBinders(self, a, scope),
+        .struct_pattern => |st| for (st.fields) |f| try capturePatternBinders(self, f.sub, scope),
+        .or_pattern => |o| for (o.alts) |a| try capturePatternBinders(self, a, scope),
+        else => {},
+    }
+}
+
+fn captureWalkBody(self: *Emitter, body: []const ast.Statement, scope: *Scope, captures: *std.ArrayListUnmanaged([]const u8), cap_types: *CaptureTypes, def: *const ast.DefDecl) CollectError!void {
+    for (body) |s| try captureWalkStmt(self, s, scope, captures, cap_types, def);
+}
+
+/// Walk `child_body` in a fresh child scope so its bindings shadow + don't
+/// leak. `seed`, if non-null, is a pattern whose binders enter the child
+/// scope first (loop / match / if-let binders).
+fn captureWalkChild(self: *Emitter, child_body: []const ast.Statement, scope: *const Scope, seed: ?*const ast.Pattern, loop_var: ?ast.Span, captures: *std.ArrayListUnmanaged([]const u8), cap_types: *CaptureTypes, def: *const ast.DefDecl) CollectError!void {
+    var child = try cloneScope(self, scope);
+    if (loop_var) |lv| try child.put(self.arena, self.source[lv.start..lv.end], {});
+    if (seed) |p| try capturePatternBinders(self, p, &child);
+    try captureWalkBody(self, child_body, &child, captures, cap_types, def);
+}
+
+fn captureWalkStmt(self: *Emitter, s: ast.Statement, scope: *Scope, captures: *std.ArrayListUnmanaged([]const u8), cap_types: *CaptureTypes, def: *const ast.DefDecl) CollectError!void {
     switch (s) {
-        .let_decl => |d| if (d.pattern.* == .ident) {
-            const name = self.source[d.pattern.ident.name.start..d.pattern.ident.name.end];
-            try locals.put(self.arena, name, {});
+        .let_decl => |d| {
+            if (d.init) |init_expr| try captureWalkExpr(self, init_expr, scope, captures, cap_types, def);
+            try capturePatternBinders(self, d.pattern, scope);
         },
         .const_decl => |d| {
-            const name = self.source[d.name.start..d.name.end];
-            try locals.put(self.arena, name, {});
+            try captureWalkExpr(self, d.init, scope, captures, cap_types, def);
+            try scope.put(self.arena, self.source[d.name.start..d.name.end], {});
         },
-        .block => |b| for (b.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals),
-        .if_stmt => |is_| {
-            for (is_.arms) |arm| for (arm.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals);
-            if (is_.else_body) |eb| for (eb) |inner| try collectLambdaLocalsInStatement(self, inner, locals);
-        },
-        .while_stmt => |ws| for (ws.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals),
-        .for_stmt => |fs| for (fs.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals),
-        .repeat_stmt => |rs| for (rs.body) |inner| try collectLambdaLocalsInStatement(self, inner, locals),
-        else => {},
-    }
-}
-
-const CollectError = error{OutOfMemory};
-
-fn collectIdentsInStatement(
-    self: *Emitter,
-    s: ast.Statement,
-    locals: *const std.StringHashMapUnmanaged(void),
-    captures: *std.ArrayListUnmanaged([]const u8),
-    def: *const ast.DefDecl,
-) CollectError!void {
-    switch (s) {
-        .let_decl => |d| if (d.init) |init_expr| try collectIdentsInExpr(self, init_expr, locals, captures, def),
-        .const_decl => |d| try collectIdentsInExpr(self, d.init, locals, captures, def),
         .assign => |a| {
-            try collectIdentsInExpr(self, a.target, locals, captures, def);
-            try collectIdentsInExpr(self, a.value, locals, captures, def);
+            try captureWalkExpr(self, a.target, scope, captures, cap_types, def);
+            try captureWalkExpr(self, a.value, scope, captures, cap_types, def);
         },
-        .return_stmt => |rs| if (rs.value) |v| try collectIdentsInExpr(self, v, locals, captures, def),
-        .expr_stmt => |es| try collectIdentsInExpr(self, es.expr, locals, captures, def),
-        .discard => |d| try collectIdentsInExpr(self, d.expr, locals, captures, def),
-        .print_stmt => |ps| for (ps.args) |a| try collectIdentsInExpr(self, a, locals, captures, def),
-        .block => |b| for (b.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def),
+        .inc_dec => |id| try captureWalkExpr(self, id.target, scope, captures, cap_types, def),
+        .return_stmt => |rs| if (rs.value) |v| try captureWalkExpr(self, v, scope, captures, cap_types, def),
+        .expr_stmt => |es| try captureWalkExpr(self, es.expr, scope, captures, cap_types, def),
+        .discard => |d| try captureWalkExpr(self, d.expr, scope, captures, cap_types, def),
+        .print_stmt => |ps| for (ps.args) |a| try captureWalkExpr(self, a, scope, captures, cap_types, def),
+        .block => |b| try captureWalkChild(self, b.body, scope, null, null, captures, cap_types, def),
         .if_stmt => |is_| {
             for (is_.arms) |arm| {
-                if (arm.cond) |c| try collectIdentsInExpr(self, c, locals, captures, def);
-                if (arm.let_expr) |le| try collectIdentsInExpr(self, le, locals, captures, def);
-                if (arm.let_guard) |lg| try collectIdentsInExpr(self, lg, locals, captures, def);
-                for (arm.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def);
+                if (arm.cond) |c| try captureWalkExpr(self, c, scope, captures, cap_types, def);
+                if (arm.let_expr) |le| try captureWalkExpr(self, le, scope, captures, cap_types, def);
+                try captureWalkArm(self, arm.body, scope, arm.let_pattern, arm.let_guard, captures, cap_types, def);
             }
-            if (is_.else_body) |eb| for (eb) |inner| try collectIdentsInStatement(self, inner, locals, captures, def);
+            if (is_.else_body) |eb| try captureWalkChild(self, eb, scope, null, null, captures, cap_types, def);
         },
         .while_stmt => |ws| {
-            if (ws.cond) |c| try collectIdentsInExpr(self, c, locals, captures, def);
-            if (ws.let_expr) |le| try collectIdentsInExpr(self, le, locals, captures, def);
-            if (ws.let_guard) |lg| try collectIdentsInExpr(self, lg, locals, captures, def);
-            for (ws.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def);
+            if (ws.cond) |c| try captureWalkExpr(self, c, scope, captures, cap_types, def);
+            if (ws.let_expr) |le| try captureWalkExpr(self, le, scope, captures, cap_types, def);
+            try captureWalkArm(self, ws.body, scope, ws.let_pattern, ws.let_guard, captures, cap_types, def);
         },
-        .for_stmt => |fs| for (fs.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def),
+        .for_stmt => |fs| {
+            try captureWalkExpr(self, fs.iter, scope, captures, cap_types, def);
+            if (fs.step) |step_e| try captureWalkExpr(self, step_e, scope, captures, cap_types, def);
+            try captureWalkChild(self, fs.body, scope, null, fs.binding, captures, cap_types, def);
+        },
         .repeat_stmt => |rs| {
-            for (rs.body) |inner| try collectIdentsInStatement(self, inner, locals, captures, def);
-            try collectIdentsInExpr(self, rs.cond, locals, captures, def);
+            // `repeat … until cond`: the cond runs after the body, in its scope.
+            var child = try cloneScope(self, scope);
+            try captureWalkBody(self, rs.body, &child, captures, cap_types, def);
+            try captureWalkExpr(self, rs.cond, &child, captures, cap_types, def);
+        },
+        .match_stmt => |ms| {
+            try captureWalkExpr(self, ms.scrutinee, scope, captures, cap_types, def);
+            for (ms.arms) |arm| try captureWalkArm(self, arm.body, scope, arm.pattern, arm.guard, captures, cap_types, def);
         },
         else => {},
     }
 }
 
-fn collectIdentsInExpr(
-    self: *Emitter,
-    e: *const ast.Expr,
-    locals: *const std.StringHashMapUnmanaged(void),
-    captures: *std.ArrayListUnmanaged([]const u8),
-    def: *const ast.DefDecl,
-) CollectError!void {
+/// An arm body with optional pattern binders + a guard, all in a child scope.
+fn captureWalkArm(self: *Emitter, body: []const ast.Statement, scope: *const Scope, pat: ?*const ast.Pattern, guard: ?*const ast.Expr, captures: *std.ArrayListUnmanaged([]const u8), cap_types: *CaptureTypes, def: *const ast.DefDecl) CollectError!void {
+    var child = try cloneScope(self, scope);
+    if (pat) |p| try capturePatternBinders(self, p, &child);
+    if (guard) |g| try captureWalkExpr(self, g, &child, captures, cap_types, def);
+    try captureWalkBody(self, body, &child, captures, cap_types, def);
+}
+
+fn captureWalkExpr(self: *Emitter, e: *const ast.Expr, scope: *const Scope, captures: *std.ArrayListUnmanaged([]const u8), cap_types: *CaptureTypes, def: *const ast.DefDecl) CollectError!void {
     switch (e.*) {
         .ident => |i| {
             const name = self.source[i.span.start..i.span.end];
-            if (locals.contains(name)) return;
-            // Skip ident shapes that don't correspond to a binding
-            // (function names typed as call targets, class names,
-            // etc.). For PR scope: include only names that match a
-            // parent let / param. The caller filters again.
-            for (captures.items) |existing| {
-                if (std.mem.eql(u8, existing, name)) return;
-            }
+            if (scope.contains(name)) return;
+            if (self.typeOf(e)) |ty| try cap_types.put(self.arena, name, ty);
+            for (captures.items) |existing| if (std.mem.eql(u8, existing, name)) return;
             try captures.append(self.arena, name);
         },
-        .paren => |p| try collectIdentsInExpr(self, p.inner, locals, captures, def),
-        .unary => |u| try collectIdentsInExpr(self, u.operand, locals, captures, def),
+        // `self` inside a method-defined lambda is a capture: the lambda
+        // body is a separate def, so it reads the enclosing method's
+        // receiver from its env, not from an `fp+4` it doesn't own.
+        .self_expr => |se| {
+            const name = self.source[se.span.start..se.span.end];
+            if (scope.contains(name)) return;
+            if (self.typeOf(e)) |ty| try cap_types.put(self.arena, name, ty);
+            for (captures.items) |existing| if (std.mem.eql(u8, existing, name)) return;
+            try captures.append(self.arena, name);
+        },
+        .paren => |p| try captureWalkExpr(self, p.inner, scope, captures, cap_types, def),
+        .unary => |u| try captureWalkExpr(self, u.operand, scope, captures, cap_types, def),
         .binary => |b| {
-            try collectIdentsInExpr(self, b.lhs, locals, captures, def);
-            try collectIdentsInExpr(self, b.rhs, locals, captures, def);
+            try captureWalkExpr(self, b.lhs, scope, captures, cap_types, def);
+            try captureWalkExpr(self, b.rhs, scope, captures, cap_types, def);
+        },
+        .range => |r| {
+            try captureWalkExpr(self, r.start, scope, captures, cap_types, def);
+            try captureWalkExpr(self, r.end, scope, captures, cap_types, def);
         },
         .call => |c| {
-            try collectIdentsInExpr(self, c.callee, locals, captures, def);
-            for (c.args) |a| try collectIdentsInExpr(self, a, locals, captures, def);
+            try captureWalkExpr(self, c.callee, scope, captures, cap_types, def);
+            for (c.args) |a| try captureWalkExpr(self, a, scope, captures, cap_types, def);
         },
         .method_call => |m| {
-            try collectIdentsInExpr(self, m.receiver, locals, captures, def);
-            for (m.args) |a| try collectIdentsInExpr(self, a, locals, captures, def);
+            try captureWalkExpr(self, m.receiver, scope, captures, cap_types, def);
+            for (m.args) |a| try captureWalkExpr(self, a, scope, captures, cap_types, def);
         },
-        .field => |f| try collectIdentsInExpr(self, f.receiver, locals, captures, def),
-        .is_test => |it| try collectIdentsInExpr(self, it.lhs, locals, captures, def),
-        .ref_of => |r| try collectIdentsInExpr(self, r.inner, locals, captures, def),
-        .cast => |c| try collectIdentsInExpr(self, c.inner, locals, captures, def),
-        // Nested lambda — any name the inner lambda captures from
-        // OUTSIDE its own param + locals is a free var from the
-        // enclosing scope. If that name isn't local to THIS
-        // lambda either, it transitively becomes a capture of this
-        // lambda too — at closure-creation time we populate the
-        // inner closure's slot by re-reading our own env.
-        .lambda => |inner| {
-            var inner_locals: std.StringHashMapUnmanaged(void) = .{};
-            for (inner.params) |p| {
-                const name = self.source[p.name.start..p.name.end];
-                try inner_locals.put(self.arena, name, {});
+        .field => |f| try captureWalkExpr(self, f.receiver, scope, captures, cap_types, def),
+        .tuple_index => |ti| try captureWalkExpr(self, ti.receiver, scope, captures, cap_types, def),
+        .index => |ix| {
+            try captureWalkExpr(self, ix.receiver, scope, captures, cap_types, def);
+            try captureWalkExpr(self, ix.index, scope, captures, cap_types, def);
+        },
+        .is_test => |it| try captureWalkExpr(self, it.lhs, scope, captures, cap_types, def),
+        .ref_of => |r| try captureWalkExpr(self, r.inner, scope, captures, cap_types, def),
+        .cast => |c| try captureWalkExpr(self, c.inner, scope, captures, cap_types, def),
+        .str_lit => |sl| for (sl.parts) |part| switch (part) {
+            .interp => |ip| try captureWalkExpr(self, ip.expr, scope, captures, cap_types, def),
+            .lit => {},
+        },
+        .list_lit => |ll| for (ll.elems) |el| try captureWalkExpr(self, el, scope, captures, cap_types, def),
+        .list_repeat => |lr| {
+            try captureWalkExpr(self, lr.value, scope, captures, cap_types, def);
+            try captureWalkExpr(self, lr.count, scope, captures, cap_types, def);
+        },
+        .struct_lit => |stl| for (stl.fields) |f| try captureWalkExpr(self, f.value, scope, captures, cap_types, def),
+        .tuple_lit => |tl| for (tl.elems) |el| try captureWalkExpr(self, el, scope, captures, cap_types, def),
+        // `do` / `if` value blocks open a nested scope.
+        .do_expr => |de| try captureWalkChild(self, de.body, scope, null, null, captures, cap_types, def),
+        .if_expr => |ie| {
+            for (ie.arms) |arm| {
+                if (arm.cond) |c| try captureWalkExpr(self, c, scope, captures, cap_types, def);
+                if (arm.let_expr) |le| try captureWalkExpr(self, le, scope, captures, cap_types, def);
+                try captureWalkArm(self, arm.body, scope, arm.let_pattern, arm.let_guard, captures, cap_types, def);
             }
-            for (inner.body) |stmt| try collectLambdaLocalsInStatement(self, stmt, &inner_locals);
+            if (ie.else_body) |eb| try captureWalkChild(self, eb, scope, null, null, captures, cap_types, def);
+        },
+        // Nested lambda — names IT captures from outside its own params +
+        // locals that ALSO aren't bound in THIS scope are transitively
+        // captures of this lambda (we re-read them from our env at the
+        // inner closure's creation).
+        .lambda => {
             var inner_captures: std.ArrayListUnmanaged([]const u8) = .empty;
-            for (inner.body) |stmt| try collectIdentsInStatement(self, stmt, &inner_locals, &inner_captures, def);
+            var inner_types: CaptureTypes = .{};
+            try collectFreeVars(self, &e.lambda, &inner_captures, &inner_types, def);
             for (inner_captures.items) |inner_cap| {
-                // Skip if local to this lambda's own scope.
-                if (locals.contains(inner_cap)) continue;
-                // De-dup against captures we've already recorded.
-                var seen = false;
+                if (scope.contains(inner_cap)) continue;
                 for (captures.items) |existing| {
-                    if (std.mem.eql(u8, existing, inner_cap)) {
-                        seen = true;
-                        break;
-                    }
+                    if (std.mem.eql(u8, existing, inner_cap)) break;
+                } else {
+                    try captures.append(self.arena, inner_cap);
+                    if (inner_types.get(inner_cap)) |ty| try cap_types.put(self.arena, inner_cap, ty);
                 }
-                if (!seen) try captures.append(self.arena, inner_cap);
             }
         },
         else => {},
     }
+}
+
+/// The root ident of an assignment target — peels `.field` / `.index` /
+/// `.tuple_index` down to the base binding (null for a `self` / non-ident
+/// base).
+fn rootIdent(e: *const ast.Expr) ?*const ast.Expr {
+    return switch (e.*) {
+        .ident => e,
+        .field => |f| rootIdent(f.receiver),
+        .index => |ix| rootIdent(ix.receiver),
+        .tuple_index => |ti| rootIdent(ti.receiver),
+        else => null,
+    };
+}
+
+/// Record what an assignment mutates. A bare `x = …` mutates the binding
+/// `x`. A `x.field = …` / `x[i] = …` mutates the aggregate `x` IN PLACE,
+/// so its root counts as mutated — but only for an inline aggregate (a
+/// class field write goes through a shared pointer and needs no
+/// promotion).
+fn markAssignTarget(self: *Emitter, target: *const ast.Expr, mutated: *std.StringHashMapUnmanaged(void)) void {
+    if (target.* == .ident) {
+        mutated.put(self.arena, self.source[target.ident.span.start..target.ident.span.end], {}) catch return;
+        return;
+    }
+    const root = rootIdent(target) orelse return;
+    const ty = self.typeOf(root) orelse return;
+    if (!isInlineAggregateType(self, ty)) return;
+    mutated.put(self.arena, self.source[root.ident.span.start..root.ident.span.end], {}) catch return;
 }
 
 fn collectMutatedInStatement(
@@ -931,14 +1201,8 @@ fn collectMutatedInStatement(
     mutated: *std.StringHashMapUnmanaged(void),
 ) void {
     switch (s) {
-        .assign => |a| if (a.target.* == .ident) {
-            const name = self.source[a.target.ident.span.start..a.target.ident.span.end];
-            mutated.put(self.arena, name, {}) catch return;
-        },
-        .inc_dec => |id| if (id.target.* == .ident) {
-            const name = self.source[id.target.ident.span.start..id.target.ident.span.end];
-            mutated.put(self.arena, name, {}) catch return;
-        },
+        .assign => |a| markAssignTarget(self, a.target, mutated),
+        .inc_dec => |id| markAssignTarget(self, id.target, mutated),
         .block => |b| for (b.body) |inner| collectMutatedInStatement(self, inner, mutated),
         .if_stmt => |is_| {
             for (is_.arms) |arm| for (arm.body) |inner| collectMutatedInStatement(self, inner, mutated);
@@ -947,9 +1211,14 @@ fn collectMutatedInStatement(
         .while_stmt => |ws| for (ws.body) |inner| collectMutatedInStatement(self, inner, mutated),
         .for_stmt => |fs| for (fs.body) |inner| collectMutatedInStatement(self, inner, mutated),
         .repeat_stmt => |rs| for (rs.body) |inner| collectMutatedInStatement(self, inner, mutated),
+        .match_stmt => |ms| for (ms.arms) |arm| for (arm.body) |inner| collectMutatedInStatement(self, inner, mutated),
         .return_stmt => |rs| if (rs.value) |v| collectMutatedInExpr(self, v, mutated),
         .expr_stmt => |es| collectMutatedInExpr(self, es.expr, mutated),
         .print_stmt => |ps| for (ps.args) |a| collectMutatedInExpr(self, a, mutated),
+        // A `let`/`const` whose init is (or contains) a lambda: descend so
+        // a binding mutated inside that closure body counts as mutated.
+        .let_decl => |d| if (d.init) |init_expr| collectMutatedInExpr(self, init_expr, mutated),
+        .const_decl => |d| collectMutatedInExpr(self, d.init, mutated),
         else => {},
     }
 }
@@ -963,6 +1232,24 @@ fn collectMutatedInExpr(
         // A lambda body's assignments to captured names mutate
         // the captured binding from the parent's perspective.
         for (e.lambda.body) |stmt| collectMutatedInStatement(self, stmt, mutated);
+    } else if (e.* == .do_expr) {
+        // A `do … end` value block (common as a lambda body) runs
+        // statements — its assignments count.
+        for (e.do_expr.body) |stmt| collectMutatedInStatement(self, stmt, mutated);
+    } else if (e.* == .if_expr) {
+        for (e.if_expr.arms) |arm| for (arm.body) |stmt| collectMutatedInStatement(self, stmt, mutated);
+        if (e.if_expr.else_body) |eb| for (eb) |stmt| collectMutatedInStatement(self, stmt, mutated);
+    } else if (e.* == .method_call) {
+        // A method takes `self` by pointer and may mutate an inline
+        // aggregate receiver in place (`v.push(…)` grows a Vec header), so
+        // conservatively count its root as mutated — a read-only method
+        // just over-shares the buffer, which is harmless.
+        if (rootIdent(e.method_call.receiver)) |root| {
+            if (self.typeOf(root)) |ty| if (isInlineAggregateType(self, ty)) {
+                mutated.put(self.arena, self.source[root.ident.span.start..root.ident.span.end], {}) catch {};
+            };
+        }
+        for (e.method_call.args) |a| collectMutatedInExpr(self, a, mutated);
     } else if (e.* == .binary) {
         collectMutatedInExpr(self, e.binary.lhs, mutated);
         collectMutatedInExpr(self, e.binary.rhs, mutated);
@@ -993,6 +1280,7 @@ fn collectEscapingCaptures(
         .while_stmt => |ws| for (ws.body) |inner| collectEscapingCaptures(self, inner, info, out),
         .for_stmt => |fs| for (fs.body) |inner| collectEscapingCaptures(self, inner, info, out),
         .repeat_stmt => |rs| for (rs.body) |inner| collectEscapingCaptures(self, inner, info, out),
+        .match_stmt => |ms| for (ms.arms) |arm| for (arm.body) |inner| collectEscapingCaptures(self, inner, info, out),
         else => {},
     }
 }
@@ -1012,6 +1300,16 @@ fn collectEscapingFromExpr(
             return;
         }
     }
+}
+
+/// `true` when `name` resolves to a module-level callable or type — a
+/// free function, class, enum, or struct. These are globally addressable
+/// (a lambda body reaches them directly), so they are never captured.
+fn isModuleName(self: *const Emitter, name: []const u8) bool {
+    return self.fn_banks.contains(name) or
+        self.class_decls.contains(name) or
+        self.enum_decls.contains(name) or
+        self.struct_decls.contains(name);
 }
 
 fn findLambdaInfo(self: *Emitter, expr: *const ast.Expr) ?*const LambdaInfo {

--- a/src/lang/codegen/mem_builtin.zig
+++ b/src/lang/codegen/mem_builtin.zig
@@ -3,6 +3,7 @@ const ast = @import("../ast.zig");
 const codegen = @import("../codegen.zig");
 const opcodes = @import("opcodes.zig");
 const isa = @import("isa.zig");
+const lambda = @import("lambda.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -151,7 +152,19 @@ pub fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
         return;
     }
     const name = self.source[e.ident.span.start..e.ident.span.end];
+    // A captured aggregate: the env slot holds its base pointer.
+    if (self.captures.get(name)) |slot| {
+        if (slot.is_aggregate) {
+            try lambda.emitCaptureLoad(self, slot);
+            return;
+        }
+    }
     if (self.locals.get(name)) |ofs| {
+        // A promoted aggregate's slot holds a heap pointer = the base.
+        if (lambda.isPromoted(self, name)) {
+            try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
+            return;
+        }
         // Local: address = fp + ofs (ofs is negative).
         try isa.movRegToReg(self, Reg.fp, Reg.acu);
         if (ofs < 0) {
@@ -168,6 +181,11 @@ pub fn emitAddrOf(self: *Emitter, e: *const ast.Expr) !void {
         return;
     }
     if (self.params.get(name)) |ofs| {
+        // A promoted aggregate param's slot holds a heap pointer = the base.
+        if (lambda.isPromoted(self, name)) {
+            try isa.movRegOffsetToReg(self, Reg.fp, ofs, Reg.acu);
+            return;
+        }
         // Param: address = fp + ofs (ofs is positive).
         try isa.movRegToReg(self, Reg.fp, Reg.acu);
         // @as: positive i8 → u16.

--- a/src/lang/codegen/statements.zig
+++ b/src/lang/codegen/statements.zig
@@ -215,6 +215,29 @@ pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
             return;
         }
     }
+    // Lookup order mirrors `emitIdent`: locals → params → captures →
+    // globals, so an inner-scope local shadows an enclosing capture.
+    if (self.locals.get(name)) |ofs| {
+        // A promoted local stores through its cell pointer; a plain one
+        // writes the value word into its slot.
+        if (lambda.isPromoted(self, name)) {
+            try lambda.emitPromotedAssign(self, ofs, a.value);
+        } else {
+            try self.emitExpr(a.value);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+        }
+        return;
+    }
+    if (self.params.get(name)) |ofs| {
+        // A captured-and-promoted param writes through its cell pointer.
+        if (lambda.isPromoted(self, name)) {
+            try lambda.emitPromotedAssign(self, ofs, a.value);
+        } else {
+            try self.emitExpr(a.value);
+            try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
+        }
+        return;
+    }
     // Captured-binding write inside a lambda body — store through the
     // env-relative cell pointer (the parent promoted the binding so the
     // write is visible everywhere).
@@ -222,24 +245,8 @@ pub fn emitAssign(self: *Emitter, a_in: ast.AssignStmt) !void {
         try lambda.emitCaptureStore(self, slot, a.value);
         return;
     }
-    // Promoted local in the parent fn — store through the local-slot
-    // cell pointer.
-    if (lambda.isPromoted(self, name)) {
-        if (self.locals.get(name)) |ofs| {
-            try lambda.emitPromotedAssign(self, ofs, a.value);
-            return;
-        }
-    }
-    try self.emitExpr(a.value); // result in acu
-    if (self.locals.get(name)) |ofs| {
-        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
-        return;
-    }
-    if (self.params.get(name)) |ofs| {
-        try isa.movRegToRegOffset(self, Reg.acu, Reg.fp, ofs);
-        return;
-    }
     if (self.globals.get(name)) |g| {
+        try self.emitExpr(a.value);
         try self.emitGlobalStore(Reg.acu, g);
         return;
     }
@@ -349,6 +356,7 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
     if (optBindingType(self, d)) |opt| {
         const slot = try self.allocLocalSized(dup_name, self.widthOfType(opt));
         if (d.init) |init_expr| try vec_builtin.emitOptionalInto(self, init_expr, opt.optional, slot);
+        if (lambda.isPromoted(self, name)) try lambda.emitPromoteAggregate(self, slot, self.widthOfType(opt));
         return;
     }
 
@@ -364,6 +372,7 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
     if (struct_name) |sname| {
         const slot = try self.allocLocalSized(dup_name, self.structWidth(sname));
         if (d.init) |init_expr| try value_struct.emitInto(self, init_expr, sname, slot);
+        if (lambda.isPromoted(self, name)) try lambda.emitPromoteAggregate(self, slot, self.structWidth(sname));
         return;
     }
 
@@ -385,6 +394,7 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
                 try value_struct.copyBytes(self, Reg.r1, Reg.r2, vec_builtin.header_size);
             }
         }
+        if (lambda.isPromoted(self, name)) try lambda.emitPromoteAggregate(self, slot, vec_builtin.header_size);
         return;
     }
 
@@ -400,6 +410,7 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
                 try value_struct.emitTupleInto(self, init_expr, elems, slot);
             } else try self.unsupported(d.span, "tuple binding initialized from a non-tuple value");
         }
+        if (lambda.isPromoted(self, name)) try lambda.emitPromoteAggregate(self, slot, width);
         return;
     }
 
@@ -421,6 +432,7 @@ pub fn emitLetDecl(self: *Emitter, d: ast.LetDecl) !void {
                 try value_struct.emitArrayInto(self, init_expr, info.elem, info.count, slot);
             } else try self.unsupported(d.span, "array binding initialized from a non-array value");
         }
+        if (lambda.isPromoted(self, name)) try lambda.emitPromoteAggregate(self, slot, width);
         return;
     }
 

--- a/src/lang/codegen/value_struct.zig
+++ b/src/lang/codegen/value_struct.zig
@@ -17,6 +17,7 @@ const isa = @import("isa.zig");
 const class = @import("class.zig");
 const strings = @import("strings.zig");
 const overflow = @import("overflow.zig");
+const do_expr = @import("do_expr.zig");
 
 const Emitter = codegen.Emitter;
 const Op = opcodes.Op;
@@ -100,6 +101,18 @@ pub fn emitIntoSret(self: *Emitter, src: *const ast.Expr, sname: []const u8, ptr
 }
 
 fn emitIntoDest(self: *Emitter, src: *const ast.Expr, sname: []const u8, dest: Dest) error{OutOfMemory}!void {
+    // A `do … end` value block: run its scoped prefix, then materialize
+    // its tail expression into `dest`.
+    if (src.* == .do_expr) {
+        const p = try do_expr.emitPrefix(self, src.do_expr);
+        if (p.tail) |tail| {
+            try emitIntoDest(self, tail, sname, dest);
+        } else {
+            try self.unsupported(src.do_expr.span, "`do` value block must end in an expression");
+        }
+        try do_expr.emitSuffix(self, p);
+        return;
+    }
     if (src.* == .struct_lit) {
         try emitLitInto(self, src.struct_lit, sname, dest);
         return;
@@ -143,6 +156,16 @@ pub fn emitTupleIntoSret(self: *Emitter, src: *const ast.Expr, elems: []const *c
 }
 
 fn emitTupleIntoDest(self: *Emitter, src: *const ast.Expr, elems: []const *const types.Type, dest: Dest) error{OutOfMemory}!void {
+    if (src.* == .do_expr) {
+        const p = try do_expr.emitPrefix(self, src.do_expr);
+        if (p.tail) |tail| {
+            try emitTupleIntoDest(self, tail, elems, dest);
+        } else {
+            try self.unsupported(src.do_expr.span, "`do` value block must end in an expression");
+        }
+        try do_expr.emitSuffix(self, p);
+        return;
+    }
     if (src.* == .tuple_lit) {
         for (src.tuple_lit.elems, 0..) |elem, i| {
             // safety: tuple arity ≤ 4 (§3.4) fits u8.
@@ -205,6 +228,16 @@ pub fn emitArrayInto(self: *Emitter, src: *const ast.Expr, elem: *const types.Ty
 }
 
 fn emitArrayIntoDest(self: *Emitter, src: *const ast.Expr, elem: *const types.Type, count: u32, dest: Dest) error{OutOfMemory}!void {
+    if (src.* == .do_expr) {
+        const p = try do_expr.emitPrefix(self, src.do_expr);
+        if (p.tail) |tail| {
+            try emitArrayIntoDest(self, tail, elem, count, dest);
+        } else {
+            try self.unsupported(src.do_expr.span, "`do` value block must end in an expression");
+        }
+        try do_expr.emitSuffix(self, p);
+        return;
+    }
     const ew = self.widthOfType(elem);
     if (src.* == .list_lit) {
         for (src.list_lit.elems, 0..) |e, i| {

--- a/src/lang/typecheck.zig
+++ b/src/lang/typecheck.zig
@@ -543,6 +543,27 @@ pub const Checker = struct {
         try self.walkStatementSequence(body);
     }
 
+    /// Type of a `do … end` value block (§4.3): the body runs in a fresh
+    /// scope and the block evaluates to its last expression's type (or
+    /// `nil` if the last item is a statement). A trailing bare `do … end`
+    /// is itself a value block, so descend into it.
+    fn doBlockType(self: *Checker, body: []const ast.Statement, hint: ?*const types.Type) WalkError!?*const types.Type {
+        const saved = self.current_scope;
+        var child: Scope = .init(self.arena, saved);
+        self.current_scope = &child;
+        defer self.current_scope = saved;
+        if (body.len == 0) return try self.primitive(.nil_);
+        try self.walkStatementSequence(body[0 .. body.len - 1]);
+        return switch (body[body.len - 1]) {
+            .expr_stmt => |es| try self.inferExpr(es.expr, hint),
+            .block => |b| try self.doBlockType(b.body, hint),
+            else => blk: {
+                try self.walkStatement(body[body.len - 1]);
+                break :blk try self.primitive(.nil_);
+            },
+        };
+    }
+
     /// Walk a flat statement list and absorb the "fall-through gain"
     /// from `if x == nil then return end` patterns — code following
     /// such an `if` may treat `x` as statically non-nil for the rest
@@ -1532,10 +1553,7 @@ pub const Checker = struct {
                 }
                 return null;
             },
-            .do_expr => |d| {
-                try self.walkInScope(d.body);
-                return null;
-            },
+            .do_expr => |d| return try self.doBlockType(d.body, hint),
             .if_expr => |ie| {
                 try self.checkIfChain(ie.arms, ie.else_body);
                 return null;

--- a/tests/lang/codegen.test.zig
+++ b/tests/lang/codegen.test.zig
@@ -3854,6 +3854,495 @@ test "codegen/closure: AC4 — returned closure keeps env alive (escape analysis
     try std.testing.expectEqualStrings("1\n2\n", writer.written());
 }
 
+test "codegen/closure: a captured variable used in string interpolation resolves" {
+    // The capture analysis descends into `$(…)` interpolation parts, so
+    // `v` enters the closure's capture set and the body reads it.
+    try runAndExpect(
+        \\def main()
+        \\  let v: i16 = 7
+        \\  let r = || -> str "val is $(v)"
+        \\  print r()
+        \\end
+    , "val is 7\n");
+}
+
+test "codegen/closure: a capture reached through a field access in interpolation resolves" {
+    try runAndExpect(
+        \\class Hero
+        \\  let hp: i16
+        \\  def init(self)
+        \\    self.hp = 30
+        \\  end
+        \\end
+        \\def main()
+        \\  let hero = Hero()
+        \\  let r = || -> str "hp $(hero.hp)"
+        \\  print r()
+        \\end
+    , "hp 30\n");
+}
+
+test "codegen/closure: two captures interpolated in one string resolve" {
+    try runAndExpect(
+        \\def main()
+        \\  let a: i16 = 3
+        \\  let b: i16 = 4
+        \\  let r = || -> str "$(a) and $(b)"
+        \\  print r()
+        \\end
+    , "3 and 4\n");
+}
+
+test "codegen/closure: a `for` loop variable inside a lambda is a local, not a capture" {
+    try runAndExpect(
+        \\def main()
+        \\  let f = || -> i16 do
+        \\    let xs: [i16; 3] = [1, 2, 3]
+        \\    let total: i16 = 0
+        \\    for k in xs
+        \\      total = total + k
+        \\    end
+        \\    total
+        \\  end
+        \\  print f()
+        \\end
+    , "6\n");
+}
+
+test "codegen/closure: a captured `for`-loop range bound resolves" {
+    try runAndExpect(
+        \\def main()
+        \\  let lo: i16 = 1
+        \\  let hi: i16 = 4
+        \\  let f = || -> i16 do
+        \\    let total: i16 = 0
+        \\    for k in lo..hi
+        \\      total = total + 1
+        \\    end
+        \\    total
+        \\  end
+        \\  print f()
+        \\end
+    , "3\n");
+}
+
+test "codegen/closure: a `do`-block lambda body captures an enclosing free variable" {
+    try runAndExpect(
+        \\def main()
+        \\  let count: i16 = 7
+        \\  let f = || -> i16 do
+        \\    let x: i16 = count + 1
+        \\    x
+        \\  end
+        \\  print f()
+        \\end
+    , "8\n");
+}
+
+test "codegen/closure: a read-only struct capture survives the frame (escaping)" {
+    // `pt` is read-only, so the closure heap-copies it at construction and
+    // reads its field after `make` returns (value semantics, escape-safe).
+    try runAndExpect(
+        \\struct Pt
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def make(pt: Pt) -> fn() -> i16
+        \\  return || -> i16 pt.x
+        \\end
+        \\def main()
+        \\  let g = make(Pt { x: 11, y: 22 })
+        \\  print g()
+        \\end
+    , "11\n");
+}
+
+test "codegen/closure: a mutated struct capture is a shared upvalue" {
+    // `c` is mutated by the closure, so it is promoted to a shared heap
+    // buffer — the write is visible to the enclosing scope afterward.
+    try runAndExpect(
+        \\struct Counter
+        \\  n: i16
+        \\end
+        \\def main()
+        \\  let c = Counter { n: 5 }
+        \\  let inc = || -> i16 do
+        \\    c.n = c.n + 1
+        \\    c.n
+        \\  end
+        \\  print inc()
+        \\  print c.n
+        \\end
+    , "6\n6\n");
+}
+
+test "codegen/closure: two closures share one mutated struct upvalue" {
+    try runAndExpect(
+        \\struct Counter
+        \\  n: i16
+        \\end
+        \\def main()
+        \\  let c = Counter { n: 0 }
+        \\  let inc = || -> i16 do
+        \\    c.n = c.n + 1
+        \\    c.n
+        \\  end
+        \\  let get = || -> i16 c.n
+        \\  print inc()
+        \\  print inc()
+        \\  print get()
+        \\end
+    , "1\n2\n2\n");
+}
+
+test "codegen/closure: a mutated array capture shares one buffer with the frame" {
+    try runAndExpect(
+        \\def main()
+        \\  let xs: [i16; 2] = [0, 0]
+        \\  let setf = || -> i16 do
+        \\    xs[1] = 5
+        \\    xs[1]
+        \\  end
+        \\  print setf()
+        \\  print xs[1]
+        \\end
+    , "5\n5\n");
+}
+
+test "codegen/closure: a captured optional unwraps inside the lambda body" {
+    // `opt` is a 4-byte aggregate; `if let` over the capture reads it.
+    try runAndExpect(
+        \\def main()
+        \\  let opt: i16? = 99
+        \\  let f = lambda () -> i16
+        \\    if let v = opt
+        \\      return v
+        \\    end
+        \\    return 0
+        \\  end
+        \\  print f()
+        \\end
+    , "99\n");
+}
+
+test "codegen/closure: a captured Vec shares its header — a push is visible outside" {
+    // A method call may grow the receiver's header, so the captured Vec is
+    // promoted to a shared upvalue; the closure's push updates one header.
+    try runAndExpect(
+        \\def main()
+        \\  let v: Vec(i16) = Vec.new()
+        \\  let add = || -> i16 do
+        \\    v.push(1)
+        \\    v.len() as i16
+        \\  end
+        \\  print add()
+        \\  print v.len() as i16
+        \\end
+    , "1\n1\n");
+}
+
+test "codegen/closure: a method-defined lambda captures self and reads a field" {
+    // `self` inside a returned closure is captured (the body reads the
+    // receiver from its env), so `self.v` resolves after the method returns.
+    try runAndExpect(
+        \\class Box
+        \\  let v: i16
+        \\  def init(self)
+        \\    self.v = 42
+        \\  end
+        \\  def getter(self) -> fn() -> i16
+        \\    return || -> i16 self.v
+        \\  end
+        \\end
+        \\def main()
+        \\  let b = Box()
+        \\  let g = b.getter()
+        \\  print g()
+        \\end
+    , "42\n");
+}
+
+test "codegen/closure: a captured self mutates a shared field across calls" {
+    // The closure holds the receiver pointer by value, so `self.n` writes
+    // hit the same heap object and persist between calls.
+    try runAndExpect(
+        \\class Counter
+        \\  let n: i16
+        \\  def init(self)
+        \\    self.n = 0
+        \\  end
+        \\  def stepper(self) -> fn() -> i16
+        \\    return || -> i16 do
+        \\      self.n = self.n + 1
+        \\      self.n
+        \\    end
+        \\  end
+        \\end
+        \\def main()
+        \\  let c = Counter()
+        \\  let advance = c.stepper()
+        \\  print advance()
+        \\  print advance()
+        \\end
+    , "1\n2\n");
+}
+
+test "codegen/closure: a captured self calls a method" {
+    try runAndExpect(
+        \\class Adder
+        \\  let base: i16
+        \\  def init(self)
+        \\    self.base = 10
+        \\  end
+        \\  def bump(self, n: i16) -> i16
+        \\    return self.base + n
+        \\  end
+        \\  def make(self) -> fn() -> i16
+        \\    return || -> i16 self.bump(5)
+        \\  end
+        \\end
+        \\def main()
+        \\  let a = Adder()
+        \\  let f = a.make()
+        \\  print f()
+        \\end
+    , "15\n");
+}
+
+test "codegen/closure: a free function called in a lambda body is not captured" {
+    // `helper` names a module-level function — globally addressable, so
+    // the lambda body calls it directly rather than capturing it.
+    try runAndExpect(
+        \\def helper(x: i16) -> i16
+        \\  return x + 5
+        \\end
+        \\def main()
+        \\  let f = || -> i16 helper(10)
+        \\  print f()
+        \\end
+    , "15\n");
+}
+
+test "codegen/closure: a lambda mixes a real capture with a free function call" {
+    // `base` is a genuine capture (enclosing local); `dbl` is a module
+    // function resolved directly — only `base` consumes an env slot.
+    try runAndExpect(
+        \\def dbl(n: i16) -> i16
+        \\  return n + n
+        \\end
+        \\def main()
+        \\  let base: i16 = 6
+        \\  let f = || -> i16 dbl(base)
+        \\  print f()
+        \\end
+    , "12\n");
+}
+
+test "codegen/closure: a class constructed inside a lambda body is not captured" {
+    try runAndExpect(
+        \\class Box
+        \\  let v: i16
+        \\  def init(self)
+        \\    self.v = 7
+        \\  end
+        \\  def get(self) -> i16
+        \\    return self.v
+        \\  end
+        \\end
+        \\def main()
+        \\  let f = || -> i16 Box().get()
+        \\  print f()
+        \\end
+    , "7\n");
+}
+
+test "codegen/closure: a capture shadowed by a `do`-block local resolves again after the block" {
+    // The `do` block's `let w` is scoped out at block end, so `w` in
+    // `w + inner` reads the captured outer `w` (50), not the stale 7.
+    try runAndExpect(
+        \\def main()
+        \\  let w: i16 = 50
+        \\  let f = lambda () -> i16
+        \\    let inner: i16 = do
+        \\      let w: i16 = 7
+        \\      w
+        \\    end
+        \\    return w + inner
+        \\  end
+        \\  print f()
+        \\end
+    , "57\n");
+}
+
+test "codegen/closure: a `for`-loop var shadowing a capture is scoped out after the loop" {
+    // The loop var `i` shadows the captured `i` only inside the loop;
+    // `sum + i` after the loop reads the capture (50).
+    try runAndExpect(
+        \\def main()
+        \\  let i: i16 = 50
+        \\  let f = lambda () -> i16
+        \\    let sum: i16 = 0
+        \\    for i in 0..3
+        \\      sum = sum + i
+        \\    end
+        \\    return sum + i
+        \\  end
+        \\  print f()
+        \\end
+    , "53\n");
+}
+
+test "codegen/closure: a returned closure capturing a param keeps its value after the frame is gone" {
+    // The param `p` escapes `make`, so it is promoted to a heap cell at
+    // entry; the closure reads the cell after `make` returns.
+    try runAndExpect(
+        \\def make(p: i16) -> fn() -> i16
+        \\  return || -> i16 p + 1
+        \\end
+        \\def main()
+        \\  let g = make(7)
+        \\  print g()
+        \\end
+    , "8\n");
+}
+
+test "codegen/closure: a mutated captured param shares one cell across calls" {
+    // The closure mutates the captured param through its heap cell, so
+    // the increment persists between calls.
+    try runAndExpect(
+        \\def make(p: i16) -> fn() -> i16
+        \\  return || -> i16 do
+        \\    p = p + 1
+        \\    p
+        \\  end
+        \\end
+        \\def main()
+        \\  let g = make(7)
+        \\  print g()
+        \\  print g()
+        \\end
+    , "8\n9\n");
+}
+
+test "codegen/closure: a capture mutated by a closure bound in a match arm is promoted" {
+    // The escaping-capture walk descends into match-arm bodies, so `n`
+    // is promoted and the mutation persists across calls.
+    try runAndExpect(
+        \\def make(tag: i16) -> fn() -> i16
+        \\  let n: i16 = 3
+        \\  match tag
+        \\    case 0 =>
+        \\      return || -> i16 do
+        \\        n = n + 1
+        \\        n
+        \\      end
+        \\    case _ =>
+        \\      return || -> i16 n
+        \\  end
+        \\end
+        \\def main()
+        \\  let g = make(0)
+        \\  print g()
+        \\  print g()
+        \\end
+    , "4\n5\n");
+}
+
+test "codegen/do: a `do … end` value block evaluates to its last expression" {
+    try runAndExpect(
+        \\def main()
+        \\  let x: i16 = do
+        \\    let a: i16 = 3
+        \\    a + 4
+        \\  end
+        \\  print x
+        \\end
+    , "7\n");
+}
+
+test "codegen/do: an un-annotated `do` block sizes its slot from the inferred type" {
+    try runAndExpect(
+        \\def main()
+        \\  let v = do
+        \\    let a: i16 = 40
+        \\    a + 2
+        \\  end
+        \\  print v
+        \\end
+    , "42\n");
+}
+
+test "codegen/do: a `do` block can produce a tuple value" {
+    try runAndExpect(
+        \\def main()
+        \\  let p: (i16, i16) = do
+        \\    let w: i16 = 10
+        \\    let h: i16 = 20
+        \\    (w, h)
+        \\  end
+        \\  print p.0
+        \\  print p.1
+        \\end
+    , "10\n20\n");
+}
+
+test "codegen/do: a `do` block can produce a struct value" {
+    try runAndExpect(
+        \\struct P
+        \\  x: i16
+        \\  y: i16
+        \\end
+        \\def main()
+        \\  let s: P = do
+        \\    P { x: 5, y: 6 }
+        \\  end
+        \\  print s.x
+        \\  print s.y
+        \\end
+    , "5\n6\n");
+}
+
+test "codegen/do: a `do` block can produce an array value" {
+    try runAndExpect(
+        \\def main()
+        \\  let arr: [i16; 3] = do
+        \\    [9, 8, 7]
+        \\  end
+        \\  print arr[0]
+        \\  print arr[2]
+        \\end
+    , "9\n7\n");
+}
+
+test "codegen/do: a `do` block's defer fires but doesn't clobber its value" {
+    try runAndExpect(
+        \\def note(n: i16)
+        \\  print n
+        \\end
+        \\def main()
+        \\  let x: i16 = do
+        \\    defer note(1)
+        \\    9
+        \\  end
+        \\  print x
+        \\end
+    , "1\n9\n");
+}
+
+test "codegen/do: a trailing nested `do … end` is the value, not nil" {
+    try runAndExpect(
+        \\def main()
+        \\  let x: i16 = do
+        \\    let a: i16 = 7
+        \\    do
+        \\      a + 1
+        \\    end
+        \\  end
+        \\  print x
+        \\end
+    , "8\n");
+}
+
 test "codegen/closure: nested lambda — inner closure pulls captures through outer env" {
     var compiled = try compileSource(
         \\def main()

--- a/tests/lang/codegen/do_expr.test.zig
+++ b/tests/lang/codegen/do_expr.test.zig
@@ -1,0 +1,10 @@
+/// Smoke that the `do_expr` codegen module is reachable through the
+/// public barrel. End-to-end `do … end` value-block coverage (scalar
+/// / tuple / struct / array results, scratch locals, defers) lives in
+/// `tests/lang/codegen.test.zig`.
+const std = @import("std");
+const gero = @import("gero");
+
+test "codegen/do_expr: module compiles through the barrel" {
+    _ = gero.lang.internal.codegen.do_expr;
+}


### PR DESCRIPTION
## What

Lowers `do … end` as a value expression (§4.3) and reworks closure
capture analysis to be scope-correct (§4.7.1–4.7.2). Together these let
`docs/examples/syntax_overview.gr` — the complete-syntax tour —
type-check and run end-to-end; it is no longer `gero-example: fmt-only`.

## `do … end` as an expression (§4.3)

`let x = do … end` runs the block's scoped statements and evaluates to
its last expression, for any result type (scalar, tuple, struct,
array). Inner locals reserve frame space; the block's defers fire
without clobbering the value.

## Closure capture rework (§4.7.1–4.7.2)

The previous free-variable walker was flat and unscoped. Replaced with a
scoped single pass plus the emission to back it:

- **Scope-correct.** A capture shadowed by a block / loop / `match`-arm
  local resolves to the outer binding again after the inner scope ends.
  `match`-arm and parameter captures are tracked; the walk descends into
  `$(…)` string interpolation.
- **Module names aren't captured.** A free function / class / enum /
  struct named in a lambda body is addressed directly.
- **Escaping parameters** stay alive across the return as upvalues.
- **`self` capture.** A method-defined lambda reads the receiver from
  its env, so `self.field` / `self.method()` / shared field mutation
  work in a returned closure.
- **Aggregate capture.** Closures capture structs, arrays, tuples,
  `Vec`, and scalar optionals. Per §4.7.2: a read-only aggregate is
  copied at construction (value semantics, escape-safe); an aggregate
  the closure mutates becomes a shared heap upvalue, so writes are
  visible to the enclosing scope and to every closure over it.

## Tests

24 new closure / `do`-expression spec tests covering shadowing, match
captures, escaping params, module-name resolution, self capture, and
read-only + shared-mutate aggregate capture across every aggregate kind.
Full `zig build ci` green (Debug / ReleaseSafe / ReleaseFast /
ReleaseSmall × linux / macos / windows / wasi) + example gates.

## Out of scope (cleanly rejected)

Calling a function value through a non-ident callee (e.g. a tuple
element) remains `E_CODEGEN_UNSUPPORTED` — orthogonal, pre-existing.

Closes #344
